### PR TITLE
Updated RTPS SEDP to process all QoS policies even if some are disabled locally due to profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ lib*.so*
 /setenv.cmd
 /user_macros.GNU
 /build
+/ipch

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -182,13 +182,11 @@ namespace {
         TheServiceParticipant->initial_DurabilityQosPolicy();
     return qos != def_qos;
   }
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
   bool not_default(const DDS::DurabilityServiceQosPolicy& qos) {
     DDS::DurabilityServiceQosPolicy def_qos =
         TheServiceParticipant->initial_DurabilityServiceQosPolicy();
     return qos != def_qos;
   }
-#endif
   bool not_default(const DDS::LifespanQosPolicy& qos) {
     DDS::LifespanQosPolicy def_qos =
         TheServiceParticipant->initial_LifespanQosPolicy();
@@ -214,13 +212,16 @@ namespace {
         TheServiceParticipant->initial_OwnershipQosPolicy();
     return qos != def_qos;
   }
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   bool not_default(const DDS::OwnershipStrengthQosPolicy& qos) {
+#ifdef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
+    ACE_UNUSED_ARG(qos);
+    return false;
+#else
     DDS::OwnershipStrengthQosPolicy def_qos =
         TheServiceParticipant->initial_OwnershipStrengthQosPolicy();
     return qos != def_qos;
-  }
 #endif
+  }
   bool not_default(const DDS::DestinationOrderQosPolicy& qos) {
     DDS::DestinationOrderQosPolicy def_qos =
         TheServiceParticipant->initial_DestinationOrderQosPolicy();
@@ -379,14 +380,12 @@ int to_param_list(const DiscoveredWriterData& writer_data,
     add_param(param_list, param);
   }
 
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
   if (not_default(writer_data.ddsPublicationData.durability_service))
   {
     Parameter param;
     param.durability_service(writer_data.ddsPublicationData.durability_service);
     add_param(param_list, param);
   }
-#endif
 
   if (not_default(writer_data.ddsPublicationData.deadline))
   {
@@ -444,14 +443,12 @@ int to_param_list(const DiscoveredWriterData& writer_data,
     add_param(param_list, param);
   }
 
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   if (not_default(writer_data.ddsPublicationData.ownership_strength))
   {
     Parameter param;
     param.ownership_strength(writer_data.ddsPublicationData.ownership_strength);
     add_param(param_list, param);
   }
-#endif
 
   if (not_default(writer_data.ddsPublicationData.destination_order))
   {
@@ -842,7 +839,9 @@ int from_param_list(const ParameterList& param_list,
       TheServiceParticipant->initial_UserDataQosPolicy();
   writer_data.ddsPublicationData.ownership =
       TheServiceParticipant->initial_OwnershipQosPolicy();
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
+#ifdef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
+  writer_data.ddsPublicationData.ownership_strength.value = 0;
+#else
   writer_data.ddsPublicationData.ownership_strength =
       TheServiceParticipant->initial_OwnershipStrengthQosPolicy();
 #endif
@@ -913,11 +912,9 @@ int from_param_list(const ParameterList& param_list,
       case PID_OWNERSHIP:
         writer_data.ddsPublicationData.ownership = param.ownership();
         break;
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
       case PID_OWNERSHIP_STRENGTH:
         writer_data.ddsPublicationData.ownership_strength = param.ownership_strength();
         break;
-#endif
       case PID_DESTINATION_ORDER:
         writer_data.ddsPublicationData.destination_order = param.destination_order();
         break;

--- a/dds/DCPS/RTPS/RtpsBaseMessageTypes.idl
+++ b/dds/DCPS/RTPS/RtpsBaseMessageTypes.idl
@@ -234,9 +234,7 @@ module OpenDDS {
     const ParameterId_t PID_HISTORY = 0x0040;
     const ParameterId_t PID_RESOURCE_LIMITS = 0x0041;
     const ParameterId_t PID_OWNERSHIP = 0x001f;
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
     const ParameterId_t PID_OWNERSHIP_STRENGTH = 0x0006;
-#endif
     const ParameterId_t PID_PRESENTATION = 0x0021;
     const ParameterId_t PID_PARTITION = 0x0029;
     const ParameterId_t PID_TIME_BASED_FILTER = 0x0004;
@@ -328,10 +326,8 @@ module OpenDDS {
         DDS::ResourceLimitsQosPolicy resource_limits;
       case PID_OWNERSHIP:
         DDS::OwnershipQosPolicy ownership;
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
       case PID_OWNERSHIP_STRENGTH:
         DDS::OwnershipStrengthQosPolicy ownership_strength;
-#endif
       case PID_PRESENTATION:
         DDS::PresentationQosPolicy presentation;
       case PID_PARTITION:

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -387,7 +387,11 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer)
     mc_port = port_common + outer_->disco_->d0();
 
   u_short participantId = (hdr_.guidPrefix[10] << 8) | hdr_.guidPrefix[11];
+
+#ifdef OPENDDS_SAFETY_PROFILE
   const u_short startingParticipantId = participantId;
+#endif
+
   while (!open_unicast_socket(port_common, participantId)) {
     ++participantId;
   }


### PR DESCRIPTION
Avoids reading uninitialized memory when minimum profile is in effect, may fix built-in topics for those cases.