### PR TITLE
Fixed problem with publisher not using send_counter in normal send, thus...

### DIFF
--- a/tests/FACE/Reliability/Publisher/Publisher.cpp
+++ b/tests/FACE/Reliability/Publisher/Publisher.cpp
@@ -92,7 +92,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
   // End Testing of timeout settings for send
 
   std::cout << "Publisher: about to send_message()" << std::endl;
-  for (FACE::Long i = 0; i < 20; ++i) {
+  for (FACE::Long i = send_counter; i < 20; ++i) {
     Messenger::Message msg = {"Hello, world.", i, 0};
     FACE::TRANSACTION_ID_TYPE txn;
     std::cout << "  sending " << i << std::endl;


### PR DESCRIPTION
... causing duplication of 0 and 1 in messages.