### PR TITLE
TS API Update: Get_Connection_Parameters() - Redmine Task #2373

### DIFF
--- a/FACE/TS.hpp
+++ b/FACE/TS.hpp
@@ -34,7 +34,7 @@ namespace TS {
   OpenDDS_FACE_Export
   void Get_Connection_Parameters(
     /* inout */ CONNECTION_NAME_TYPE& connection_name,
-    /* inout */ CONNECTION_ID_TYPE& connection_id,
+    /* inout (0 to specify out)*/ CONNECTION_ID_TYPE& connection_id,
     /* out */ TRANSPORT_CONNECTION_STATUS_TYPE& connection_status,
     /* out */ RETURN_CODE_TYPE& return_code);
 

--- a/tests/FACE/Messenger/Publisher/Publisher.cpp
+++ b/tests/FACE/Messenger/Publisher/Publisher.cpp
@@ -25,6 +25,34 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
   FACE::TS::Get_Connection_Parameters(name, connId, connectionStatus, status);
   if (status != FACE::RC_NO_ERROR) return static_cast<int>(status);
 
+  //Check that name & connection validated ok
+  FACE::CONNECTION_NAME_TYPE goodName = "pub";
+  FACE::TS::Get_Connection_Parameters(goodName, connId, connectionStatus, status);
+  if (status != FACE::RC_NO_ERROR) {
+    std::cout << "ERROR: Get_Connection_Parameters with goodName and good connection Id failed\n";
+  }
+
+  //Check that wrong name & connection validated - INVALID_PARAM
+  FACE::CONNECTION_NAME_TYPE badName = "wrong_pub";
+  FACE::TS::Get_Connection_Parameters(badName, connId, connectionStatus, status);
+  if (status != FACE::INVALID_PARAM) {
+    std::cout << "ERROR: Get_Connection_Parameters with bad name and good connection Id failed to return INVALID_PARAM\n";
+  }
+
+  //Check that name & wrong connection validated - INVALID_PARAM
+  FACE::CONNECTION_ID_TYPE wrongConnectionId = 5;
+  FACE::TS::Get_Connection_Parameters(goodName, wrongConnectionId, connectionStatus, status);
+  if (status != FACE::INVALID_PARAM) {
+    std::cout << "ERROR: Get_Connection_Parameters with good name and bad connection Id failed to return INVALID_PARAM\n";
+  }
+
+  //Check that no name & no connection validated - INVALID_PARAM
+  FACE::CONNECTION_NAME_TYPE noName = {};
+  FACE::CONNECTION_ID_TYPE noConnectionId = 0;
+  FACE::TS::Get_Connection_Parameters(noName, noConnectionId, connectionStatus, status);
+  if (status != FACE::INVALID_PARAM) {
+    std::cout << "ERROR: Get_Connection_Parameters with no name and no connection Id failed to return INVALID_PARAM\n";
+  }
   FACE::CONNECTION_ID_TYPE getConnectionId = 0;
   FACE::TS::Get_Connection_Parameters(name, getConnectionId, connectionStatus, status);
   if (status != FACE::RC_NO_ERROR) return static_cast<int>(status);


### PR DESCRIPTION
Treat name and ID as both optional. If not provided, fill in, if both provided, validate, if neither provided, error. Connection_Id is only out param if specified as 0 otherwise will assume connection id has been specified.  Updated Messenger test's get connection params validation section with a couple additional scenarios to test new functionality.