### PR TITLE
TS API Update: If multiple callbacks registered, Task #2380

### DIFF
--- a/dds/FACE/FaceTSS.h
+++ b/dds/FACE/FaceTSS.h
@@ -129,9 +129,15 @@ public:
                            FACE::RETURN_CODE_TYPE&);
 
   Listener(Callback callback, FACE::CONNECTION_ID_TYPE connection_id)
-    : callback_(callback)
-    , connection_id_(connection_id)
-  {}
+    : connection_id_(connection_id)
+  {
+    callbacks_.push_back(callback);
+  }
+
+  void add_callback(Callback callback) {
+    GuardType guard(callbacks_lock_);
+    callbacks_.push_back(callback);
+  }
 
 private:
   void on_requested_deadline_missed(DDS::DataReader_ptr,
@@ -167,12 +173,19 @@ private:
       if (sinfo.valid_data) {
         update_status(connection_id_, DDS::RETCODE_OK);
         FACE::RETURN_CODE_TYPE retcode;
-        callback_(0, sample, 0, 0, 0, retcode);
+        GuardType guard(callbacks_lock_);
+        ACE_DEBUG((LM_DEBUG, "Listener::on_data_available - invoking %d callbacks\n", callbacks_.size()));
+        for (size_t i = 0; i < callbacks_.size(); ++i) {
+          callbacks_.at(i)(0, sample, 0, 0, 0, retcode);
+        }
       }
     }
   }
 
-  const Callback callback_;
+  typedef ACE_SYNCH_MUTEX     LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  LockType callbacks_lock_;
+  OPENDDS_VECTOR(Callback) callbacks_;
   const FACE::CONNECTION_ID_TYPE connection_id_;
 };
 
@@ -192,9 +205,14 @@ void register_callback(FACE::CONNECTION_ID_TYPE connection_id,
     return_code = FACE::INVALID_PARAM;
     return;
   }
-
-  DDS::DataReaderListener_var listener = new Listener<Msg>(callback, connection_id);
-  readers[connection_id]->set_listener(listener, DDS::DATA_AVAILABLE_STATUS);
+  DDS::DataReaderListener_ptr existing_listener = readers[connection_id]->get_listener();
+  if (existing_listener) {
+    Listener<Msg>* typedListener = dynamic_cast<Listener<Msg>*>(existing_listener);
+    typedListener->add_callback(callback);
+  } else {
+    DDS::DataReaderListener_var listener = new Listener<Msg>(callback, connection_id);
+    readers[connection_id]->set_listener(listener, DDS::DATA_AVAILABLE_STATUS);
+  }
   return_code = FACE::RC_NO_ERROR;
 }
 

--- a/tests/FACE/Messenger/Subscriber/Subscriber.cpp
+++ b/tests/FACE/Messenger/Subscriber/Subscriber.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 
 bool callbackHappened = false;
+int callback_count = 0;
 
 void callback(FACE::TRANSACTION_ID_TYPE,
               Messenger::Message& msg,
@@ -18,7 +19,8 @@ void callback(FACE::TRANSACTION_ID_TYPE,
               const FACE::WAITSET_TYPE,
               FACE::RETURN_CODE_TYPE& return_code)
 {
-  std::cout << "In callback(): "
+  ++callback_count;
+  std::cout << "In callback() (the " << callback_count << " time) : "
             << msg.text << '\t' << msg.count << std::endl;
   callbackHappened = true;
   return_code = FACE::RC_NO_ERROR;
@@ -43,9 +45,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     std::cout << "Subscriber: about to Register_Callback()" << std::endl;
     FACE::TS::Register_Callback(connId, 0, callback, 0, status);
     if (status != FACE::RC_NO_ERROR) return static_cast<int>(status);
+    FACE::TS::Register_Callback(connId, 0, callback, 0, status);
+    if (status != FACE::RC_NO_ERROR) return static_cast<int>(status);
     ACE_OS::sleep(15);
-    if (!callbackHappened) {
-      std::cout << "ERROR: no callback seen" << std::endl;
+    if (!callbackHappened || callback_count != 2) {
+      std::cout << "ERROR: number callbacks seen incorrect (seen: " << callback_count << " expected: 2)" << std::endl;
       testPassed = false;
     }
     FACE::TS::Unregister_Callback(connId, status);


### PR DESCRIPTION
If multiple callbacks registered, all should get a copy of the message.
Adapt Messenger test to register 2 callbacks instead of just one.