### PR TITLE
Rtps msg lifespan updates

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -638,6 +638,7 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
   CORBA::ULong rds_len = 0;
   DDS::InstanceHandleSeq handles;
 
+  ACE_GUARD(ACE_Thread_Mutex, wait_guard, sync_unreg_rem_assocs_lock_);
   {
     // Ensure the same acquisition order as in wait_for_acknowledgments().
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
@@ -1654,14 +1655,18 @@ DataWriterImpl::dispose_and_unregister(DDS::InstanceHandle_t handle,
 void
 DataWriterImpl::unregister_instances(const DDS::Time_t& source_timestamp)
 {
-  PublicationInstanceMapType::iterator it =
-    this->data_container_->instances_.begin();
+  {
+    ACE_GUARD(ACE_Thread_Mutex, guard, sync_unreg_rem_assocs_lock_);
 
-  while (it != this->data_container_->instances_.end()) {
-    DDS::InstanceHandle_t handle = it->first;
-    ++it; // avoid mangling the iterator
+    PublicationInstanceMapType::iterator it =
+      this->data_container_->instances_.begin();
 
-    this->unregister_instance_i(handle, source_timestamp);
+    while (it != this->data_container_->instances_.end()) {
+      DDS::InstanceHandle_t handle = it->first;
+      ++it; // avoid mangling the iterator
+
+      this->unregister_instance_i(handle, source_timestamp);
+    }
   }
 }
 

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -596,14 +596,14 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
       ACE_Message_Block* const end_historic_samples =
         create_control_message(END_HISTORIC_SAMPLES, header, data, timestamp);
 
+      this->controlTracker.message_sent();
       guard.release();
       SendControlStatus ret = send_w_control(list, header, end_historic_samples, remote_id);
       if (ret == SEND_CONTROL_ERROR) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
                              ACE_TEXT("DataWriterImpl::association_complete_i: ")
                              ACE_TEXT("send_w_control failed.\n")));
-      } else {
-        this->controlTracker.message_sent();
+        this->controlTracker.message_dropped();
       }
     }
   }
@@ -2610,10 +2610,12 @@ SendControlStatus
 DataWriterImpl::send_control(const DataSampleHeader& header,
                              ACE_Message_Block* msg)
 {
+  controlTracker.message_sent();
+
   SendControlStatus status = TransportClient::send_control(header, msg);
 
-  if (status == SEND_CONTROL_OK) {
-    controlTracker.message_sent();
+  if (status != SEND_CONTROL_OK) {
+    controlTracker.message_dropped();
   }
 
   return status;

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -695,6 +695,10 @@ private:
   DDS::ReturnCode_t send_end_historic_samples(const RepoId& readerId);
 
   bool liveliness_asserted_;
+
+  // Lock used to synchronize remove_associations calls from discovery
+  // and unregister_instances during deletion of datawriter from application
+  ACE_Thread_Mutex sync_unreg_rem_assocs_lock_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -197,6 +197,7 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
 
   // Wait for any control messages to be transported during
   // unregistering of instances.
+  dw_servant->wait_pending();
   dw_servant->wait_control_pending();
 
   CORBA::String_var topic_name = dw_servant->get_topic_name();

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -420,6 +420,10 @@ private:
   /// List of data that has already been sent.
   SendStateDataSampleList   sent_data_;
 
+  /// List of data that has been released by WriteDataContainer
+  /// but is still in process of delivery (or dropping) by transport
+  SendStateDataSampleList  orphaned_to_transport_;
+
   /// The list of all samples written to this datawriter in
   /// writing order.
   WriterDataSampleList   data_holder_;

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
@@ -29,15 +29,18 @@ void
 TransportCustomizedElement::release_element(bool dropped_by_transport)
 {
   DBG_ENTRY_LVL("TransportCustomizedElement", "release_element", 6);
-
+  TransportQueueElement* decided = 0;
   if (orig_) {
-    orig_->decision_made(dropped_by_transport);
+    decided = orig_;
   }
 
   if (allocator_) {
     ACE_DES_FREE(this, allocator_->free, TransportCustomizedElement);
   } else {
     delete this;
+  }
+  if (decided) {
+    decided->decision_made(dropped_by_transport);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -64,8 +64,6 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport* transport,
                 config->nak_response_delay_),
     heartbeat_reply_(this, &RtpsUdpDataLink::send_heartbeat_replies,
                      config->heartbeat_response_delay_),
-    acked_by_all_check_(this, &RtpsUdpDataLink::process_acked_by_all,
-                        ACE_Time_Value::zero),
     heartbeat_(this)
 {
   std::memcpy(local_prefix_, local_prefix, sizeof(GuidPrefix_t));
@@ -86,35 +84,41 @@ RtpsUdpDataLink::add_delayed_notification(TransportQueueElement* element)
 void RtpsUdpDataLink::do_remove_sample(const RepoId& pub_id,
   const TransportQueueElement::MatchCriteria& criteria)
 {
-  bool remove = false;
-  TransportQueueElement* tqe_to_remove;
-  SequenceNumber sn_to_remove;
+  typedef OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*) SeqToTqeMap;
+  SeqToTqeMap sn_tqe_map;
+  SeqToTqeMap to_deliver;
+  typedef SeqToTqeMap::iterator iter_t;
+
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
 
     RtpsWriterMap::iterator iter = writers_.find(pub_id);
     if (iter != writers_.end() && !iter->second.elems_not_acked_.empty()) {
-      OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator it = iter->second.elems_not_acked_.begin();
+      to_deliver.insert(iter->second.to_deliver_.begin(), iter->second.to_deliver_.end());
+      iter->second.to_deliver_.clear();
+      iter_t it = iter->second.elems_not_acked_.begin();
       while (it != iter->second.elems_not_acked_.end()) {
         if (criteria.matches(*it->second)) {
-          tqe_to_remove = it->second;
-          sn_to_remove = it->first;
-          iter->second.elems_not_acked_.erase(it);
-          remove = true;
-          break;
+          sn_tqe_map.insert(std::make_pair(it->first, it->second));
+          iter->second.send_buff_->release_acked(it->first);
+          iter_t last = it;
+          ++it;
+          iter->second.elems_not_acked_.erase(last);
         } else {
           ++it;
         }
       }
     }
   }
-  if (remove) {
-    tqe_to_remove->data_dropped(true);
-    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    RtpsWriterMap::iterator iter = writers_.find(pub_id);
-    if (iter != writers_.end()) {
-      iter->second.send_buff_->release_acked(sn_to_remove);
-    }
+  iter_t deliver_iter = to_deliver.begin();
+  while (deliver_iter != to_deliver.end()) {
+    deliver_iter->second->data_delivered();
+    ++deliver_iter;
+  }
+  iter_t drop_iter = sn_tqe_map.begin();
+  while (drop_iter != sn_tqe_map.end()) {
+    drop_iter->second->data_dropped(true);
+    ++drop_iter;
   }
 }
 
@@ -340,6 +344,57 @@ RtpsUdpDataLink::check_handshake_complete(const RepoId& local_id,
 }
 
 void
+RtpsUdpDataLink::pre_stop_i()
+{
+  DBG_ENTRY_LVL("RtpsUdpDataLink","pre_stop_i",6);
+  DataLink::pre_stop_i();
+  OPENDDS_VECTOR(TransportQueueElement*) to_deliver;
+  OPENDDS_VECTOR(TransportQueueElement*) to_drop;
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+
+    typedef OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
+
+    RtpsWriterMap::iterator iter = writers_.begin();
+    while (iter != writers_.end()) {
+      RtpsWriter& writer = iter->second;
+      if (!writer.to_deliver_.empty()) {
+        iter_t iter = writer.to_deliver_.begin();
+        while (iter != writer.to_deliver_.end()) {
+          to_deliver.push_back(iter->second);
+          writer.send_buff_->release_acked(iter->first);
+          writer.to_deliver_.erase(iter);
+          iter = writer.to_deliver_.begin();
+        }
+      }
+      if (!writer.elems_not_acked_.empty()) {
+        iter_t iter = writer.elems_not_acked_.begin();
+        while (iter != writer.elems_not_acked_.end()) {
+          to_drop.push_back(iter->second);
+          writer.send_buff_->release_acked(iter->first);
+          writer.elems_not_acked_.erase(iter);
+          iter = writer.elems_not_acked_.begin();
+        }
+      }
+      RtpsWriterMap::iterator last = iter;
+      ++iter;
+      writers_.erase(last);
+    }
+  }
+  typedef OPENDDS_VECTOR(TransportQueueElement*)::iterator tqe_iter;
+  tqe_iter deliver_it = to_deliver.begin();
+  while (deliver_it != to_deliver.end()) {
+    (*deliver_it)->data_delivered();
+    ++deliver_it;
+  }
+  tqe_iter drop_it = to_drop.begin();
+  while (drop_it != to_drop.end()) {
+    (*drop_it)->data_dropped(true);
+    ++drop_it;
+  }
+}
+
+void
 RtpsUdpDataLink::send_i(TransportQueueElement* element, bool relink)
 {
   // Lock here to maintain the locking order:
@@ -353,6 +408,8 @@ void
 RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
                                         const RepoId& local_id)
 {
+  OPENDDS_VECTOR(TransportQueueElement*) to_deliver;
+  OPENDDS_VECTOR(TransportQueueElement*) to_drop;
   ACE_GUARD(ACE_Thread_Mutex, g, lock_);
   using std::pair;
   const GuidConverter conv(local_id);
@@ -364,6 +421,27 @@ RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
       rw->second.remote_readers_.erase(remote_id);
 
       if (rw->second.remote_readers_.empty()) {
+        RtpsWriter& writer = rw->second;
+        typedef OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
+
+        if (!writer.to_deliver_.empty()) {
+          iter_t iter = writer.to_deliver_.begin();
+          while (iter != writer.to_deliver_.end()) {
+            to_deliver.push_back(iter->second);
+            writer.send_buff_->release_acked(iter->first);
+            writer.to_deliver_.erase(iter);
+            iter = writer.to_deliver_.begin();
+          }
+        }
+        if (!writer.elems_not_acked_.empty()) {
+          iter_t iter = writer.elems_not_acked_.begin();
+          while (iter != writer.elems_not_acked_.end()) {
+            to_drop.push_back(iter->second);
+            writer.send_buff_->release_acked(iter->first);
+            writer.elems_not_acked_.erase(iter);
+            iter = writer.elems_not_acked_.begin();
+          }
+        }
         writers_.erase(rw);
       }
     }
@@ -389,6 +467,18 @@ RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
       }
     }
   }
+  g.release();
+  typedef OPENDDS_VECTOR(TransportQueueElement*)::iterator tqe_iter;
+  tqe_iter deliver_it = to_deliver.begin();
+  while (deliver_it != to_deliver.end()) {
+    (*deliver_it)->data_delivered();
+    ++deliver_it;
+  }
+  tqe_iter drop_it = to_drop.begin();
+  while (drop_it != to_drop.end()) {
+    (*drop_it)->data_dropped(true);
+    ++drop_it;
+  }
 }
 
 void
@@ -396,7 +486,6 @@ RtpsUdpDataLink::stop_i()
 {
   nack_reply_.cancel();
   heartbeat_reply_.cancel();
-  acked_by_all_check_.cancel();
   heartbeat_.disable();
   unicast_socket_.close();
   multicast_socket_.close();
@@ -1467,12 +1556,10 @@ RtpsUdpDataLink::received(const RTPS::AckNackSubmessage& acknack,
   if (!final) {
     ri->second.requested_changes_.push_back(acknack.readerSNState);
   }
-
+  process_acked_by_all_i(g, local);
   g.release();
   if (!final) {
     nack_reply_.schedule(); // timer will invoke send_nack_replies()
-  } else {
-    acked_by_all_check_.schedule();
   }
   typedef OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
   for (iter_t it = pendingCallbacks.begin();
@@ -1630,15 +1717,6 @@ RtpsUdpDataLink::send_nack_replies()
     if (all_readers_ack == SequenceNumber::MAX_VALUE) {
       continue;
     }
-    //if any messages fully acked, call data delivered and remove from map
-    typedef OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
-    iter_t it = writer.elems_not_acked_.begin();
-    while (it != writer.elems_not_acked_.end() && it->first < all_readers_ack) {
-      it->second->data_delivered();
-      writer.send_buff_->release_acked(it->first);
-      writer.elems_not_acked_.erase(it);
-      it = writer.elems_not_acked_.begin();
-    }
   }
 }
 
@@ -1695,68 +1773,66 @@ RtpsUdpDataLink::send_nackfrag_replies(RtpsWriter& writer,
 }
 
 void
-RtpsUdpDataLink::process_acked_by_all()
+RtpsUdpDataLink::process_acked_by_all_i(ACE_Guard<ACE_Thread_Mutex>& g, const RepoId& pub_id)
 {
   using namespace OpenDDS::RTPS;
   typedef RtpsWriterMap::iterator rw_iter;
-
+  typedef OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
   OPENDDS_VECTOR(RepoId) to_check;
-  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-  for (rw_iter rw_init = writers_.begin(); rw_init != writers_.end(); ++rw_init) {
-    to_check.push_back(rw_init->first);
+  rw_iter rw = writers_.find(pub_id);
+  if (rw == writers_.end()) {
+    return;
   }
-  // Reply from local DW to remote DR: GAP or DATA
-  for (size_t i = 0; i < to_check.size(); ++i) {
-    rw_iter rw = writers_.find(to_check.at(i));
-    if (rw == writers_.end()) {
-      continue;
+  RtpsWriter& writer = rw->second;
+  if (!writer.elems_not_acked_.empty()) {
+
+    //start with the max sequence number writer knows about and decrease
+    //by what the min over all readers is
+    SequenceNumber all_readers_ack = SequenceNumber::MAX_VALUE;
+
+    typedef ReaderInfoMap::iterator ri_iter;
+    const ri_iter end = writer.remote_readers_.end();
+    for (ri_iter ri = writer.remote_readers_.begin(); ri != end; ++ri) {
+      if (ri->second.cur_cumulative_ack_ < all_readers_ack) {
+        all_readers_ack = ri->second.cur_cumulative_ack_;
+      }
     }
-    RtpsWriter& writer = rw->second;
-    if (!writer.elems_not_acked_.empty()) {
+    if (all_readers_ack == SequenceNumber::MAX_VALUE) {
+      return;
+    }
+    OPENDDS_VECTOR(SequenceNumber) sns;
+    //if any messages fully acked, call data delivered and remove from map
 
-      //start with the max sequence number writer knows about and decrease
-      //by what the min over all readers is
-      SequenceNumber all_readers_ack = SequenceNumber::MAX_VALUE;
+    iter_t it = writer.elems_not_acked_.begin();
+    while (it != writer.elems_not_acked_.end()) {
+      if (it->first < all_readers_ack) {
+        writer.to_deliver_.insert(std::make_pair(it->first, it->second));
+        writer.send_buff_->release_acked(it->first);
+        iter_t last = it;
+        ++it;
+        writer.elems_not_acked_.erase(last);
+      } else {
+        break;
+      }
+    }
+    TransportQueueElement* tqe_to_deliver;
 
-      typedef ReaderInfoMap::iterator ri_iter;
-      const ri_iter end = writer.remote_readers_.end();
-      for (ri_iter ri = writer.remote_readers_.begin(); ri != end; ++ri) {
-        if (ri->second.cur_cumulative_ack_ < all_readers_ack) {
-          all_readers_ack = ri->second.cur_cumulative_ack_;
-        }
+    while (true) {
+      rw_iter deliver_on_writer = writers_.find(pub_id);
+      if (deliver_on_writer == writers_.end()) {
+        break;
       }
-      if (all_readers_ack == SequenceNumber::MAX_VALUE) {
-        continue;
+      RtpsWriter& writer = deliver_on_writer->second;
+      iter_t to_deliver_iter = writer.to_deliver_.begin();
+      if (to_deliver_iter == writer.to_deliver_.end()) {
+        break;
       }
-      OPENDDS_VECTOR(TransportQueueElement*) tqes;
-      OPENDDS_VECTOR(SequenceNumber) sns;
-      //if any messages fully acked, call data delivered and remove from map
-      typedef OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
-      iter_t it = writer.elems_not_acked_.begin();
-      while (it != writer.elems_not_acked_.end()) {
-        if (it->first < all_readers_ack) {
-          tqes.push_back(it->second);
-          sns.push_back(it->first);
-          iter_t last = it;
-          ++it;
-          writer.elems_not_acked_.erase(last);
-        } else {
-          break;
-        }
-      }
+      tqe_to_deliver = to_deliver_iter->second;
+      writer.to_deliver_.erase(to_deliver_iter);
       g.release();
-      for (size_t x = 0; x < tqes.size(); ++x) {
-        tqes.at(x)->data_delivered();
-      }
+
+      tqe_to_deliver->data_delivered();
       g.acquire();
-      rw_iter rw_cleanup = writers_.find(to_check.at(i));
-      if (rw_cleanup == writers_.end()) {
-        continue;
-      }
-      RtpsWriter& writer = rw_cleanup->second;
-      for (size_t y = 0; y < sns.size(); ++y) {
-        writer.send_buff_->release_acked(sns.at(y));
-      }
     }
   }
 }
@@ -2092,14 +2168,12 @@ RtpsUdpDataLink::ReaderInfo::expecting_durable_data() const
 
 RtpsUdpDataLink::RtpsWriter::~RtpsWriter()
 {
+  typedef OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
+  if (!to_deliver_.empty()) {
+    ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: RtpsWriter::~RtpsWriter - deleting with %d elements left to deliver\n", to_deliver_.size()));
+  }
   if (!elems_not_acked_.empty()) {
-    OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator iter = elems_not_acked_.begin();
-    while (iter != elems_not_acked_.end()) {
-      iter->second->data_delivered();
-      send_buff_->release_acked(iter->first);
-      elems_not_acked_.erase(iter);
-      iter = elems_not_acked_.begin();
-    }
+    ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: RtpsWriter::~RtpsWriter - deleting with %d elements left not fully acknowledged\n", elems_not_acked_.size()));
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -100,6 +100,8 @@ public:
 
   bool check_handshake_complete(const RepoId& local, const RepoId& remote);
 
+  virtual void pre_stop_i();
+
 private:
   virtual void stop_i();
   virtual void send_i(TransportQueueElement* element, bool relink = true);
@@ -190,7 +192,9 @@ private:
     ReaderInfoMap remote_readers_;
     RcHandle<SingleSendBuffer> send_buff_;
     SequenceNumber expected_;
-    OPENDDS_MAP(SequenceNumber, TransportQueueElement*) elems_not_acked_;
+    OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*) elems_not_acked_;
+    //Only accessed with RtpsUdpDataLink lock held
+    OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*) to_deliver_;
     CORBA::Long heartbeat_count_;
     bool durable_;
 
@@ -319,7 +323,7 @@ private:
 
   // Timers for reliability:
   void send_nack_replies();
-  void process_acked_by_all();
+  void process_acked_by_all_i(ACE_Guard<ACE_Thread_Mutex>& g, const RepoId& pub_id);
   void send_heartbeats();
   void send_heartbeats_manual(const TransportSendControlElement* tsce);
   void send_heartbeat_replies();
@@ -350,7 +354,7 @@ private:
     ACE_Time_Value timeout_;
     bool scheduled_;
 
-  } nack_reply_, heartbeat_reply_, acked_by_all_check_;
+  } nack_reply_, heartbeat_reply_;
 
 
   struct HeartBeat : ACE_Event_Handler {


### PR DESCRIPTION
Working to resolve issues in the rtps transport layer (RtpsUdpDataLink) to deal with processing acknowledgements and lifetimes of transport queue elements (and derived) up to WriteDataContainer and DataSampleElements.  Moving away from handling the processing of acknowledgements in a timer based solution into a direct processing solution.