### PR TITLE
MSVC14 support

### DIFF
--- a/dds/DCPS/Definitions.h
+++ b/dds/DCPS/Definitions.h
@@ -46,6 +46,10 @@
 #define OPENDDS_GCC33_TEMPLATE_DEPENDENT template
 #endif
 
+#define OPENDDS_DELETED_COPY_CTOR_ASSIGN(CLASS)         \
+  ACE_UNIMPLEMENTED_FUNC(CLASS(const CLASS&))           \
+  ACE_UNIMPLEMENTED_FUNC(CLASS& operator=(const CLASS&))
+
 // If features content_filtered_topic, multi_topic, and query_condition
 // are all disabled, define a macro to indicate common code these
 // three features depend on should not be built.

--- a/dds/DCPS/MultiTopicDataReaderBase.h
+++ b/dds/DCPS/MultiTopicDataReaderBase.h
@@ -25,6 +25,7 @@ namespace DCPS {
 class OpenDDS_Dcps_Export MultiTopicDataReaderBase
   : public virtual LocalObject<DataReaderEx> {
 public:
+  MultiTopicDataReaderBase() {}
 
   void init(const DDS::DataReaderQos& dr_qos,
     DDS::DataReaderListener_ptr a_listener, DDS::StatusMask mask,
@@ -174,6 +175,8 @@ protected:
 
   // key: topicName for this reader
   OPENDDS_MAP(OPENDDS_STRING, QueryPlan) query_plans_;
+
+  OPENDDS_DELETED_COPY_CTOR_ASSIGN(MultiTopicDataReaderBase);
 };
 
 }

--- a/dds/DCPS/MultiTopicDataReader_T.h
+++ b/dds/DCPS/MultiTopicDataReader_T.h
@@ -26,6 +26,8 @@ class MultiTopicDataReader_T
 public:
   typedef TAO::DCPS::ZeroCopyDataSeq<Sample> SampleSeq;
 
+  MultiTopicDataReader_T() {}
+
   void init_typed(DataReaderEx* dr);
   const MetaStruct& getResultingMeta();
   void incoming_sample(void* sample, const DDS::SampleInfo& info,

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -709,7 +709,7 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
       // DDS::DataReaderListener_var listener
       // = listener_for(DDS::SUBSCRIPTION_MATCHED_STATUS);
 
-      if (!CORBA::is_nil(listener_.in())) {
+      if (listener_.in()) {
         listener_->on_recorder_matched(
           this,
           this->subscription_match_status_);

--- a/dds/DCPS/RemoveAssociationSweeper.h
+++ b/dds/DCPS/RemoveAssociationSweeper.h
@@ -1,5 +1,4 @@
 /*
- * $Id$
  *
  *
  * Distributed under the OpenDDS License.

--- a/dds/DCPS/TypeSupportImpl.h
+++ b/dds/DCPS/TypeSupportImpl.h
@@ -27,6 +27,7 @@ template <typename Message> struct DDSTraits;
 class OpenDDS_Dcps_Export TypeSupportImpl
   : public virtual LocalObject<TypeSupport> {
 public:
+  TypeSupportImpl() {}
 
   virtual ~TypeSupportImpl();
 
@@ -41,6 +42,8 @@ public:
 
 private:
   CORBA::String_var type_name_;
+
+  OPENDDS_DELETED_COPY_CTOR_ASSIGN(TypeSupportImpl);
 };
 
 }


### PR DESCRIPTION
requires workaround to avoid compiler-generated copy ctor and assignment for a few classes