### PR TITLE
Use a simpler string as the default type name in TypeSupport.

### DIFF
--- a/DevGuideExamples/FACE/Simple/face_config.ini
+++ b/DevGuideExamples/FACE/Simple/face_config.ini
@@ -14,7 +14,7 @@ use_multicast=0
 
 [topic/Message]
 platform_view_guid=103
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]

--- a/DevGuideExamples/FACE/Simple/face_config_static.ini
+++ b/DevGuideExamples/FACE/Simple/face_config_static.ini
@@ -26,7 +26,7 @@ local_address=127.0.0.1:21071
 
 [topic/Message]
 platform_view_guid=103
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]

--- a/dds/DCPS/TypeSupportImpl.cpp
+++ b/dds/DCPS/TypeSupportImpl.cpp
@@ -34,10 +34,10 @@ TypeSupportImpl::register_type(DDS::DomainParticipant_ptr participant,
 char*
 TypeSupportImpl::get_type_name()
 {
-  if (this->type_name_.in() == 0) {
-    return CORBA::string_dup(this->_interface_repository_id());
+  if (type_name_.in() == 0) {
+    return CORBA::string_dup(default_type_name());
   } else {
-    return CORBA::string_dup(this->type_name_.in());
+    return CORBA::string_dup(type_name_.in());
   }
 }
 

--- a/dds/DCPS/TypeSupportImpl.h
+++ b/dds/DCPS/TypeSupportImpl.h
@@ -41,6 +41,8 @@ public:
   virtual char* get_type_name();
 
 private:
+  virtual const char* default_type_name() const = 0;
+
   CORBA::String_var type_name_;
 
   OPENDDS_DELETED_COPY_CTOR_ASSIGN(TypeSupportImpl);

--- a/dds/DCPS/TypeSupportImpl_T.h
+++ b/dds/DCPS/TypeSupportImpl_T.h
@@ -79,6 +79,11 @@ namespace OpenDDS {
       return TraitsType::gen_has_key(MessageType());
     }
 
+    const char* default_type_name() const
+    {
+      return TraitsType::type_name();
+    }
+
     static typename TraitsType::TypeSupportType::_ptr_type _narrow(CORBA::Object_ptr obj) {
       return TypeSupportType::_narrow(obj);
     }

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -213,9 +213,9 @@ void Get_Connection_Parameters(CONNECTION_NAME_TYPE& connection_name,
         return_code = NOT_AVAILABLE;
         return;
       }
-      cur_status.LAST_MSG_VALIDITY = receiver.last_msg_header.message_validity;
       if (receiver.total_msgs_recvd != 0) {
         cur_status.REFRESH_PERIOD = receiver.sum_recvd_msgs_latency/receiver.total_msgs_recvd;
+        cur_status.LAST_MSG_VALIDITY = receiver.last_msg_header.message_validity;
       } else {
         cur_status.REFRESH_PERIOD = 0;
       }

--- a/tests/DCPS/StaticDiscovery/run_test.pl
+++ b/tests/DCPS/StaticDiscovery/run_test.pl
@@ -108,7 +108,7 @@ sub runTest {
     print $fh "\n";
     print $fh "[topic/TheTopic]\n";
     print $fh "name=TheTopic\n";
-    print $fh "type_name=IDL:TestMsg/TestMsgTypeSupport:1.0\n";
+    print $fh "type_name=TestMsg::TestMsg\n";
     print $fh "max_message_size=300\n";
     print $fh "\n";
     print $fh "[datawriterqos/ReliableWriter]\n";

--- a/tests/DCPS/StaticDiscoveryReconnect/config.ini
+++ b/tests/DCPS/StaticDiscoveryReconnect/config.ini
@@ -3,7 +3,7 @@ DCPSDefaultDiscovery=DEFAULT_STATIC
 
 [topic/TheTopic]
 name=TheTopic
-type_name=IDL:TestMsg/TestMsgTypeSupport:1.0
+type_name=TestMsg::TestMsg
 max_message_size=300
 
 [config/ConfigR]

--- a/tests/FACE/CallbackAndReceive/face_config.ini
+++ b/tests/FACE/CallbackAndReceive/face_config.ini
@@ -14,7 +14,7 @@ use_multicast=0
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]

--- a/tests/FACE/GetConnectionParameters/face_config.ini
+++ b/tests/FACE/GetConnectionParameters/face_config.ini
@@ -14,7 +14,7 @@ use_multicast=0
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]

--- a/tests/FACE/Header/face_config.ini
+++ b/tests/FACE/Header/face_config.ini
@@ -14,7 +14,7 @@ use_multicast=0
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:HeaderTest/MessageTypeSupport:1.0
+type_name=HeaderTest::Message
 max_message_size=300
 
 [connection/pub]

--- a/tests/FACE/Messenger/face_config.ini
+++ b/tests/FACE/Messenger/face_config.ini
@@ -14,7 +14,7 @@ use_multicast=0
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]

--- a/tests/FACE/Messenger/face_config_static.ini
+++ b/tests/FACE/Messenger/face_config_static.ini
@@ -27,7 +27,7 @@ transports=rtps_subb
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]

--- a/tests/FACE/MultiDomainMessenger/face_config.ini
+++ b/tests/FACE/MultiDomainMessenger/face_config.ini
@@ -27,7 +27,7 @@ transports=rtps2
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub1]

--- a/tests/FACE/Partition/face_config.ini
+++ b/tests/FACE/Partition/face_config.ini
@@ -17,7 +17,7 @@ transports=the_rtps_transport
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub_1]

--- a/tests/FACE/Reliability/face_config.ini
+++ b/tests/FACE/Reliability/face_config.ini
@@ -14,12 +14,12 @@ use_multicast=0
 
 [topic/Message]
 platform_view_guid=1
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [topic/Message_INF]
 platform_view_guid=2
-type_name=IDL:Messenger/MessageTypeSupport:1.0
+type_name=Messenger::Message
 max_message_size=300
 
 [connection/pub]


### PR DESCRIPTION
The old way was to use the IDL IfR ID for the generated TypeSupport interface.
This resulted in strings that look like "IDL:Scope/NameTypeSupport:1.0".
Since this DDS spec allows the implementation to pick any name, this commit
changes it to the simpler C++ scoped name, in this example Scope::Name.