### PR TITLE
Add unlink during the backup and open sub routine to protect against …

### DIFF
--- a/configure
+++ b/configure
@@ -586,6 +586,7 @@ sub backup_and_open {
     copy($file, $backup);
     print "WARNING: overwriting existing $file (saved a backup copy as " .
       "$backup)\n";
+    unlink $file;
   }
   if ($opts{'dry-run'}) {
     return File::Temp->new();

--- a/configure
+++ b/configure
@@ -1179,6 +1179,11 @@ if ($cross_compile) {
     $opts{'no-opendds-safety-profile'} = 0; # only set for target
   }
 
+  unless ($opts{'static'}) {
+    push_libpath(\%targetEnv, $targetEnv{'ACE_ROOT'} . $slash . 'lib');
+    push_libpath(\%targetEnv, $targetEnv{'DDS_ROOT'} . $slash . 'lib');
+  }
+
   configure_build(\%targetEnv);
 
   write_environment(\%targetEnv, $targetEnv{'ACE_ROOT'} . '/ace')


### PR DESCRIPTION
…symlinked files, particularly during cross compile for safety profile builds