### PR TITLE
Fix MultiDiscoveryTest for safety profile builds where 2 instances of…

### DIFF
--- a/tests/DCPS/MultiDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/MultiDiscovery/DataReaderListenerImpl.cpp
@@ -21,10 +21,10 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 {
   ACE_DEBUG((LM_DEBUG, "(%P|%t) DataReader %C is done\n", id_.c_str()));
   if (expected_samples_ && received_samples_ != expected_samples_) {
-    ACE_ERROR((LM_ERROR, "ERROR: expected %d but received %d\n",
-               expected_samples_, received_samples_));
+    ACE_ERROR((LM_ERROR, "ERROR: DataReader %C expected %d but received %d\n",
+               id_.c_str(), expected_samples_, received_samples_));
   } else if (expected_samples_) {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) Expected number of samples received\n"));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) DataReader %C Expected number of samples received\n", id_.c_str()));
   }
 }
 

--- a/tests/DCPS/MultiDiscovery/config.ini
+++ b/tests/DCPS/MultiDiscovery/config.ini
@@ -6,6 +6,7 @@ DiscoveryConfig=DEFAULT_STATIC
 
 [domain/31]
 DiscoveryConfig=uni_rtps
+DefaultTransportConfig=config_31
 
 [topic/TheTopic]
 name=TheTopic
@@ -24,40 +25,6 @@ reliability.kind=BEST_EFFORT
 
 [datareaderqos/BestEffortReader]
 reliability.kind=BEST_EFFORT
-
-[endpoint/Writer12]
-domain=12
-participant=000000000012
-entity=000012
-type=writer
-config=Config1
-topic=TheTopic
-datawriterqos=ReliableWriter
-
-[transport/Rtps1]
-transport_type=rtps_udp
-use_multicast=0
-local_address=127.0.0.1:21075
-
-[config/Config1]
-transports=Rtps1
-
-[endpoint/Reader21]
-domain=12
-participant=000000000021
-entity=000021
-type=reader
-config=Config2
-topic=TheTopic
-datareaderqos=ReliableReader
-
-[transport/Rtps2]
-transport_type=rtps_udp
-use_multicast=0
-local_address=127.0.0.1:21076
-
-[config/Config2]
-transports=Rtps2
 
 [endpoint/Writer23]
 domain=23
@@ -96,6 +63,9 @@ transports=Rtps4
 [rtps_discovery/uni_rtps]
 SedpMulticast=0
 ResendPeriod=2
+
+[config/config_31]
+transports=the_rtps_transport
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp

--- a/tests/DCPS/MultiDiscovery/run_test.pl
+++ b/tests/DCPS/MultiDiscovery/run_test.pl
@@ -12,6 +12,7 @@ use warnings;
 
 my $result = 0;
 my $reliable = 1;
+my $dcps_debug_lvl = 0;
 
 sub runTest {
     my $delay = shift;
@@ -33,18 +34,18 @@ sub runTest {
     my $dr_static = 1;
     my $origin = 1;
 
-    $test->process("alpha", 'MultiDiscoveryTest', "-DCPSConfigFile config.ini -origin $origin -reliable $reliable -dw_static_disc 0 -dr_static_disc 0 -wdomain 12 -rdomain 31 -writer 000012 -reader 000013");
+    $test->process("alpha", 'MultiDiscoveryTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl -origin $origin -reliable $reliable -dw_static_disc 0 -dr_static_disc 0 -wdomain 12 -rdomain 31 -writer 000012 -reader 000013");
     $test->start_process("alpha");
     sleep $delay;
 
     print "Spawning beta - Writer (23) in domain 23 using static discovery and Reader (21) in domain 12 using default discovery\n";
     $origin = 0;
-    $test->process("beta", 'MultiDiscoveryTest', "-DCPSConfigFile config.ini -origin $origin -reliable $reliable -dw_static_disc $dw_static -dr_static_disc 0 -wdomain 23 -rdomain 12 -dw_participant 000000000023 -writer 000023 -reader 000021");
+    $test->process("beta", 'MultiDiscoveryTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl -origin $origin -reliable $reliable -dw_static_disc $dw_static -dr_static_disc 0 -wdomain 23 -rdomain 12 -dw_participant 000000000023 -writer 000023 -reader 000021");
     $test->start_process("beta");
     sleep $delay;
 
     print "Spawning gamma - Writer (31) in domain 31 using rtps discovery and Reader (32) in domain 23 using static discovery\n";
-    $test->process("gamma", 'MultiDiscoveryTest', "-DCPSConfigFile config.ini -origin $origin -reliable $reliable -dw_static_disc 0 -dr_static_disc $dr_static -wdomain 31 -rdomain 23 -dr_participant 000000000032 -writer 000031 -reader 000032");
+    $test->process("gamma", 'MultiDiscoveryTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl -origin $origin -reliable $reliable -dw_static_disc 0 -dr_static_disc $dr_static -wdomain 31 -rdomain 23 -dr_participant 000000000032 -writer 000031 -reader 000032");
     $test->start_process("gamma");
 
     my $res = $test->finish(150);


### PR DESCRIPTION
… rtps discovery are used.  Set the transport config for domain 31 to not use mulitcast.  Add DataReader id's to log messages to make reading log easier.  Add debug level control to run_test.pl.