### PR TITLE
Remove the DataWriterRemoteImpl's reference back to the DataWriterImp…

### DIFF
--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -557,6 +557,10 @@ InfoRepoDiscovery::remove_publication(DDS::DomainId_t domainId,
                                       const RepoId& participantId,
                                       const RepoId& publicationId)
 {
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, false);
+    removeDataWriterRemote(publicationId);
+  }
   bool removed = false;
   try {
     get_dcps_info()->remove_publication(domainId, participantId, publicationId);
@@ -565,8 +569,6 @@ InfoRepoDiscovery::remove_publication(DDS::DomainId_t domainId,
     ex._tao_print_exception("ERROR: InfoRepoDiscovery::remove_publication: ");
   }
 
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, false);
-  removeDataWriterRemote(publicationId);
 
   return removed;
 }

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -569,7 +569,6 @@ InfoRepoDiscovery::remove_publication(DDS::DomainId_t domainId,
     ex._tao_print_exception("ERROR: InfoRepoDiscovery::remove_publication: ");
   }
 
-
   return removed;
 }
 
@@ -653,6 +652,10 @@ InfoRepoDiscovery::remove_subscription(DDS::DomainId_t domainId,
                                        const RepoId& participantId,
                                        const RepoId& subscriptionId)
 {
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, false);
+    removeDataReaderRemote(subscriptionId);
+  }
   bool removed = false;
   try {
     get_dcps_info()->remove_subscription(domainId, participantId, subscriptionId);
@@ -660,8 +663,7 @@ InfoRepoDiscovery::remove_subscription(DDS::DomainId_t domainId,
   } catch (const CORBA::Exception& ex) {
     ex._tao_print_exception("ERROR: InfoRepoDiscovery::remove_subscription: ");
   }
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, false);
-  removeDataReaderRemote(subscriptionId);
+
   return removed;
 }
 

--- a/dds/InfoRepo/DCPS_IR_Subscription.cpp
+++ b/dds/InfoRepo/DCPS_IR_Subscription.cpp
@@ -139,7 +139,13 @@ DCPS_IR_Subscription::association_complete(const OpenDDS::DCPS::RepoId& remote)
 void
 DCPS_IR_Subscription::call_association_complete(const OpenDDS::DCPS::RepoId& remote)
 {
-  reader_->association_complete(remote);
+  try {
+    reader_->association_complete(remote);
+  } catch (const CORBA::Exception& ex) {
+    ex._tao_print_exception(
+      "(%P|%t) ERROR: Exception caught in DCPS_IR_Subscription::call_association_complete:");
+    participant_->mark_dead();
+  }
 }
 
 int DCPS_IR_Subscription::remove_associated_publication(DCPS_IR_Publication* pub,
@@ -456,9 +462,18 @@ void DCPS_IR_Subscription::disassociate_publication(OpenDDS::DCPS::RepoId id,
 
 void DCPS_IR_Subscription::update_incompatible_qos()
 {
-  if (this->participant_->isOwner()) {
-    reader_->update_incompatible_qos(incompatibleQosStatus_);
-    incompatibleQosStatus_.count_since_last_send = 0;
+  if (participant_->is_alive() && this->participant_->isOwner()) {
+    try {
+      reader_->update_incompatible_qos(incompatibleQosStatus_);
+      incompatibleQosStatus_.count_since_last_send = 0;
+    } catch (const CORBA::Exception& ex) {
+      if (OpenDDS::DCPS::DCPS_debug_level > 0) {
+        ex._tao_print_exception(
+          "(%P|%t) ERROR: Exception caught in DCPS_IR_Subscription::update_incompatible_qos:");
+      }
+
+      participant_->mark_dead();
+    }
   }
 }
 

--- a/dds/InfoRepo/DCPS_IR_Topic_Description.cpp
+++ b/dds/InfoRepo/DCPS_IR_Topic_Description.cpp
@@ -252,7 +252,7 @@ DCPS_IR_Topic* DCPS_IR_Topic_Description::get_first_topic()
 
 void DCPS_IR_Topic_Description::try_associate_publication(DCPS_IR_Publication* publication)
 {
-  // for each subscription check for compatiblity
+  // for each subscription check for compatibility
   DCPS_IR_Subscription* subscription = 0;
   OpenDDS::DCPS::IncompatibleQosStatus* qosStatus = 0;
 


### PR DESCRIPTION
…l (parent) prior to notifying the orb so that asynchronous add_association calls do not still see the DataWriterImpl and access it after it has gone away