### PR TITLE
Don't call get_ip_interfaces in safety profile.

### DIFF
--- a/configure
+++ b/configure
@@ -291,6 +291,12 @@ if (!exists $platforminfo{$opts{'target'}}) {
 addCurLibPathRef(\%hostEnv);
 addCurLibPathRef(\%targetEnv);
 
+
+if (defined $opts{'safety-profile'} && $opts{'safety-profile'} eq '') {
+  print "Defaulting safety profile to extended\n";
+  $opts{'safety-profile'} = 'extended';
+}
+
 if ($opts{'host'} ne $opts{'target'} || $opts{'safety-profile'}) {
   print "Setting cross-compile build\n" if $opts{'verbose'};
   $cross_compile = 1;

--- a/dds/DCPS/transport/framework/NetworkAddress.cpp
+++ b/dds/DCPS/transport/framework/NetworkAddress.cpp
@@ -188,7 +188,13 @@ void get_interface_addrs(OPENDDS_VECTOR(ACE_INET_Addr)& addrs)
   size_t if_cnt = 0;
   size_t endpoint_count = 0;
 
-  int result = ACE::get_ip_interfaces(if_cnt, if_addrs);
+  
+  int result = 
+#ifdef OPENDDS_SAFETY_PROFILE
+    -1;
+#else
+    ACE::get_ip_interfaces(if_cnt, if_addrs);
+#endif
 
   struct Array_Guard {
     Array_Guard(ACE_INET_Addr *ptr) : ptr_(ptr) {}
@@ -198,12 +204,7 @@ void get_interface_addrs(OPENDDS_VECTOR(ACE_INET_Addr)& addrs)
     ACE_INET_Addr* const ptr_;
   } guardObject(if_addrs);
 
-  if (result != 0 || if_cnt < 1) {
-    ACE_ERROR((LM_ERROR,
-      ACE_TEXT("(%P|%t) ERROR: Unable to probe network. %p\n"),
-      ACE_TEXT("ACE::get_ip_interfaces")));
-
-  } else {
+  if (!result) {
     size_t lo_cnt = 0;  // Loopback interface count
 #if defined (ACE_HAS_IPV6)
     size_t ipv4_cnt = 0;

--- a/dds/DCPS/transport/framework/NetworkAddress.cpp
+++ b/dds/DCPS/transport/framework/NetworkAddress.cpp
@@ -188,8 +188,7 @@ void get_interface_addrs(OPENDDS_VECTOR(ACE_INET_Addr)& addrs)
   size_t if_cnt = 0;
   size_t endpoint_count = 0;
 
-  
-  int result = 
+  int result =
 #ifdef OPENDDS_SAFETY_PROFILE
     -1;
 #else


### PR DESCRIPTION
Prevent error logs from ACE and DCPS.