### PR TITLE
Convert ACE_OS::printf to ACE_DEBUG

### DIFF
--- a/dds/FACE/config/ConnectionSettings.cpp
+++ b/dds/FACE/config/ConnectionSettings.cpp
@@ -53,17 +53,17 @@ ConnectionSettings::set(const char* name, const char* value)
       direction_ = FACE::DESTINATION;
     } else if (!std::strcmp(value, "bi_directional") ||
                !std::strcmp(value, "not_defined_connection_direction_type")) {
-      ACE_OS::printf("Direction not supported: %s\n", value);
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("Direction not supported: %C\n"), value));
       status = 1;
     } else {
-      ACE_OS::printf("Don't know of direction %s\n", value);
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("Don't know of direction %C\n"), value));
       status = 1;
     }
   } else if (!std::strcmp(name, "config")) {
     std::strncpy(config_name_, value, sizeof(config_name_));
   } else {
     // no match
-    ACE_OS::printf("Don't know of setting %s\n", name);
+    ACE_DEBUG((LM_ERROR, ACE_TEXT("Don't know of setting %C\n"), name));
     status = 1;
   }
 

--- a/dds/FACE/config/ConnectionSettings.cpp
+++ b/dds/FACE/config/ConnectionSettings.cpp
@@ -1,6 +1,8 @@
 #include "ConnectionSettings.h"
 
 #include "ace/OS_NS_stdio.h"
+#include "ace/Log_Priority.h"
+#include "ace/Log_Msg.h"
 
 #include <cstring>
 
@@ -53,17 +55,17 @@ ConnectionSettings::set(const char* name, const char* value)
       direction_ = FACE::DESTINATION;
     } else if (!std::strcmp(value, "bi_directional") ||
                !std::strcmp(value, "not_defined_connection_direction_type")) {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("Direction not supported: %C\n"), value));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("Direction not supported: %C\n"), value));
       status = 1;
     } else {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("Don't know of direction %C\n"), value));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("Don't know of direction %C\n"), value));
       status = 1;
     }
   } else if (!std::strcmp(name, "config")) {
     std::strncpy(config_name_, value, sizeof(config_name_));
   } else {
     // no match
-    ACE_DEBUG((LM_ERROR, ACE_TEXT("Don't know of setting %C\n"), name));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("Don't know of setting %C\n"), name));
     status = 1;
   }
 

--- a/dds/FACE/config/Parser.cpp
+++ b/dds/FACE/config/Parser.cpp
@@ -5,6 +5,8 @@
 
 #include "ace/Configuration_Import_Export.h"
 #include "ace/OS_NS_stdio.h"
+#include "ace/Log_Priority.h"
+#include "ace/Log_Msg.h"
 
 #include <cstring>
 
@@ -355,7 +357,7 @@ Parser::parse_topic(ACE_Configuration_Heap& config,
         status = status || topic.set(value_name.c_str(), value.c_str());
       }
     } else {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
       status = -1;
       break;
     }
@@ -388,7 +390,7 @@ Parser::parse_connection(ACE_Configuration_Heap& config,
         status = status || connection.set(value_name.c_str(), value.c_str());
       }
     } else {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
       status = -1;
       break;
     }
@@ -424,7 +426,7 @@ Parser::parse_qos(ACE_Configuration_Heap& config,
                  qos.set_qos(level, value_name.c_str(), value.c_str());
       }
     } else {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
       status = -1;
       break;
     }
@@ -445,7 +447,7 @@ Parser::parse_sections(ACE_Configuration_Heap& config,
                           0, // don't create if missing
                           key) != 0) {
     if (required) {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("Could not open %C section in config file, status %d\n"), section_type, status));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("Could not open %C section in config file, status %d\n"), section_type, status));
       status = -1;
     }
   // Else, we can open this section
@@ -463,7 +465,7 @@ Parser::parse_sections(ACE_Configuration_Heap& config,
                               section_name.c_str(),
                               0, // don't create if missing
                               subkey) != 0) {
-        ACE_DEBUG((LM_ERROR, ACE_TEXT("Could not open subsections of %C\n"), section_name.c_str()));
+        ACE_ERROR((LM_ERROR, ACE_TEXT("Could not open subsections of %C\n"), section_name.c_str()));
         break;
       }
 
@@ -484,7 +486,7 @@ Parser::parse_sections(ACE_Configuration_Heap& config,
         status = parse_qos(
             config, subkey, section_name.c_str(), QosSettings::subscriber);
       } else {
-        ACE_DEBUG((LM_ERROR, ACE_TEXT("unknown section %C\n"), section_type));
+        ACE_ERROR((LM_ERROR, ACE_TEXT("unknown section %C\n"), section_type));
       }
     }
   }

--- a/dds/FACE/config/Parser.cpp
+++ b/dds/FACE/config/Parser.cpp
@@ -355,7 +355,7 @@ Parser::parse_topic(ACE_Configuration_Heap& config,
         status = status || topic.set(value_name.c_str(), value.c_str());
       }
     } else {
-      ACE_OS::printf("unexpected value type %d\n", value_type);
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
       status = -1;
       break;
     }
@@ -388,7 +388,7 @@ Parser::parse_connection(ACE_Configuration_Heap& config,
         status = status || connection.set(value_name.c_str(), value.c_str());
       }
     } else {
-      ACE_OS::printf("unexpected value type %d\n", value_type);
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
       status = -1;
       break;
     }
@@ -424,7 +424,7 @@ Parser::parse_qos(ACE_Configuration_Heap& config,
                  qos.set_qos(level, value_name.c_str(), value.c_str());
       }
     } else {
-      ACE_OS::printf("unexpected value type %d\n", value_type);
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("unexpected value type %d\n"), value_type));
       status = -1;
       break;
     }
@@ -445,8 +445,7 @@ Parser::parse_sections(ACE_Configuration_Heap& config,
                           0, // don't create if missing
                           key) != 0) {
     if (required) {
-      ACE_OS::printf("Could not open %s section in config file, status %d\n",
-                     section_type, status);
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("Could not open %C section in config file, status %d\n"), section_type, status));
       status = -1;
     }
   // Else, we can open this section
@@ -464,7 +463,7 @@ Parser::parse_sections(ACE_Configuration_Heap& config,
                               section_name.c_str(),
                               0, // don't create if missing
                               subkey) != 0) {
-        ACE_OS::printf("Could not open subsections of %s\n", section_name.c_str());
+        ACE_DEBUG((LM_ERROR, ACE_TEXT("Could not open subsections of %C\n"), section_name.c_str()));
         break;
       }
 
@@ -485,7 +484,7 @@ Parser::parse_sections(ACE_Configuration_Heap& config,
         status = parse_qos(
             config, subkey, section_name.c_str(), QosSettings::subscriber);
       } else {
-        ACE_OS::printf("unknown section %s\n", section_type);
+        ACE_DEBUG((LM_ERROR, ACE_TEXT("unknown section %C\n"), section_type));
       }
     }
   }

--- a/dds/FACE/config/TopicSettings.cpp
+++ b/dds/FACE/config/TopicSettings.cpp
@@ -1,6 +1,8 @@
 #include "TopicSettings.h"
 
 #include "ace/OS_NS_stdio.h"
+#include "ace/Log_Priority.h"
+#include "ace/Log_Msg.h"
 
 #include <cstring>
 
@@ -18,7 +20,7 @@ TopicSettings::set(const char* name, const char* value)
     std::strncpy(type_name_, value, sizeof(type_name_));
   } else {
     // no match
-    ACE_DEBUG((LM_ERROR, ACE_TEXT("Don't know of setting %C\n"), name));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("Don't know of setting %C\n"), name));
     status = 1;
   }
 

--- a/dds/FACE/config/TopicSettings.cpp
+++ b/dds/FACE/config/TopicSettings.cpp
@@ -18,7 +18,7 @@ TopicSettings::set(const char* name, const char* value)
     std::strncpy(type_name_, value, sizeof(type_name_));
   } else {
     // no match
-    ACE_OS::printf("Don't know of setting %s\n", name);
+    ACE_DEBUG((LM_ERROR, ACE_TEXT("Don't know of setting %C\n"), name));
     status = 1;
   }
 


### PR DESCRIPTION
Convert ACE_OS::printf calls to ACE_DEBUG in FACE config file parsing.
All other printf like calls were checked to be calls to snprintf.