### PR TITLE
Send acknack when reader is going away

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2531,6 +2531,7 @@ DataReaderImpl::prepare_to_delete()
 {
   this->set_deleted(true);
   this->stop_associating();
+  this->send_final_acks();
 }
 
 SubscriptionInstance*

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -251,6 +251,8 @@ public:
 
   void set_scheduling_release(bool scheduling_release);
 
+  virtual void send_final_acks (const RepoId& readerid);
+
 protected:
 
   /// This is how the subclass "announces" to this DataLink base class

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -401,5 +401,10 @@ DataLink::default_listener() const
   return this->default_listener_;
 }
 
+ACE_INLINE
+void
+DataLink::send_final_acks (const RepoId& /*readerid*/)
+{ }
+
 }
 }

--- a/dds/DCPS/transport/framework/DataLinkSet.h
+++ b/dds/DCPS/transport/framework/DataLinkSet.h
@@ -70,6 +70,8 @@ public:
 
   bool empty();
 
+  void send_final_acks(const RepoId& readerid);
+
   typedef ACE_SYNCH_MUTEX     LockType;
   typedef ACE_Guard<LockType> GuardType;
 

--- a/dds/DCPS/transport/framework/DataLinkSet.inl
+++ b/dds/DCPS/transport/framework/DataLinkSet.inl
@@ -249,3 +249,16 @@ OpenDDS::DCPS::DataLinkSet::copy_map_to(MapType& target)
     target.insert(*itr);
   }
 }
+
+ACE_INLINE void
+OpenDDS::DCPS::DataLinkSet::send_final_acks(const RepoId& readerid)
+{
+  GuardType guard(this->lock_);
+  for (MapType::iterator itr = map_.begin();
+       itr != map_.end();
+       ++itr) {
+    itr->second->send_final_acks(readerid);
+  }
+
+  map_.clear();
+}

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -728,6 +728,12 @@ TransportClient::stop_associating(const GUID_t* repos, CORBA::ULong length)
 }
 
 void
+TransportClient::send_final_acks()
+{
+  links_.send_final_acks (get_repo_id());
+}
+
+void
 TransportClient::disassociate(const RepoId& peerId)
 {
   GuidConverter peerId_conv(peerId);

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -75,6 +75,7 @@ protected:
   void disassociate(const RepoId& peerId);
   void stop_associating();
   void stop_associating(const GUID_t* repos, CORBA::ULong length);
+  void send_final_acks();
 
   // Discovery:
   void register_for_reader(const RepoId& participant,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -117,6 +117,8 @@ public:
 
   virtual void pre_stop_i();
 
+  virtual void send_final_acks (const RepoId& readerid);
+
 private:
   virtual void stop_i();
   virtual void send_i(TransportQueueElement* element, bool relink = true);
@@ -477,6 +479,8 @@ private:
 
   typedef OPENDDS_SET(InterestingAckNack) InterestingAckNackSetType;
   InterestingAckNackSetType interesting_ack_nacks_;
+
+  void send_ack_nacks(RtpsReaderMap::iterator rr, bool finalFlag = false);
 };
 
 } // namespace DCPS

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -96,8 +96,10 @@ public:
     if (reliable_) {
       qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
       qos.reliability.max_blocking_time.sec = DDS::DURATION_INFINITE_SEC;
-      // qos.resource_limits.max_instances = 10;
-      // qos.history.depth = 10;
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+      qos.resource_limits.max_instances = 10;
+      qos.history.depth = 10;
+#endif
     } else {
       qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
     }
@@ -382,8 +384,6 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_Guard<ACE_Thread_Mutex> g(readers_done_lock);
       while (readers_done != static_cast<int>(readers.size()))
         readers_done_cond.wait();
-      // Sleep allows an ACKNACK to be generated.
-      ACE_OS::sleep(3);
     }
 
     if (built_in_read_errors) {


### PR DESCRIPTION
The following sequence was observed in the StaticDiscovery test:

Writer             Reader
Send last sample
...
                   Process last sample
                   ...
                   Terminate
...
Wait for acks
...
Timeout

The goal is to avoid the timeout.  There are three options:
1. Decrease the WaitForAck timeout.
2. Add a delay to the reader so that it will receive a heartbeat from
the writer and send an acknack.
3. Have the reader send an acknack before it goes away.  If the writer
receives it then it will not timeout.

This commit implements option 3.

The StaticDiscoveryTest was modified to set the history depth when
available.