### PR TITLE
Fix datarace in callback subscriber for MultiDomainMessenger Test

### DIFF
--- a/tests/FACE/MultiDomainMessenger/Subscriber/Subscriber.cpp
+++ b/tests/FACE/MultiDomainMessenger/Subscriber/Subscriber.cpp
@@ -9,6 +9,7 @@
 #include "ace/Log_Msg.h"
 #include <cstring>
 
+ACE_Thread_Mutex mutex;
 bool callbackHappened = false;
 int callback_count = 0;
 
@@ -19,6 +20,7 @@ void callback(FACE::TRANSACTION_ID_TYPE,
               const FACE::WAITSET_TYPE,
               FACE::RETURN_CODE_TYPE& return_code)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(mutex);
   ++callback_count;
   ACE_DEBUG((LM_INFO, "In callback() (the %d time): %C\t%d\t"
              "message_type_id: %Ld\tmessage_size: %d\n",


### PR DESCRIPTION
The same callback is used for two different FACE connections.  The
callback updates a global counter and flag.  The callback may be invoked
concurrently, thus, the counter and flag must be protected by a lock.