### PR TITLE
Update safety profile logging

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -342,13 +342,6 @@ Service_Participant::get_domain_participant_factory(int &argc,
                      ACE_TEXT("(%P|%t) NOTICE: not using file configuration - no configuration ")
                      ACE_TEXT("file specified.\n")));
         }
-#if defined OPENDDS_SAFETY_PROFILE && !defined ACE_FACE_DEV
-        if (!got_log_fname) {
-          // Neither log file nor config file specified
-          set_log_file_name("safetyprofile.log");
-        }
-#endif
-
 
       } else {
         // Load configuration only if the configuration
@@ -1548,11 +1541,6 @@ Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
       GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("ORBLogFile"), log_fname);
       if (!log_fname.empty()) {
         set_log_file_name(log_fname.c_str());
-#if defined OPENDDS_SAFETY_PROFILE && !defined ACE_FACE_DEV
-      } else {
-        // No log file specified
-        set_log_file_name("safetyprofile.log");
-#endif
       }
     }
 

--- a/tests/DCPS/CompatibilityTest/run_test.pl
+++ b/tests/DCPS/CompatibilityTest/run_test.pl
@@ -19,12 +19,7 @@ PerlDDS::add_lib_path('../common');
 # single reader with single instances test
 my $is_rtps_disc = 0;
 my $DCPScfg = "";
-my $DCPSREPO;
 my $level = 4;
-
-my $dcpsrepo_ior = "repo.ior";
-
-unlink $dcpsrepo_ior;
 
 if ($ARGV[0] eq "rtps_disc") {
   $DCPScfg = "-DCPSConfigFile " . $ARGV[0] . ".ini ";
@@ -57,58 +52,32 @@ sub run_compatibility_tests {
   print "Test #" . $testnum . "\n";
   print "\n\n"; # Provide some visual relief between test cases.
 
+  my $test = new PerlDDS::TestFramework();
+  $test->setup_discovery() unless $is_rtps_disc;
+
   my $sub_time = 40;
   my $pub_time = $sub_time;
   my $sub_parameters = "-l $sub_lease_time -x $sub_time -c $compatibility -d $sub_durability_kind -k $sub_liveliness_kind -r $sub_reliability_kind -DCPSDebugLevel $level $DCPScfg -";
 
-  my $Subscriber = PerlDDS::create_process ("subscriber", $sub_parameters);
+  $test->process("subscriber", "subscriber", $sub_parameters);
 
   my $pub_parameters = "-c $compatibility -d $pub_durability_kind -k $pub_liveliness_kind -r $pub_reliability_kind -l $pub_lease_time -x $pub_time -DCPSDebugLevel $level $DCPScfg";
 
-  my $Publisher = PerlDDS::create_process ("publisher", "$pub_parameters");
+  $test->process("publisher", "publisher", "$pub_parameters");
 
-  print $Subscriber->CommandLine() . "\n";
-  my $SubscriberResult = $Subscriber->Spawn();
-  print "Subscriber PID: " . $Subscriber->{PROCESS} . "\n" if $Subscriber->{PROCESS};
-
-  if ($SubscriberResult != 0) {
-    print STDERR "ERROR: subscriber returned $SubscriberResult \n";
-    $status = 1;
-  }
+  $test->start_process("subscriber");
 
   sleep 3;
 
-  print $Publisher->CommandLine() . "\n";
-  my $PublisherResult = $Publisher->SpawnWaitKill ($pub_time + 20);
-  print "Publisher PID: " . $Publisher->{PROCESS} . "\n" if $Publisher->{PROCESS};
+  $test->start_process("publisher");
 
-  if ($PublisherResult != 0) {
-    print STDERR "ERROR: publisher returned $PublisherResult \n";
+  my $result = $test->finish($sub_time + 20);
+
+  if ($result != 0) {
+    print STDERR "ERROR: test returned $result \n";
     $status = 1;
   }
 
-  $SubscriberResult = $Subscriber->WaitKill($sub_time + 20);
-
-  if ($SubscriberResult != 0) {
-    print STDERR "ERROR: subscriber returned $SubscriberResult \n";
-    $status = 1;
-  }
-
-}
-
-if (!$is_rtps_disc) {
-  $DCPSREPO = PerlDDS::create_process ("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                       "-o $dcpsrepo_ior");
-
-  print $DCPSREPO->CommandLine() . "\n";
-  $DCPSREPO->Spawn ();
-  print "Repository PID: " . $DCPSREPO->{PROCESS} . "\n" if $DCPSREPO->{PROCESS};
-
-  if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
-    exit 1;
-  }
 }
 
 my $configs = new PerlACE::ConfigList;
@@ -128,20 +97,5 @@ run_compatibility_tests("false", "transient_local", "automatic", "5", "best_effo
 run_compatibility_tests("false", "volatile", "automatic", "5", "reliable", "transient_local", "automatic", "5", "reliable");
 # there are more to test later, but they are currently treated as invalid
 # since there are not supported in the code
-
-if (!$is_rtps_disc) {
-  my $ir = $DCPSREPO->TerminateWaitKill(5);
-
-  if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-  }
-}
-if ($status == 0) {
-  print "test PASSED.\n";
-}
-else {
-  print STDERR "test FAILED.\n";
-}
 
 exit $status;

--- a/tests/DCPS/Deadline/run_test.pl
+++ b/tests/DCPS/Deadline/run_test.pl
@@ -25,58 +25,17 @@ if ($ARGV[0] eq 'rtps_disc') {
 my $pub_opts = "-DCPSConfigFile " . ($is_rtps_disc ? "rtps_disc.ini" : "pub.ini");
 my $sub_opts = "-DCPSConfigFile " . ($is_rtps_disc ? "rtps_disc.ini" : "sub.ini");
 
-my $dcpsrepo_ior = "repo.ior";
+my $test = new PerlDDS::TestFramework();
+$test->setup_discovery() unless $is_rtps_disc;
+$test->process("subscriber", "subscriber", $sub_opts);
+$test->process("publisher", "publisher", $pub_opts);
+$test->start_process("publisher");
+$test->start_process("subscriber");
 
-unlink $dcpsrepo_ior;
-
-my $DCPSREPO = PerlDDS::create_process("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                       "-o $dcpsrepo_ior");
-my $Subscriber = PerlDDS::create_process("subscriber", $sub_opts);
-my $Publisher = PerlDDS::create_process("publisher", $pub_opts);
-
-
-if (!$is_rtps_disc) {
-  print $DCPSREPO->CommandLine() . "\n";
-  $DCPSREPO->Spawn();
-  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill();
-    exit 1;
-  }
-}
-
-print $Publisher->CommandLine() . "\n";
-print $Subscriber->CommandLine() . "\n";
-$Publisher->Spawn();
-
-$Subscriber->Spawn();
-
-my $PublisherResult = $Publisher->WaitKill(300);
-if ($PublisherResult != 0) {
-  print STDERR "ERROR: publisher returned $PublisherResult \n";
+my $result = $test->finish(300);
+if ($result != 0) {
+  print STDERR "ERROR: test returned $result \n";
   $status = 1;
-}
-
-my $SubscriberResult = $Subscriber->WaitKill(30);
-if ($SubscriberResult != 0) {
-  print STDERR "ERROR: subscriber returned $SubscriberResult \n";
-  $status = 1;
-}
-
-if (!$is_rtps_disc) {
-  my $ir = $DCPSREPO->TerminateWaitKill(5);
-  if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-  }
-}
-
-unlink $dcpsrepo_ior;
-
-if ($status == 0) {
-  print "test PASSED.\n";
-} else {
-  print STDERR "test FAILED.\n";
 }
 
 exit $status;

--- a/tests/DCPS/DpShutdown/run_test.pl
+++ b/tests/DCPS/DpShutdown/run_test.pl
@@ -20,21 +20,14 @@ $debugOpts .= "-DCPSDebugLevel $debug " if $debug;
 
 unlink $debugFile;
 
-$CL = PerlDDS::create_process ("dpshutdown",
-                              "$debugOpts $pub_opts");
-print $CL->CommandLine() . "\n";
-
-$client = $CL->SpawnWaitKill (30);
+my $test = new PerlDDS::TestFramework();
+$test->process("dpshutdown", "dpshutdown", "$debugOpts $pub_opts");
+$test->start_process("dpshutdown");
+$client = $test->finish(30);
 
 if ($client != 0) {
     print STDERR "ERROR: client returned $client\n";
     $status = 1;
-}
-
-if ($status == 0) {
-  print "test PASSED.\n";
-} else {
-  print STDERR "test FAILED.\n";
 }
 
 exit $status;

--- a/tests/DCPS/GuardCondition/run_test.pl
+++ b/tests/DCPS/GuardCondition/run_test.pl
@@ -9,8 +9,10 @@ use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
 use strict;
 
-my $TEST = PerlDDS::create_process('GuardConditionTest');
-my $result = $TEST->SpawnWaitKill(60);
+my $test = new PerlDDS::TestFramework();
+$test->process("GuardConditionTest", 'GuardConditionTest');
+$test->start_process("GuardConditionTest");
+my $result = $test->finish(60);
 if ($result != 0) {
   print STDERR "ERROR: test returned $result\n";
   exit 1;

--- a/tests/DCPS/ManyTopicTest/run_test.pl
+++ b/tests/DCPS/ManyTopicTest/run_test.pl
@@ -85,63 +85,30 @@ else {
   exit 1;
 }
 
-my $dcpsrepo_ior = "repo.ior";
-
-unlink $dcpsrepo_ior;
-
 my $sub_parameters = "-t all";
 my $pub_parameters = "-t all";
 
-my $DCPSREPO = PerlDDS::create_process("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                       "-o $dcpsrepo_ior");
-
+my $test = new PerlDDS::TestFramework();
 if ($rtps_disc) {
   $sub_parameters .= ' -DCPSConfigFile rtps_disc.ini';
   $pub_parameters .= ' -DCPSConfigFile rtps_disc.ini';
 }
 else {
-  $DCPSREPO->Spawn();
-
-  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill();
-    exit 1;
-  }
+  $test->setup_discovery();
 }
 
-my $Subscriber = PerlDDS::create_process("subscriber", $sub_parameters);
-my $Sub2 = PerlDDS::create_process("subscriber", $sub_parameters);
-my $Publisher = PerlDDS::create_process("publisher", $pub_parameters);
+$test->process("subscriber1", "subscriber", $sub_parameters);
+$test->process("subscriber2", "subscriber", $sub_parameters);
+$test->process("publisher", "publisher", $pub_parameters);
 
-$Publisher->Spawn();
-$Subscriber->Spawn();
-$Sub2->Spawn();
+$test->start_process("publisher");
+$test->start_process("subscriber1");
+$test->start_process("subscriber2");
 
-my $PublisherResult = $Publisher->WaitKill(300);
-if ($PublisherResult != 0) {
-  print STDERR "ERROR: publisher returned $PublisherResult\n";
+my $result = $test->finish(300);
+if ($result != 0) {
+  print STDERR "ERROR: publisher returned $result\n";
   $status = 1;
-}
-
-my $SubscriberResult = $Subscriber->WaitKill(30);
-if ($SubscriberResult != 0) {
-  print STDERR "ERROR: subscriber returned $SubscriberResult\n";
-  $status = 1;
-}
-
-my $Sub2Result = $Sub2->WaitKill(5);
-if ($Sub2Result != 0) {
-  print STDERR "ERROR: subscriber2 returned $Sub2Result\n";
-  $status = 1;
-}
-
-if (!$rtps_disc) {
-  my $ir = $DCPSREPO->TerminateWaitKill(5);
-
-  if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-  }
 }
 
 unlink $subscriber1_completed;
@@ -151,12 +118,5 @@ unlink $subscriber3_completed;
 unlink $publisher1_completed;
 unlink $publisher2_completed;
 unlink $publisher3_completed;
-
-if ($status == 0) {
-  print "test PASSED.\n";
-}
-else {
-  print STDERR "test FAILED.\n";
-}
 
 exit $status;

--- a/tests/DCPS/RegisterInstance/run_test.pl
+++ b/tests/DCPS/RegisterInstance/run_test.pl
@@ -25,14 +25,13 @@ PerlDDS::add_lib_path('../FooType');
 
 $options = "-DCPSConfigFile rtps_disc.ini -ORBLogFile $logfile";
 
-$Topic = PerlDDS::create_process ("register_instance_test", "$options");
+my $test = new PerlDDS::TestFramework();
+$test->process("register_instance_test", "register_instance_test", "$options");
+$test->start_process("register_instance_test");
+$result = $test->finish(60);
 
-print $Topic->CommandLine() . "\n";
-
-$TopicResult = $Topic->SpawnWaitKill (60);
-
-if ($TopicResult != 0) {
-    print STDERR "ERROR: topic_test returned $TopicResult\n";
+if ($result != 0) {
+    print STDERR "ERROR: test returned $result\n";
     $status = 1;
 }
 

--- a/tests/DCPS/RegisterInstance/run_test.pl
+++ b/tests/DCPS/RegisterInstance/run_test.pl
@@ -26,6 +26,9 @@ PerlDDS::add_lib_path('../FooType');
 $options = "-DCPSConfigFile rtps_disc.ini -ORBLogFile $logfile";
 
 my $test = new PerlDDS::TestFramework();
+$test->ignore_error("register instance with container failed");
+$test->ignore_error("register failed");
+
 $test->process("register_instance_test", "register_instance_test", "$options");
 $test->start_process("register_instance_test");
 $result = $test->finish(60);

--- a/tests/DCPS/RtpsMessages/run_test.pl
+++ b/tests/DCPS/RtpsMessages/run_test.pl
@@ -9,8 +9,10 @@ use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
 use strict;
 
-my $TEST = PerlDDS::create_process('RtpsMessagesTest');
-my $result = $TEST->SpawnWaitKill(60);
+my $test = new PerlDDS::TestFramework();
+$test->process('RtpsMessagesTest', 'RtpsMessagesTest', "");
+$test->start_process('RtpsMessagesTest');
+my $result = $test->finish(60);
 if ($result != 0) {
   print STDERR "ERROR: test returned $result\n";
   exit 1;

--- a/tests/DCPS/Serializer/run_test.pl
+++ b/tests/DCPS/Serializer/run_test.pl
@@ -12,10 +12,9 @@ use PerlDDS::Run_Test;
 
 my $args = "--test" ;
 
-$test = PerlDDS::create_process( "./SerializerTest", $args) ;
-
-my $status = $test->SpawnWaitKill( 60);
+my $test = new PerlDDS::TestFramework();
+$test->process("SerializerTest", "SerializerTest", $args);
+$test->start_process("SerializerTest");
+my $status = $test->finish(60);
 print STDERR "ERROR: client returned $status\n" if $status ;
-
 exit ($status ne 0)? 1 : 0 ;
-

--- a/tests/DCPS/SetQosDeadline/run_test.pl
+++ b/tests/DCPS/SetQosDeadline/run_test.pl
@@ -21,62 +21,23 @@ if ($ARGV[0] eq 'rtps_disc') {
 my $pub_opts = "-DCPSConfigFile " . ($is_rtps_disc ? "rtps_disc.ini" : "pub.ini");
 my $sub_opts = "-DCPSConfigFile " . ($is_rtps_disc ? "rtps_disc.ini" : "sub.ini");
 
-my $dcpsrepo_ior = "repo.ior";
-
-unlink $dcpsrepo_ior;
-
-my $DCPSREPO = PerlDDS::create_process("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                       "-o $dcpsrepo_ior");
-my $Subscriber = PerlDDS::create_process("subscriber", $sub_opts);
-my $Publisher = PerlDDS::create_process("publisher", $pub_opts);
-
-
-if (!$is_rtps_disc) {
-  print $DCPSREPO->CommandLine() . "\n";
-  $DCPSREPO->Spawn();
-  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill();
-    exit 1;
-  }
-}
+my $test = new PerlDDS::TestFramework();
+$test->setup_discovery() unless $is_rtps_disc;
+$test->process("subscriber", "subscriber", $sub_opts);
+$test->process("publisher", "publisher", $pub_opts);
 
 my $synch_file = "dr_unmatch_done";
 unlink $synch_file;
 
-print $Publisher->CommandLine() . "\n";
-print $Subscriber->CommandLine() . "\n";
-$Publisher->Spawn();
+$test->start_process("publisher");
+$test->start_process("subscriber");
 
-$Subscriber->Spawn();
-
-my $PublisherResult = $Publisher->WaitKill(300);
-if ($PublisherResult != 0) {
-  print STDERR "ERROR: publisher returned $PublisherResult \n";
+my $result = $test->finish(300);
+if ($result != 0) {
+  print STDERR "ERROR: test returned $result\n";
   $status = 1;
-}
-
-my $SubscriberResult = $Subscriber->WaitKill(30);
-if ($SubscriberResult != 0) {
-  print STDERR "ERROR: subscriber returned $SubscriberResult \n";
-  $status = 1;
-}
-
-if (!$is_rtps_disc) {
-  my $ir = $DCPSREPO->TerminateWaitKill(5);
-  if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-  }
 }
 
 unlink $synch_file;
-unlink $dcpsrepo_ior;
-
-if ($status == 0) {
-  print "test PASSED.\n";
-} else {
-  print STDERR "test FAILED.\n";
-}
 
 exit $status;

--- a/tests/DCPS/SetQosPartition/run_test.pl
+++ b/tests/DCPS/SetQosPartition/run_test.pl
@@ -9,51 +9,13 @@ use lib "$DDS_ROOT/bin";
 use Env (ACE_ROOT);
 use lib "$ACE_ROOT/bin";
 use PerlDDS::Run_Test;
-
-$status = 0;
-
-my $debug = 10;
-my $transportDebug = 10;
-my $debugFile = "debug.out";
-my $is_rtps_disc = 0;
-my $DCPScfg = "";
-
-if ($ARGV[0] eq "rtps_disc") {
-  $DCPScfg = $ARGV[0] . ".ini";
-  $is_rtps_disc = 1;
-} elsif ($ARGV[0] eq "rtps_disc_tcp") {
-  $DCPScfg = $ARGV[0] . ".ini";
-  $is_rtps_disc = 1;
-}
-
-my $debugOpts = "";
-
-$debugOpts .= "-DCPSDebugLevel $debug " if $debug;
-$debugOpts .= "-DCPSTransportDebugLevel $transportDebug " if $transportDebug;
-$debugOpts .= "-ORBLogFile $debugFile " if $debugFile and ($debug or $transportDebug);
-
-my $opts;
-
-$opts .= " " . $debugOpts if $debug or $transportDebug;
-
-$pub_opts = "$opts -DCPSConfigFile " .  ($is_rtps_disc ? $DCPScfg : "pub.ini");
-$sub_opts = "$opts -DCPSConfigFile " .  ($is_rtps_disc ? $DCPScfg : "sub.ini");
-
-$repo_bit_opt = $opts;
-
-unlink $debugFile;
+use strict;
 
 my $test = new PerlDDS::TestFramework();
-$test->setup_discovery("$repo_bit_opt") unless $is_rtps_disc;
-$test->process("subscriber", "subscriber", "$sub_opts");
-$test->process("publisher", "publisher", "$pub_opts");
-$test->start_process("publisher");
-$test->start_process("subscriber");
-
-my $result = $test->finish(300);
-if ($result != 0) {
-    print STDERR "ERROR: test returned $result\n";
-    $status = 1;
-}
-
-exit $status;
+$test->{'dcps_debug_level'} = $test->{'dcps_transport_debug_level'} = 10;
+$test->setup_discovery();
+$test->process("sub", "subscriber", "-DCPSPendingTimeout 0");
+$test->process("pub", "publisher", "-DCPSPendingTimeout 0");
+$test->start_process("pub");
+$test->start_process("sub");
+exit $test->finish(300);

--- a/tests/DCPS/SetQosPartition/subscriber.cpp
+++ b/tests/DCPS/SetQosPartition/subscriber.cpp
@@ -189,7 +189,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       if (listener_servant1->num_reads() > expected
         || listener_servant2->num_reads() > expected)
       {
-        cerr << "ERROR: received more than excepted messages" << endl;
+        cerr << "ERROR: received more than expected messages" << endl;
         exit (1);
       }
 

--- a/tests/DCPS/TopicReuse/run_test.pl
+++ b/tests/DCPS/TopicReuse/run_test.pl
@@ -14,28 +14,14 @@ use strict;
 my $status = 0;
 my $debug = 0;
 # $debug = 10;
-my $debugFile = "test.log";
 my $debugOpts = "-DCPSDebugLevel $debug" if $debug;
-
-unlink $debugFile;
-
 my $pub_opts = "-DCPSConfigFile rtps_disc.ini";
-
-my $CL = PerlDDS::create_process("tpreuse", "$debugOpts $pub_opts");
-
-print $CL->CommandLine() . "\n";
-
-my $client = $CL->SpawnWaitKill(60);
-
+my $test = new PerlDDS::TestFramework();
+$test->process("tpreuse", "tpreuse", "$debugOpts $pub_opts");
+$test->start_process("tpreuse");
+my $client = $test->finish(60);
 if ($client != 0) {
     print STDERR "ERROR: client returned $client\n";
     $status = 1;
 }
-
-if ($status == 0) {
-  print "test PASSED.\n";
-} else {
-  print STDERR "test FAILED.\n";
-}
-
 exit $status;

--- a/tests/DCPS/UnitTests/run_test.pl
+++ b/tests/DCPS/UnitTests/run_test.pl
@@ -25,11 +25,14 @@ if(defined $ARGV[0])
 my $something_ran = 0;
 
 sub run_unit_tests {
+  my $test = new PerlDDS::TestFramework();
+
   if($single_test ne '') {
-    $TST = PerlDDS::create_process("$single_test", "");
+    $test->process("$single_test", "$single_test", "");
     $something_ran = 1;
     print STDERR "Running only $single_test\n";
-    my $retcode = $TST->SpawnWaitKill(60);
+    $test->start_process("$single_test");
+    my $retcode = $test->finish(60);
     if ($retcode != 0) {
       $status = 1;
     }
@@ -46,9 +49,9 @@ sub run_unit_tests {
           # each process runs to completion before the next starts
           my $LONE_PROCESS = 1;
           if ($executable eq "UnitTests_BIT_DataReader") {
-            $TST = PerlDDS::create_process("$executable", "-DCPSConfigFile rtps.ini", $LONE_PROCESS);
+            $test->process ("$executable", "$executable", "-DCPSConfigFile rtps.ini", $LONE_PROCESS);
           } else {
-            $TST = PerlDDS::create_process("$executable", "", $LONE_PROCESS);
+            $test->process ("$executable", "$executable", "", $LONE_PROCESS);
           }
         }
         else {
@@ -56,7 +59,7 @@ sub run_unit_tests {
         }
         $something_ran = 1;
         print STDOUT "Running $file\n";
-        my $retcode = $TST->SpawnWaitKill(60);
+        my $retcode = $test->finish(60);
         if ($retcode != 0) {
           ++$status;
         }

--- a/tests/DCPS/WriteDataContainer/run_test.pl
+++ b/tests/DCPS/WriteDataContainer/run_test.pl
@@ -12,37 +12,18 @@ use PerlDDS::Run_Test;
 
 $status = 0;
 
-$dcpsrepo_ior = "repo.ior";
-
-unlink $dcpsrepo_ior;
-
-
 $parameters = "-DcpsBit 0 -ORBVerboseLogging 1 -DCPSDebugLevel 10";
 
 if ($ARGV[0] eq 'by_instance') {
   $parameters .= " -i";
 }
 
-
-$ZCTest = PerlDDS::create_process ("WriteDataContainerTest", $parameters);
-
-print $ZCTest->CommandLine(), "\n";
-if ($ZCTest->Spawn () != 0) {
-    print STDERR "ERROR: Couldn't spawn main\ntest FAILED.\n";
-    return 1;
-}
-
-$result = $ZCTest->WaitKill (60);
-
+my $test = new PerlDDS::TestFramework();
+$test->process("WriteDataContainerTest", "WriteDataContainerTest", $parameters);
+$test->start_process("WriteDataContainerTest");
+$result = $test->finish(60);
 if ($result != 0) {
     print STDERR "ERROR: main returned $result \n";
     $status = 1;
-}
-
-if ($status == 0) {
-  print "test PASSED.\n";
-}
-else {
-  print STDERR "test FAILED.\n";
 }
 exit $status;

--- a/tests/DCPS/ZeroCopyRead/run_test.pl
+++ b/tests/DCPS/ZeroCopyRead/run_test.pl
@@ -13,11 +13,6 @@ use strict;
 
 my $status = 0;
 
-my $dcpsrepo_ior = "repo.ior";
-
-
-unlink $dcpsrepo_ior;
-
 # -b
 my $parameters = "-DcpsBit 0";
 # or could have
@@ -27,48 +22,15 @@ if ($ARGV[0] eq 'by_instance') {
   $parameters .= " -i";
 }
 
-# -ORBDebugLevel 1 -NOBITS
-my $DCPSREPO = PerlDDS::create_process("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                    "-o $dcpsrepo_ior"
-                                    . " -NOBITS");
+my $test = new PerlDDS::TestFramework();
 
-my $ZCTest = PerlDDS::create_process("main", $parameters);
-
-if (!$PerlDDS::SafetyProfile && $DCPSREPO->Spawn () != 0) {
-    print STDERR "ERROR: Couldn't spawn InfoRepo\ntest FAILED.\n";
-    exit 1;
-}
-
-if (!$PerlDDS::SafetyProfile && PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
-    exit 1;
-}
-
-if ($ZCTest->Spawn () != 0) {
-    print STDERR "ERROR: Couldn't spawn main\ntest FAILED.\n";
-    exit 1;
-}
-
-my $result = $ZCTest->WaitKill(60);
-
+$test->setup_discovery("-NOBITS") if !$PerlDDS::SafetyProfile;
+$test->process("main", "main", $parameters);
+$test->start_process("main");
+my $result = $test->finish(60);
 if ($result != 0) {
     print STDERR "ERROR: main returned $result \n";
     $status = 1;
 }
 
-my $ir = 0;
-$DCPSREPO->TerminateWaitKill(5) unless $PerlDDS::SafetyProfile;
-
-if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-}
-
-if ($status == 0) {
-  print "test PASSED.\n";
-}
-else {
-  print STDERR "test FAILED.\n";
-}
 exit $status;

--- a/tests/FACE/Compiler/idl_test1_main/run_test.pl
+++ b/tests/FACE/Compiler/idl_test1_main/run_test.pl
@@ -14,14 +14,15 @@ $status = 0;
 
 PerlDDS::add_lib_path('../idl_test1_lib');
 
-$TESTDVR = PerlDDS::create_process ("idl_test1");
+my $test = new PerlDDS::TestFramework();
+$test->process ("idl_test1", "idl_test1", "");
+$test->start_process ("idl_test1");
 
-$status = $TESTDVR->SpawnWaitKill (300);
+$status = $test->finish(300);
 
 if ($status != 0) {
     print STDERR "ERROR: idl_test1 returned $status\n";
     $status = 1;
 }
-
 
 exit $status;

--- a/tests/FACE/Compiler/idl_test3_main/run_test.pl
+++ b/tests/FACE/Compiler/idl_test3_main/run_test.pl
@@ -14,14 +14,15 @@ $status = 0;
 
 PerlDDS::add_lib_path('../idl_test3_lib');
 
-$TESTDVR = PerlDDS::create_process ("idl_test3");
+my $test = new PerlDDS::TestFramework();
+$test->process ("idl_test3", "idl_test3", "");
+$test->start_process ("idl_test3");
 
-$status = $TESTDVR->SpawnWaitKill (300);
+$status = $test->finish(300);
 
 if ($status != 0) {
     print STDERR "ERROR: idl_test1 returned $status\n";
     $status = 1;
 }
-
 
 exit $status;

--- a/tests/FACE/Compiler/idl_test_fixed/run_test.pl
+++ b/tests/FACE/Compiler/idl_test_fixed/run_test.pl
@@ -12,9 +12,11 @@ use PerlDDS::Run_Test;
 
 $status = 0;
 
-$TESTDVR = PerlDDS::create_process ("TestFixed");
+my $test = new PerlDDS::TestFramework();
+$test->process ("TestFixed", "TestFixed", "");
+$test->start_process ("TestFixed");
 
-$status = $TESTDVR->SpawnWaitKill (300);
+$status = $test->finish(300);
 
 if ($status != 0) {
     print STDERR "ERROR: TestFixed returned $status\n";

--- a/tests/transport/rtps/publisher.cpp
+++ b/tests/transport/rtps/publisher.cpp
@@ -540,6 +540,8 @@ int
 ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
   try {
+    TheParticipantFactoryWithArgs(argc, argv);
+
     ACE_TString host;
     u_short port = 0;
 
@@ -556,8 +558,6 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         break;
       }
     }
-
-    TheServiceParticipant->get_domain_participant_factory();
 
     return DDS_TEST::test(host, port);
 

--- a/tests/transport/rtps/subscriber.cpp
+++ b/tests/transport/rtps/subscriber.cpp
@@ -195,6 +195,8 @@ int
 ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
   try {
+    TheParticipantFactoryWithArgs(argc, argv);
+
     std::cerr << "STARTING MAIN IN SUBSCRIBER\n";
     ACE_TString host;
     u_short port = 0;
@@ -217,8 +219,6 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       std::cerr << "ERROR: -h <host> and -p <port> options are required\n";
       return 1;
     }
-
-    TheServiceParticipant->get_domain_participant_factory();
 
     TransportInst_rch inst = TheTransportRegistry->create_inst("my_rtps",
                                                                "rtps_udp");

--- a/tests/transport/rtps_reliability/run_test.pl
+++ b/tests/transport/rtps_reliability/run_test.pl
@@ -7,8 +7,10 @@ use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
 use strict;
 
-my $TEST = PerlDDS::create_process('rtps_reliability');
-my $result = $TEST->SpawnWaitKill(60);
+my $test = new PerlDDS::TestFramework();
+$test->process('rtps_reliability', 'rtps_reliability');
+$test->start_process('rtps_reliability');
+my $result = $test->finish (60);
 if ($result != 0) {
   print STDERR "ERROR: test returned $result\n";
   exit 1;


### PR DESCRIPTION
Removed the default safetyprofile.log.  Tests enabled in safety profile
must use the test framework whichw will supply and translate a log file
name.