### PR TITLE
Add -DCPSDefaultAddress

### DIFF
--- a/bin/PerlDDS/ProcessFactory.pm
+++ b/bin/PerlDDS/ProcessFactory.pm
@@ -30,6 +30,11 @@ sub create_process {
     }
 
     my $target = PerlDDS::create_test_target($config_name, $os);
+
+    if (defined($target) && defined($target->{IP_ADDRESS}) && $arguments !~ /-DCPSDefaultAddress /) {
+        $arguments .= " -DCPSDefaultAddress $target->{IP_ADDRESS}";
+    }
+
     if (defined $target) {
       return $target->CreateProcess($executable, $arguments);
     }

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -300,7 +300,11 @@ Sedp::unicast_locators(OpenDDS::DCPS::LocatorSeq& locators) const
       rtps_inst->local_address_config_str_.rfind(':') == 0) {
     typedef OPENDDS_VECTOR(ACE_INET_Addr) AddrVector;
     AddrVector addrs;
-    OpenDDS::DCPS::get_interface_addrs(addrs);
+    if (TheServiceParticipant->default_address ().empty ()) {
+      OpenDDS::DCPS::get_interface_addrs(addrs);
+    } else {
+      addrs.push_back (ACE_INET_Addr (static_cast<u_short> (0), TheServiceParticipant->default_address ().c_str ()));
+    }
     for (AddrVector::iterator adr_it = addrs.begin(); adr_it != addrs.end(); ++adr_it) {
       idx = locators.length();
       locators.length(idx + 1);

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -144,6 +144,7 @@ static bool got_default_discovery = false;
 #endif
 static bool got_log_fname = false;
 static bool got_log_verbose = false;
+static bool got_default_address = false;
 
 Service_Participant::Service_Participant()
   :
@@ -546,6 +547,11 @@ Service_Participant::parse_args(int &argc, ACE_TCHAR *argv[])
       set_log_verbose(ACE_OS::atoi(currentArg));
       arg_shifter.consume_arg();
       got_log_verbose = true;
+
+    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSDefaultAddress"))) != 0) {
+      this->default_address_ = ACE_TEXT_ALWAYS_CHAR(currentArg);
+      arg_shifter.consume_arg();
+      got_default_address = true;
 
     } else {
       arg_shifter.ignore_arg();
@@ -1554,6 +1560,13 @@ Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
       unsigned long verbose_logging = 0;
       GET_CONFIG_VALUE(cf, sect, ACE_TEXT("ORBVerboseLogging"), verbose_logging, unsigned long);
       set_log_verbose(verbose_logging);
+    }
+
+    if (got_default_address) {
+      ACE_DEBUG((LM_DEBUG,
+                 ACE_TEXT("(%P|%t) NOTICE: using DCPSDefaultAddress value from command option (overrides value if it's in config file).\n")));
+    } else {
+      GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("DCPSDefaultAddress"), this->default_address_)
     }
 
     // These are not handled on the command line.

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -291,6 +291,8 @@ public:
     bit_enabled_ = b;
   }
 
+  ACE_TString default_address() const;
+
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
   /// Get the data durability cache corresponding to the given
   /// DurabilityQosPolicy and sample list depth.
@@ -507,6 +509,9 @@ private:
   /// The timeout for lookup data from the builtin topic
   /// @c DataReader.
   int bit_lookup_duration_msec_;
+
+  /// The default network address to use.
+  ACE_TString default_address_;
 
   /// The configuration object that imports the configuration
   /// file.

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -339,5 +339,12 @@ Service_Participant::is_shut_down() const
   return this->shut_down_;
 }
 
+ACE_INLINE
+ACE_TString
+Service_Participant::default_address() const
+{
+  return this->default_address_;
+}
+
 } // namespace DDS
 } // namespace OpenDDS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -13,6 +13,7 @@
 #include "ace/Configuration.h"
 #include "dds/DCPS/RTPS/BaseMessageUtils.h"
 #include "dds/DCPS/transport/framework/NetworkAddress.h"
+#include "dds/DCPS/Service_Participant.h"
 
 #include <cstring>
 
@@ -146,7 +147,11 @@ RtpsUdpInst::populate_locator(OpenDDS::DCPS::TransportLocator& info) const
       this->local_address_string().rfind(':') == 0) {
     typedef OPENDDS_VECTOR(ACE_INET_Addr) AddrVector;
     AddrVector addrs;
-    get_interface_addrs(addrs);
+    if (TheServiceParticipant->default_address ().empty ()) {
+      get_interface_addrs(addrs);
+    } else {
+      addrs.push_back (ACE_INET_Addr (static_cast<u_short> (0), TheServiceParticipant->default_address ().c_str ()));
+    }
     for (AddrVector::iterator adr_it = addrs.begin(); adr_it != addrs.end(); ++adr_it) {
       idx = locators.length();
       locators.length(idx + 1);


### PR DESCRIPTION
Safety profile builds must be configured with an address for discovery and transport.  One way to do this is to specify a local_address in the configuration file.  To avoid (1) manually editing every test configuration file and (2) parsing every configuration file to determine if and how the local_address should appear, we introduced a configuration variable for the common section (and command-line option) called DCPSDefaultAddress.  The default address overrides any that would be determined automatically but does not override a local_address appearing in a file.

This commit introduces the following changes:
* Adds default_address to the Service_Participant.
* Causes Sedp to use the default address when computing locators for Spdp.
* Causes Rtps to use the default address when computing locators for Sedp.
* The test framework will set the default address to 127.0.0.1 when safety profile is enabled.  If the process has a hostname configured (via DOC_TEST_*_HOSTNAME), then the framework will use the hostname as the default address.