### PR TITLE
Fix DCPS/Partition test

### DIFF
--- a/tests/DCPS/Partition/Partition_Table.h
+++ b/tests/DCPS/Partition/Partition_Table.h
@@ -66,12 +66,12 @@ namespace Test
 
     PartitionConfig const PartitionConfigs[] =
       {
-        PartitionConfig (One,   2),
-        PartitionConfig (Two,   0),
-        PartitionConfig (Three, 2),
+        PartitionConfig (One,   3),
+        PartitionConfig (Two,   1),
+        PartitionConfig (Three, 3),
         PartitionConfig (Four,  1),
         PartitionConfig (Five,  0),
-        PartitionConfig (Six,   2)
+        PartitionConfig (Six,   3)
       };
   }
 

--- a/tests/DCPS/Partition/run_test.pl
+++ b/tests/DCPS/Partition/run_test.pl
@@ -16,7 +16,6 @@ unlink $data_file;
 
 my $test = new PerlDDS::TestFramework();
 $test->enable_console_logging();
-$test->{report_errors_in_log_file} = 0;
 
 $test->process('sub', 'subscriber');
 $test->process('pub', 'publisher', "-ORBLogFile $data_file");


### PR DESCRIPTION
Expected counts of matched subscriptions were wrong.  Apparently, they did not take into acount "*" matching everything.  Adjusted the expected values and enabled error checking in log files.