### PR TITLE
Apply DCPSDefaultTransport to tcp, udp, and multicast

### DIFF
--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -336,6 +336,12 @@ MulticastTransport::configure_i(TransportInst* config)
 
   this->config_i_->_add_ref();
 
+  // Override with DCPSDefaultAddress.
+  if (this->config_i_->local_address_.empty () &&
+      !TheServiceParticipant->default_address ().empty ()) {
+    this->config_i_->local_address_ = TheServiceParticipant->default_address ().c_str ();
+  }
+
   if (!this->config_i_->group_address_.is_multicast()) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -255,6 +255,12 @@ RtpsUdpTransport::configure_i(TransportInst* config)
                      false);
   }
 
+  // Override with DCPSDefaultAddress.
+  if (this->config_i_->local_address() == ACE_INET_Addr () &&
+      !TheServiceParticipant->default_address ().empty ()) {
+    this->config_i_->local_address(0, TheServiceParticipant->default_address ().c_str ());
+  }
+
   // Open the socket here so that any addresses/ports left
   // unspecified in the RtpsUdpInst are known by the time we get to
   // connection_info_i().  Opening the sockets here also allows us to

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -22,6 +22,7 @@
 #include "dds/DCPS/AssociationData.h"
 #include "dds/DCPS/debug.h"
 #include "dds/DCPS/GuidConverter.h"
+#include "dds/DCPS/Service_Participant.h"
 
 #include <sstream>
 
@@ -363,6 +364,12 @@ TcpTransport::configure_i(TransportInst* config)
                       ACE_TEXT("(%P|%t) ERROR: connection checker failed to open : %p\n"),
                       ACE_TEXT("open")),
                      false);
+  }
+
+  // Override with DCPSDefaultAddress.
+  if (this->tcp_config_->local_address() == ACE_INET_Addr () &&
+      !TheServiceParticipant->default_address ().empty ()) {
+    this->tcp_config_->local_address(0, TheServiceParticipant->default_address ().c_str ());
   }
 
   // Open our acceptor object so that we can accept passive connections

--- a/dds/DCPS/transport/udp/UdpTransport.cpp
+++ b/dds/DCPS/transport/udp/UdpTransport.cpp
@@ -177,10 +177,16 @@ UdpTransport::configure_i(TransportInst* config)
 
   create_reactor_task();
 
+  // Override with DCPSDefaultAddress.
+  if (this->config_i_->local_address() == ACE_INET_Addr () &&
+      !TheServiceParticipant->default_address ().empty ()) {
+    this->config_i_->local_address(0, TheServiceParticipant->default_address ().c_str ());
+  }
+
   // Our "server side" data link is created here, similar to the acceptor_
   // in the TcpTransport implementation.  This establishes a socket as an
   // endpoint that we can advertise to peers via connection_info_i().
-  server_link_ = make_datalink(ACE_INET_Addr(), 0 /* priority */, false);
+  server_link_ = make_datalink(this->config_i_->local_address(), 0 /* priority */, false);
   return true;
 }
 


### PR DESCRIPTION
The tcp, udp, and multicast transports have a local_address config parameter.  The value of DCPSDefaultAddress will be used in lieu of local_address if local_address is not set and DCPSDefaultAddress is set.