### PR TITLE
Disable PoolAllocator use in standard library for the benefit of older compilers 

### DIFF
--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -122,7 +122,7 @@ bool operator!=(const PoolAllocator<T>&, const PoolAllocator<U>&)
 #define OPENDDS_LIST(T) std::list<T >
 #define OPENDDS_QUEUE(T) std::queue<T >
 
-#endif // OPENDDS_SAFETY_PROFILE
+#endif // OPENDDS_SAFETY_PROFILE && ACE_HAS_ALLOC_HOOKS
 
 
 #endif // OPENDDS_DCPS_POOL_ALLOCATOR_H

--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -9,7 +9,7 @@
 #include <queue>
 #include <set>
 
-#ifdef OPENDDS_SAFETY_PROFILE
+#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
 #include "dcps_export.h"
 #include "SafetyProfilePool.h"
 

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -15,7 +15,9 @@
 
 namespace OpenDDS { namespace RTPS {
 
+#ifndef OPENDDS_SAFETY_PROFILE
 using DCPS::operator!=;
+#endif
 
 namespace {
   void add_param(ParameterList& param_list, const Parameter& param) {

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -42,7 +42,9 @@ namespace {
 bool qosChanged(DDS::PublicationBuiltinTopicData& dest,
                 const DDS::PublicationBuiltinTopicData& src)
 {
+#ifndef OPENDDS_SAFETY_PROFILE
   using OpenDDS::DCPS::operator!=;
+#endif
   bool changed = false;
 
   // check each Changeable QoS policy value in Publication BIT Data
@@ -93,7 +95,9 @@ bool qosChanged(DDS::PublicationBuiltinTopicData& dest,
 bool qosChanged(DDS::SubscriptionBuiltinTopicData& dest,
                 const DDS::SubscriptionBuiltinTopicData& src)
 {
+#ifndef OPENDDS_SAFETY_PROFILE
   using OpenDDS::DCPS::operator!=;
+#endif
   bool changed = false;
 
   // check each Changeable QoS policy value in Subcription BIT Data

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -195,7 +195,9 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
   } else {
     // update an existing participant
     pdata.ddsParticipantData.key = iter->second.pdata_.ddsParticipantData.key;
+#ifndef OPENDDS_SAFETY_PROFILE
     using OpenDDS::DCPS::operator!=;
+#endif
     if (iter->second.pdata_.ddsParticipantData.user_data !=
         pdata.ddsParticipantData.user_data) {
       iter->second.pdata_.ddsParticipantData.user_data =

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -15,7 +15,9 @@
 
 #include <cstring>
 
+#ifndef OPENDDS_SAFETY_PROFILE
 using OpenDDS::DCPS::operator==;
+#endif
 
 namespace FACE {
 namespace TS {

--- a/tests/DCPS/FooTest4/main.cpp
+++ b/tests/DCPS/FooTest4/main.cpp
@@ -184,7 +184,9 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       ::DDS::SubscriberQos default_sub_qos;
       dp->get_default_subscriber_qos (default_sub_qos);
 
+#ifndef OPENDDS_SAFETY_PROFILE
       using OpenDDS::DCPS::operator==;
+#endif
       if (! (sub_qos_got == default_sub_qos))
       {
         ACE_ERROR ((LM_ERROR,


### PR DESCRIPTION
For example GCC 4.1, which mistakenly causes free to be called.