### PR TITLE
appveyor_run_test.pl update:

### DIFF
--- a/DevGuideExamples/DCPS/Messenger/appveyor_run_test.pl
+++ b/DevGuideExamples/DCPS/Messenger/appveyor_run_test.pl
@@ -13,7 +13,7 @@ use strict;
 
 my $status = 0;
 my $common_opts = "-ORBDebugLevel 1 -ORBVerboseLogging 1 -DCPSDebugLevel 2 ".
-    "-DCPSTransportDebugLevel 3";
+    "-DCPSTransportDebugLevel 3 -DCPSDefaultAddress 127.0.0.1";
 
 my $pub_opts = $common_opts;
 my $sub_opts = $common_opts;


### PR DESCRIPTION
Set Default Address as a workaround due to failure currently
on appveyor to successfully connect on dynamically discovered
fully qualified hostname.