### PR TITLE
Updated handling of QoS in WriteDataContainer:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ lib*.dylib
 *.sln
 *.suo
 .*.swp
+*.VC.db
 *.VC.opendb
 
 /setenv.sh

--- a/dds/DCPS/DataDurabilityCache.cpp
+++ b/dds/DCPS/DataDurabilityCache.cpp
@@ -481,11 +481,12 @@ OpenDDS::DCPS::DataDurabilityCache::insert(
 
   // Apply DURABILITY_SERVICE QoS HISTORY and RESOURCE_LIMITS related
   // settings prior to data insertion into the cache.
-  CORBA::Long const depth =
-    get_instance_sample_list_depth(
-      qos.history_kind,
-      qos.history_depth,
-      qos.max_samples_per_instance);
+  int depth = qos.history_kind == DDS::KEEP_ALL_HISTORY_QOS
+    ? qos.max_samples_per_instance
+    : qos.history_depth;
+
+  if (depth == DDS::LENGTH_UNLIMITED)
+    depth = 0x7fffffff;
 
   // Iterator to first DataSampleElement to be copied.
   SendStateDataSampleList::iterator element(the_data.begin());

--- a/dds/DCPS/DataSampleElement.h
+++ b/dds/DCPS/DataSampleElement.h
@@ -169,6 +169,7 @@ private:
 
   /// Thread of data within the instance.
   mutable DataSampleElement* next_instance_sample_;
+  mutable DataSampleElement* previous_instance_sample_;
 
   /// Thread of data being unsent/sending/sent/released.
   mutable DataSampleElement* next_send_sample_;

--- a/dds/DCPS/DataSampleElement.inl
+++ b/dds/DCPS/DataSampleElement.inl
@@ -28,6 +28,7 @@ DataSampleElement::DataSampleElement(
     previous_writer_sample_(0),
     next_writer_sample_(0),
     next_instance_sample_(0),
+    previous_instance_sample_(0),
     next_send_sample_(0),
     previous_send_sample_(0)
 
@@ -55,6 +56,7 @@ DataSampleElement::DataSampleElement(const DataSampleElement& elem)
   , previous_writer_sample_(elem.previous_writer_sample_)
   , next_writer_sample_(elem.next_writer_sample_)
   , next_instance_sample_(elem.next_instance_sample_)
+  , previous_instance_sample_(elem.previous_instance_sample_)
   , next_send_sample_(elem.next_send_sample_)
   , previous_send_sample_(elem.previous_send_sample_)
 
@@ -89,6 +91,7 @@ DataSampleElement::operator=(const DataSampleElement& rhs)
   previous_writer_sample_ = rhs.previous_writer_sample_;
   next_writer_sample_ = rhs.next_writer_sample_;
   next_instance_sample_ = rhs.next_instance_sample_;
+  previous_instance_sample_ = rhs.previous_instance_sample_;
   next_send_sample_ = rhs.next_send_sample_;
   previous_send_sample_ = rhs.previous_send_sample_;
   send_listener_ = rhs.send_listener_;

--- a/dds/DCPS/InstanceDataSampleList.h
+++ b/dds/DCPS/InstanceDataSampleList.h
@@ -32,10 +32,8 @@ class DataSampleElement;
 class OpenDDS_Dcps_Export InstanceDataSampleList {
 
  public:
-
-  /// Default constructor clears the list.
   InstanceDataSampleList();
-  ~InstanceDataSampleList(){};
+  ~InstanceDataSampleList(){}
 
   /// Reset to initial state.
   void reset();
@@ -43,6 +41,10 @@ class OpenDDS_Dcps_Export InstanceDataSampleList {
   ssize_t size() const;
   DataSampleElement* head() const;
   DataSampleElement* tail() const;
+
+  static bool on_some_list(const DataSampleElement* iter);
+  static DataSampleElement* next(const DataSampleElement* iter);
+  static DataSampleElement* prev(const DataSampleElement* iter);
 
   void enqueue_tail(const DataSampleElement* element);
 

--- a/dds/DCPS/InstanceDataSampleList.inl
+++ b/dds/DCPS/InstanceDataSampleList.inl
@@ -48,6 +48,20 @@ InstanceDataSampleList::tail() const
 }
 
 ACE_INLINE
+DataSampleElement*
+InstanceDataSampleList::next(const DataSampleElement* iter)
+{
+  return iter->next_instance_sample_;
+}
+
+ACE_INLINE
+DataSampleElement*
+InstanceDataSampleList::prev(const DataSampleElement* iter)
+{
+  return iter->previous_instance_sample_;
+}
+
+ACE_INLINE
 void
 InstanceDataSampleList::enqueue_tail(const DataSampleElement* sample)
 {
@@ -58,16 +72,17 @@ InstanceDataSampleList::enqueue_tail(const DataSampleElement* sample)
 
   mSample->next_instance_sample_ = 0;
 
-  ++ size_ ;
+  ++size_;
 
   if (head_ == 0) {
     // First sample on queue.
-    head_ = tail_ = mSample ;
+    head_ = tail_ = mSample;
 
   } else {
     // Another sample on an existing queue.
-    tail_->next_instance_sample_ = mSample ;
-    tail_ = mSample ;
+    tail_->next_instance_sample_ = mSample;
+    mSample->previous_instance_sample_ = tail_;
+    tail_ = mSample;
   }
 }
 
@@ -85,11 +100,13 @@ InstanceDataSampleList::dequeue_head(DataSampleElement*& stale)
     return false;
 
   } else {
-    --size_ ;
-    head_ = head_->next_instance_sample_ ;
+    --size_;
+    head_ = head_->next_instance_sample_;
 
     if (head_ == 0) {
       tail_ = 0;
+    } else {
+      head_->previous_instance_sample_ = 0;
     }
 
     stale->next_instance_sample_ = 0;

--- a/dds/DCPS/OwnershipManager.h
+++ b/dds/DCPS/OwnershipManager.h
@@ -28,14 +28,17 @@ class DataReaderImpl;
 
 class OpenDDS_Dcps_Export OwnershipManager {
 public:
-  typedef OPENDDS_VECTOR(DataReaderImpl* ) ReaderVec;
-  // The TypeInstanceMap is only used for EXCLUSIVE ownership.
+  typedef OPENDDS_VECTOR(DataReaderImpl*) ReaderVec;
+
+  // TypeInstanceMap is only used for EXCLUSIVE ownership.
   struct InstanceMap {
-    InstanceMap () : map_(0) {};
-    InstanceMap (void* map, DataReaderImpl* reader)
-    : map_(map) {
-      readers_.push_back (reader);
-    };
+    InstanceMap() : map_(0) {}
+    InstanceMap(void* map, DataReaderImpl* reader)
+    : map_(map)
+    {
+      readers_.push_back(reader);
+    }
+
     void* map_;
     ReaderVec readers_;
   };
@@ -43,22 +46,23 @@ public:
   typedef OPENDDS_MAP(OPENDDS_STRING, InstanceMap) TypeInstanceMap;
 
   struct WriterInfo {
-    WriterInfo (const PublicationId& pub_id,
-                const CORBA::Long& ownership_strength)
-                         : pub_id_ (pub_id),
-                           ownership_strength_ (ownership_strength)
-                           {};
-    WriterInfo ()
-                      : pub_id_ (GUID_UNKNOWN),
-                        ownership_strength_ (0)
-                        {};
+    WriterInfo(const PublicationId& pub_id,
+               const CORBA::Long& ownership_strength)
+      : pub_id_(pub_id)
+      , ownership_strength_(ownership_strength)
+    {}
+
+    WriterInfo()
+      : pub_id_(GUID_UNKNOWN)
+      , ownership_strength_(0)
+    {}
 
     PublicationId pub_id_;
     CORBA::Long ownership_strength_;
   };
 
   typedef OPENDDS_VECTOR(WriterInfo) WriterInfos;
-  typedef OPENDDS_VECTOR(InstanceState* ) InstanceStateVec;
+  typedef OPENDDS_VECTOR(InstanceState*) InstanceStateVec;
 
   struct OwnershipWriterInfos {
     WriterInfo owner_;
@@ -66,31 +70,32 @@ public:
     InstanceStateVec instance_states_;
   };
 
-  typedef OPENDDS_MAP( ::DDS::InstanceHandle_t, OwnershipWriterInfos) InstanceOwnershipWriterInfos;
+  typedef OPENDDS_MAP(DDS::InstanceHandle_t, OwnershipWriterInfos)
+    InstanceOwnershipWriterInfos;
 
-  OwnershipManager ();
-  ~OwnershipManager ();
+  OwnershipManager();
+  ~OwnershipManager();
 
   /**
   * Acquire/release lock for type instance map.
   * The following functions are synchnorized by instance_lock_.
   */
-  int instance_lock_acquire ();
-  int instance_lock_release ();
+  int instance_lock_acquire();
+  int instance_lock_release();
 
   /**
   * The instance map per type is created by the concrete datareader
   * when first sample with the type is received.
   */
-  void set_instance_map (const char* type_name,
-                         void* instance_map,
-                         DataReaderImpl* reader);
+  void set_instance_map(const char* type_name,
+                        void* instance_map,
+                        DataReaderImpl* reader);
 
   /**
   * Accesor of the instance map for provided type. It is called once
   * for each new instance in a datareader.
   */
-  void* get_instance_map (const char* type_name, DataReaderImpl* reader);
+  void* get_instance_map(const char* type_name, DataReaderImpl* reader);
 
   /**
   * The readers that access the instance map are keep tracked as ref
@@ -99,36 +104,36 @@ public:
   * is deleted upon the last reader unregistering an instance of the
   * type.
   */
-  void  unregister_reader (const char* type_name,
-                           DataReaderImpl* reader);
+  void  unregister_reader(const char* type_name,
+                          DataReaderImpl* reader);
 
   /**
   * Remove a writer from all instances ownership collection.
   */
-  void remove_writer (const PublicationId& pub_id);
+  void remove_writer(const PublicationId& pub_id);
 
   /**
   * Remove all writers that write to the specified instance.
   */
-  void remove_writers (const ::DDS::InstanceHandle_t& instance_handle);
+  void remove_writers(const DDS::InstanceHandle_t& instance_handle);
 
   /**
   * Remove a writer that write to the specified instance.
   * Return true if it's the owner writer removed.
   */
-  bool remove_writer (const ::DDS::InstanceHandle_t& instance_handle,
-                      const PublicationId& pub_id);
+  bool remove_writer(const DDS::InstanceHandle_t& instance_handle,
+                     const PublicationId& pub_id);
 
   /**
   * Return true if the provide writer is the owner of the instance.
   */
-  bool is_owner (const ::DDS::InstanceHandle_t& instance_handle,
-                 const PublicationId& pub_id);
+  bool is_owner(const DDS::InstanceHandle_t& instance_handle,
+                const PublicationId& pub_id);
 
   /**
   * Determine if the provided publication can be the owner.
   */
-  bool select_owner(const ::DDS::InstanceHandle_t& instance_handle,
+  bool select_owner(const DDS::InstanceHandle_t& instance_handle,
                     const PublicationId& pub_id,
                     const CORBA::Long& ownership_strength,
                     InstanceState* instance_state);
@@ -136,31 +141,31 @@ public:
   /**
   * Remove an owner of the specified instance.
   */
-  void remove_owner (const ::DDS::InstanceHandle_t& instance_handle);
+  void remove_owner(const DDS::InstanceHandle_t& instance_handle);
 
   void remove_instance(InstanceState* instance_state);
 
   /**
   * Update the ownership strength of a publication.
   */
-  void update_ownership_strength (const PublicationId& pub_id,
-                                  const CORBA::Long& ownership_strength);
+  void update_ownership_strength(const PublicationId& pub_id,
+                                 const CORBA::Long& ownership_strength);
 
 private:
 
-  bool remove_writer (const ::DDS::InstanceHandle_t& instance_handle,
-                      OwnershipWriterInfos& infos,
-                      const PublicationId& pub_id);
-
-  void remove_owner (const ::DDS::InstanceHandle_t& instance_handle,
+  bool remove_writer(const DDS::InstanceHandle_t& instance_handle,
                      OwnershipWriterInfos& infos,
-                     bool sort);
+                     const PublicationId& pub_id);
+  
+  void remove_owner(const DDS::InstanceHandle_t& instance_handle,
+                    OwnershipWriterInfos& infos,
+                    bool sort);
 
-  void remove_candidate (OwnershipWriterInfos& infos,const PublicationId& pub_id);
+  void remove_candidate(OwnershipWriterInfos& infos,const PublicationId& pub_id);
 
-  void broadcast_new_owner (const ::DDS::InstanceHandle_t& instance_handle,
-                            OwnershipWriterInfos& infos,
-                            const PublicationId& owner);
+  void broadcast_new_owner(const DDS::InstanceHandle_t& instance_handle,
+                           OwnershipWriterInfos& infos,
+                           const PublicationId& owner);
 
   ACE_Thread_Mutex instance_lock_;
   TypeInstanceMap type_instance_map_;

--- a/dds/DCPS/OwnershipManager.h
+++ b/dds/DCPS/OwnershipManager.h
@@ -156,7 +156,7 @@ private:
   bool remove_writer(const DDS::InstanceHandle_t& instance_handle,
                      OwnershipWriterInfos& infos,
                      const PublicationId& pub_id);
-  
+
   void remove_owner(const DDS::InstanceHandle_t& instance_handle,
                     OwnershipWriterInfos& infos,
                     bool sort);

--- a/dds/DCPS/PublicationInstance.h
+++ b/dds/DCPS/PublicationInstance.h
@@ -71,6 +71,9 @@ struct OpenDDS_Dcps_Export PublicationInstance : public PoolAllocationBase {
   ACE_Time_Value   cur_sample_tv_;
 
   long             deadline_timer_id_;
+
+  /// Only used by WriteDataContainer::reenqueue_all() while WDC is locked.
+  ssize_t durable_samples_remaining_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/Qos_Helper.h
+++ b/dds/DCPS/Qos_Helper.h
@@ -39,12 +39,6 @@ DDS::Duration_t time_value_to_duration(const ACE_Time_Value& tv);
 ACE_INLINE OpenDDS_Dcps_Export
 DDS::Duration_t time_to_duration(const DDS::Time_t& t);
 
-ACE_INLINE OpenDDS_Dcps_Export
-CORBA::Long get_instance_sample_list_depth(
-  DDS::HistoryQosPolicyKind history,
-  long                        history_depth,
-  long                        max_samples_per_instance);
-
 /// Validate DDS::Duration_t value (infinite or positive and
 /// non-zero).
 ACE_INLINE OpenDDS_Dcps_Export

--- a/dds/DCPS/Qos_Helper.inl
+++ b/dds/DCPS/Qos_Helper.inl
@@ -709,38 +709,6 @@ DDS::Duration_t time_to_duration(const DDS::Time_t& t)
 }
 
 ACE_INLINE
-CORBA::Long
-get_instance_sample_list_depth(
-  DDS::HistoryQosPolicyKind history_kind,
-  long                        history_depth,
-  long                        max_samples_per_instance)
-{
-  CORBA::Long depth = 0;
-
-  if (history_kind == DDS::KEEP_ALL_HISTORY_QOS) {
-    // The spec says history_depth is "has no effect"
-    // when history_kind = KEEP_ALL so use
-    // max_samples_per_instance.
-    depth = max_samples_per_instance;
-
-  } else { // history.kind == DDS::KEEP_LAST_HISTORY_QOS
-    depth = history_depth;
-  }
-
-  if (depth == DDS::LENGTH_UNLIMITED) {
-    // DDS::LENGTH_UNLIMITED is negative so make it a positive
-    // value that is for all intents and purposes unlimited and we
-    // can use it for comparisons.  Use 2147483647L because that
-    // is the greatest value a signed CORBA::Long (a signed 32 bit
-    // integer) can have.
-    // WARNING: The client risks running out of memory in this case.
-    depth = 0x7fffffff; // ACE_Numeric_Limits<CORBA::Long>::max ();
-  }
-
-  return depth;
-}
-
-ACE_INLINE
 bool valid_duration(const DDS::Duration_t& t)
 {
   DDS::Duration_t const DDS_DURATION_INFINITY = {

--- a/dds/DCPS/SendStateDataSampleList.cpp
+++ b/dds/DCPS/SendStateDataSampleList.cpp
@@ -23,23 +23,21 @@ namespace DCPS {
 
 const SendStateDataSampleList*
 SendStateDataSampleList::send_list_containing_element(const DataSampleElement* element,
-                                                 OPENDDS_VECTOR(SendStateDataSampleList*) send_lists)
+                                                      SendStateDataSampleList** begin,
+                                                      SendStateDataSampleList** end)
 {
-  DataSampleElement* head = const_cast<DataSampleElement*>(element);
+  const DataSampleElement* head = element;
 
   while (head->previous_send_sample_ != 0) {
     head = head->previous_send_sample_;
   }
 
-  SendStateDataSampleList* list_containing_element = 0;
-
-  for(OPENDDS_VECTOR(SendStateDataSampleList*)::iterator it = send_lists.begin(); it != send_lists.end(); ++it) {
+  for (SendStateDataSampleList** it = begin; it != end; ++it) {
     if ((*it)->head_ == head) {
-        list_containing_element = *it;
-        break;
+      return *it;
     }
   }
-  return list_containing_element;
+  return 0;
 }
 
 

--- a/dds/DCPS/SendStateDataSampleList.h
+++ b/dds/DCPS/SendStateDataSampleList.h
@@ -90,6 +90,7 @@ private:
  * @c over the "send samples" in a @c SendStateDataSampleList.
  */
 class OpenDDS_Dcps_Export SendStateDataSampleListConstIterator
+  : public std::iterator<std::bidirectional_iterator_tag, DataSampleElement>
 {
 public:
   typedef const DataSampleElement* pointer;
@@ -145,22 +146,36 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
 
   friend class ::DDS_TEST;
 
+  static const SendStateDataSampleList*
+    send_list_containing_element(const DataSampleElement* element,
+                                 SendStateDataSampleList** begin,
+                                 SendStateDataSampleList** end);
+
  public:
 
   /// STL-style bidirectional iterator and const-iterator types.
   typedef SendStateDataSampleListIterator iterator;
   typedef SendStateDataSampleListConstIterator const_iterator;
 
+  typedef std::reverse_iterator<iterator> reverse_iterator;
+  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+
   /// Default constructor clears the list.
   SendStateDataSampleList();
-  ~SendStateDataSampleList(){};
+  ~SendStateDataSampleList(){}
 
   /// Returns a pointer to the SendStateDataSampleList containing a
   /// given DataSampleElement for use in the typical situation where
   /// the send state of a DataSampleElement is tracked by shifting
   /// it between distinct SendStateDataSampleLists, one for each state
-  static const SendStateDataSampleList* send_list_containing_element(const DataSampleElement* element,
-                                                                OPENDDS_VECTOR(SendStateDataSampleList*) send_lists);
+  template <size_t N>
+  static const SendStateDataSampleList*
+    send_list_containing_element(const DataSampleElement* element,
+                                 SendStateDataSampleList* (&send_lists)[N])
+  {
+    return send_list_containing_element(element,
+                                        &send_lists[0], &send_lists[N]);
+  }
 
   /// Reset to initial state.
   void reset();
@@ -168,6 +183,8 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
   ssize_t size() const;
   DataSampleElement* head() const;
   DataSampleElement* tail() const;
+
+  void enqueue_head(const DataSampleElement* element);
 
   void enqueue_tail(const DataSampleElement* element);
   void enqueue_tail(SendStateDataSampleList list);
@@ -184,18 +201,23 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
   iterator end();
   const_iterator end() const;
 
+  reverse_iterator rbegin();
+  const_reverse_iterator rbegin() const;
+  reverse_iterator rend();
+  const_reverse_iterator rend() const;
+
  protected:
 
-   /// The first element of the list.
-   DataSampleElement* head_;
+  /// The first element of the list.
+  DataSampleElement* head_;
 
-   /// The last element of the list.
-   DataSampleElement* tail_;
+  /// The last element of the list.
+  DataSampleElement* tail_;
 
-   /// Number of elements in the list.
-   ssize_t                size_;
-   //TBD size is never negative so should be size_t but this ripples through
-   // the transport code so leave it for now. SHH
+  /// Number of elements in the list.
+  ssize_t                size_;
+  //TBD size is never negative so should be size_t but this ripples through
+  // the transport code so leave it for now. SHH
 
 };
 

--- a/dds/DCPS/SendStateDataSampleList.inl
+++ b/dds/DCPS/SendStateDataSampleList.inl
@@ -50,6 +50,29 @@ SendStateDataSampleList::tail() const
 
 ACE_INLINE
 void
+SendStateDataSampleList::enqueue_head(const DataSampleElement* sample)
+{
+  ++size_;
+
+  // const_cast here so that higher layers don't need to pass around so many
+  // non-const pointers to DataSampleElement.  Ideally the design would be
+  // changed to accommodate const-correctness throughout.
+  DataSampleElement* mSample = const_cast<DataSampleElement*>(sample);
+
+  if (head_ == 0) {
+    // First sample in list.
+    head_ = tail_ = mSample;
+
+  } else {
+    // Add to existing list.
+    mSample->next_send_sample_ = head_;
+    head_->previous_send_sample_ = mSample;
+    head_ = mSample;
+  }
+}
+
+ACE_INLINE
+void
 SendStateDataSampleList::enqueue_tail(const DataSampleElement* sample)
 {
   ++size_;
@@ -135,6 +158,34 @@ SendStateDataSampleList::const_iterator
 SendStateDataSampleList::end() const
 {
   return const_iterator(this->head_, this->tail_, 0);
+}
+
+ACE_INLINE
+SendStateDataSampleList::reverse_iterator
+SendStateDataSampleList::rbegin()
+{
+  return reverse_iterator(end());
+}
+
+ACE_INLINE
+SendStateDataSampleList::reverse_iterator
+SendStateDataSampleList::rend()
+{
+  return reverse_iterator(begin());
+}
+
+ACE_INLINE
+SendStateDataSampleList::const_reverse_iterator
+SendStateDataSampleList::rbegin() const
+{
+  return const_reverse_iterator(end());
+}
+
+ACE_INLINE
+SendStateDataSampleList::const_reverse_iterator
+SendStateDataSampleList::rend() const
+{
+  return const_reverse_iterator(begin());
 }
 
 } // namespace DCPS

--- a/dds/DCPS/SendStateDataSampleList.inl
+++ b/dds/DCPS/SendStateDataSampleList.inl
@@ -60,12 +60,12 @@ SendStateDataSampleList::enqueue_head(const DataSampleElement* sample)
   DataSampleElement* mSample = const_cast<DataSampleElement*>(sample);
 
   if (head_ == 0) {
-    // First sample in list.
     head_ = tail_ = mSample;
+    sample->next_send_sample_ = sample->previous_send_sample_ = 0;
 
   } else {
-    // Add to existing list.
-    mSample->next_send_sample_ = head_;
+    sample->next_send_sample_ = head_;
+    sample->previous_send_sample_ = 0;
     head_->previous_send_sample_ = mSample;
     head_ = mSample;
   }
@@ -83,14 +83,12 @@ SendStateDataSampleList::enqueue_tail(const DataSampleElement* sample)
   DataSampleElement* mSample = const_cast<DataSampleElement*>(sample);
 
   if (head_ == 0) {
-    // First sample in list.
     head_ = tail_ = mSample;
+    sample->next_send_sample_ = sample->previous_send_sample_ = 0;
 
   } else {
-    // Add to existing list.
-    //sample->previous_writer_sample_ = tail_;
-    //tail_->next_writer_sample_ = sample;
-    mSample->previous_send_sample_ = tail_;
+    sample->previous_send_sample_ = tail_;
+    sample->next_send_sample_ = 0;
     tail_->next_send_sample_ = mSample;
     tail_ = mSample;
   }
@@ -109,9 +107,9 @@ SendStateDataSampleList::dequeue_head(DataSampleElement*& stale)
     return false;
 
   } else {
-    --size_ ;
+    --size_;
 
-    head_ = head_->next_send_sample_ ;
+    head_ = head_->next_send_sample_;
 
     if (head_ == 0) {
       tail_ = 0;
@@ -120,13 +118,8 @@ SendStateDataSampleList::dequeue_head(DataSampleElement*& stale)
       head_->previous_send_sample_ = 0;
     }
 
-    //else
-    //  {
-    //    head_->previous_writer_sample_ = 0;
-    //  }
-
-    stale->next_send_sample_ = 0 ;
-    stale->previous_send_sample_ = 0 ;
+    stale->next_send_sample_ = 0;
+    stale->previous_send_sample_ = 0;
 
     return true;
   }

--- a/dds/DCPS/WriterDataSampleList.h
+++ b/dds/DCPS/WriterDataSampleList.h
@@ -34,7 +34,7 @@ class OpenDDS_Dcps_Export WriterDataSampleList {
 
   /// Default constructor clears the list.
   WriterDataSampleList();
-  ~WriterDataSampleList(){};
+  ~WriterDataSampleList(){}
 
   /// Reset to initial state.
   void reset();

--- a/dds/DCPS/transport/framework/NetworkAddress.cpp
+++ b/dds/DCPS/transport/framework/NetworkAddress.cpp
@@ -465,14 +465,7 @@ bool open_appropriate_socket_type(ACE_SOCK_Dgram& socket, const ACE_INET_Addr& l
   }
   return true;
 #else
-  if (socket.open(local_address) != 0) {
-    ACE_ERROR_RETURN((LM_WARNING,
-      ACE_TEXT("(%P|%t) WARNING:")
-      ACE_TEXT("open_appropriate_socket_type: socket open not successful:")
-      ACE_TEXT("errno: %d\n"), errno),
-      false);
-  }
-  return true;
+  return socket.open(local_address) == 0;
 #endif
 }
 }

--- a/tests/DCPS/FooTest3_0/PubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/PubDriver.cpp
@@ -304,6 +304,11 @@ PubDriver::initialize(int& argc, ACE_TCHAR *argv[])
     dw_qos.liveliness.lease_duration.nanosec = 0;
   }
 
+  if (test_to_run_ == ALLOCATOR_TEST)
+  {
+    dw_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  }
+
   datawriter_
     = publisher_->create_datawriter(topic_.in (),
                                     dw_qos,

--- a/tests/FACE/Header/Subscriber/Subscriber.cpp
+++ b/tests/FACE/Header/Subscriber/Subscriber.cpp
@@ -97,38 +97,31 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
                   << std::dec << "\tttid: " << txn << std::endl;
       ++recv_msg_count;
       receiveMessageHappened = true;
-      if ((msg.count != expected) && expected > 0) {
-        std::cerr << "ERROR: Expected count " << expected << ", got "
-                  << msg.count << std::endl;
-        status = FACE::INVALID_PARAM;
+      FACE::TS::MessageHeader hdr;
+      FACE::TS::Receive_Message(connId, timeout, txn, hdr, sizeof(FACE::TS::MessageHeader), status);
+      if (status != FACE::RC_NO_ERROR) {
+        std::cout << "ERROR: Receive_Message for header failed for tid: " << txn << " with status: " << status << std::endl;
         break;
-      } else {
-        FACE::TS::MessageHeader hdr;
-        FACE::TS::Receive_Message(connId, timeout, txn, hdr, sizeof(FACE::TS::MessageHeader), status);
-        if (status != FACE::RC_NO_ERROR) {
-          std::cout << "ERROR: Receive_Message for header failed for tid: " << txn << " with status: " << status << std::endl;
-          break;
-        }
-        std::cout << "Message Header - tid: " << txn
-                  << "\n\tplatform view guid: " << hdr.platform_view_guid
-                  << "\n\tsource timestamp: " << hdr.message_timestamp
-                  << "\n\tinstance guid: " << std::hex << hdr.message_instance_guid
-                  << "\n\tsource guid: " << std::dec << hdr.message_source_guid
-                  << "\n\tvalidity " << hdr.message_validity << std::endl;
-        if (hdr.message_source_guid != 9645061) {
-          std::cout << "ERROR: Receive_Message for header failed.  Header source guid " << hdr.message_source_guid
-                    << " != 9645061" << std::endl;
-          status = FACE::INVALID_PARAM;
-          return status;
-        }
-        if (hdr.message_instance_guid != msg.msg_instance_guid) {
-            std::cout << "ERROR: Receive_Message for header failed.  message_instance_guid " << std::hex << hdr.message_instance_guid
-                      << " != " << msg.msg_instance_guid << std::endl;
-            status = FACE::INVALID_PARAM;
-            return status;
-        }
-        expected = msg.count + 1;
       }
+      std::cout << "Message Header - tid: " << txn
+                << "\n\tplatform view guid: " << hdr.platform_view_guid
+                << "\n\tsource timestamp: " << hdr.message_timestamp
+                << "\n\tinstance guid: " << std::hex << hdr.message_instance_guid
+                << "\n\tsource guid: " << std::dec << hdr.message_source_guid
+                << "\n\tvalidity " << hdr.message_validity << std::endl;
+      if (hdr.message_source_guid != 9645061) {
+        std::cout << "ERROR: Receive_Message for header failed.  Header source guid " << hdr.message_source_guid
+                  << " != 9645061" << std::endl;
+        status = FACE::INVALID_PARAM;
+        return status;
+      }
+      if (hdr.message_instance_guid != msg.msg_instance_guid) {
+        std::cout << "ERROR: Receive_Message for header failed.  message_instance_guid " << std::hex << hdr.message_instance_guid
+                  << " != " << msg.msg_instance_guid << std::endl;
+        status = FACE::INVALID_PARAM;
+        return status;
+      }
+      expected = msg.count + 1;
     }
   }
   bool testPassed = true;

--- a/tests/FACE/Reliability/Publisher/Publisher.cpp
+++ b/tests/FACE/Reliability/Publisher/Publisher.cpp
@@ -47,6 +47,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
       std::cout << "Test 1: PASSED" << std::endl;
       timeout_tests_status = FACE::RC_NO_ERROR;
     }
+    ACE_OS::sleep(1);
   }
   {
     std::cout << "Test 2: sending with TIMEOUT=0 MAX_BLOCKING=Default (100000000 nsec), should return INVALID_PARAM" << std::endl;
@@ -59,6 +60,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
       std::cout << "Test 2: PASSED" << std::endl;
       timeout_tests_status = FACE::RC_NO_ERROR;
     }
+    ACE_OS::sleep(1);
   }
 
   {
@@ -71,6 +73,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
         --retries;
       }
       FACE::TS::Send_Message(connId, 100000000, txn_INF, msg_INF, size_INF, timeout_tests_status);
+      ACE_OS::sleep(1);
     } while (timeout_tests_status == FACE::TIMED_OUT && retries > 0);
     if (timeout_tests_status != FACE::RC_NO_ERROR) {
       std::cout << "Test 3: ERROR: Send with TIMEOUT=100000000 nsec MAX_BLOCKING=Default (100000000 nsec) did not succeed." << std::endl;
@@ -90,6 +93,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
         --retries;
       }
       FACE::TS::Send_Message(connId, 200000000, txn_INF, msg_INF, size_INF, timeout_tests_status);
+      ACE_OS::sleep(1);
     } while (timeout_tests_status == FACE::TIMED_OUT && retries > 0);
     if (timeout_tests_status != FACE::RC_NO_ERROR) {
       std::cout << "Test 4: ERROR: Send with TIMEOUT=200000000 nsec MAX_BLOCKING=Default (100000000 nsec) did not succeed." << std::endl;
@@ -113,6 +117,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
         --retries;
       }
       FACE::TS::Send_Message(connId, FACE::INF_TIME_VALUE, txn, msg, size, status);
+      ACE_OS::sleep(1);
     } while (status == FACE::TIMED_OUT && retries > 0);
 
     if (status != FACE::RC_NO_ERROR) break;

--- a/tests/FACE/Utils.h
+++ b/tests/FACE/Utils.h
@@ -1,0 +1,16 @@
+#ifndef FACE_TEST_UTILS
+#define FACE_TEST_UTILS
+
+#include "FACE/common.hpp"
+
+namespace TestUtils {
+
+inline
+FACE::TIMEOUT_TYPE seconds_to_timeout(int sec)
+{
+  return ACE_INT64(sec) * 1000 * 1000 * 1000;
+}
+
+}
+
+#endif


### PR DESCRIPTION
- RESOURCE_LIMITS.max_samples_per_instance controls total samples that can be
  stored per instance, independent of HISTORY
- HISTORY.depth controls number of samples (per instance) that will be made
  available to late-joining readers if DURABILITY is enabled
  - KEEP_ALL history uses max_samples_per_instance as its depth
- WriteDataContainer is more eager to remove samples that are no longer needed
- WriteDataContainer will not remove samples that are required to implement
  DURABILITY, hence if RELIABILITY is enabled this can block a write() just
  like other "no resource available" scenarios