### PR TITLE
Portability and memory fixes for pull request #272

### DIFF
--- a/dds/DCPS/SendStateDataSampleList.h
+++ b/dds/DCPS/SendStateDataSampleList.h
@@ -13,6 +13,7 @@
 #include "Definitions.h"
 #include "transport/framework/TransportDefs.h"
 #include "Dynamic_Cached_Allocator_With_Overflow_T.h"
+#include "ace/config-lite.h"
 
 #include <iterator>
 
@@ -157,8 +158,21 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
   typedef SendStateDataSampleListIterator iterator;
   typedef SendStateDataSampleListConstIterator const_iterator;
 
+#if defined __SUNPRO_CC && __SUNPRO_CC <= 0x5130 \
+   && defined _RWSTD_NO_CLASS_PARTIAL_SPEC
+  typedef std::reverse_iterator<iterator, std::bidirectional_iterator_tag,
+                                DataSampleElement, DataSampleElement&,
+                                DataSampleElement*, std::ptrdiff_t>
+    reverse_iterator;
+  typedef std::reverse_iterator<const_iterator, std::bidirectional_iterator_tag,
+                                const DataSampleElement,
+                                const DataSampleElement&,
+                                const DataSampleElement*, std::ptrdiff_t>
+    const_reverse_iterator;
+#else
   typedef std::reverse_iterator<iterator> reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+#endif
 
   /// Default constructor clears the list.
   SendStateDataSampleList();

--- a/dds/DCPS/SendStateDataSampleList.h
+++ b/dds/DCPS/SendStateDataSampleList.h
@@ -41,11 +41,12 @@ class OpenDDS_Dcps_Export SendStateDataSampleListIterator
 {
 public:
 
-  /// Default constructor.
+  /// Default constructor required by ForwardIterator concept
+  SendStateDataSampleListIterator(){}
+
   /**
    * This constructor is used when constructing an "end" iterator.
    */
-
   SendStateDataSampleListIterator(DataSampleElement* head,
                          DataSampleElement* tail,
                          DataSampleElement* current);
@@ -71,8 +72,6 @@ public:
   }
 
 private:
-  SendStateDataSampleListIterator();
-
   DataSampleElement* head_;
   DataSampleElement* tail_;
   DataSampleElement* current_;
@@ -97,6 +96,8 @@ public:
   typedef const DataSampleElement* pointer;
   typedef const DataSampleElement& reference;
 
+  /// Default constructor required by ForwardIterator concept
+  SendStateDataSampleListConstIterator(){}
 
   SendStateDataSampleListConstIterator(const DataSampleElement* head,
                                   const DataSampleElement* tail,
@@ -124,8 +125,6 @@ public:
   }
 
 private:
-  SendStateDataSampleListConstIterator();
-
   const DataSampleElement* head_;
   const DataSampleElement* tail_;
   const DataSampleElement* current_;

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -592,7 +592,13 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       if (containing_list == &this->orphaned_to_transport_) {
         orphaned_to_transport_.dequeue(sample);
         release_buffer(stale);
+
+      } else if (!containing_list) {
+        // samples that were retrieved from get_resend_data()
+        // are not on any send-state list
+        release_buffer(stale);
       }
+
       //No-op: elements may be removed from all WriteDataContainer lists during shutdown
       //and inform transport of their release.  Transport will call data-delivered on the
       //elements as it processes the removal but they will already be gone from the send lists.
@@ -762,6 +768,13 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
                  ACE_TEXT("The dropped sample is not in sending_data_ and ")
                  ACE_TEXT("WAS IN unsent_data_ list.\n")));
     } else {
+
+      if (!containing_list) {
+        // samples that were retrieved from get_resend_data()
+        // are not on any send-state list
+        release_buffer(stale);
+      }
+
       //No-op: elements may be removed from all WriteDataContainer lists during shutdown
       //and inform transport of their release.  Transport will call data-dropped on the
       //elements as it processes the removal but they will already be gone from the send lists.

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -589,16 +589,6 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
                  ACE_TEXT("WAS IN unsent_data_ list.\n")));
     } else {
 
-      if (containing_list == &this->orphaned_to_transport_) {
-        orphaned_to_transport_.dequeue(sample);
-        release_buffer(stale);
-
-      } else if (!containing_list) {
-        // samples that were retrieved from get_resend_data()
-        // are not on any send-state list
-        release_buffer(stale);
-      }
-
       //No-op: elements may be removed from all WriteDataContainer lists during shutdown
       //and inform transport of their release.  Transport will call data-delivered on the
       //elements as it processes the removal but they will already be gone from the send lists.
@@ -614,6 +604,16 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
                      OPENDDS_STRING(converter).c_str()));
         }
         writer_->controlTracker.message_delivered();
+      }
+
+      if (containing_list == &this->orphaned_to_transport_) {
+        orphaned_to_transport_.dequeue(sample);
+        release_buffer(stale);
+
+      } else if (!containing_list) {
+        // samples that were retrieved from get_resend_data()
+        // are not on any send-state list
+        release_buffer(stale);
       }
 
       if (!pending_data())
@@ -769,12 +769,6 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
                  ACE_TEXT("WAS IN unsent_data_ list.\n")));
     } else {
 
-      if (!containing_list) {
-        // samples that were retrieved from get_resend_data()
-        // are not on any send-state list
-        release_buffer(stale);
-      }
-
       //No-op: elements may be removed from all WriteDataContainer lists during shutdown
       //and inform transport of their release.  Transport will call data-dropped on the
       //elements as it processes the removal but they will already be gone from the send lists.
@@ -791,11 +785,17 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
         }
         writer_->controlTracker.message_dropped();
       }
+
       if (containing_list == &this->orphaned_to_transport_) {
         orphaned_to_transport_.dequeue(sample);
         release_buffer(stale);
         if (!pending_data())
           empty_condition_.broadcast();
+
+      } else if (!containing_list) {
+        // samples that were retrieved from get_resend_data()
+        // are not on any send-state list
+        release_buffer(stale);
       }
     }
 


### PR DESCRIPTION
-  Release buffers for resent samples upon callback to WDC
- Standard-conforming iterators (Forward or stronger) need default constructors.
- Adapt to non-standard SunCC standard library.