### PR TITLE
WriteDataContainer and DataLink bug fixes

### DIFF
--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1027,6 +1027,10 @@ WriteDataContainer::obtain_buffer(DataSampleElement*& element,
 
   PublicationInstance* instance = get_handle_instance(handle);
 
+  if (!instance) {
+    return DDS::RETCODE_BAD_PARAMETER;
+  }
+
   ACE_NEW_MALLOC_RETURN(
     element,
     static_cast<DataSampleElement*>(

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -87,7 +87,7 @@ public:
   //Allows DataLink::stop to be done on the reactor thread so that
   //this thread avoids possibly deadlocking trying to access reactor
   //to stop strategies or schedule timers
-  void schedule_stop(ACE_Time_Value& schedule_to_stop_at);
+  void schedule_stop(const ACE_Time_Value& schedule_to_stop_at);
   /// The stop method is used to stop the DataLink prior to shutdown.
   void stop();
 
@@ -327,6 +327,8 @@ private:
                        const RepoId& readerId,
                        const RepoIdSet& incl_excl,
                        ReceiveListenerSet::ConstrainReceiveSet constrain);
+
+  void notify_reactor();
 
   typedef ACE_SYNCH_MUTEX     LockType;
 


### PR DESCRIPTION
- Check for invalid (but non-0) instance handle in write()
- One more fix to DataLink ref counting when interacting with Reactor