### PR TITLE
Solaris: Fix NOSIGNAL collision, nm variant

### DIFF
--- a/FACE/TS_common.hpp
+++ b/FACE/TS_common.hpp
@@ -2,6 +2,11 @@
 #define FACE_TS_COMMON_HPP_HEADER_FILE
 #include "common.hpp"
 
+// Solaris already has NOSIGNAL in system headers
+// which we do not use
+#ifdef NOSIGNAL
+#undef NOSIGNAL
+#endif
 
 namespace FACE {
 

--- a/FACE/TS_common.hpp
+++ b/FACE/TS_common.hpp
@@ -4,7 +4,7 @@
 
 // Solaris already has NOSIGNAL in system headers
 // which we do not use
-#if (defined (__sun) && defined (NOSIGNAL)) 
+#if (defined (__sun) && defined (NOSIGNAL))
 #undef NOSIGNAL
 #endif
 

--- a/FACE/TS_common.hpp
+++ b/FACE/TS_common.hpp
@@ -4,7 +4,7 @@
 
 // Solaris already has NOSIGNAL in system headers
 // which we do not use
-#ifdef NOSIGNAL
+#if (defined (__sun) && defined (NOSIGNAL)) 
 #undef NOSIGNAL
 #endif
 

--- a/java/build_scripts/jni_check.pl
+++ b/java/build_scripts/jni_check.pl
@@ -17,7 +17,11 @@ if ($^O eq 'MSWin32') {
   $nm = 'dumpbin /exports';
   @decorators = (['', '.dll'], ['', 'd.dll'], ['lib', '.dll']);
 } else {
-  $nm = 'nm -g -P';
+  if ($^O eq 'solaris') {
+    $nm = 'gnm -g -P';
+  } else {
+    $nm = 'nm -g -P';
+  }
   $pattern = '^_?(Java_\\S+) T ';
   @decorators = (['lib', '.so'], ['lib', '.sl'], ['lib', '.a'], ['lib', '.so'],
                  ['lib', '.dylib'], ['lib', '.so'], ['lib', '.dll']);


### PR DESCRIPTION
- Use the GNU version of nm (gnm) in jni_check.pl since solaris nm produces a slightly different output
- undef NOSIGNAL in FACE header if predefined by environment.