### PR TITLE
Fixed the missing lock in RtpsUpdDataLink which causes Sigfault in so…

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2561,6 +2561,7 @@ RtpsUdpDataLink::HeartBeat::disable()
 void
 RtpsUdpDataLink::send_final_acks (const RepoId& readerid)
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
   RtpsReaderMap::iterator rr = readers_.find (readerid);
   if (rr != readers_.end ()) {
     send_ack_nacks (rr, true);


### PR DESCRIPTION
Fixed the missing lock in RtpsUpdDataLink which causes Sigfault in some tests.