### PR TITLE
Use ACE_Event_Handler reference counting policy for ReactorIntercepto…

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -145,14 +145,11 @@ DataReaderImpl::~DataReaderImpl()
   }
 
   end_historic_sweeper_->wait();
-  end_historic_sweeper_->destroy();
 
   remove_association_sweeper_->wait();
-  remove_association_sweeper_->destroy();
 
   liveliness_timer_->cancel_timer();
   liveliness_timer_->wait();
-  liveliness_timer_->destroy();
 
   if (initialized_) {
     delete rd_allocator_;
@@ -179,7 +176,7 @@ DataReaderImpl::cleanup()
       iter != instances_.end();
       ++iter) {
     SubscriptionInstance *ptr = iter->second;
-    if (this->watchdog_ && ptr->deadline_timer_id_ != -1) {
+    if (this->watchdog_.in() && ptr->deadline_timer_id_ != -1) {
       this->watchdog_->cancel_timer(ptr);
     }
   }
@@ -977,21 +974,19 @@ DDS::ReturnCode_t DataReaderImpl::set_qos(
         || qos_.deadline.period.nanosec != qos.deadline.period.nanosec) {
       if (qos_.deadline.period.sec == DDS::DURATION_INFINITE_SEC
           && qos_.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
-        this->watchdog_ =
+        this->watchdog_.reset(
             new RequestedDeadlineWatchdog(
                 this->sample_lock_,
                 qos.deadline,
                 this,
                 this->dr_local_objref_.in(),
                 this->requested_deadline_missed_status_,
-                this->last_deadline_missed_total_count_);
+                this->last_deadline_missed_total_count_));
 
       } else if (qos.deadline.period.sec == DDS::DURATION_INFINITE_SEC
           && qos.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
         this->watchdog_->cancel_all();
-        this->watchdog_->destroy();
-        this->watchdog_ = 0;
-
+        this->watchdog_.reset();
       } else {
         this->watchdog_->reset_interval(
             duration_to_time_value(qos.deadline.period));
@@ -1291,14 +1286,14 @@ DataReaderImpl::enable()
   if (this->watchdog_ == 0
       && (deadline_period.sec != DDS::DURATION_INFINITE_SEC
           || deadline_period.nanosec != DDS::DURATION_INFINITE_NSEC)) {
-    this->watchdog_ =
+    this->watchdog_.reset(
         new RequestedDeadlineWatchdog(
             this->sample_lock_,
             this->qos_.deadline,
             this,
             this->dr_local_objref_.in(),
             this->requested_deadline_missed_status_,
-            this->last_deadline_missed_total_count_);
+            this->last_deadline_missed_total_count_));
   }
 
   Discovery_rch disco = TheServiceParticipant->get_discovery(domain_id_);
@@ -1560,7 +1555,7 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     }
 #endif
 
-    if (this->watchdog_) {
+    if (this->watchdog_.in()) {
       instance->last_sample_tv_ = instance->cur_sample_tv_;
       instance->cur_sample_tv_ = ACE_OS::gettimeofday();
 
@@ -1662,7 +1657,7 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     this->writer_activity(sample.header_);
     SubscriptionInstance* instance = 0;
 
-    if (this->watchdog_) {
+    if (this->watchdog_.in()) {
       // Find the instance first for timer cancellation since
       // the instance may be deleted during dispose and can
       // not be accessed.
@@ -1691,7 +1686,7 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     this->writer_activity(sample.header_);
     SubscriptionInstance* instance = 0;
 
-    if (this->watchdog_) {
+    if (this->watchdog_.in()) {
       // Find the instance first for timer cancellation since
       // the instance may be deleted during dispose and can
       // not be accessed.
@@ -1720,7 +1715,7 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     this->writer_activity(sample.header_);
     SubscriptionInstance* instance = 0;
 
-    if (this->watchdog_) {
+    if (this->watchdog_.in()) {
       // Find the instance first for timer cancellation since
       // the instance may be deleted during dispose and can
       // not be accessed.
@@ -2929,7 +2924,7 @@ void DataReaderImpl::post_read_or_take()
 
 void DataReaderImpl::reschedule_deadline()
 {
-  if (this->watchdog_) {
+  if (this->watchdog_.in()) {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, instance_guard, this->instances_lock_);
     for (SubscriptionInstanceMapType::iterator iter = this->instances_.begin();
         iter != this->instances_.end();

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -38,6 +38,7 @@
 #include "Service_Participant.h"
 #include "PoolAllocator.h"
 #include "RemoveAssociationSweeper.h"
+#include "RcEventHandler.h"
 
 #include "ace/String_Base.h"
 #include "ace/Reverse_Lock_T.h"
@@ -112,6 +113,7 @@ public:
 };
 
 #endif
+
 
 // Class to cleanup in case EndHistoricSamples is missed
 class EndHistoricSamplesMissedSweeper : public ReactorInterceptor {
@@ -692,8 +694,8 @@ private:
   DDS::DomainId_t              domain_id_;
   SubscriberImpl*              subscriber_servant_;
   DDS::DataReader_var          dr_local_objref_;
-  EndHistoricSamplesMissedSweeper* end_historic_sweeper_;
-  RemoveAssociationSweeper<DataReaderImpl>*        remove_association_sweeper_;
+  RcEventHandler<EndHistoricSamplesMissedSweeper> end_historic_sweeper_;
+  RcEventHandler<RemoveAssociationSweeper<DataReaderImpl> > remove_association_sweeper_;
 
   CORBA::Long                  depth_;
   size_t                       n_chunks_;
@@ -802,12 +804,12 @@ private:
       }
     };
   };
-  LivelinessTimer* liveliness_timer_;
+  RcEventHandler<LivelinessTimer> liveliness_timer_;
 
   CORBA::Long last_deadline_missed_total_count_;
   /// Watchdog responsible for reporting missed offered
   /// deadlines.
-  RequestedDeadlineWatchdog* watchdog_;
+  RcEventHandler<RequestedDeadlineWatchdog> watchdog_;
 
   /// Flag indicates that this datareader is a builtin topic
   /// datareader.

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -930,20 +930,19 @@ DataWriterImpl::set_qos(const DDS::DataWriterQos & qos)
           || qos_.deadline.period.nanosec != qos.deadline.period.nanosec) {
         if (qos_.deadline.period.sec == DDS::DURATION_INFINITE_SEC
             && qos_.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
-          this->watchdog_ =
+          this->watchdog_.reset(
                              new OfferedDeadlineWatchdog(
                                this->lock_,
                                qos.deadline,
                                this,
                                this->dw_local_objref_.in(),
                                this->offered_deadline_missed_status_,
-                               this->last_deadline_missed_total_count_);
+                               this->last_deadline_missed_total_count_));
 
         } else if (qos.deadline.period.sec == DDS::DURATION_INFINITE_SEC
                    && qos.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
           this->watchdog_->cancel_all();
-          this->watchdog_->destroy();
-          this->watchdog_ = 0;
+          this->watchdog_.reset();
 
         } else {
           this->watchdog_->reset_interval(
@@ -1361,13 +1360,13 @@ DataWriterImpl::enable()
 
   if (deadline_period.sec != DDS::DURATION_INFINITE_SEC
       || deadline_period.nanosec != DDS::DURATION_INFINITE_NSEC) {
-    this->watchdog_ = new OfferedDeadlineWatchdog(
+    this->watchdog_.reset( new OfferedDeadlineWatchdog(
                          this->lock_,
                          this->qos_.deadline,
                          this,
                          this->dw_local_objref_.in(),
                          this->offered_deadline_missed_status_,
-                         this->last_deadline_missed_total_count_);
+                         this->last_deadline_missed_total_count_));
   }
 
   Discovery_rch disco = TheServiceParticipant->get_discovery(this->domain_id_);
@@ -2577,7 +2576,7 @@ DataWriterImpl::persist_data()
 void
 DataWriterImpl::reschedule_deadline()
 {
-  if (this->watchdog_ != 0) {
+  if (this->watchdog_.in()) {
     this->data_container_->reschedule_deadline();
   }
 }

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -23,6 +23,7 @@
 #include "Qos_Helper.h"
 #include "CoherentChangeControl.h"
 #include "GuidUtils.h"
+#include "RcEventHandler.h"
 
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
 #include "FilterEvaluator.h"
@@ -671,7 +672,7 @@ private:
   CORBA::Long last_deadline_missed_total_count_;
   /// Watchdog responsible for reporting missed offered
   /// deadlines.
-  OfferedDeadlineWatchdog* watchdog_;
+  RcEventHandler<OfferedDeadlineWatchdog> watchdog_;
   /// The flag indicates whether the liveliness timer is scheduled and
   /// needs be cancelled.
   bool                       cancel_timer_;

--- a/dds/DCPS/RcEventHandler.h
+++ b/dds/DCPS/RcEventHandler.h
@@ -1,0 +1,148 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RCEVENTHANDLER_H
+#define OPENDDS_RCEVENTHANDLER_H
+
+#include "ace/Event_Handler.h"
+
+namespace OpenDDS {
+namespace DCPS {
+
+/// Templated Reference counted handle to a pointer.
+/// A non-DDS specific helper class.
+template <typename T>
+class RcEventHandler {
+public:
+
+  RcEventHandler()
+    : ptr_(0)
+  {}
+
+  explicit RcEventHandler(T* p)
+    : ptr_(p)
+  {
+    if (p)
+      p->reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
+  }
+
+  RcEventHandler(const RcEventHandler& b)
+    : ptr_(b.ptr_)
+  {
+    this->bump_up();
+  }
+
+  ~RcEventHandler()
+  {
+    this->bump_down();
+  }
+
+  void reset(T* p=0)
+  {
+    RcEventHandler tmp(p);
+    swap(tmp);
+  }
+
+  RcEventHandler& operator=(const RcEventHandler& b)
+  {
+    RcEventHandler tmp(b);
+    swap(tmp);
+    return *this;
+  }
+
+  void swap(RcEventHandler& rhs)
+  {
+    T* t = this->ptr_;
+    this->ptr_ = rhs.ptr_;
+    rhs.ptr_ = t;
+  }
+
+  T* operator->() const
+  {
+    return this->ptr_;
+  }
+
+  T& operator*() const
+  {
+    return *this->ptr_;
+  }
+
+  bool is_nil() const
+  {
+    return this->ptr_ == 0;
+  }
+
+  bool operator == (T* p) const {
+    return this->ptr_ == p;
+  }
+
+  T* in() const
+  {
+    return this->ptr_;
+  }
+
+  T*& inout()
+  {
+    return this->ptr_;
+  }
+
+  T*& out()
+  {
+    this->bump_down();
+    return this->ptr_;
+  }
+
+  T* _retn()
+  {
+    T* retval = this->ptr_;
+    this->ptr_ = 0;
+    return retval;
+  }
+
+  bool operator==(const RcEventHandler& rhs)
+  {
+    return in() == rhs.in();
+  }
+
+  bool operator!=(const RcEventHandler& rhs)
+  {
+    return in() != rhs.in();
+  }
+
+private:
+
+  void bump_up()
+  {
+    if (this->ptr_ != 0) {
+      this->ptr_->add_reference();
+    }
+  }
+
+  void bump_down()
+  {
+    if (this->ptr_ != 0) {
+      this->ptr_->remove_reference();
+      this->ptr_ = 0;
+    }
+  }
+
+  /// The actual "unsmart" pointer to the T object.
+  T* ptr_;
+};
+
+
+template <typename T>
+void swap(RcEventHandler<T>& lhs, RcEventHandler<T>& rhs)
+{
+  lhs.swap(rhs);
+}
+
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+#endif  /* OPENDDS_RCEVENTHANDLER_H */

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -17,8 +17,6 @@ ReactorInterceptor::ReactorInterceptor(ACE_Reactor* reactor,
                                        ACE_thread_t owner)
   : owner_(owner)
   , condition_(mutex_)
-  , registration_counter_(0)
-  , destroy_(false)
 {
   if (reactor == 0) {
     ACE_DEBUG((LM_ERROR, "(%P|%t) ERROR: ReactorInterceptor initialized with null reactor\n"));
@@ -50,7 +48,6 @@ void ReactorInterceptor::wait()
   if (should_execute_immediately()) {
     handle_exception_i(guard);
     reactor()->purge_pending_notifications(this);
-    registration_counter_ = 0;
   } else {
     while (!command_queue_.empty()) {
       condition_.wait();
@@ -58,23 +55,10 @@ void ReactorInterceptor::wait()
   }
 }
 
-void ReactorInterceptor::destroy()
-{
-  ACE_GUARD(ACE_Thread_Mutex, guard, this->mutex_);
-  if (!reactor_is_shut_down() && registration_counter_ > 0) {
-    // Wait until we get handle exception.
-    destroy_ = true;
-  } else {
-    guard.release();
-    delete this;
-  }
-}
 
 int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, this->mutex_, 0);
-
-  --registration_counter_;
 
   return handle_exception_i(guard);
 }
@@ -89,16 +73,12 @@ void ReactorInterceptor::process_command_queue()
   }
 }
 
-int ReactorInterceptor::handle_exception_i(ACE_Guard<ACE_Thread_Mutex>& guard)
+int ReactorInterceptor::handle_exception_i(ACE_Guard<ACE_Thread_Mutex>&)
 {
   process_command_queue();
 
   condition_.signal();
 
-  if (registration_counter_ == 0 && destroy_) {
-    guard.release();
-    delete this;
-  }
   return 0;
 }
 

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -27,9 +27,6 @@ public:
     virtual void execute() = 0;
   };
 
-  ReactorInterceptor(ACE_Reactor* reactor,
-                     ACE_thread_t owner);
-
   bool should_execute_immediately();
   void process_command_queue();
 
@@ -50,28 +47,27 @@ public:
   {
     ACE_GUARD(ACE_Thread_Mutex, guard, this->mutex_);
     command_queue_.push(new T(t));
-    ++registration_counter_;
     this->reactor()->notify(this);
   }
 
   void wait();
 
-  void destroy();
-
   virtual bool reactor_is_shut_down() const = 0;
 
 protected:
+  ReactorInterceptor(ACE_Reactor* reactor,
+                     ACE_thread_t owner);
+
   virtual ~ReactorInterceptor();
 
 private:
+
   int handle_exception(ACE_HANDLE /*fd*/);
   int handle_exception_i(ACE_Guard<ACE_Thread_Mutex>& guard);
   ACE_thread_t owner_;
   ACE_Thread_Mutex mutex_;
   ACE_Condition_Thread_Mutex condition_;
   OPENDDS_QUEUE(Command*) command_queue_;
-  ACE_UINT64 registration_counter_;
-  bool destroy_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -96,7 +96,6 @@ RecorderImpl::~RecorderImpl()
   }
 
   remove_association_sweeper_->wait();
-  remove_association_sweeper_->destroy();
 }
 
 

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -189,7 +189,7 @@ WriteDataContainer::enqueue(
   // Extract the instance queue.
   InstanceDataSampleList& instance_list = instance->samples_;
 
-  if (this->writer_->watchdog_) {
+  if (this->writer_->watchdog_.in()) {
     instance->last_sample_tv_ = instance->cur_sample_tv_;
     instance->cur_sample_tv_ = ACE_OS::gettimeofday();
     this->writer_->watchdog_->execute(instance, false);
@@ -329,7 +329,7 @@ WriteDataContainer::register_instance(
   // The registered_sample is shallow copied.
   registered_sample = instance->registered_sample_->duplicate();
 
-  if (this->writer_->watchdog_) {
+  if (this->writer_->watchdog_.in()) {
     this->writer_->watchdog_->schedule_timer(instance);
   }
 
@@ -368,7 +368,7 @@ WriteDataContainer::unregister(
   // Unregister the instance with typed DataWriter.
   this->writer_->unregistered(instance_handle);
 
-  if (this->writer_->watchdog_)
+  if (this->writer_->watchdog_.in())
     this->writer_->watchdog_->cancel_timer(instance);
 
   return DDS::RETCODE_OK;
@@ -424,7 +424,7 @@ WriteDataContainer::dispose(DDS::InstanceHandle_t instance_handle,
     }
   }
 
-  if (this->writer_->watchdog_)
+  if (this->writer_->watchdog_.in())
     this->writer_->watchdog_->cancel_timer(instance);
   return DDS::RETCODE_OK;
 }

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -89,7 +89,6 @@ TransportClient::~TransportClient()
   }
 
   pending_assoc_timer_->wait();
-  pending_assoc_timer_->destroy();
 
   for (OPENDDS_VECTOR(TransportImpl_rch)::iterator it = impls_.begin();
        it != impls_.end(); ++it) {

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -19,6 +19,7 @@
 #include "dds/DCPS/PoolAllocator.h"
 #include "dds/DCPS/PoolAllocationBase.h"
 #include "dds/DCPS/DiscoveryListener.h"
+#include "dds/DCPS/RcEventHandler.h"
 
 #include "ace/Time_Value.h"
 #include "ace/Event_Handler.h"
@@ -164,7 +165,7 @@ private:
   typedef OPENDDS_MAP_CMP(RepoId, DataLink_rch, GUID_tKeyLessThan) DataLinkIndex;
   typedef OPENDDS_VECTOR(TransportImpl_rch) ImplsType;
 
-  struct PendingAssoc : ACE_Event_Handler, public RcObject<ACE_SYNCH_MUTEX> {
+  struct PendingAssoc : ACE_Event_Handler {
     bool active_, removed_;
     ImplsType impls_;
     CORBA::ULong blob_index_;
@@ -177,11 +178,9 @@ private:
 
     bool initiate_connect(TransportClient* tc, Guard& guard);
     int handle_timeout(const ACE_Time_Value& time, const void* arg);
-    ACE_Event_Handler::Reference_Count add_reference() {  this->_add_ref(); return 1; }
-    ACE_Event_Handler::Reference_Count remove_reference() { this->_remove_ref(); return 1; }
   };
 
-  typedef RcHandle<PendingAssoc> PendingAssoc_rch;
+  typedef RcEventHandler<PendingAssoc> PendingAssoc_rch;
 
   typedef OPENDDS_MAP_CMP(RepoId, PendingAssoc_rch, GUID_tKeyLessThan) PendingMap;
 
@@ -256,7 +255,7 @@ private:
       }
     };
   };
-  PendingAssocTimer* pending_assoc_timer_;
+  RcEventHandler<PendingAssocTimer> pending_assoc_timer_;
 
   // Associated Impls and DataLinks:
 

--- a/dds/DCPS/transport/multicast/MulticastSession.cpp
+++ b/dds/DCPS/transport/multicast/MulticastSession.cpp
@@ -96,7 +96,6 @@ MulticastSession::~MulticastSession()
 {
   syn_watchdog_->cancel();
   syn_watchdog_->wait();
-  syn_watchdog_->destroy();
 }
 
 bool

--- a/dds/DCPS/transport/multicast/MulticastSession.h
+++ b/dds/DCPS/transport/multicast/MulticastSession.h
@@ -20,6 +20,7 @@
 #include "dds/DCPS/transport/framework/TransportHeader.h"
 #include "dds/DCPS/transport/framework/DataLinkWatchdog_T.h"
 #include "dds/DCPS/transport/framework/TransportReassembly.h"
+#include "dds/DCPS/RcEventHandler.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Reactor;
@@ -123,7 +124,7 @@ protected:
 
 private:
   ACE_Thread_Mutex ack_lock_;
-  SynWatchdog* syn_watchdog_;
+  RcEventHandler<SynWatchdog> syn_watchdog_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/multicast/ReliableSession.cpp
+++ b/dds/DCPS/transport/multicast/ReliableSession.cpp
@@ -70,7 +70,6 @@ ReliableSession::~ReliableSession()
 {
   nak_watchdog_->cancel();
   nak_watchdog_->wait();
-  nak_watchdog_->destroy();
 }
 
 bool

--- a/dds/DCPS/transport/multicast/ReliableSession.h
+++ b/dds/DCPS/transport/multicast/ReliableSession.h
@@ -17,6 +17,7 @@
 
 #include "dds/DCPS/DisjointSequence.h"
 #include "dds/DCPS/PoolAllocator.h"
+#include "dds/DCPS/RcEventHandler.h"
 
 namespace OpenDDS {
 namespace DCPS {
@@ -78,7 +79,7 @@ public:
   virtual void syn_hook(const SequenceNumber& seq);
 
 private:
-  NakWatchdog* nak_watchdog_;
+  RcEventHandler<NakWatchdog> nak_watchdog_;
 
   DisjointSequence nak_sequence_;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -65,8 +65,8 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport* transport,
                 config->nak_response_delay_),
     heartbeat_reply_(this, &RtpsUdpDataLink::send_heartbeat_replies,
                      config->heartbeat_response_delay_),
-  heartbeat_(reactor_task->get_reactor(), reactor_task->get_reactor_owner(), this, &RtpsUdpDataLink::send_heartbeats),
-  heartbeatchecker_(reactor_task->get_reactor(), reactor_task->get_reactor_owner(), this, &RtpsUdpDataLink::check_heartbeats)
+  heartbeat_(new HeartBeat(reactor_task->get_reactor(), reactor_task->get_reactor_owner(), this, &RtpsUdpDataLink::send_heartbeats)),
+  heartbeatchecker_(new HeartBeat(reactor_task->get_reactor(), reactor_task->get_reactor_owner(), this, &RtpsUdpDataLink::check_heartbeats))
 {
   std::memcpy(local_prefix_, local_prefix, sizeof(GuidPrefix_t));
 }
@@ -257,7 +257,7 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
 
   g.release();
   if (enable_heartbeat) {
-    heartbeat_.schedule_enable();
+    heartbeat_->schedule_enable();
   }
 }
 
@@ -296,7 +296,7 @@ RtpsUdpDataLink::register_for_reader(const RepoId& writerid,
   heartbeat_counts_[writerid] = 0;
   g.release();
   if (enableheartbeat) {
-    heartbeat_.schedule_enable();
+    heartbeat_->schedule_enable();
   }
 }
 
@@ -340,7 +340,7 @@ RtpsUdpDataLink::register_for_writer(const RepoId& readerid,
   interesting_writers_.insert(InterestingRemoteMapType::value_type(writerid, InterestingRemote(readerid, address, listener)));
   g.release();
   if (enableheartbeatchecker) {
-    heartbeatchecker_.schedule_enable();
+    heartbeatchecker_->schedule_enable();
   }
 }
 
@@ -528,7 +528,7 @@ RtpsUdpDataLink::stop_i()
 {
   nack_reply_.cancel();
   heartbeat_reply_.cancel();
-  heartbeat_.disable();
+  heartbeat_->disable();
   unicast_socket_.close();
   multicast_socket_.close();
 }
@@ -2195,7 +2195,7 @@ RtpsUdpDataLink::send_heartbeats()
   ACE_GUARD(ACE_Thread_Mutex, c, reader_no_longer_exists_lock_);
 
   if (writers_.empty() && interesting_readers_.empty()) {
-    heartbeat_.disable();
+    heartbeat_->disable();
   }
 
   using namespace OpenDDS::RTPS;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -31,6 +31,8 @@
 #include "dds/DCPS/PoolAllocator.h"
 #include "dds/DCPS/DiscoveryListener.h"
 #include "dds/DCPS/ReactorInterceptor.h"
+#include "dds/DCPS/RcEventHandler.h"
+
 
 class DDS_TEST;
 
@@ -418,7 +420,9 @@ private:
       HeartBeat* heartbeat_;
     };
 
-  } heartbeat_, heartbeatchecker_;
+  };
+
+  RcEventHandler<HeartBeat> heartbeat_, heartbeatchecker_;
 
   /// Data structure representing an "interesting" remote entity for static discovery.
   struct InterestingRemote {


### PR DESCRIPTION
Use ACE_Event_Handler reference policy to handle ReactorInterceptor object lifetime. 

Some tests failed because the interceptor objects were accessed after deletion. That was because the interceptor object use reactor_is_shut_down() to determine whether there would be more callbacks from reactor before it deleted itself. However, the logic was flawed because reactor_is_shut_down()  only indicated the starting of reactor shutdown process, it doesn't mean there wouldn't be any pending callbacks. Changing the flag to be set after the reactor being shut down doesn't help either. It only guarantees no double deletion but not guarantees the delete would happen.