### PR TITLE
When C++11 is enabled make use of C++11 shared_ptr and to_string instead…

### DIFF
--- a/examples/DCPS/ishapes/Circle.cpp
+++ b/examples/DCPS/ishapes/Circle.cpp
@@ -4,7 +4,7 @@
 
 
 Circle::Circle(const QRect& bounds,
-               boost::shared_ptr<ShapeDynamics> dynamics,
+               shared_ptr<ShapeDynamics> dynamics,
                const QPen& pen,
                const QBrush& brush,
                bool targeted)

--- a/examples/DCPS/ishapes/Circle.hpp
+++ b/examples/DCPS/ishapes/Circle.hpp
@@ -1,7 +1,6 @@
 #ifndef _CIRCLE_HPP
 #define _CIRCLE_HPP
 
-#include <boost/shared_ptr.hpp>
 #include <Shape.hpp>
 #include <ShapeDynamics.hpp>
 
@@ -9,7 +8,7 @@ class Circle : public Shape {
 public:
 
     Circle(const QRect& bounds,
-           boost::shared_ptr<ShapeDynamics> dynamics,
+           shared_ptr<ShapeDynamics> dynamics,
            const QPen& pen,
            const QBrush& brush,
            bool targeted = false);
@@ -24,7 +23,7 @@ private:
     Circle& operator=(Circle&);
 
 private:
-    boost::shared_ptr<ShapeDynamics> dynamics_;
+    shared_ptr<ShapeDynamics> dynamics_;
 };
 
 #endif /* _CIRCLE_HPP */

--- a/examples/DCPS/ishapes/DDSShapeDynamics.cpp
+++ b/examples/DCPS/ishapes/DDSShapeDynamics.cpp
@@ -1,7 +1,6 @@
 #include "DDSShapeDynamics.hpp"
 #include <iostream>
 
-#include <boost/cstdint.hpp>
 extern char* colorString_[];
 
 using org::omg::dds::demo::ShapeType;
@@ -48,8 +47,8 @@ DDSShapeDynamics::simulate() {
         DDS::ANY_INSTANCE_STATE);
 
   if (samples.length() > 0) {
-    boost::int32_t sampleIndex = -1;
-    boost::uint32_t i = 0;
+    CORBA::Long sampleIndex = -1;
+    CORBA::ULong i = 0;
 
     QPoint tmp;
     plist_.erase(plist_.begin(), plist_.end());

--- a/examples/DCPS/ishapes/DDSShapeDynamics.hpp
+++ b/examples/DCPS/ishapes/DDSShapeDynamics.hpp
@@ -7,8 +7,6 @@
 #include <QtGui/QtGui>
 #include <Shape.hpp>
 
-#include <boost/shared_ptr.hpp>
-
 #define CN 9
 
 class DDSShapeDynamics : public ShapeDynamics {
@@ -29,23 +27,20 @@ public:
        int x0, int y0,
        org::omg::dds::demo::ShapeTypeDataReader_var& shapeReader,
        const std::string& color,
-       int colorIdx
-       );
+       int colorIdx);
 
   virtual ~DDSShapeDynamics();
 
 public:
-
-  void setShape(boost::shared_ptr<Shape> shape) {
+  void setShape(shared_ptr<Shape> shape) {
     shape_ = shape;
   }
-
 
   virtual void simulate();
 private:
   DDSShapeDynamics(const DDSShapeDynamics& orig);
 
-  boost::shared_ptr<Shape> shape_;
+  shared_ptr<Shape> shape_;
   int x0_;
   int y0_;
   org::omg::dds::demo::ShapeTypeDataReader_var shapeReader_;

--- a/examples/DCPS/ishapes/Shape.hpp
+++ b/examples/DCPS/ishapes/Shape.hpp
@@ -4,6 +4,16 @@
 #include <QtCore/QRect>
 #include <QtGui/QPen>
 #include <QtGui/QBrush>
+#if defined (ACE_HAS_CPP11)
+# include <memory>
+using std::shared_ptr;
+#define STD_TO_STRING std::to_string
+#else
+# include <boost/shared_ptr.hpp>
+using boost::shared_ptr;
+#define STD_TO_STRING boost::lexical_cast<std::string>
+#endif /* ACE_HAS_CPP11 */
+
 
 class Shape {
 public:

--- a/examples/DCPS/ishapes/ShapesDialog.cpp
+++ b/examples/DCPS/ishapes/ShapesDialog.cpp
@@ -1,4 +1,3 @@
-#include <boost/shared_ptr.hpp>
 #include "config.hpp"
 #include "ShapesDialog.hpp"
 #include <QtGui/QtGui>
@@ -9,7 +8,6 @@
 #include <Triangle.hpp>
 #include <BouncingShapeDynamics.hpp>
 #include <DDSShapeDynamics.hpp>
-#include <boost/lexical_cast.hpp>
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DdsDcpsInfrastructureC.h>
 
@@ -203,10 +201,10 @@ ShapesDialog::onPublishButtonClicked() {
     ShapeTypeDataWriter_var dw =
       ShapeTypeDataWriter::_narrow(writer);
 
-    boost::shared_ptr<BouncingShapeDynamics>
+    shared_ptr<BouncingShapeDynamics>
       dynamics(new BouncingShapeDynamics(x, y, rect, constr, PI/6, speed,
            shape, dw));
-    boost::shared_ptr<Shape>
+    shared_ptr<Shape>
       circle(new Circle(rect, dynamics, pen, brush));
     shapesWidget->addShape(circle);
 
@@ -232,10 +230,10 @@ ShapesDialog::onPublishButtonClicked() {
     ShapeTypeDataWriter_var dw =
       ShapeTypeDataWriter::_narrow(writer);
 
-    boost::shared_ptr<BouncingShapeDynamics>
+    shared_ptr<BouncingShapeDynamics>
       dynamics(new BouncingShapeDynamics(x, y, rect, constr, PI/6, speed,
            shape, dw));
-    boost::shared_ptr<Shape>
+    shared_ptr<Shape>
       square(new Square(rect, dynamics, pen, brush));
     shapesWidget->addShape(square);
     // std::cout << "CREATE SQUARE" << std::endl;
@@ -261,10 +259,10 @@ ShapesDialog::onPublishButtonClicked() {
     ShapeTypeDataWriter_var dw =
       ShapeTypeDataWriter::_narrow(writer);
 
-    boost::shared_ptr<BouncingShapeDynamics>
+    shared_ptr<BouncingShapeDynamics>
       dynamics(new BouncingShapeDynamics(x, y, rect, constr, PI/6, speed,
            shape, dw));
-    boost::shared_ptr<Shape>
+    shared_ptr<Shape>
       triangle(new Triangle(rect, dynamics, pen, brush));
     shapesWidget->addShape(triangle);
     // std::cout << "CREATE TRIANGLE" << std::endl;
@@ -296,15 +294,11 @@ ShapesDialog::onSubscribeButtonClicked() {
   filterParams_ = DDS::StringSeq();
   if (filterDialog_->isEnabled()) {
     QRect rect =  filterDialog_->getFilterBounds();
-    std::string x0 =
-      boost::lexical_cast<std::string>(rect.x());
-    std::string x1 =
-      boost::lexical_cast<std::string>(rect.x() + rect.width());
+    std::string x0 = STD_TO_STRING (rect.x());
+    std::string x1 = STD_TO_STRING (rect.x() + rect.width());
 
-    std::string y0 =
-      boost::lexical_cast<std::string>(rect.y());
-    std::string y1 =
-      boost::lexical_cast<std::string>(rect.y() + rect.height());
+    std::string y0 = STD_TO_STRING (rect.y());
+    std::string y1 = STD_TO_STRING (rect.y() + rect.height());
     filterParams_.length(4);
     filterParams_[0] = x0.c_str();
     filterParams_[1] = x1.c_str();
@@ -392,9 +386,9 @@ ShapesDialog::onSubscribeButtonClicked() {
   case CIRCLE: {
     for (int i = 0; i < CN; ++i) {
       std::string colorStr(colorString_[i]);
-      boost::shared_ptr<DDSShapeDynamics>
+      shared_ptr<DDSShapeDynamics>
         dynamics(new DDSShapeDynamics(x, y, dr, colorStr, i));
-      boost::shared_ptr<Shape>
+      shared_ptr<Shape>
         circle(new Circle(rect, dynamics, pen, brush, true));
       dynamics->setShape(circle);
       shapesWidget->addShape(circle);
@@ -405,9 +399,9 @@ ShapesDialog::onSubscribeButtonClicked() {
   case SQUARE: {
     for (int i = 0; i < CN; ++i) {
       std::string colorStr(colorString_[i]);
-      boost::shared_ptr<DDSShapeDynamics>
+      shared_ptr<DDSShapeDynamics>
         dynamics(new DDSShapeDynamics(x, y, dr, colorStr, i));
-      boost::shared_ptr<Shape>
+      shared_ptr<Shape>
         square(new Square(rect, dynamics, pen, brush, true));
       dynamics->setShape(square);
       shapesWidget->addShape(square);
@@ -417,9 +411,9 @@ ShapesDialog::onSubscribeButtonClicked() {
   case TRIANGLE: {
     for (int i = 0; i < CN; ++i) {
       std::string colorStr(colorString_[i]);
-      boost::shared_ptr<DDSShapeDynamics>
+      shared_ptr<DDSShapeDynamics>
         dynamics(new DDSShapeDynamics(x, y, dr, colorStr, i));
-      boost::shared_ptr<Shape>
+      shared_ptr<Shape>
         triangle(new Triangle(rect, dynamics, pen, brush, true));
       dynamics->setShape(triangle);
       shapesWidget->addShape(triangle);

--- a/examples/DCPS/ishapes/ShapesWidget.cpp
+++ b/examples/DCPS/ishapes/ShapesWidget.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <QtGui/QtGui>
-#include <boost/shared_ptr.hpp>
-#include "ShapesWidget.hpp"
-
+#include <ShapesWidget.hpp>
 
 ShapesWidget::ShapesWidget(QWidget *parent)
 : QWidget(parent),
@@ -17,7 +15,7 @@ ShapesWidget::~ShapesWidget() {
 }
 
 void
-ShapesWidget::addShape(boost::shared_ptr<Shape> shape) {
+ShapesWidget::addShape(shared_ptr<Shape> shape) {
     shapeList_.push_back(shape);
 }
 

--- a/examples/DCPS/ishapes/ShapesWidget.hpp
+++ b/examples/DCPS/ishapes/ShapesWidget.hpp
@@ -6,15 +6,13 @@
 #include <QtCore/QRect>
 #include <QtGui/QPixmap>
 #include <vector>
-#include <boost/shared_ptr.hpp>
-
 #include <Shape.hpp>
 
 class ShapesWidget  : public QWidget
 {
   Q_OBJECT
   public:
-  typedef std::vector<boost::shared_ptr<Shape> > ShapeList;
+  typedef std::vector<shared_ptr<Shape> > ShapeList;
   typedef std::vector<QRect> FilterList;
 public:
 
@@ -27,7 +25,7 @@ public:
 
 public slots:
   void nextAnimationFrame();
-  void addShape(boost::shared_ptr<Shape> shape);
+  void addShape(shared_ptr<Shape> shape);
 
 protected:
   void paintEvent(QPaintEvent *event);

--- a/examples/DCPS/ishapes/Square.cpp
+++ b/examples/DCPS/ishapes/Square.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 Square::Square(const QRect& bounds,
-               boost::shared_ptr<ShapeDynamics> dynamics,
+               shared_ptr<ShapeDynamics> dynamics,
                const QPen& pen,
                const QBrush& brush,
                bool targeted)

--- a/examples/DCPS/ishapes/Square.hpp
+++ b/examples/DCPS/ishapes/Square.hpp
@@ -2,14 +2,13 @@
 #define _SQUARE_HPP
 
 #include <QtGui/QtGui>
-#include <boost/shared_ptr.hpp>
 #include <Shape.hpp>
 #include <ShapeDynamics.hpp>
 
 class Square : public Shape {
 public:
     Square(const QRect& bounds,
-           boost::shared_ptr<ShapeDynamics> dynamics,
+           shared_ptr<ShapeDynamics> dynamics,
            const QPen& pen,
            const QBrush& brush,
            bool targeted = false);
@@ -24,7 +23,7 @@ private:
     Square& operator=(const Square&);
 
 private:
-    boost::shared_ptr<ShapeDynamics> dynamics_;
+    shared_ptr<ShapeDynamics> dynamics_;
 
 };
 

--- a/examples/DCPS/ishapes/Triangle.cpp
+++ b/examples/DCPS/ishapes/Triangle.cpp
@@ -3,7 +3,7 @@
 #include "Triangle.hpp"
 
 Triangle::Triangle(const QRect& bounds,
-                   boost::shared_ptr<ShapeDynamics> dynamics,
+                   shared_ptr<ShapeDynamics> dynamics,
                    const QPen& pen,
                    const QBrush& brush,
                    bool targeted)

--- a/examples/DCPS/ishapes/Triangle.hpp
+++ b/examples/DCPS/ishapes/Triangle.hpp
@@ -1,14 +1,13 @@
 #ifndef _TRIANGLE_HPP
 #define _TRIANGLE_HPP
 
-#include <boost/shared_ptr.hpp>
 #include <Shape.hpp>
 #include <ShapeDynamics.hpp>
 
 class Triangle : public Shape {
 public:
   Triangle(const QRect& bounds,
-           boost::shared_ptr<ShapeDynamics> dynamics,
+           shared_ptr<ShapeDynamics> dynamics,
            const QPen& pen,
            const QBrush& brush,
            bool targeted = false);
@@ -25,7 +24,7 @@ private:
   Triangle& operator=(const Triangle&);
 
 private:
-  boost::shared_ptr<ShapeDynamics> dynamics_;
+  shared_ptr<ShapeDynamics> dynamics_;
   QPolygon triangle_;
 };
 


### PR DESCRIPTION
… of using boost

    * examples/DCPS/ishapes/Circle.cpp:
    * examples/DCPS/ishapes/Circle.hpp:
    * examples/DCPS/ishapes/DDSShapeDynamics.cpp:
    * examples/DCPS/ishapes/DDSShapeDynamics.hpp:
    * examples/DCPS/ishapes/Shape.hpp:
    * examples/DCPS/ishapes/ShapesDialog.cpp:
    * examples/DCPS/ishapes/ShapesWidget.cpp:
    * examples/DCPS/ishapes/ShapesWidget.hpp:
    * examples/DCPS/ishapes/Square.cpp:
    * examples/DCPS/ishapes/Square.hpp:
    * examples/DCPS/ishapes/Triangle.cpp:
    * examples/DCPS/ishapes/Triangle.hpp: