### PR TITLE
Remove the type specific datareader/writer implementation typedef from the user type…

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1098,7 +1098,7 @@ namespace OpenDDS {
         bool removed = endpoint_manager().disassociate(iter->second.pdata_);
         if (removed) {
 #ifndef DDS_HAS_MINIMUM_BIT
-          OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
+          ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
           // bit may be null if the DomainParticipant is shutting down
           if (bit && iter->second.bit_ih_ != DDS::HANDLE_NIL) {
             bit->set_instance_state(iter->second.bit_ih_,
@@ -1115,14 +1115,14 @@ namespace OpenDDS {
       }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-      OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit()
+      ParticipantBuiltinTopicDataDataReaderImpl* part_bit()
       {
         if (!bit_subscriber_.in())
           return 0;
 
         DDS::DataReader_var d =
           bit_subscriber_->lookup_datareader(DCPS::BUILT_IN_PARTICIPANT_TOPIC);
-        return dynamic_cast<OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
+        return dynamic_cast<ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
       }
 #endif /* DDS_HAS_MINIMUM_BIT */
 

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -23,6 +23,10 @@
 
 namespace OpenDDS {
   namespace DCPS {
+    typedef DataReaderImpl_T<DDS::ParticipantBuiltinTopicData> ParticipantBuiltinTopicDataDataReaderImpl;
+    typedef DataReaderImpl_T<DDS::PublicationBuiltinTopicData> PublicationBuiltinTopicDataDataReaderImpl;
+    typedef DataReaderImpl_T<DDS::SubscriptionBuiltinTopicData> SubscriptionBuiltinTopicDataDataReaderImpl;
+    typedef DataReaderImpl_T<DDS::TopicBuiltinTopicData> TopicBuiltinTopicDataDataReaderImpl;
 
     inline void assign(DCPS::EntityKey_t& lhs, unsigned int rhs)
     {
@@ -1094,7 +1098,7 @@ namespace OpenDDS {
         bool removed = endpoint_manager().disassociate(iter->second.pdata_);
         if (removed) {
 #ifndef DDS_HAS_MINIMUM_BIT
-          DDS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
+          OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
           // bit may be null if the DomainParticipant is shutting down
           if (bit && iter->second.bit_ih_ != DDS::HANDLE_NIL) {
             bit->set_instance_state(iter->second.bit_ih_,
@@ -1111,14 +1115,14 @@ namespace OpenDDS {
       }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-      DDS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit()
+      OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit()
       {
         if (!bit_subscriber_.in())
           return 0;
 
         DDS::DataReader_var d =
           bit_subscriber_->lookup_datareader(DCPS::BUILT_IN_PARTICIPANT_TOPIC);
-        return dynamic_cast<DDS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
+        return dynamic_cast<OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
       }
 #endif /* DDS_HAS_MINIMUM_BIT */
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -659,7 +659,7 @@ Sedp::Task::svc_i(Msg::MsgType which_bit, const DDS::InstanceHandle_t bit_ih)
 #ifndef DDS_HAS_MINIMUM_BIT
   switch (which_bit) {
   case Msg::MSG_REMOVE_FROM_PUB_BIT: {
-    DDS::PublicationBuiltinTopicDataDataReaderImpl* bit = sedp_->pub_bit();
+    OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl* bit = sedp_->pub_bit();
     // bit may be null if the DomainParticipant is shutting down
     if (bit && bit_ih != DDS::HANDLE_NIL) {
       bit->set_instance_state(bit_ih,
@@ -668,7 +668,7 @@ Sedp::Task::svc_i(Msg::MsgType which_bit, const DDS::InstanceHandle_t bit_ih)
     break;
   }
   case Msg::MSG_REMOVE_FROM_SUB_BIT: {
-    DDS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sedp_->sub_bit();
+    OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sedp_->sub_bit();
     // bit may be null if the DomainParticipant is shutting down
     if (bit && bit_ih != DDS::HANDLE_NIL) {
       bit->set_instance_state(bit_ih,
@@ -686,7 +686,7 @@ Sedp::Task::svc_i(Msg::MsgType which_bit, const DDS::InstanceHandle_t bit_ih)
 }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-DDS::TopicBuiltinTopicDataDataReaderImpl*
+OpenDDS::DCPS::TopicBuiltinTopicDataDataReaderImpl*
 Sedp::topic_bit()
 {
   DDS::Subscriber_var sub = spdp_.bit_subscriber();
@@ -695,10 +695,10 @@ Sedp::topic_bit()
 
   DDS::DataReader_var d =
     sub->lookup_datareader(DCPS::BUILT_IN_TOPIC_TOPIC);
-  return dynamic_cast<DDS::TopicBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<OpenDDS::DCPS::TopicBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 
-DDS::PublicationBuiltinTopicDataDataReaderImpl*
+OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl*
 Sedp::pub_bit()
 {
   DDS::Subscriber_var sub = spdp_.bit_subscriber();
@@ -707,10 +707,10 @@ Sedp::pub_bit()
 
   DDS::DataReader_var d =
     sub->lookup_datareader(DCPS::BUILT_IN_PUBLICATION_TOPIC);
-  return dynamic_cast<DDS::PublicationBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 
-DDS::SubscriptionBuiltinTopicDataDataReaderImpl*
+OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl*
 Sedp::sub_bit()
 {
   DDS::Subscriber_var sub = spdp_.bit_subscriber();
@@ -719,7 +719,7 @@ Sedp::sub_bit()
 
   DDS::DataReader_var d =
     sub->lookup_datareader(DCPS::BUILT_IN_SUBSCRIPTION_TOPIC);
-  return dynamic_cast<DDS::SubscriptionBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 #endif /* DDS_HAS_MINIMUM_BIT */
 
@@ -1002,7 +1002,7 @@ Sedp::data_received(DCPS::MessageId message_id,
       {
         // Release lock for call into pub_bit
         ACE_GUARD(ACE_Reverse_Lock< ACE_Thread_Mutex>, rg, rev_lock);
-        DDS::PublicationBuiltinTopicDataDataReaderImpl* bit = pub_bit();
+        OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl* bit = pub_bit();
         if (bit) { // bit may be null if the DomainParticipant is shutting down
           instance_handle =
             bit->store_synthetic_data(wdata_copy.ddsPublicationData,
@@ -1030,7 +1030,7 @@ Sedp::data_received(DCPS::MessageId message_id,
     } else if (qosChanged(iter->second.writer_data_.ddsPublicationData,
                           wdata.ddsPublicationData)) { // update existing
 #ifndef DDS_HAS_MINIMUM_BIT
-      DDS::PublicationBuiltinTopicDataDataReaderImpl* bit = pub_bit();
+      OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl* bit = pub_bit();
       if (bit) { // bit may be null if the DomainParticipant is shutting down
         bit->store_synthetic_data(iter->second.writer_data_.ddsPublicationData,
                                   DDS::NOT_NEW_VIEW_STATE);
@@ -1163,7 +1163,7 @@ Sedp::data_received(DCPS::MessageId message_id,
       {
         // Release lock for call into sub_bit
         ACE_GUARD(ACE_Reverse_Lock< ACE_Thread_Mutex>, rg, rev_lock);
-        DDS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sub_bit();
+        OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sub_bit();
         if (bit) { // bit may be null if the DomainParticipant is shutting down
           instance_handle =
             bit->store_synthetic_data(rdata_copy.ddsSubscriptionData,
@@ -1192,7 +1192,7 @@ Sedp::data_received(DCPS::MessageId message_id,
       if (qosChanged(iter->second.reader_data_.ddsSubscriptionData,
                      rdata.ddsSubscriptionData)) {
 #ifndef DDS_HAS_MINIMUM_BIT
-        DDS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sub_bit();
+        OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sub_bit();
         if (bit) { // bit may be null if the DomainParticipant is shutting down
           bit->store_synthetic_data(
                 iter->second.reader_data_.ddsSubscriptionData,

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -281,9 +281,9 @@ private:
   DCPS::TransportInst_rch transport_inst_;
 
 #ifndef DDS_HAS_MINIMUM_BIT
-  DDS::TopicBuiltinTopicDataDataReaderImpl* topic_bit();
-  DDS::PublicationBuiltinTopicDataDataReaderImpl* pub_bit();
-  DDS::SubscriptionBuiltinTopicDataDataReaderImpl* sub_bit();
+  OpenDDS::DCPS::TopicBuiltinTopicDataDataReaderImpl* topic_bit();
+  OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl* pub_bit();
+  OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl* sub_bit();
 #endif /* DDS_HAS_MINIMUM_BIT */
 
   void populate_discovered_writer_msg(

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -165,7 +165,7 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
     participants_[guid] = DiscoveredParticipant(pdata, time);
     DDS::InstanceHandle_t bit_instance_handle = DDS::HANDLE_NIL;
 #ifndef DDS_HAS_MINIMUM_BIT
-    OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
+    DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
     if (bit) {
       ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rg, rev_lock);
       bit_instance_handle =
@@ -203,7 +203,7 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
       iter->second.pdata_.ddsParticipantData.user_data =
         pdata.ddsParticipantData.user_data;
 #ifndef DDS_HAS_MINIMUM_BIT
-      OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
+      DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
       if (bit) {
         ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rg, rev_lock);
         bit->store_synthetic_data(pdata.ddsParticipantData,
@@ -273,7 +273,7 @@ Spdp::fini_bit()
 }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*
+DCPS::ParticipantBuiltinTopicDataDataReaderImpl*
 Spdp::part_bit()
 {
   if (!bit_subscriber_.in())
@@ -281,7 +281,7 @@ Spdp::part_bit()
 
   DDS::DataReader_var d =
     bit_subscriber_->lookup_datareader(DCPS::BUILT_IN_PARTICIPANT_TOPIC);
-  return dynamic_cast<OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<DCPS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 #endif /* DDS_HAS_MINIMUM_BIT */
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -165,7 +165,7 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
     participants_[guid] = DiscoveredParticipant(pdata, time);
     DDS::InstanceHandle_t bit_instance_handle = DDS::HANDLE_NIL;
 #ifndef DDS_HAS_MINIMUM_BIT
-    DDS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
+    OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
     if (bit) {
       ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rg, rev_lock);
       bit_instance_handle =
@@ -203,7 +203,7 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
       iter->second.pdata_.ddsParticipantData.user_data =
         pdata.ddsParticipantData.user_data;
 #ifndef DDS_HAS_MINIMUM_BIT
-      DDS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
+      OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
       if (bit) {
         ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rg, rev_lock);
         bit->store_synthetic_data(pdata.ddsParticipantData,
@@ -273,7 +273,7 @@ Spdp::fini_bit()
 }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-DDS::ParticipantBuiltinTopicDataDataReaderImpl*
+OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*
 Spdp::part_bit()
 {
   if (!bit_subscriber_.in())
@@ -281,7 +281,7 @@ Spdp::part_bit()
 
   DDS::DataReader_var d =
     bit_subscriber_->lookup_datareader(DCPS::BUILT_IN_PARTICIPANT_TOPIC);
-  return dynamic_cast<DDS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 #endif /* DDS_HAS_MINIMUM_BIT */
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -80,7 +80,7 @@ private:
   void data_received(const DataSubmessage& data, const ParameterList& plist);
 
 #ifndef DDS_HAS_MINIMUM_BIT
-  DDS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit();
+  OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit();
 #endif /* DDS_HAS_MINIMUM_BIT */
 
   struct SpdpTransport : ACE_Event_Handler, public OpenDDS::DCPS::PoolAllocationBase {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -80,7 +80,7 @@ private:
   void data_received(const DataSubmessage& data, const ParameterList& plist);
 
 #ifndef DDS_HAS_MINIMUM_BIT
-  OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit();
+  DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit();
 #endif /* DDS_HAS_MINIMUM_BIT */
 
   struct SpdpTransport : ACE_Event_Handler, public OpenDDS::DCPS::PoolAllocationBase {

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -113,7 +113,7 @@ void StaticEndpointManager::init_bit()
       //data.topic_data = topic_details.qos_.topic_data;
       data.group_data = writer.publisher_qos.group_data;
 #ifndef DDS_HAS_MINIMUM_BIT
-      DDS::PublicationBuiltinTopicDataDataReaderImpl* bit = pub_bit();
+      OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl* bit = pub_bit();
       if (bit) { // bit may be null if the DomainParticipant is shutting down
         bit->store_synthetic_data(data, DDS::NEW_VIEW_STATE);
       }
@@ -157,7 +157,7 @@ void StaticEndpointManager::init_bit()
       data.group_data = reader.subscriber_qos.group_data;
 
 #ifndef DDS_HAS_MINIMUM_BIT
-      DDS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sub_bit();
+      OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl* bit = sub_bit();
       if (bit) { // bit may be null if the DomainParticipant is shutting down
         bit->store_synthetic_data(data, DDS::NEW_VIEW_STATE);
       }
@@ -569,7 +569,7 @@ StaticEndpointManager::writer_does_not_exist(const RepoId& writerid, const RepoI
 }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-DDS::PublicationBuiltinTopicDataDataReaderImpl*
+OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl*
 StaticEndpointManager::pub_bit()
 {
   DDS::Subscriber_var sub = participant_.bit_subscriber();
@@ -577,10 +577,10 @@ StaticEndpointManager::pub_bit()
     return 0;
 
   DDS::DataReader_var d = sub->lookup_datareader(BUILT_IN_PUBLICATION_TOPIC);
-  return dynamic_cast<DDS::PublicationBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 
-DDS::SubscriptionBuiltinTopicDataDataReaderImpl*
+OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl*
 StaticEndpointManager::sub_bit()
 {
   DDS::Subscriber_var sub = participant_.bit_subscriber();
@@ -588,7 +588,7 @@ StaticEndpointManager::sub_bit()
     return 0;
 
   DDS::DataReader_var d = sub->lookup_datareader(BUILT_IN_SUBSCRIPTION_TOPIC);
-  return dynamic_cast<DDS::SubscriptionBuiltinTopicDataDataReaderImpl*>(d.in());
+  return dynamic_cast<OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl*>(d.in());
 }
 #endif /* DDS_HAS_MINIMUM_BIT */
 

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -197,8 +197,8 @@ public:
   virtual void writer_exists(const RepoId& writerid, const RepoId& readerid);
   virtual void writer_does_not_exist(const RepoId& writerid, const RepoId& readerid);
 #ifndef DDS_HAS_MINIMUM_BIT
-  DDS::PublicationBuiltinTopicDataDataReaderImpl* pub_bit();
-  DDS::SubscriptionBuiltinTopicDataDataReaderImpl* sub_bit();
+  OpenDDS::DCPS::PublicationBuiltinTopicDataDataReaderImpl* pub_bit();
+  OpenDDS::DCPS::SubscriptionBuiltinTopicDataDataReaderImpl* sub_bit();
 #endif /* DDS_HAS_MINIMUM_BIT */
 
 

--- a/dds/DCPS/TypeSupportImpl_T.h
+++ b/dds/DCPS/TypeSupportImpl_T.h
@@ -39,7 +39,7 @@ namespace OpenDDS {
     {
       typedef DataWriterImpl_T<MessageType> DataWriterImplType;
 
-      DataWriterImplType* writer_impl;
+      DataWriterImplType* writer_impl = 0;
       ACE_NEW_RETURN(writer_impl,
                      DataWriterImplType(),
                      ::DDS::DataWriter::_nil());

--- a/dds/idl/ts_generator.cpp
+++ b/dds/idl/ts_generator.cpp
@@ -86,8 +86,6 @@ bool ts_generator::gen_struct(AST_Structure*, UTL_ScopedName* name,
   be_global->add_include(dc.c_str());
 
   static const char* h_includes[] = {
-    "dds/DCPS/DataWriterImpl_T.h",
-    "dds/DCPS/DataReaderImpl_T.h",
     "dds/DCPS/TypeSupportImpl_T.h"
   };
   add_includes(h_includes, BE_GlobalData::STREAM_H);
@@ -141,8 +139,6 @@ bool ts_generator::gen_struct(AST_Structure*, UTL_ScopedName* name,
   {
     ScopedNamespaceGuard hGuard(name, be_global->header_);
     be_global->header_ <<
-      "  typedef OpenDDS::DCPS::DataWriterImpl_T<" << cxxName << "> " << short_name << "DataWriterImpl;\n"
-      "  typedef OpenDDS::DCPS::DataReaderImpl_T<" << cxxName << "> " << short_name << "DataReaderImpl;\n"
       "  typedef OpenDDS::DCPS::TypeSupportImpl_T<" << cxxName << "> " << short_name << "TypeSupportImpl;\n";
   }
 

--- a/performance-tests/DCPS/MulticastListenerTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/DataReaderListener.cpp
@@ -7,15 +7,13 @@
 #include "ace/Truncate.h"
 
 
-template<class Tseq, class R, class R_ptr, class Rimpl>
+template<class Tseq, class R, class R_ptr, class R_var>
 ::DDS::ReturnCode_t read (DataReaderListenerImpl* listener,
                           ::DDS::DataReader_ptr reader,
                           ACE_Array<bool>& pub_finished)
 {
-  R_ptr pt_dr
+  R_var var_dr
     = R::_narrow(reader);
-
-  Rimpl* dr_servant = dynamic_cast<Rimpl*> (pt_dr);
 
   const ::CORBA::Long max_read_samples = 100;
   Tseq samples(max_read_samples);
@@ -25,7 +23,7 @@ template<class Tseq, class R, class R_ptr, class Rimpl>
   DDS::ReturnCode_t status;
   // initialize to zero.
 
-  status = dr_servant->read (
+  status = var_dr->read (
     samples,
     infos,
     max_read_samples,
@@ -258,7 +256,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt128Seq,
                       ::Xyz::Pt128DataReader,
                       ::Xyz::Pt128DataReader_ptr,
-                      ::Xyz::Pt128DataReaderImpl>
+                      ::Xyz::Pt128DataReader_var>
                         (this,
                         reader,
                         pub_finished_);
@@ -270,7 +268,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt512Seq,
                       ::Xyz::Pt512DataReader,
                       ::Xyz::Pt512DataReader_ptr,
-                      ::Xyz::Pt512DataReaderImpl>
+                      ::Xyz::Pt512DataReader_var>
                         (this,
                         reader,
                         pub_finished_);
@@ -282,7 +280,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt2048Seq,
                       ::Xyz::Pt2048DataReader,
                       ::Xyz::Pt2048DataReader_ptr,
-                      ::Xyz::Pt2048DataReaderImpl>
+                      ::Xyz::Pt2048DataReader_var>
                         (this,
                         reader,
                         pub_finished_);
@@ -294,7 +292,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt8192Seq,
                       ::Xyz::Pt8192DataReader,
                       ::Xyz::Pt8192DataReader_ptr,
-                      ::Xyz::Pt8192DataReaderImpl>
+                      ::Xyz::Pt8192DataReader_var>
                         (this,
                         reader,
                         pub_finished_);

--- a/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
@@ -22,7 +22,7 @@ extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
 
 
 
-template<class T, class W, class W_var, class W_ptr, class Wimpl>
+template<class T, class W, class W_var, class W_ptr>
 void write (long id,
             int size,
             int num_messages,
@@ -42,8 +42,6 @@ void write (long id,
     = W::_narrow(writer);
   ACE_ASSERT (! CORBA::is_nil (pt_dw.in ()));
 
-  Wimpl* pt_servant = dynamic_cast<Wimpl*> (pt_dw.in ());
-
   ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) %T Writer::svc starting to write.\n")));
 
@@ -54,8 +52,7 @@ void write (long id,
   for (int i = 0; i < num_messages; i ++)
     {
       data.sequence_num = i;
-      pt_servant->write(data,
-                        handle);
+      pt_dw->write(data, handle);
       THROTTLE
     }
   }
@@ -63,8 +60,7 @@ void write (long id,
   for (int j = 0; j < 200; j ++)
     {
       data.sequence_num = -1;
-      pt_servant->write(data,
-                        handle);
+      pt_dw->write(data, handle);
       // throttle twice to slow the rate to ensure one gets sent.
       THROTTLE
       THROTTLE
@@ -137,8 +133,7 @@ Writer::svc ()
         write < ::Xyz::Pt128,
                ::Xyz::Pt128DataWriter,
                ::Xyz::Pt128DataWriter_var,
-               ::Xyz::Pt128DataWriter_ptr,
-               ::Xyz::Pt128DataWriterImpl>
+               ::Xyz::Pt128DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -152,8 +147,7 @@ Writer::svc ()
         write < ::Xyz::Pt512,
                ::Xyz::Pt512DataWriter,
                ::Xyz::Pt512DataWriter_var,
-               ::Xyz::Pt512DataWriter_ptr,
-               ::Xyz::Pt512DataWriterImpl>
+               ::Xyz::Pt512DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -167,8 +161,7 @@ Writer::svc ()
         write < ::Xyz::Pt2048,
                ::Xyz::Pt2048DataWriter,
                ::Xyz::Pt2048DataWriter_var,
-               ::Xyz::Pt2048DataWriter_ptr,
-               ::Xyz::Pt2048DataWriterImpl>
+               ::Xyz::Pt2048DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -182,8 +175,7 @@ Writer::svc ()
         write < ::Xyz::Pt8192,
                ::Xyz::Pt8192DataWriter,
                ::Xyz::Pt8192DataWriter_var,
-               ::Xyz::Pt8192DataWriter_ptr,
-               ::Xyz::Pt8192DataWriterImpl>
+               ::Xyz::Pt8192DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,

--- a/performance-tests/DCPS/SimpleE2ETest/Reader.cpp
+++ b/performance-tests/DCPS/SimpleE2ETest/Reader.cpp
@@ -10,7 +10,7 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 
 
-template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
+template<class Tseq, class R, class R_var, class R_ptr>
 ::DDS::ReturnCode_t read (TestStats* stats,
                           ::DDS::Subscriber_ptr subscriber,
                           ::DDS::DataReader_ptr reader)
@@ -23,8 +23,6 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
                 ACE_TEXT("(%P|%t) _narrow failed.\n")));
       throw TestException() ;
     }
-
-  Rimpl* dr_servant = dynamic_cast<Rimpl*> (pt_dr.in ());
 
   const ::CORBA::Long max_read_samples = 100;
   Tseq samples(max_read_samples);
@@ -44,8 +42,8 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
   // initialize to zero.
   ::DDS::SampleRejectedStatus rejected;
   ::DDS::SampleLostStatus lost;
-  if ((dr_servant->get_sample_rejected_status (rejected) != ::DDS::RETCODE_OK)
-    || (dr_servant->get_sample_lost_status (lost) != ::DDS::RETCODE_OK))
+  if ((pt_dr->get_sample_rejected_status (rejected) != ::DDS::RETCODE_OK)
+    || (pt_dr->get_sample_lost_status (lost) != ::DDS::RETCODE_OK))
   {
     ACE_ERROR((LM_ERROR,"ERROR: Failed to get sample reject or lost status.\n"));
     ACE_OS::exit (7);
@@ -54,7 +52,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
   while ( !stats->all_packets_received () )
     {
 
-      status = dr_servant->read (
+      status = pt_dr->read (
         samples,
         infos,
         max_read_samples,
@@ -77,7 +75,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
           zero_reads++;
 
           //ACE_DEBUG((LM_DEBUG,"got RETCODE_NO_DATA\n"));
-          if (dr_servant->get_sample_rejected_status (rejected) != ::DDS::RETCODE_OK)
+          if (pt_dr->get_sample_rejected_status (rejected) != ::DDS::RETCODE_OK)
             {
               ACE_ERROR((LM_ERROR,
                 ACE_TEXT ("ERROR: Failed to get sample rejected status.\n")));
@@ -90,7 +88,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
               stats->samples_received(rejected.total_count_change);
             }
 
-          if (dr_servant->get_sample_lost_status (lost) != ::DDS::RETCODE_OK)
+          if (pt_dr->get_sample_lost_status (lost) != ::DDS::RETCODE_OK)
             {
               ACE_ERROR((LM_ERROR,
                 ACE_TEXT ("ERROR: Failed to get sample lost status.\n")));
@@ -150,14 +148,6 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
 
   return ::DDS::RETCODE_OK;
 }
-
-
-
-
-
-
-
-
 
 Reader::Reader(::DDS::Subscriber_ptr subscriber,
                ::DDS::DataReader_ptr reader,
@@ -221,8 +211,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt128Seq,
                        ::Xyz::Pt128DataReader,
                        ::Xyz::Pt128DataReader_var,
-                       ::Xyz::Pt128DataReader_ptr,
-                       ::Xyz::Pt128DataReaderImpl>
+                       ::Xyz::Pt128DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),
@@ -237,8 +226,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt512Seq,
                        ::Xyz::Pt512DataReader,
                        ::Xyz::Pt512DataReader_var,
-                       ::Xyz::Pt512DataReader_ptr,
-                       ::Xyz::Pt512DataReaderImpl>
+                       ::Xyz::Pt512DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),
@@ -253,8 +241,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt2048Seq,
                        ::Xyz::Pt2048DataReader,
                        ::Xyz::Pt2048DataReader_var,
-                       ::Xyz::Pt2048DataReader_ptr,
-                       ::Xyz::Pt2048DataReaderImpl>
+                       ::Xyz::Pt2048DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),
@@ -269,8 +256,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt8192Seq,
                        ::Xyz::Pt8192DataReader,
                        ::Xyz::Pt8192DataReader_var,
-                       ::Xyz::Pt8192DataReader_ptr,
-                       ::Xyz::Pt8192DataReaderImpl>
+                       ::Xyz::Pt8192DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),

--- a/performance-tests/DCPS/SimpleE2ETest/Writer.cpp
+++ b/performance-tests/DCPS/SimpleE2ETest/Writer.cpp
@@ -8,7 +8,7 @@
 #include "ace/OS_NS_unistd.h"
 
 
-template<class T, class W, class W_var, class W_ptr, class Wimpl>
+template<class T, class W, class W_var, class W_ptr>
 void write (long id,
             int size,
             int num_messages,
@@ -27,8 +27,6 @@ void write (long id,
     = W::_narrow(writer);
   ACE_ASSERT (! CORBA::is_nil (pt_dw.in ()));
 
-  Wimpl* pt_servant = dynamic_cast<Wimpl*> (pt_dw.in ());
-
   //SHH remove this kludge when the transport is fixed.
   ACE_OS::sleep(5); // ensure that the connection has been fully established
   ACE_DEBUG((LM_DEBUG,
@@ -41,9 +39,7 @@ void write (long id,
   for (int i = 0; i < num_messages; i ++)
   {
     data.sequence_num = i;
-    ::DDS::ReturnCode_t ret
-       = pt_servant->write(data,
-                      handle);
+    ::DDS::ReturnCode_t ret = pt_dw->write(data, handle);
     if (ret != ::DDS::RETCODE_OK)
       {
         ACE_ERROR((LM_ERROR,
@@ -111,8 +107,7 @@ Writer::svc ()
         write < ::Xyz::Pt128,
                ::Xyz::Pt128DataWriter,
                ::Xyz::Pt128DataWriter_var,
-               ::Xyz::Pt128DataWriter_ptr,
-               ::Xyz::Pt128DataWriterImpl>
+               ::Xyz::Pt128DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -125,8 +120,7 @@ Writer::svc ()
         write < ::Xyz::Pt512,
                ::Xyz::Pt512DataWriter,
                ::Xyz::Pt512DataWriter_var,
-               ::Xyz::Pt512DataWriter_ptr,
-               ::Xyz::Pt512DataWriterImpl>
+               ::Xyz::Pt512DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -139,8 +133,7 @@ Writer::svc ()
         write < ::Xyz::Pt2048,
                ::Xyz::Pt2048DataWriter,
                ::Xyz::Pt2048DataWriter_var,
-               ::Xyz::Pt2048DataWriter_ptr,
-               ::Xyz::Pt2048DataWriterImpl>
+               ::Xyz::Pt2048DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -153,8 +146,7 @@ Writer::svc ()
         write < ::Xyz::Pt8192,
                ::Xyz::Pt8192DataWriter,
                ::Xyz::Pt8192DataWriter_var,
-               ::Xyz::Pt8192DataWriter_ptr,
-               ::Xyz::Pt8192DataWriterImpl>
+               ::Xyz::Pt8192DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,

--- a/performance-tests/DCPS/SimpleLatency/PubListener.cpp
+++ b/performance-tests/DCPS/SimpleLatency/PubListener.cpp
@@ -93,8 +93,8 @@ extern long total_samples;
 AckDataReaderListenerImpl::AckDataReaderListenerImpl(CORBA::Long /*size*/)
   :writer_ (),
    reader_ (),
-   dr_servant_ (0),
-   dw_servant_ (0),
+   dr_servant_ (),
+   dw_servant_ (),
    handle_ (),
    sample_num_(1),
    done_ (0),
@@ -120,15 +120,11 @@ void AckDataReaderListenerImpl::init(DDS::DataReader_ptr dr,
   this->reader_ = DDS::DataReader::_duplicate (dr);
   use_zero_copy_ = use_zero_copy_read;
 
-  AckMessageDataReader_var ackmessage_dr =
-    AckMessageDataReader::_narrow(this->reader_.in());
   this->dr_servant_ =
-    dynamic_cast<AckMessageDataReaderImpl*>(ackmessage_dr.in());
+    AckMessageDataReader::_narrow(this->reader_.in());
 
-  PubMessageDataWriter_var pubmessage_dw =
-    PubMessageDataWriter::_narrow (this->writer_.in ());
   this->dw_servant_ =
-    dynamic_cast<PubMessageDataWriterImpl*>(pubmessage_dw.in());
+    PubMessageDataWriter::_narrow (this->writer_.in ());
   DDSPerfTest::PubMessage msg;
   this->handle_ = this->dw_servant_->register_instance(msg);
 }

--- a/performance-tests/DCPS/SimpleLatency/PubListener.h
+++ b/performance-tests/DCPS/SimpleLatency/PubListener.h
@@ -70,8 +70,8 @@ private:
 
   DDS::DataWriter_var writer_;
   DDS::DataReader_var reader_;
-  DDSPerfTest::AckMessageDataReaderImpl* dr_servant_;
-  DDSPerfTest::PubMessageDataWriterImpl* dw_servant_;
+  DDSPerfTest::AckMessageDataReader_var dr_servant_;
+  DDSPerfTest::PubMessageDataWriter_var dw_servant_;
   DDS::InstanceHandle_t handle_;
   CORBA::Long sample_num_;
   int   done_;

--- a/performance-tests/DCPS/SimpleLatency/SubListener.cpp
+++ b/performance-tests/DCPS/SimpleLatency/SubListener.cpp
@@ -12,8 +12,8 @@ using namespace DDSPerfTest;
 PubDataReaderListenerImpl::PubDataReaderListenerImpl()
   : writer_ (),
     reader_ (),
-    dr_servant_(0),
-    dw_servant_(0),
+    dr_servant_(),
+    dw_servant_(),
     handle_(),
     sample_num_(1),
     done_ (0),
@@ -29,17 +29,13 @@ void PubDataReaderListenerImpl::init(DDS::DataReader_ptr dr,
   this->reader_ = DDS::DataReader::_duplicate (dr);
   use_zero_copy_ = use_zero_copy_read;
 
-  AckMessageDataWriter_var ackmessage_dw =
-    AckMessageDataWriter::_narrow (this->writer_.in ());
   this->dw_servant_ =
-    dynamic_cast<AckMessageDataWriterImpl*>(ackmessage_dw.in());
+    AckMessageDataWriter::_narrow (this->writer_.in ());
   DDSPerfTest::AckMessage msg;
   this->handle_ = this->dw_servant_->register_instance(msg);
 
-  PubMessageDataReader_var pubmessage_dr =
-    PubMessageDataReader::_unchecked_narrow(this->reader_.in());
   this->dr_servant_ =
-    dynamic_cast<PubMessageDataReaderImpl*>(pubmessage_dr.in());
+    PubMessageDataReader::_unchecked_narrow(this->reader_.in());
 }
 
 // Implementation skeleton destructor

--- a/performance-tests/DCPS/SimpleLatency/SubListener.h
+++ b/performance-tests/DCPS/SimpleLatency/SubListener.h
@@ -70,8 +70,8 @@ private:
 
   DDS::DataWriter_var writer_;
   DDS::DataReader_var reader_;
-  DDSPerfTest::PubMessageDataReaderImpl* dr_servant_;
-  DDSPerfTest::AckMessageDataWriterImpl* dw_servant_;
+  DDSPerfTest::PubMessageDataReader_var dr_servant_;
+  DDSPerfTest::AckMessageDataWriter_var dw_servant_;
   DDS::InstanceHandle_t handle_;
   //  DDS::DataReader_var reader_;
   CORBA::Long  sample_num_;

--- a/performance-tests/DCPS/TCPListenerTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/TCPListenerTest/DataReaderListener.cpp
@@ -7,7 +7,7 @@
 
 extern long subscriber_delay_msec; // from common.h
 
-template<class Tseq, class Iseq, class R, class R_ptr, class R_var, class Rimpl>
+template<class Tseq, class Iseq, class R, class R_ptr, class R_var>
 int read (::DDS::DataReader_ptr reader, bool use_zero_copy_reads)
 {
   // Since our listener is on the DataReader we always know
@@ -272,8 +272,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
                         ::DDS::SampleInfoSeq,
                       ::Xyz::Pt128DataReader,
                       ::Xyz::Pt128DataReader_ptr,
-                      ::Xyz::Pt128DataReader_var,
-                      ::Xyz::Pt128DataReaderImpl>
+                      ::Xyz::Pt128DataReader_var>
                           (reader, use_zero_copy_reads_);
       }
       break;
@@ -284,8 +283,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
                         ::DDS::SampleInfoSeq,
                       ::Xyz::Pt512DataReader,
                       ::Xyz::Pt512DataReader_ptr,
-                      ::Xyz::Pt512DataReader_var,
-                      ::Xyz::Pt512DataReaderImpl>
+                      ::Xyz::Pt512DataReader_var>
                           (reader, use_zero_copy_reads_);
       }
       break;
@@ -296,8 +294,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
                         ::DDS::SampleInfoSeq,
                       ::Xyz::Pt2048DataReader,
                       ::Xyz::Pt2048DataReader_ptr,
-                      ::Xyz::Pt2048DataReader_var,
-                      ::Xyz::Pt2048DataReaderImpl>
+                      ::Xyz::Pt2048DataReader_var>
                           (reader, use_zero_copy_reads_);
       }
       break;
@@ -308,8 +305,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
                         ::DDS::SampleInfoSeq,
                       ::Xyz::Pt8192DataReader,
                       ::Xyz::Pt8192DataReader_ptr,
-                      ::Xyz::Pt8192DataReader_var,
-                      ::Xyz::Pt8192DataReaderImpl>
+                      ::Xyz::Pt8192DataReader_var>
                           (reader, use_zero_copy_reads_);
       }
       break;

--- a/performance-tests/DCPS/TCPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPListenerTest/Writer.cpp
@@ -9,7 +9,7 @@
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
 
-template<class T, class W, class W_var, class W_ptr, class Wimpl>
+template<class T, class W, class W_var, class W_ptr>
 void write (long id,
             int size,
             int num_messages,
@@ -48,8 +48,6 @@ void write (long id,
   }
   }
 }
-
-
 
 
 Writer::Writer(::DDS::DataWriter_ptr writer,
@@ -114,8 +112,7 @@ Writer::svc ()
         write < ::Xyz::Pt128,
                ::Xyz::Pt128DataWriter,
                ::Xyz::Pt128DataWriter_var,
-               ::Xyz::Pt128DataWriter_ptr,
-               ::Xyz::Pt128DataWriterImpl>
+               ::Xyz::Pt128DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -128,8 +125,7 @@ Writer::svc ()
         write < ::Xyz::Pt512,
                ::Xyz::Pt512DataWriter,
                ::Xyz::Pt512DataWriter_var,
-               ::Xyz::Pt512DataWriter_ptr,
-               ::Xyz::Pt512DataWriterImpl>
+               ::Xyz::Pt512DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -142,8 +138,7 @@ Writer::svc ()
         write < ::Xyz::Pt2048,
                ::Xyz::Pt2048DataWriter,
                ::Xyz::Pt2048DataWriter_var,
-               ::Xyz::Pt2048DataWriter_ptr,
-               ::Xyz::Pt2048DataWriterImpl>
+               ::Xyz::Pt2048DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -156,8 +151,7 @@ Writer::svc ()
         write < ::Xyz::Pt8192,
                ::Xyz::Pt8192DataWriter,
                ::Xyz::Pt8192DataWriter_var,
-               ::Xyz::Pt8192DataWriter_ptr,
-               ::Xyz::Pt8192DataWriterImpl>
+               ::Xyz::Pt8192DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,

--- a/performance-tests/DCPS/TCPProfilingTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/DataReaderListener.cpp
@@ -20,7 +20,7 @@ int read (::DDS::DataReader_ptr reader, bool useZeroCopy)
       ACE_OS::sleep (delay);
     }
 
-   ::CORBA::Long const max_read_samples = 100;
+  const ::CORBA::Long max_read_samples = 100;
   int samples_recvd = 0;
   // initialize to zero.
 

--- a/performance-tests/DCPS/TCPProfilingTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/DataReaderListener.cpp
@@ -10,15 +10,8 @@ extern long subscriber_delay_msec; // from common.h
 
 int read (::DDS::DataReader_ptr reader, bool useZeroCopy)
 {
-  // TWF: There is an optimization to the test by
-  // using a pointer to the known servant and
-  // static_casting it to the servant
   ::profilingTest::testMsgDataReader_var var_dr
     = ::profilingTest::testMsgDataReader::_narrow(reader);
-
-  ::profilingTest::testMsgDataReader_ptr pt_dr = var_dr.ptr();
-  ::profilingTest::testMsgDataReaderImpl* dr_servant =
-      dynamic_cast< ::profilingTest::testMsgDataReaderImpl*>(pt_dr);
 
   if (subscriber_delay_msec)
     {
@@ -27,15 +20,14 @@ int read (::DDS::DataReader_ptr reader, bool useZeroCopy)
       ACE_OS::sleep (delay);
     }
 
-  const ::CORBA::Long max_read_samples = 100;
+   ::CORBA::Long const max_read_samples = 100;
   int samples_recvd = 0;
-  DDS::ReturnCode_t status;
   // initialize to zero.
 
   ::profilingTest::testMsgSeq samples(useZeroCopy ? 0 : max_read_samples, max_read_samples);
   ::DDS::SampleInfoSeq        infos  (useZeroCopy ? 0 : max_read_samples, max_read_samples, 0);
 
-  status = dr_servant->read (
+  DDS::ReturnCode_t status = var_dr->read (
     samples,
     infos,
     max_read_samples,

--- a/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
@@ -31,9 +31,6 @@ void write (long id,
     = ::profilingTest::testMsgDataWriter::_narrow(writer);
   ACE_ASSERT (! CORBA::is_nil (pt_dw.in ()));
 
-  ::profilingTest::testMsgDataWriterImpl* pt_servant =
-    dynamic_cast< ::profilingTest::testMsgDataWriterImpl*>(pt_dw.in ());
-
   ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) %T Writer::svc starting to write.\n")));
 
@@ -43,8 +40,7 @@ void write (long id,
   for (int i = 0; i < num_messages; i ++)
   {
     data.count = i;
-    pt_servant->write(data,
-                      handle);
+    pt_dw->write(data, handle);
   }
 }
 

--- a/performance-tests/DCPS/UDPListenerTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/DataReaderListener.cpp
@@ -6,14 +6,12 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 
 
-template<class Tseq, class R, class R_ptr, class Rimpl>
+template<class Tseq, class R, class R_ptr, class R_var>
 ::DDS::ReturnCode_t read (::DDS::DataReader_ptr reader,
                           ACE_Array<bool>& pub_finished)
 {
-  R_ptr pt_dr
+  R_var var_dr
     = R::_narrow(reader);
-
-  Rimpl* dr_servant = dynamic_cast<Rimpl*> (pt_dr);
 
   const ::CORBA::Long max_read_samples = 100;
   Tseq samples(max_read_samples);
@@ -23,7 +21,7 @@ template<class Tseq, class R, class R_ptr, class Rimpl>
   DDS::ReturnCode_t status;
   // initialize to zero.
 
-  status = dr_servant->read (
+  status = var_dr->read (
     samples,
     infos,
     max_read_samples,
@@ -64,14 +62,6 @@ template<class Tseq, class R, class R_ptr, class Rimpl>
 
   return samples_recvd;
 }
-
-
-
-
-
-
-
-
 
 // Implementation skeleton constructor
 DataReaderListenerImpl::DataReaderListenerImpl (int num_publishers,
@@ -245,7 +235,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt128Seq,
                       ::Xyz::Pt128DataReader,
                       ::Xyz::Pt128DataReader_ptr,
-                      ::Xyz::Pt128DataReaderImpl>
+                      ::Xyz::Pt128DataReader_var>
                         (
                         reader,
                         pub_finished_);
@@ -257,7 +247,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt512Seq,
                       ::Xyz::Pt512DataReader,
                       ::Xyz::Pt512DataReader_ptr,
-                      ::Xyz::Pt512DataReaderImpl>
+                      ::Xyz::Pt512DataReader_var>
                         (
                         reader,
                         pub_finished_);
@@ -269,7 +259,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt2048Seq,
                       ::Xyz::Pt2048DataReader,
                       ::Xyz::Pt2048DataReader_ptr,
-                      ::Xyz::Pt2048DataReaderImpl>
+                      ::Xyz::Pt2048DataReader_var>
                         (
                         reader,
                         pub_finished_);
@@ -281,7 +271,7 @@ int DataReaderListenerImpl::read_samples (::DDS::DataReader_ptr reader)
       num_read = read < ::Xyz::Pt8192Seq,
                       ::Xyz::Pt8192DataReader,
                       ::Xyz::Pt8192DataReader_ptr,
-                      ::Xyz::Pt8192DataReaderImpl>
+                      ::Xyz::Pt8192DataReader_var>
                         (
                         reader,
                         pub_finished_);

--- a/performance-tests/DCPS/UDPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/Writer.cpp
@@ -22,7 +22,7 @@ extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
 
 
 
-template<class T, class W, class W_var, class W_ptr, class Wimpl>
+template<class T, class W, class W_var, class W_ptr>
 void write (long id,
             int size,
             int num_messages,
@@ -42,8 +42,6 @@ void write (long id,
     = W::_narrow(writer);
   ACE_ASSERT (! CORBA::is_nil (pt_dw.in ()));
 
-  Wimpl* pt_servant = dynamic_cast<Wimpl*> (pt_dw.in ());
-
   //SHH remove this kludge when the transport is fixed.
   ACE_OS::sleep(2); // ensure that the connection has been fully established
   ACE_DEBUG((LM_DEBUG,
@@ -56,8 +54,7 @@ void write (long id,
   for (int i = 0; i < num_messages; i ++)
     {
       data.sequence_num = i;
-      pt_servant->write(data,
-                        handle);
+      pt_dw->write(data, handle);
       THROTTLE
     }
   }
@@ -65,8 +62,7 @@ void write (long id,
   for (int j = 0; j < 1000; j ++)
     {
       data.sequence_num = -1;
-      pt_servant->write(data,
-                        handle);
+      pt_dw->write(data, handle);
       // throttle twice to slow the rate to ensure one gets sent.
       THROTTLE
       THROTTLE
@@ -139,8 +135,7 @@ Writer::svc ()
         write < ::Xyz::Pt128,
                ::Xyz::Pt128DataWriter,
                ::Xyz::Pt128DataWriter_var,
-               ::Xyz::Pt128DataWriter_ptr,
-               ::Xyz::Pt128DataWriterImpl>
+               ::Xyz::Pt128DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -154,8 +149,7 @@ Writer::svc ()
         write < ::Xyz::Pt512,
                ::Xyz::Pt512DataWriter,
                ::Xyz::Pt512DataWriter_var,
-               ::Xyz::Pt512DataWriter_ptr,
-               ::Xyz::Pt512DataWriterImpl>
+               ::Xyz::Pt512DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -169,8 +163,7 @@ Writer::svc ()
         write < ::Xyz::Pt2048,
                ::Xyz::Pt2048DataWriter,
                ::Xyz::Pt2048DataWriter_var,
-               ::Xyz::Pt2048DataWriter_ptr,
-               ::Xyz::Pt2048DataWriterImpl>
+               ::Xyz::Pt2048DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -184,8 +177,7 @@ Writer::svc ()
         write < ::Xyz::Pt8192,
                ::Xyz::Pt8192DataWriter,
                ::Xyz::Pt8192DataWriter_var,
-               ::Xyz::Pt8192DataWriter_ptr,
-               ::Xyz::Pt8192DataWriterImpl>
+               ::Xyz::Pt8192DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,

--- a/performance-tests/DCPS/UDPNoKeyTest/Reader.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/Reader.cpp
@@ -12,7 +12,7 @@
 
 
 
-template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
+template<class Tseq, class R, class R_var, class R_ptr>
 ::DDS::ReturnCode_t read (TestStats* stats,
                           ::DDS::Subscriber_ptr subscriber,
                           ::DDS::DataReader_ptr reader)
@@ -25,8 +25,6 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
                 ACE_TEXT("(%P|%t) _narrow failed.\n")));
       throw TestException() ;
     }
-
-  Rimpl* dr_servant = dynamic_cast<Rimpl*> (pt_dr.in ());
 
   const ::CORBA::Long max_read_samples = 100;
   Tseq samples(max_read_samples);
@@ -50,7 +48,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
   int zero_reads = 0;
   DDS::ReturnCode_t status;
   ::DDS::SampleRejectedStatus rejected;
-  if (dr_servant->get_sample_rejected_status (rejected) != ::DDS::RETCODE_OK)
+  if (pt_dr->get_sample_rejected_status (rejected) != ::DDS::RETCODE_OK)
   {
     ACE_ERROR_RETURN((LM_ERROR,
       "ERROR: failed to get sample rejected status\n"),
@@ -58,7 +56,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
   }
 
   ::DDS::SampleLostStatus lost;
-  if (dr_servant->get_sample_lost_status (lost) != ::DDS::RETCODE_OK)
+  if (pt_dr->get_sample_lost_status (lost) != ::DDS::RETCODE_OK)
   {
     ACE_ERROR_RETURN((LM_ERROR,
       "ERROR: failed to get sample lost status\n"),
@@ -71,9 +69,9 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
   while ( !stats->all_packets_received () && ! end_messages )
     {
 
-      // very slow status = dr_servant->read_next_sample(sample, si) ;
+      // very slow status = pt_dr->read_next_sample(sample, si) ;
 
-      status = dr_servant->read (
+      status = pt_dr->read (
         samples,
         infos,
         max_read_samples,
@@ -130,7 +128,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
 
 
           //ACE_DEBUG((LM_DEBUG,"got RETCODE_NO_DATA\n"));
-          ::DDS::ReturnCode_t ret = dr_servant->get_sample_rejected_status (rejected);
+          ::DDS::ReturnCode_t ret = pt_dr->get_sample_rejected_status (rejected);
           if (ret != ::DDS::RETCODE_OK)
           {
             ACE_ERROR_RETURN ((LM_ERROR,
@@ -144,7 +142,7 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
               stats->samples_received(rejected.total_count_change);
             }
 
-          ret = dr_servant->get_sample_lost_status (lost);
+          ret = pt_dr->get_sample_lost_status (lost);
           if (ret != ::DDS::RETCODE_OK)
           {
             ACE_ERROR_RETURN ((LM_ERROR,
@@ -175,9 +173,6 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
           //    ACE_OS::exit (7);
           //  }
 
-
-
-
         }
     }
 
@@ -187,14 +182,6 @@ template<class Tseq, class R, class R_var, class R_ptr, class Rimpl>
 
   return ::DDS::RETCODE_OK;
 }
-
-
-
-
-
-
-
-
 
 Reader::Reader(::DDS::Subscriber_ptr subscriber,
                ::DDS::DataReader_ptr reader,
@@ -258,8 +245,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt128Seq,
                        ::Xyz::Pt128DataReader,
                        ::Xyz::Pt128DataReader_var,
-                       ::Xyz::Pt128DataReader_ptr,
-                       ::Xyz::Pt128DataReaderImpl>
+                       ::Xyz::Pt128DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),
@@ -274,8 +260,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt512Seq,
                        ::Xyz::Pt512DataReader,
                        ::Xyz::Pt512DataReader_var,
-                       ::Xyz::Pt512DataReader_ptr,
-                       ::Xyz::Pt512DataReaderImpl>
+                       ::Xyz::Pt512DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),
@@ -290,8 +275,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt2048Seq,
                        ::Xyz::Pt2048DataReader,
                        ::Xyz::Pt2048DataReader_var,
-                       ::Xyz::Pt2048DataReader_ptr,
-                       ::Xyz::Pt2048DataReaderImpl>
+                       ::Xyz::Pt2048DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),
@@ -306,8 +290,7 @@ Reader::svc ()
         status = read < ::Xyz::Pt8192Seq,
                        ::Xyz::Pt8192DataReader,
                        ::Xyz::Pt8192DataReader_var,
-                       ::Xyz::Pt8192DataReader_ptr,
-                       ::Xyz::Pt8192DataReaderImpl>
+                       ::Xyz::Pt8192DataReader_ptr>
                          (
                           &stats_,
                           subscriber_.in (),

--- a/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
@@ -19,9 +19,7 @@
   }
 
 
-
-
-template<class T, class W, class W_var, class W_ptr, class Wimpl>
+template<class T, class W, class W_var, class W_ptr>
 void write (long id,
             int size,
             int num_messages,
@@ -41,8 +39,6 @@ void write (long id,
     = W::_narrow(writer);
   ACE_ASSERT (! CORBA::is_nil (pt_dw.in ()));
 
-  Wimpl* pt_servant = dynamic_cast<Wimpl*> (pt_dw.in ());
-
   //SHH remove this kludge when the transport is fixed.
   ACE_OS::sleep(2); // ensure that the connection has been fully established
   ACE_DEBUG((LM_DEBUG,
@@ -55,8 +51,7 @@ void write (long id,
   for (int i = 0; i < num_messages; i ++)
     {
       data.sequence_num = i;
-      pt_servant->write(data,
-                        handle);
+      pt_dw->write(data, handle);
       THROTTLE
     }
   }
@@ -64,8 +59,7 @@ void write (long id,
   for (int j = 0; j < 500; j ++)
     {
       data.sequence_num = -1;
-      pt_servant->write(data,
-                        handle);
+      pt_dw->write(data, handle);
       // throttle twice to slow the rate to ensure one gets sent.
       THROTTLE
       THROTTLE
@@ -141,8 +135,7 @@ Writer::svc ()
         write < ::Xyz::Pt128,
                ::Xyz::Pt128DataWriter,
                ::Xyz::Pt128DataWriter_var,
-               ::Xyz::Pt128DataWriter_ptr,
-               ::Xyz::Pt128DataWriterImpl>
+               ::Xyz::Pt128DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -156,8 +149,7 @@ Writer::svc ()
         write < ::Xyz::Pt512,
                ::Xyz::Pt512DataWriter,
                ::Xyz::Pt512DataWriter_var,
-               ::Xyz::Pt512DataWriter_ptr,
-               ::Xyz::Pt512DataWriterImpl>
+               ::Xyz::Pt512DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -171,8 +163,7 @@ Writer::svc ()
         write < ::Xyz::Pt2048,
                ::Xyz::Pt2048DataWriter,
                ::Xyz::Pt2048DataWriter_var,
-               ::Xyz::Pt2048DataWriter_ptr,
-               ::Xyz::Pt2048DataWriterImpl>
+               ::Xyz::Pt2048DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,
@@ -186,8 +177,7 @@ Writer::svc ()
         write < ::Xyz::Pt8192,
                ::Xyz::Pt8192DataWriter,
                ::Xyz::Pt8192DataWriter_var,
-               ::Xyz::Pt8192DataWriter_ptr,
-               ::Xyz::Pt8192DataWriterImpl>
+               ::Xyz::Pt8192DataWriter_ptr>
                  (writer_id_,
                   data_size_,
                   num_messages_,

--- a/tests/DCPS/BuiltInTopic/common.cpp
+++ b/tests/DCPS/BuiltInTopic/common.cpp
@@ -256,9 +256,6 @@ int read (int expect_success)
                  -1);
     }
 
-    ::Xyz::FooDataReaderImpl* dr_servant =
-      dynamic_cast< ::Xyz::FooDataReaderImpl*> (foo_dr.in ());
-
     int num_reads = 0;
     int num_received = 0;
 
@@ -271,7 +268,7 @@ int read (int expect_success)
       ::Xyz::Foo foo;
       ::DDS::SampleInfo si ;
 
-      DDS::ReturnCode_t status = dr_servant->read_next_sample(foo, si) ;
+      DDS::ReturnCode_t status = foo_dr->read_next_sample(foo, si) ;
       num_reads ++;
 
       if (status == ::DDS::RETCODE_OK)

--- a/tests/DCPS/CompatibilityTest/DataReaderListener.cpp
+++ b/tests/DCPS/CompatibilityTest/DataReaderListener.cpp
@@ -86,15 +86,12 @@ void DataReaderListenerImpl::on_subscription_matched (
                ACE_TEXT("(%P|%t) ::Xyz::FooDataReader::_narrow failed.\n")));
       }
 
-    ::Xyz::FooDataReaderImpl* dr_servant
-      = dynamic_cast< ::Xyz::FooDataReaderImpl*>(foo_dr.in());
-
     const int num_ops_per_thread = 100;
     ::Xyz::FooSeq foo(num_ops_per_thread) ;
     ::DDS::SampleInfoSeq si(num_ops_per_thread) ;
 
     DDS::ReturnCode_t status  ;
-    status = dr_servant->read(foo, si,
+    status = foo_dr->read(foo, si,
                           num_ops_per_thread,
                           ::DDS::NOT_READ_SAMPLE_STATE,
                           ::DDS::ANY_VIEW_STATE,

--- a/tests/DCPS/ConfigTransports/DataReaderListener.cpp
+++ b/tests/DCPS/ConfigTransports/DataReaderListener.cpp
@@ -77,19 +77,16 @@ void DataReaderListenerImpl::on_data_available(::DDS::DataReader_ptr reader)
                  ACE_TEXT("(%P|%t) ::Xyz::FooDataReader::_narrow failed.\n")));
     }
 
-  ::Xyz::FooDataReaderImpl* dr_servant
-          = dynamic_cast< ::Xyz::FooDataReaderImpl*> (foo_dr.in());
-
   const int num_ops_per_thread = 100;
   ::Xyz::FooSeq foo(num_ops_per_thread);
   ::DDS::SampleInfoSeq si(num_ops_per_thread);
 
   DDS::ReturnCode_t status;
-  status = dr_servant->read(foo, si,
-                            num_ops_per_thread,
-                            ::DDS::NOT_READ_SAMPLE_STATE,
-                            ::DDS::ANY_VIEW_STATE,
-                            ::DDS::ANY_INSTANCE_STATE);
+  status = foo_dr->read(foo, si,
+                        num_ops_per_thread,
+                        ::DDS::NOT_READ_SAMPLE_STATE,
+                        ::DDS::ANY_VIEW_STATE,
+                        ::DDS::ANY_INSTANCE_STATE);
 
   if (status == ::DDS::RETCODE_OK)
     {

--- a/tests/DCPS/Federation/DataReaderListener.cpp
+++ b/tests/DCPS/Federation/DataReaderListener.cpp
@@ -6,7 +6,7 @@
 #include "tests/DCPS/FooType5/FooDefTypeSupportImpl.h"
 #include "tests/Utils/ExceptionStreams.h"
 
-template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var, class DR_impl>
+template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var>
 int read (::DDS::DataReader_ptr reader, DT& foo)
 {
   try
@@ -20,13 +20,8 @@ int read (::DDS::DataReader_ptr reader, DT& foo)
       throw BadReaderException() ;
     }
 
-    DR_impl* dr_servant = dynamic_cast<DR_impl*> (foo_dr.in ());
-
     ::DDS::SampleInfo si ;
-
-    DDS::ReturnCode_t status  ;
-
-    status = dr_servant->read_next_sample(foo, si) ;
+    DDS::ReturnCode_t const status = foo_dr->read_next_sample(foo, si) ;
 
     if (status == ::DDS::RETCODE_OK)
     {
@@ -161,8 +156,7 @@ void DataReaderListenerImpl::on_data_available(
       ::Xyz::FooNoKeySeq,
       ::Xyz::FooNoKeyDataReader,
       ::Xyz::FooNoKeyDataReader_ptr,
-      ::Xyz::FooNoKeyDataReader_var,
-      ::Xyz::FooNoKeyDataReaderImpl> (reader, foo);
+      ::Xyz::FooNoKeyDataReader_var> (reader, foo);
 
   if (ret != 0)
   {

--- a/tests/DCPS/FooTest3_0/PubDriver.h
+++ b/tests/DCPS/FooTest3_0/PubDriver.h
@@ -11,6 +11,10 @@
 #include "ace/String_Base.h"
 #include <string>
 
+namespace Xyz {
+  typedef OpenDDS::DCPS::DataWriterImpl_T<Xyz::Foo> FooDataWriterImpl;
+}
+
 class PubDriver : public ACE_Task_Base
 {
   public:

--- a/tests/DCPS/FooTest4/Reader.cpp
+++ b/tests/DCPS/FooTest4/Reader.cpp
@@ -42,9 +42,6 @@ Reader::start ()
       throw TestException() ;
     }
 
-    Xyz::FooDataReaderImpl* dr_servant =
-      dynamic_cast< ::Xyz::FooDataReaderImpl*> (foo_dr.in ());
-
     char action[5] ;
     if (use_take_)
     {
@@ -62,11 +59,11 @@ Reader::start ()
       DDS::ReturnCode_t status  ;
       if (use_take_)
       {
-        status = dr_servant->take_next_sample(foo, si) ;
+        status = foo_dr->take_next_sample(foo, si) ;
       }
       else
       {
-        status = dr_servant->read_next_sample(foo, si) ;
+        status = foo_dr->read_next_sample(foo, si) ;
       }
 
       if (status == ::DDS::RETCODE_OK)
@@ -99,7 +96,7 @@ Reader::start ()
       ACE_OS::printf ("release: %d\n", foo.release()) ;
 
       DDS::ReturnCode_t status ;
-      status = dr_servant->read(foo, si,
+      status = foo_dr->read(foo, si,
                   1,
                   ::DDS::READ_SAMPLE_STATE | ::DDS::NOT_READ_SAMPLE_STATE,
                   ::DDS::ANY_VIEW_STATE,
@@ -143,9 +140,6 @@ Reader::start1 ()
       throw TestException() ;
     }
 
-    Xyz::FooDataReaderImpl* dr_servant =
-      dynamic_cast<Xyz::FooDataReaderImpl*> (foo_dr.in ());
-
     char action[14] ;
     if (use_take_)
     {
@@ -165,7 +159,7 @@ Reader::start1 ()
     int num_print(0) ;
     if (use_take_)
     {
-      status = dr_servant->take_next_instance(foo, si,
+      status = foo_dr->take_next_instance(foo, si,
                   1,
                   handle,
                   ::DDS::NOT_READ_SAMPLE_STATE,
@@ -183,7 +177,7 @@ Reader::start1 ()
 
       PrintSampleInfo(si[0]);
 
-      dr_servant->get_key_value(key_holder, si[0].instance_handle) ;
+      foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
 
       PrintSampleInfo(si[0]) ;
 
@@ -192,7 +186,7 @@ Reader::start1 ()
       if ((num_reads_per_thread_ > 1) || multiple_instances_)
       {
         handle = si[0].instance_handle ;
-        status = dr_servant->take_instance(foo, si, num_reads_per_thread_,
+        status = foo_dr->take_instance(foo, si, num_reads_per_thread_,
                   handle,
                   ::DDS::READ_SAMPLE_STATE | ::DDS::NOT_READ_SAMPLE_STATE,
                   ::DDS::ANY_VIEW_STATE,
@@ -204,7 +198,7 @@ Reader::start1 ()
           while (status != ::DDS::RETCODE_NO_DATA)
           {
             handle = ::DDS::HANDLE_NIL ;
-            status = dr_servant->take_next_instance(foo, si,
+            status = foo_dr->take_next_instance(foo, si,
                   1,
                   handle,
                   ::DDS::NOT_READ_SAMPLE_STATE,
@@ -218,7 +212,7 @@ Reader::start1 ()
 
               PrintSampleInfo(si[0]);
 
-              dr_servant->get_key_value(key_holder, si[0].instance_handle) ;
+              foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
               ACE_OS::printf (
                   "get_key_value: handle = %d foo.x = %f foo.y = %f, foo.key = %d\n",
                   si[0].instance_handle,
@@ -243,7 +237,7 @@ Reader::start1 ()
     }
     else
     {
-      status = dr_servant->read_next_instance(foo, si,
+      status = foo_dr->read_next_instance(foo, si,
                   1,
                   handle,
                   ::DDS::NOT_READ_SAMPLE_STATE,
@@ -261,7 +255,7 @@ Reader::start1 ()
 
       PrintSampleInfo(si[0]);
 
-      dr_servant->get_key_value(key_holder, si[0].instance_handle) ;
+      foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
 
       ACE_OS::printf (
           "get_key_value: handle = %d foo.x = %f foo.y = %f, foo.key = %d\n",
@@ -271,7 +265,7 @@ Reader::start1 ()
       if ((num_reads_per_thread_ > 1) || multiple_instances_)
       {
         handle = si[0].instance_handle ;
-        status = dr_servant->read_instance(foo, si, num_reads_per_thread_,
+        status = foo_dr->read_instance(foo, si, num_reads_per_thread_,
                   handle,
                   ::DDS::NOT_READ_SAMPLE_STATE,
                   ::DDS::ANY_VIEW_STATE,
@@ -283,7 +277,7 @@ Reader::start1 ()
           while (status != ::DDS::RETCODE_NO_DATA)
           {
             handle = ::DDS::HANDLE_NIL ;
-            status = dr_servant->read_next_instance(foo, si,
+            status = foo_dr->read_next_instance(foo, si,
                   1,
                   handle,
                   ::DDS::NOT_READ_SAMPLE_STATE,
@@ -297,7 +291,7 @@ Reader::start1 ()
 
               PrintSampleInfo(si[0]);
 
-              dr_servant->get_key_value(key_holder, si[0].instance_handle) ;
+              foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
               ACE_OS::printf (
                   "get_key_value: handle = %d foo.x = %f foo.y = %f, foo.key = %d\n",
                   si[0].instance_handle,
@@ -339,7 +333,7 @@ Reader::start1 ()
       ::DDS::SampleInfoSeq si(1) ;
 
       DDS::ReturnCode_t status ;
-      status = dr_servant->read(foo, si,
+      status = foo_dr->read(foo, si,
                   1,
                   ::DDS::READ_SAMPLE_STATE | ::DDS::NOT_READ_SAMPLE_STATE,
                   ::DDS::ANY_VIEW_STATE,
@@ -383,14 +377,11 @@ Reader::start2 ()
       throw TestException() ;
     }
 
-    Xyz::FooDataReaderImpl* dr_servant =
-      dynamic_cast<Xyz::FooDataReaderImpl*> (foo_dr.in ());
-
     ::Xyz::FooSeq foo;
     ::DDS::SampleInfoSeq si ;
     DDS::ReturnCode_t status  ;
 
-    status = dr_servant->read(foo, si,
+    status = foo_dr->read(foo, si,
                               num_reads_per_thread_,
                               ::DDS::NOT_READ_SAMPLE_STATE,
                               ::DDS::ANY_VIEW_STATE,
@@ -407,7 +398,7 @@ Reader::start2 ()
         PrintSampleInfo(si[i]) ;
       }
 
-      status = dr_servant->return_loan(foo, si) ;
+      status = foo_dr->return_loan(foo, si) ;
       if (status != ::DDS::RETCODE_OK)
       {
         ACE_OS::printf ("return_loan: Error %d\n", status) ;

--- a/tests/DCPS/FooTest4_0/Reader.cpp
+++ b/tests/DCPS/FooTest4_0/Reader.cpp
@@ -129,11 +129,7 @@ Reader::read (const SampleInfoMap& si_map,
         throw TestException() ;
       }
 
-      ::Xyz::FooDataReaderImpl* dr_servant =
-        dynamic_cast<Xyz::FooDataReaderImpl*> (foo_dr.in ());
-
-      DDS::ReturnCode_t status  ;
-      status = dr_servant->read(foo, si,
+      DDS::ReturnCode_t status = foo_dr->read(foo, si,
                   max_samples_per_instance_,
                   ss,
                   vs,

--- a/tests/DCPS/FooTest4_0/Writer.cpp
+++ b/tests/DCPS/FooTest4_0/Writer.cpp
@@ -53,18 +53,14 @@ Writer::Writer(::DDS::DomainParticipant_ptr dp,
     throw TestException() ;
   }
 
-  ::Xyz::FooDataWriter_var foo_dw = ::Xyz::FooDataWriter::_narrow(
+  foo_dw_ = ::Xyz::FooDataWriter::_narrow(
       dw_.in ());
-  if (CORBA::is_nil (foo_dw.in ()))
+  if (CORBA::is_nil (foo_dw_.in ()))
   {
     ACE_ERROR ((LM_ERROR,
                ACE_TEXT("(%P|%t) ::Xyz::FooDataWriter::_narrow failed.\n")));
     throw TestException() ;
   }
-
-  fast_dw_ =
-    dynamic_cast< ::Xyz::FooDataWriterImpl*> (foo_dw.in ());
-
 }
 
 void Writer::write (char message_id, const ::Xyz::Foo &foo)
@@ -77,19 +73,19 @@ void Writer::write (char message_id, const ::Xyz::Foo &foo)
       ACE_OS::printf ("writing %c foo.x = %f foo.y = %f, foo.key = %d\n",
                       foo.c, foo.x, foo.y, foo.key);
 
-      fast_dw_->write(foo,
+      foo_dw_->write(foo,
                       handle);
       break;
 
     case ::OpenDDS::DCPS::INSTANCE_REGISTRATION:
       ACE_OS::printf ("registering foo.key = %d\n", foo.key) ;
-      handle = fast_dw_->register_instance(foo);
+      handle = foo_dw_->register_instance(foo);
       break;
 
     case ::OpenDDS::DCPS::DISPOSE_INSTANCE:
       ACE_OS::printf ("disposing foo.key = %d\n", foo.key) ;
 
-      fast_dw_->dispose(foo,
+      foo_dw_->dispose(foo,
                         handle);
       break;
 

--- a/tests/DCPS/FooTest4_0/Writer.h
+++ b/tests/DCPS/FooTest4_0/Writer.h
@@ -29,10 +29,10 @@ private:
   int init_transport () ;
   void write (char message_id, const ::Xyz::Foo& foo);
 
-  ::DDS::DomainParticipant_var dp_ ;
-  ::DDS::Publisher_var pub_ ;
-  ::DDS::DataWriter_var dw_ ;
-  ::Xyz::FooDataWriterImpl* fast_dw_ ;
+  ::DDS::DomainParticipant_var dp_;
+  ::DDS::Publisher_var pub_;
+  ::DDS::DataWriter_var dw_;
+  ::Xyz::FooDataWriter_var foo_dw_;
 };
 
 #endif /* READER_H */

--- a/tests/DCPS/FooTest5/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest5/DataReaderListener.cpp
@@ -7,7 +7,7 @@
 #include "tests/DCPS/FooType5/FooDefTypeSupportC.h"
 #include "tests/DCPS/FooType5/FooDefTypeSupportImpl.h"
 
-template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var, class DR_impl>
+template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var>
 int read (::DDS::DataReader_ptr reader)
 {
   try
@@ -21,13 +21,10 @@ int read (::DDS::DataReader_ptr reader)
       throw TestException() ;
     }
 
-    DR_impl* dr_servant =
-      dynamic_cast<DR_impl*> (foo_dr.in ());
-
     DT foo;
     ::DDS::SampleInfo si ;
 
-    DDS::ReturnCode_t status = dr_servant->take_next_sample(foo, si) ;
+    DDS::ReturnCode_t status = foo_dr->take_next_sample(foo, si) ;
 
     if (status == ::DDS::RETCODE_OK)
     {
@@ -173,8 +170,7 @@ void DataReaderListenerImpl::on_subscription_matched (
             ::Xyz::FooNoKeySeq,
             ::Xyz::FooNoKeyDataReader,
             ::Xyz::FooNoKeyDataReader_ptr,
-            ::Xyz::FooNoKeyDataReader_var,
-            ::Xyz::FooNoKeyDataReaderImpl> (reader);
+            ::Xyz::FooNoKeyDataReader_var> (reader);
     }
     else
     {
@@ -182,8 +178,7 @@ void DataReaderListenerImpl::on_subscription_matched (
         ::Xyz::FooSeq,
         ::Xyz::FooDataReader,
         ::Xyz::FooDataReader_ptr,
-        ::Xyz::FooDataReader_var,
-        ::Xyz::FooDataReaderImpl> (reader);
+        ::Xyz::FooDataReader_var> (reader);
     }
 
     if (ret != 0)

--- a/tests/DCPS/FooTest5_0/main.cpp
+++ b/tests/DCPS/FooTest5_0/main.cpp
@@ -340,9 +340,6 @@ int run_test(int argc, ACE_TCHAR *argv[])
         return 1; // failure
       }
 
-      ::Xyz::FooDataWriterImpl* fast_dw
-        = dynamic_cast<Xyz::FooDataWriterImpl*>(foo_dw.in());
-
       ::Xyz::FooDataReader_var foo_dr
         = ::Xyz::FooDataReader::_narrow(dr.in ());
       if (CORBA::is_nil (foo_dr.in ()))
@@ -352,11 +349,7 @@ int run_test(int argc, ACE_TCHAR *argv[])
         return 1; // failure
       }
 
-      ::Xyz::FooDataReaderImpl* fast_dr
-        = dynamic_cast<Xyz::FooDataReaderImpl*>(foo_dr.in());
-
-
-      // wait for association establishement before writing.
+      // wait for association establishment before writing.
       ACE_OS::sleep(5); //REMOVE if not needed
 
 
@@ -430,13 +423,11 @@ int run_test(int argc, ACE_TCHAR *argv[])
       foo.x = -1;
       foo.y = -1;
 
-      handle
-          = fast_dw->register_instance(foo);
+      handle = foo_dw->register_instance(foo);
 
       foo.x = 7;
 
-      fast_dw->write(foo,
-                     handle);
+      foo_dw->write(foo, handle);
 
       ::Xyz::Foo sample;
       ::DDS::SampleInfo info ;
@@ -448,7 +439,7 @@ int run_test(int argc, ACE_TCHAR *argv[])
                            1);
 
       DDS::ReturnCode_t status  ;
-      status = fast_dr->read_next_sample(sample, info) ;
+      status = foo_dr->read_next_sample(sample, info) ;
 
       if (status == ::DDS::RETCODE_OK)
       {

--- a/tests/DCPS/LivelinessTest/DataReaderListener.cpp
+++ b/tests/DCPS/LivelinessTest/DataReaderListener.cpp
@@ -155,16 +155,13 @@ void DataReaderListenerImpl::on_subscription_matched (
                ACE_TEXT("(%P|%t) ::Xyz::FooDataReader::_narrow failed.\n")));
       }
 
-    ::Xyz::FooDataReaderImpl* dr_servant
-      = dynamic_cast< ::Xyz::FooDataReaderImpl*>(foo_dr.in());
-
     ::Xyz::FooSeq foo(num_ops_per_thread) ;
     ::DDS::SampleInfoSeq si(num_ops_per_thread) ;
 
     DDS::ReturnCode_t status  ;
     if (use_take)
       {
-        status = dr_servant->take(foo, si,
+        status = foo_dr->take(foo, si,
                               num_ops_per_thread,
                               ::DDS::NOT_READ_SAMPLE_STATE,
                               ::DDS::ANY_VIEW_STATE,
@@ -172,7 +169,7 @@ void DataReaderListenerImpl::on_subscription_matched (
       }
     else
       {
-        status = dr_servant->read(foo, si,
+        status = foo_dr->read(foo, si,
                               num_ops_per_thread,
                               ::DDS::NOT_READ_SAMPLE_STATE,
                               ::DDS::ANY_VIEW_STATE,

--- a/tests/DCPS/LivelinessTimeout/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/LivelinessTimeout/DataReaderListenerImpl.cpp
@@ -107,15 +107,12 @@ void DataReaderListenerImpl::on_subscription_matched (
                ACE_TEXT("(%P|%t) ::Xyz::FooDataReader::_narrow failed.\n")));
       }
 
-    ::Xyz::FooDataReaderImpl* dr_servant
-      = dynamic_cast< ::Xyz::FooDataReaderImpl*>(foo_dr.in());
-
     const int num_ops_per_thread = 100;
     ::Xyz::FooSeq foo(num_ops_per_thread) ;
     ::DDS::SampleInfoSeq si(num_ops_per_thread) ;
 
     DDS::ReturnCode_t status  ;
-    status = dr_servant->read(foo, si,
+    status = foo_dr->read(foo, si,
                           num_ops_per_thread,
                           ::DDS::NOT_READ_SAMPLE_STATE,
                           ::DDS::ANY_VIEW_STATE,

--- a/tests/DCPS/ManyTopicMultiProcess/DataReaderListener1.cpp
+++ b/tests/DCPS/ManyTopicMultiProcess/DataReaderListener1.cpp
@@ -22,17 +22,14 @@ void DataReaderListenerImpl1::read(::DDS::DataReader_ptr reader)
   DDS::TopicDescription_var td = reader->get_topicdescription();
   CORBA::String_var topic = td->get_name();
 
-  ::T1::Foo1DataReaderImpl* dr_servant =
-      dynamic_cast<T1::Foo1DataReaderImpl*>(foo_dr.in());
-
   ::T1::Foo1Seq foo(num_ops_per_thread_);
   ::DDS::SampleInfoSeq si(num_ops_per_thread_);
 
-  DDS::ReturnCode_t status = dr_servant->read(foo, si,
-                                              num_ops_per_thread_,
-                                              ::DDS::NOT_READ_SAMPLE_STATE,
-                                              ::DDS::ANY_VIEW_STATE,
-                                              ::DDS::ANY_INSTANCE_STATE);
+  DDS::ReturnCode_t const status = foo_dr->read(foo, si,
+                                          num_ops_per_thread_,
+                                          ::DDS::NOT_READ_SAMPLE_STATE,
+                                          ::DDS::ANY_VIEW_STATE,
+                                          ::DDS::ANY_INSTANCE_STATE);
   if (status == ::DDS::RETCODE_OK) {
 
     for (CORBA::ULong i = 0; i < si.length(); ++i) {

--- a/tests/DCPS/ManyTopicMultiProcess/DataReaderListener4.cpp
+++ b/tests/DCPS/ManyTopicMultiProcess/DataReaderListener4.cpp
@@ -22,13 +22,10 @@ void DataReaderListenerImpl4::read(::DDS::DataReader_ptr reader)
   DDS::TopicDescription_var td = reader->get_topicdescription();
   CORBA::String_var topic = td->get_name();
 
-  ::T4::Foo4DataReaderImpl* dr_servant =
-      dynamic_cast< ::T4::Foo4DataReaderImpl*>(foo_dr.in());
-
   ::T4::Foo4Seq foo(num_ops_per_thread_);
   ::DDS::SampleInfoSeq si(num_ops_per_thread_);
 
-  DDS::ReturnCode_t status = dr_servant->read(foo, si,
+  DDS::ReturnCode_t const status = foo_dr->read(foo, si,
                                               num_ops_per_thread_,
                                               ::DDS::NOT_READ_SAMPLE_STATE,
                                               ::DDS::ANY_VIEW_STATE,

--- a/tests/DCPS/MultiDPTest/DataReaderListener.cpp
+++ b/tests/DCPS/MultiDPTest/DataReaderListener.cpp
@@ -7,7 +7,7 @@
 #include "tests/DCPS/FooType5/FooDefTypeSupportC.h"
 #include "tests/DCPS/FooType5/FooDefTypeSupportImpl.h"
 
-template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var, class DR_impl>
+template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var>
 int read (::DDS::DataReader_ptr reader)
 {
   try
@@ -21,15 +21,10 @@ int read (::DDS::DataReader_ptr reader)
       throw TestException() ;
     }
 
-    DR_impl* dr_servant =
-      dynamic_cast<DR_impl*> (foo_dr.in ());
-
     DT foo;
     ::DDS::SampleInfo si ;
 
-    DDS::ReturnCode_t status  ;
-
-    status = dr_servant->read_next_sample(foo, si) ;
+    DDS::ReturnCode_t const status = foo_dr->read_next_sample(foo, si) ;
 
     if (status == ::DDS::RETCODE_OK)
     {
@@ -150,8 +145,7 @@ void DataReaderListenerImpl::on_subscription_matched (
         ::Xyz::FooSeq,
         ::Xyz::FooDataReader,
         ::Xyz::FooDataReader_ptr,
-        ::Xyz::FooDataReader_var,
-        ::Xyz::FooDataReaderImpl> (reader);
+        ::Xyz::FooDataReader_var> (reader);
 
     if (ret != 0)
     {

--- a/tests/DCPS/MultiRepoTest/ForwardingListener.cpp
+++ b/tests/DCPS/MultiRepoTest/ForwardingListener.cpp
@@ -6,7 +6,7 @@
 #include "tests/DCPS/FooType5/FooDefTypeSupportImpl.h"
 #include "dds/DCPS/Service_Participant.h"
 
-template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var, class DR_impl>
+template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var>
 int read (::DDS::DataReader_ptr reader, DT& foo, bool& valid_data)
 {
   try
@@ -20,14 +20,9 @@ int read (::DDS::DataReader_ptr reader, DT& foo, bool& valid_data)
       throw BadReaderException() ;
     }
 
-    DR_impl* dr_servant =
-      dynamic_cast<DR_impl*> (foo_dr.in ());
-
     ::DDS::SampleInfo si ;
 
-    DDS::ReturnCode_t status  ;
-
-    status = dr_servant->read_next_sample(foo, si) ;
+    DDS::ReturnCode_t const status = foo_dr->read_next_sample(foo, si) ;
 
     if (status == ::DDS::RETCODE_OK)
     {
@@ -198,8 +193,7 @@ void ForwardingListenerImpl::on_subscription_matched (
         ::Xyz::FooNoKeySeq,
         ::Xyz::FooNoKeyDataReader,
         ::Xyz::FooNoKeyDataReader_ptr,
-        ::Xyz::FooNoKeyDataReader_var,
-        ::Xyz::FooNoKeyDataReaderImpl> (reader, foo, valid_data);
+        ::Xyz::FooNoKeyDataReader_var> (reader, foo, valid_data);
 
     if (ret != 0)
     {

--- a/tests/DCPS/UnitTests/ut_BIT_DataReader.cpp
+++ b/tests/DCPS/UnitTests/ut_BIT_DataReader.cpp
@@ -7,6 +7,7 @@
 #include "dds/DCPS/Marked_Default_Qos.h"
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/WaitSet.h"
+#include "dds/DCPS/DiscoveryBase.h"
 
 #include "dds/DCPS/StaticIncludes.h"
 #ifdef ACE_AS_STATIC_LIBS
@@ -42,8 +43,8 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
                                                      0, DEFAULT_STATUS_MASK);
   Subscriber_var bit_sub = dp->get_builtin_subscriber();
   DataReader_var dr = bit_sub->lookup_datareader(BUILT_IN_PARTICIPANT_TOPIC);
-  ParticipantBuiltinTopicDataDataReaderImpl* bit_dr =
-    dynamic_cast<ParticipantBuiltinTopicDataDataReaderImpl*>(dr.in());
+  OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl* bit_dr =
+    dynamic_cast<OpenDDS::DCPS::ParticipantBuiltinTopicDataDataReaderImpl*>(dr.in());
   ReturnCode_t result;
 
   { // Should be able to read synthetic data

--- a/tests/DCPS/ViewState/main.cpp
+++ b/tests/DCPS/ViewState/main.cpp
@@ -296,9 +296,6 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         return 1; // failure
       }
 
-      Test::SimpleDataWriterImpl* fast_dw =
-        dynamic_cast<Test::SimpleDataWriterImpl*>(foo_dw.in ());
-
       Test::SimpleDataReader_var foo_dr
         = Test::SimpleDataReader::_narrow(dr.in ());
       if (CORBA::is_nil (foo_dr.in ()))
@@ -308,10 +305,6 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         return 1; // failure
       }
 
-      Test::SimpleDataReaderImpl* fast_dr =
-        dynamic_cast<Test::SimpleDataReaderImpl*>(foo_dr.in ());
-
-
       // wait for association establishement before writing.
       // -- replaced this sleep with the while loop below;
       //    waiting on the one association we expect.
@@ -319,7 +312,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       ::DDS::InstanceHandleSeq handles;
       while (1)
       {
-          fast_dw->get_matched_subscriptions(handles);
+          foo_dw->get_matched_subscriptions(handles);
           if (handles.length() > 0)
               break;
           else
@@ -345,10 +338,10 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           // register the data so we can use the handle.
           ::DDS::InstanceHandle_t handle
-            = fast_dw->register_instance(foo1);
+            = foo_dw->register_instance(foo1);
 
           // write first sample
-          fast_dw->write(foo1, handle);
+          foo_dw->write(foo1, handle);
 
           // wait for write to propogate
           if (!wait_for_data(sub.in (), 5))
@@ -358,7 +351,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           // read should return one sample with view state NEW.
           DDS::ReturnCode_t status  ;
-          status = fast_dr->read(  data1
+          status = foo_dr->read(  data1
             , info1
             , max_samples
             , ::DDS::ANY_SAMPLE_STATE
@@ -392,7 +385,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           foo2.count = 2;
 
           // write second sample
-          fast_dw->write(foo2, handle);
+          foo_dw->write(foo2, handle);
 
           // wait for write to propogate
           if (!wait_for_data(sub.in (), 5))
@@ -404,7 +397,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           // we read previously and the instance is not reborn.
           Test::SimpleSeq     data2 (max_samples);
           ::DDS::SampleInfoSeq info2;
-          status = fast_dr->read(  data2
+          status = foo_dr->read(  data2
             , info2
             , max_samples
             , ::DDS::ANY_SAMPLE_STATE
@@ -441,7 +434,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           // Upon receiving dispose, a NEW sample is created which marks InstanceState
           // has NOT_READ_SAMPLE, but won't change the view state. The view state is
           // changed to NEW_VIEW when data sample is received.
-          fast_dw->dispose(foo1, handle);
+          foo_dw->dispose(foo1, handle);
 
           //// wait for dispose sample to propogate
           if (!wait_for_data(sub.in (), 5))
@@ -456,7 +449,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           Test::SimpleSeq     disposeData (max_samples);
           ::DDS::SampleInfoSeq disposeDataInfo;
 
-          status = fast_dr->read(  disposeData
+          status = foo_dr->read(  disposeData
             , disposeDataInfo
             , max_samples
             , ::DDS::NOT_READ_SAMPLE_STATE
@@ -478,7 +471,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           foo3.key  = 1;
           foo3.count = 3;
 
-          fast_dw->write (foo3, handle);
+          foo_dw->write (foo3, handle);
 
           //// wait for write to propogate
           if (!wait_for_data(sub.in (), 5))
@@ -494,7 +487,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           Test::SimpleSeq     data3 (max_samples);
           ::DDS::SampleInfoSeq info3;
-          status = fast_dr->read(  data3
+          status = foo_dr->read(  data3
             , info3
             , max_samples
             , ::DDS::ANY_SAMPLE_STATE
@@ -528,7 +521,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           Test::SimpleSeq     data4 (max_samples);
           ::DDS::SampleInfoSeq info4;
-          status = fast_dr->read(  data4
+          status = foo_dr->read(  data4
             , info4
             , max_samples
             , ::DDS::ANY_SAMPLE_STATE
@@ -568,7 +561,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           Test::SimpleSeq     data5 (max_samples);
           ::DDS::SampleInfoSeq info5;
-          status = fast_dr->read(  data5
+          status = foo_dr->read(  data5
             , info5
             , max_samples
             , ::DDS::ANY_SAMPLE_STATE
@@ -609,7 +602,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           //Since it's a different instance, can not use previous handle.
           //Let it automatically register.
-          fast_dw->write (xfoo, ::DDS::HANDLE_NIL);
+          foo_dw->write (xfoo, ::DDS::HANDLE_NIL);
 
           //// wait for write to propogate
           if (!wait_for_data(sub.in (), 5))
@@ -621,7 +614,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           ::DDS::SampleInfoSeq info6;
 
           // read should return one sample with view state NEW.
-          status = fast_dr->read(  data6
+          status = foo_dr->read(  data6
             , info6
             , max_samples
             , ::DDS::ANY_SAMPLE_STATE

--- a/tests/DCPS/WriteDataContainer/WriteDataContainerTest.cpp
+++ b/tests/DCPS/WriteDataContainer/WriteDataContainerTest.cpp
@@ -62,6 +62,11 @@ private:
   InstanceHandleGenerator participant_handles_;
 };
 
+namespace Test
+{
+  typedef OpenDDS::DCPS::DataWriterImpl_T<Simple> SimpleDataWriterImpl;
+}
+
 class DDS_TEST
 {
 public:

--- a/tests/DCPS/ZeroCopyRead/main.cpp
+++ b/tests/DCPS/ZeroCopyRead/main.cpp
@@ -530,9 +530,6 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         return 1; // failure
       }
 
-      Test::SimpleDataWriterImpl* fast_dw =
-        dynamic_cast<Test::SimpleDataWriterImpl*>(foo_dw.in ());
-
       Test::SimpleDataReader_var foo_dr
         = Test::SimpleDataReader::_narrow(dr.in ());
       if (CORBA::is_nil (foo_dr.in ()))
@@ -542,10 +539,6 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         return 1; // failure
       }
 
-      Test::SimpleDataReaderImpl* fast_dr =
-        dynamic_cast<Test::SimpleDataReaderImpl*>(foo_dr.in ());
-
-
       // wait for association establishement before writing.
       // -- replaced this sleep with the while loop below;
       //    waiting on the one association we expect.
@@ -553,7 +546,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       ::DDS::InstanceHandleSeq handles;
       while (1)
       {
-          fast_dw->get_matched_subscriptions(handles);
+          foo_dw->get_matched_subscriptions(handles);
           if (handles.length() > 0)
               break;
           else
@@ -595,9 +588,9 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
 
       writer_instance_handle
-          = fast_dw->register_instance(foo);
+          = foo_dw->register_instance(foo);
 
-      fast_dw->write(foo,
+      foo_dw->write(foo,
                      writer_instance_handle);
 
 
@@ -623,7 +616,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         DDS::ReturnCode_t status  ;
         if (do_by_instance)
           {
-            status = fast_dr->read ( data1
+            status = foo_dr->read ( data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -634,7 +627,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read ( data1
+            status = foo_dr->read ( data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -651,7 +644,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         ::DDS::SampleInfoSeq info2;
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data2
+            status = foo_dr->read_instance(  data2
                                     , info2
                                     , max_samples
                                     , reader_instance_handle
@@ -661,7 +654,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data2
+            status = foo_dr->read(  data2
                                     , info2
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -697,7 +690,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             test_failed = 1;
           }
 
-        status = fast_dr->return_loan(copy, copyInfo );
+        status = foo_dr->return_loan(copy, copyInfo );
 
         check_return_loan_status(status, copy, 0, 0, "t1 return_loan copy");
 
@@ -709,7 +702,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         }
 
 
-        status = fast_dr->return_loan(data2, info2 );
+        status = foo_dr->return_loan(data2, info2 );
 
         check_return_loan_status(status, data2, 0, 0, "t1 return_loan2");
 
@@ -719,7 +712,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                 ACE_TEXT("(%P|%t) t4 ERROR: bad ref count %d expecting 2\n"), item->ref_count() ));
             test_failed = 1;
         }
-        status = fast_dr->return_loan(data1, info1 );
+        status = foo_dr->return_loan(data1, info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t1 return_loan1");
 
@@ -746,7 +739,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         DDS::ReturnCode_t status  ;
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data1
+            status = foo_dr->read_instance(  data1
                                     , info1
                                     , max_samples
                                     , reader_instance_handle
@@ -756,7 +749,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data1
+            status = foo_dr->read(  data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -774,7 +767,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         ::DDS::SampleInfoSeq info2 (max_samples);
         if (do_by_instance)
           {
-            status = fast_dr->read_instance ( data2
+            status = foo_dr->read_instance ( data2
                                     , info2
                                     , max_samples
                                     , reader_instance_handle
@@ -784,7 +777,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data2
+            status = foo_dr->read(  data2
                                     , info2
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -825,16 +818,16 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             test_failed = 1;
           }
 
-        status = fast_dr->return_loan(copy, copyInfo );
+        status = foo_dr->return_loan(copy, copyInfo );
 
         check_return_loan_status(status, copy, 1, max_samples, "t2 return_loan copy");
 
-        status = fast_dr->return_loan(  data2
+        status = foo_dr->return_loan(  data2
                                       , info2 );
 
         check_return_loan_status(status, data2, 1, max_samples, "t2 return_loan2");
 
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                       , info1 );
 
         check_return_loan_status(status, data1, 1, max_samples, "t2 return_loan1");
@@ -869,7 +862,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo,
+        foo_dw->write(foo,
                         writer_instance_handle);
 
         // wait for write to propogate
@@ -881,7 +874,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         DDS::ReturnCode_t status  ;
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data1
+            status = foo_dr->read_instance(  data1
                                     , info1
                                     , max_samples
                                     , reader_instance_handle
@@ -891,7 +884,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data1
+            status = foo_dr->read(  data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -916,7 +909,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo,
+        foo_dw->write(foo,
                         writer_instance_handle);
 
         // wait for write to propogate
@@ -930,7 +923,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data2
+            status = foo_dr->read_instance(  data2
                                     , info2
                                     , max_samples
                                     , reader_instance_handle
@@ -940,7 +933,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data2
+            status = foo_dr->read(  data2
                                     , info2
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -967,7 +960,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             test_failed = 1;
 
         }
-        status = fast_dr->return_loan(  data2
+        status = foo_dr->return_loan(  data2
                                         , info2 );
 
         check_return_loan_status(status, data2, 0, 0, "t3 return_loan2");
@@ -981,7 +974,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         // Note: the info sequence data is not destroyed/freed until
         //       the info1 object goes out of scope -- so it can
         //       be reused without alloc & free.
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                         , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t3 return_loan1");
@@ -1001,7 +994,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         DDS::ReturnCode_t status  ;
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data1
+            status = foo_dr->read_instance(  data1
                                     , info1
                                     , max_samples
                                     , reader_instance_handle
@@ -1011,7 +1004,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data1
+            status = foo_dr->read(  data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -1029,7 +1022,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             ::DDS::SampleInfoSeq info2;
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data2
+            status = foo_dr->read_instance(  data2
                                     , info2
                                     , max_samples
                                     , reader_instance_handle
@@ -1039,7 +1032,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data2
+            status = foo_dr->read(  data2
                                     , info2
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -1098,7 +1091,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo, writer_instance_handle);
+        foo_dw->write(foo, writer_instance_handle);
 
         // wait for write to propogate
         if (!wait_for_data(sub.in (), 5))
@@ -1109,7 +1102,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         DDS::ReturnCode_t status  ;
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data1
+            status = foo_dr->read_instance(  data1
                                     , info1
                                     , max_samples
                                     , reader_instance_handle
@@ -1119,7 +1112,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data1
+            status = foo_dr->read(  data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -1144,7 +1137,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo, writer_instance_handle);
+        foo_dw->write(foo, writer_instance_handle);
 
         // wait for write to propogate
         if (!wait_for_data(sub.in (), 5))
@@ -1152,14 +1145,14 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                             ACE_TEXT("(%P|%t) t5 ERROR: timeout waiting for data.\n")),
                             1);
 
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                         , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t5 return_loan1");
 
         if (do_by_instance)
           {
-            status = fast_dr->read_instance(  data1
+            status = foo_dr->read_instance(  data1
                                     , info1
                                     , max_samples
                                     , reader_instance_handle
@@ -1169,7 +1162,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->read(  data1
+            status = foo_dr->read(  data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -1187,7 +1180,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         }
 
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                         , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t5 return_loan1");
@@ -1209,7 +1202,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo, writer_instance_handle);
+        foo_dw->write(foo, writer_instance_handle);
 
         // wait for write to propogate
         if (!wait_for_data(sub.in (), 5))
@@ -1220,7 +1213,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         DDS::ReturnCode_t status  ;
         if (do_by_instance)
           {
-            status = fast_dr->take_instance(  data1
+            status = foo_dr->take_instance(  data1
                                     , info1
                                     , max_samples
                                     , reader_instance_handle
@@ -1230,7 +1223,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->take(  data1
+            status = foo_dr->take(  data1
                                     , info1
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -1255,7 +1248,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         ::DDS::SampleInfoSeq info2(max_samples, 0, 0); //testing alternate ctor
         if (do_by_instance)
           {
-            status = fast_dr->take_instance ( data2
+            status = foo_dr->take_instance ( data2
                                     , info2
                                     , max_samples
                                     , reader_instance_handle
@@ -1265,7 +1258,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           }
         else
           {
-            status = fast_dr->take(  data2
+            status = foo_dr->take(  data2
                                     , info2
                                     , max_samples
                                     , ::DDS::ANY_SAMPLE_STATE
@@ -1283,12 +1276,12 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         }
 
         // ?OK to return an empty loan?
-        status = fast_dr->return_loan(  data2
+        status = foo_dr->return_loan(  data2
                                       , info2 );
 
         check_return_loan_status(status, data2, 0, 0, "t6 return_loan2");
 
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                       , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t6 return_loan1");
@@ -1313,7 +1306,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo,  ::DDS::HANDLE_NIL /*don't use instance_handle_ because it is a different instance */);
+        foo_dw->write(foo,  ::DDS::HANDLE_NIL /*don't use instance_handle_ because it is a different instance */);
 
         // wait for write to propogate
         if (!wait_for_data(sub.in (), 5))
@@ -1322,7 +1315,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                             1);
 
         DDS::ReturnCode_t status  ;
-        status = fast_dr->read(  data1
+        status = foo_dr->read(  data1
                                 , info1
                                 , max_samples
                                 , ::DDS::ANY_SAMPLE_STATE
@@ -1352,7 +1345,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         // 0 means zero-copy
         Test::SimpleSeq     data2 (0, max_samples);
         ::DDS::SampleInfoSeq info2;
-        status = fast_dr->take(  data2
+        status = foo_dr->take(  data2
                                 , info2
                                 , max_samples
                                 , ::DDS::ANY_SAMPLE_STATE
@@ -1377,12 +1370,12 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         }
 
-        status = fast_dr->return_loan(  data2
+        status = foo_dr->return_loan(  data2
                                       , info2 );
 
         check_return_loan_status(status, data2, 0, 0, "t7 return_loan2");
 
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                       , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t7 return_loan1");
@@ -1411,7 +1404,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo, writer_instance_handle);
+        foo_dw->write(foo, writer_instance_handle);
 
         // wait for write to propogate
         if (!wait_for_data(sub.in (), 5))
@@ -1420,7 +1413,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                             1);
 
         DDS::ReturnCode_t status  ;
-        status = fast_dr->read(  data1
+        status = foo_dr->read(  data1
                                 , info1
                                 , max_samples
                                 , ::DDS::ANY_SAMPLE_STATE
@@ -1450,7 +1443,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         // 0 means zero-copy
         Test::SimpleSeq     data2 (0, max_samples, &the_allocator);
         ::DDS::SampleInfoSeq info2;
-        status = fast_dr->take(  data2
+        status = foo_dr->take(  data2
                                 , info2
                                 , max_samples
                                 , ::DDS::ANY_SAMPLE_STATE
@@ -1475,7 +1468,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         }
 
-        status = fast_dr->return_loan(  data2
+        status = foo_dr->return_loan(  data2
                                       , info2 );
 
         // Note: the samples are freed in return_loan (if not reference by something else)
@@ -1484,7 +1477,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         check_return_loan_status(status, data2, 0, 0, "t8 return_loan2");
 
 
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                       , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t8 return_loan1");
@@ -1586,7 +1579,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         // since depth=1 the previous sample will be "lost"
         // from the instance container.
-        fast_dw->write(foo, writer_instance_handle);
+        foo_dw->write(foo, writer_instance_handle);
 
         // wait for write to propogate
         if (!wait_for_data(sub.in (), 5))
@@ -1595,7 +1588,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                             1);
 
         DDS::ReturnCode_t status  ;
-        status = fast_dr->read(  data0
+        status = foo_dr->read(  data0
                                 , info0
                                 , max_samples
                                 , ::DDS::ANY_SAMPLE_STATE
@@ -1625,13 +1618,13 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         }
 
         // Return the "loan" of read samples to datareader.
-        status = fast_dr->return_loan(  data0
+        status = foo_dr->return_loan(  data0
                                       , info0 );
 
         check_return_loan_status(status, data0, 0, 0, "t10 return_loan");
 
         // Return the "loan" of copied samples to the datareader.
-        status = fast_dr->return_loan(  data1
+        status = foo_dr->return_loan(  data1
                                       , info1 );
 
         check_return_loan_status(status, data1, 0, 0, "t10 return_loan");


### PR DESCRIPTION
… related namespace. This only pollutes the user type namespace and isn't used in general. Within the discovery the build in data is used, added typedefs for the necessary readers within the OpenDDS namespace, this is not for the user

    * dds/DCPS/DiscoveryBase.h:
    * dds/DCPS/RTPS/Sedp.cpp:
    * dds/DCPS/RTPS/Sedp.h:
    * dds/DCPS/RTPS/Spdp.cpp:
    * dds/DCPS/RTPS/Spdp.h:
    * dds/DCPS/StaticDiscovery.cpp:
    * dds/DCPS/StaticDiscovery.h:
    * dds/DCPS/TypeSupportImpl_T.h:
    * dds/idl/ts_generator.cpp: