### PR TITLE
Fix DataWriterImpl accessed after deletion bug

### DIFF
--- a/DevGuideExamples/DCPS/Messenger.minimal/DataReaderListenerImpl.cpp
+++ b/DevGuideExamples/DCPS/Messenger.minimal/DataReaderListenerImpl.cpp
@@ -7,6 +7,7 @@
 
 #include "DataReaderListenerImpl.h"
 #include "Boilerplate.h"
+#include <iostream>
 
 using namespace examples::boilerplate;
 

--- a/DevGuideExamples/DCPS/Messenger.minimal/Subscriber.cpp
+++ b/DevGuideExamples/DCPS/Messenger.minimal/Subscriber.cpp
@@ -10,6 +10,7 @@
 #include <dds/DCPS/Service_Participant.h>
 #include <model/Sync.h>
 #include <stdexcept>
+#include <iostream>
 
 #include "dds/DCPS/StaticIncludes.h"
 

--- a/FACE/StringManager.h
+++ b/FACE/StringManager.h
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <algorithm>
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
   class Serializer;
@@ -334,5 +335,6 @@ bool operator>>(DCPS::Serializer& ser, StringBase<FACE::WChar>& str);
 
 }
 }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #endif

--- a/FACE/types.hpp
+++ b/FACE/types.hpp
@@ -3,7 +3,9 @@
 
 #include <ace/CDR_Base.h>
 #include "OpenDDS_FACE_Export.h"
+#include "dds/Versioned_Namespace.h"
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
   namespace FaceTypes {
     template<typename CharT> class String_var;
@@ -11,6 +13,7 @@ namespace OpenDDS {
     template<typename CharT> class StringManager;
   }
 }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 namespace FACE {
   typedef ACE_CDR::Boolean Boolean;
@@ -41,10 +44,10 @@ namespace FACE {
   typedef Char& Char_out;
   typedef WChar& WChar_out;
 
-  typedef ::OpenDDS::FaceTypes::String_var<Char> String_var;
-  typedef ::OpenDDS::FaceTypes::String_out<Char> String_out;
-  typedef ::OpenDDS::FaceTypes::String_var<WChar> WString_var;
-  typedef ::OpenDDS::FaceTypes::String_out<WChar> WString_out;
+  typedef OpenDDS::FaceTypes::String_var<Char> String_var;
+  typedef OpenDDS::FaceTypes::String_out<Char> String_out;
+  typedef OpenDDS::FaceTypes::String_var<WChar> WString_var;
+  typedef OpenDDS::FaceTypes::String_out<WChar> WString_out;
 
   OpenDDS_FACE_Export Char* string_alloc(UnsignedLong len);
   OpenDDS_FACE_Export Char* string_dup(const Char* str);
@@ -55,11 +58,13 @@ namespace FACE {
   OpenDDS_FACE_Export void wstring_free(WChar* str);
 }
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
   namespace FaceTypes {
     typedef StringManager<FACE::Char> String_mgr;
     typedef StringManager<FACE::WChar> WString_mgr;
   }
 }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #endif /* FACE_TYPES_HPP_HEADER_FILE */

--- a/MPC/config/opendds_face.mpb
+++ b/MPC/config/opendds_face.mpb
@@ -1,6 +1,6 @@
 project: dcps, dcps_ts_defaults {
   requires += built_in_topics
-  avoids += uses_wchar versioned_namespace
+  avoids += uses_wchar
   libs  += OpenDDS_FACE
   after += OpenDDS_FACE
 

--- a/contrib/wrapper/example/publisher.cpp
+++ b/contrib/wrapper/example/publisher.cpp
@@ -8,6 +8,7 @@
 
 #include "StockQuoterTypeSupportImpl.h"
 #include <ace/streams.h>
+#include <ace/OS_NS_unistd.h>
 #include <orbsvcs/Time_Utilities.h>
 
 #include "Domain_Manager.h"

--- a/contrib/wrapper/example/subscriber.cpp
+++ b/contrib/wrapper/example/subscriber.cpp
@@ -11,6 +11,7 @@
 #include "ExchangeEventDataReaderListenerImpl.h"
 #include <dds/DCPS/SubscriberImpl.h>
 #include <ace/streams.h>
+#include <ace/OS_NS_unistd.h>
 #include <orbsvcs/Time_Utilities.h>
 
 #include "Domain_Manager.h"

--- a/dds/DCPS/AssociationData.h
+++ b/dds/DCPS/AssociationData.h
@@ -10,6 +10,7 @@
 
 #include "dds/DdsDcpsInfoUtilsC.h"
 #include "dds/DCPS/transport/framework/NetworkAddress.h"
+#include "dds/DCPS/transport/framework/TransportDefs.h"
 #include "ace/INET_Addr.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -20,7 +21,7 @@ namespace DCPS {
 struct AssociationData {
   RepoId               remote_id_;
   TransportLocatorSeq  remote_data_;
-  Priority          publication_transport_priority_;
+  Priority             publication_transport_priority_;
   bool                 remote_reliable_, remote_durable_;
 
   AssociationData()

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3378,6 +3378,18 @@ DataReaderImpl::unregister_for_writer(const RepoId& participant,
   TransportClient::unregister_for_writer(participant, readerid, writerid);
 }
 
+
+void DataReaderImpl::_add_ref()
+{
+  CORBA::Object::_add_ref();
+}
+
+void DataReaderImpl::_remove_ref()
+{
+  CORBA::Object::_remove_ref();
+}
+
+
 EndHistoricSamplesMissedSweeper::EndHistoricSamplesMissedSweeper(ACE_Reactor* reactor,
                                                                  ACE_thread_t owner,
                                                                  DataReaderImpl* reader)

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -252,6 +252,8 @@ public:
   /// The liveliness status need update.
   void writer_removed(WriterInfo& info);
 
+  virtual void _add_ref();
+  virtual void _remove_ref();
   /**
    * cleanup the DataWriter.
    */

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -39,6 +39,7 @@
 #include "PoolAllocator.h"
 #include "RemoveAssociationSweeper.h"
 #include "RcEventHandler.h"
+#include "Loaner.h"
 
 #include "ace/String_Base.h"
 #include "ace/Reverse_Lock_T.h"
@@ -190,6 +191,7 @@ class OpenDDS_Dcps_Export DataReaderImpl
     public virtual EntityImpl,
     public virtual TransportClient,
     public virtual TransportReceiveListener,
+    public virtual Loaner,
     private WriterInfoListener {
 public:
   friend class RequestedDeadlineWatchdog;
@@ -417,26 +419,11 @@ public:
 
   bool is_bit() const;
 
-  /** This method provides virtual access to type specific code
-   * that is used when loans are automatically returned.
-   * The destructor of the sequence supporing zero-copy read calls this
-   * method on the datareader that provided the loan.
-   *
-   * @param seq - The sequence of loaned values.
-   *
-   * @returns Always RETCODE_OK.
-   *
-   * thows NONE.
-   */
-  virtual DDS::ReturnCode_t auto_return_loan(void* seq) = 0;
-
   /** This method is used for a precondition check of delete_datareader.
    *
    * @returns the number of outstanding zero-copy samples loaned out.
    */
   virtual int num_zero_copies();
-
-  virtual void dec_ref_data_element(ReceivedDataElement* r) = 0;
 
   /// Release the instance with the handle.
   void release_instance(DDS::InstanceHandle_t handle);
@@ -535,7 +522,7 @@ public:
   void set_subscriber_qos(const DDS::SubscriberQos & qos);
 
   // Set the instance related writers to reevaluate the owner.
-  void reset_ownership (::DDS::InstanceHandle_t instance);
+  void reset_ownership (DDS::InstanceHandle_t instance);
 
   virtual EntityImpl* parent() const;
 

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -58,6 +58,9 @@ public:
   virtual void unregister_for_reader(const RepoId& /*participant*/,
                                      const RepoId& /*writerid*/,
                                      const RepoId& /*readerid*/) { }
+
+  virtual void _add_ref() = 0;
+  virtual void _remove_ref() = 0;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -115,6 +115,8 @@ DataWriterImpl::DataWriterImpl()
     TheServiceParticipant->monitor_factory_->create_data_writer_periodic_monitor(this);
 
   db_lock_pool_ = new DataBlockLockPool((unsigned long)n_chunks_);
+
+  ACE_Event_Handler::reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
 }
 
 // This method is called when there are no longer any reference to the
@@ -365,7 +367,7 @@ DataWriterImpl::ReaderInfo::ReaderInfo(const char* filterClassName,
   , filter_class_name_(filterClassName)
   , filter_(filter)
   , expression_params_(params)
-  , eval_(*filter ? participant->get_filter_eval(filter) : 0)
+  , eval_(*filter ? participant->get_filter_eval(filter) : RcHandle<FilterEvaluator>())
   , expected_sequence_(SequenceNumber::SEQUENCENUMBER_UNKNOWN())
   , durable_(durable)
 {}
@@ -1349,7 +1351,7 @@ DataWriterImpl::enable()
 
     } else {
       cancel_timer_ = true;
-      this->_add_ref();
+      //this->_add_ref();
     }
   }
 
@@ -2365,7 +2367,7 @@ int
 DataWriterImpl::handle_close(ACE_HANDLE,
                              ACE_Reactor_Mask)
 {
-  this->_remove_ref();
+  //this->_remove_ref();
   return 0;
 }
 
@@ -2656,6 +2658,45 @@ DataWriterImpl::send_control(const DataSampleHeader& header,
 
   return status;
 }
+
+void
+DataWriterImpl::_add_ref()
+{
+  CORBA::Object::_add_ref();
+}
+
+void
+DataWriterImpl::_remove_ref()
+{
+  CORBA::Object::_remove_ref();
+}
+
+ACE_Event_Handler::Reference_Count
+DataWriterImpl::add_reference()
+{
+  CORBA::Object::_add_ref();
+  return 1;
+}
+
+ACE_Event_Handler::Reference_Count
+DataWriterImpl::remove_reference()
+{
+  CORBA::Object::_remove_ref();
+  return 1;
+}
+
+void
+DataWriterImpl::listener_add_ref()
+{
+  CORBA::Object::_add_ref();
+}
+
+void
+DataWriterImpl::listener_remove_ref()
+{
+  CORBA::Object::_remove_ref();
+}
+
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -80,7 +80,7 @@ class OpenDDS_Dcps_Export DataWriterImpl
     public virtual EntityImpl,
     public virtual TransportClient,
     public virtual TransportSendListener,
-    public virtual ACE_Event_Handler {
+    private ACE_Event_Handler {
 public:
   friend class WriteDataContainer;
   friend class PublisherImpl;
@@ -187,6 +187,14 @@ public:
                                           const DDS::StringSeq& params);
 
   virtual void inconsistent_topic();
+
+
+  virtual void _add_ref();
+  virtual void _remove_ref();
+
+  virtual ACE_Event_Handler::Reference_Count add_reference();
+  virtual ACE_Event_Handler::Reference_Count remove_reference();
+
 
   /**
    * cleanup the DataWriter.
@@ -582,8 +590,8 @@ private:
 
   void association_complete_i(const RepoId& remote_id);
 
-  void listener_add_ref() { EntityImpl::_add_ref(); }
-  void listener_remove_ref() { EntityImpl::_remove_ref(); }
+  void listener_add_ref();
+  void listener_remove_ref();
 
   friend class ::DDS_TEST; // allows tests to get at privates
 

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -17,6 +17,7 @@
 #include "dds/DCPS/DataReaderImpl_T.h"
 #include "dds/DdsDcpsCoreTypeSupportImpl.h"
 #include "ace/Select_Reactor.h"
+#include "ace/Condition_Thread_Mutex.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
-#include "dds/DdsDcpsGuidC.h"
 #include "DomainParticipantImpl.h"
+#include "dds/DdsDcpsGuidC.h"
 #include "FeatureDisabledQosCheck.h"
 #include "Service_Participant.h"
 #include "Qos_Helper.h"
@@ -37,6 +37,7 @@
 
 #include "tao/debug.h"
 #include "ace/Reactor.h"
+#include "ace/OS_NS_unistd.h"
 
 namespace Util {
 

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
@@ -28,20 +28,8 @@ DataWriterRemoteImpl::~DataWriterRemoteImpl()
 void
 DataWriterRemoteImpl::detach_parent()
 {
-  // ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
   this->parent_ = 0;
 }
-
-// namespace
-// {
-//   DDS::DataWriter_var getDataWriter(DataWriterCallbacks* callbacks)
-//   {
-//     // the DataWriterCallbacks will always be a DataWriter
-//     DDS::DataWriter_var var =
-//       DDS::DataWriter::_duplicate(dynamic_cast<DDS::DataWriter*>(callbacks));
-//     return var;
-//   }
-// }
 
 void
 DataWriterRemoteImpl::add_association(const RepoId& yourId,
@@ -57,13 +45,6 @@ DataWriterRemoteImpl::add_association(const RepoId& yourId,
                std::string(reader_converter).c_str()));
   }
 
-  // DataWriterCallbacks* parent = 0;
-  // DDS::DataWriter_var dwv;
-  // {
-  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-  //   dwv = getDataWriter(this->parent_);
-  //   parent = this->parent_;
-  // }
   if (parent_.in()) {
     parent_->add_association(yourId, reader, active);
   }
@@ -72,13 +53,6 @@ DataWriterRemoteImpl::add_association(const RepoId& yourId,
 void
 DataWriterRemoteImpl::association_complete(const RepoId& remote_id)
 {
-  // DataWriterCallbacks* parent = 0;
-  // DDS::DataWriter_var dwv;
-  // {
-  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-  //   dwv = getDataWriter(this->parent_);
-  //   parent = this->parent_;
-  // }
   if (parent_.in()) {
     parent_->association_complete(remote_id);
   }
@@ -88,13 +62,6 @@ void
 DataWriterRemoteImpl::remove_associations(const ReaderIdSeq& readers,
                                           CORBA::Boolean notify_lost)
 {
-  // DataWriterCallbacks* parent = 0;
-  // DDS::DataWriter_var dwv;
-  // {
-  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-  //   dwv = getDataWriter(this->parent_);
-  //   parent = this->parent_;
-  // }
   if (parent_.in()) {
     parent_->remove_associations(readers, notify_lost);
   }
@@ -104,13 +71,6 @@ void
 DataWriterRemoteImpl::update_incompatible_qos(
   const IncompatibleQosStatus& status)
 {
-  // DataWriterCallbacks* parent = 0;
-  // DDS::DataWriter_var dwv;
-  // {
-  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-  //   dwv = getDataWriter(this->parent_);
-  //   parent = this->parent_;
-  // }
   if (parent_.in()) {
     parent_->update_incompatible_qos(status);
   }
@@ -120,13 +80,6 @@ void
 DataWriterRemoteImpl::update_subscription_params(const RepoId& readerId,
                                                  const DDS::StringSeq& params)
 {
-  // DataWriterCallbacks* parent = 0;
-  // DDS::DataWriter_var dwv;
-  // {
-  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-  //   dwv = getDataWriter(this->parent_);
-  //   parent = this->parent_;
-  // }
   if (parent_.in()) {
     parent_->update_subscription_params(readerId, params);
   }

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
@@ -15,7 +15,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 DataWriterRemoteImpl::DataWriterRemoteImpl(DataWriterCallbacks* parent)
-  : parent_(parent)
+  : parent_(parent, false)
 {
 }
 
@@ -28,20 +28,20 @@ DataWriterRemoteImpl::~DataWriterRemoteImpl()
 void
 DataWriterRemoteImpl::detach_parent()
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
+  // ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
   this->parent_ = 0;
 }
 
-namespace
-{
-  DDS::DataWriter_var getDataWriter(DataWriterCallbacks* callbacks)
-  {
-    // the DataWriterCallbacks will always be a DataWriter
-    DDS::DataWriter_var var =
-      DDS::DataWriter::_duplicate(dynamic_cast<DDS::DataWriter*>(callbacks));
-    return var;
-  }
-}
+// namespace
+// {
+//   DDS::DataWriter_var getDataWriter(DataWriterCallbacks* callbacks)
+//   {
+//     // the DataWriterCallbacks will always be a DataWriter
+//     DDS::DataWriter_var var =
+//       DDS::DataWriter::_duplicate(dynamic_cast<DDS::DataWriter*>(callbacks));
+//     return var;
+//   }
+// }
 
 void
 DataWriterRemoteImpl::add_association(const RepoId& yourId,
@@ -57,30 +57,30 @@ DataWriterRemoteImpl::add_association(const RepoId& yourId,
                std::string(reader_converter).c_str()));
   }
 
-  DataWriterCallbacks* parent = 0;
-  DDS::DataWriter_var dwv;
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-    dwv = getDataWriter(this->parent_);
-    parent = this->parent_;
-  }
-  if (parent) {
-    parent->add_association(yourId, reader, active);
+  // DataWriterCallbacks* parent = 0;
+  // DDS::DataWriter_var dwv;
+  // {
+  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
+  //   dwv = getDataWriter(this->parent_);
+  //   parent = this->parent_;
+  // }
+  if (parent_.in()) {
+    parent_->add_association(yourId, reader, active);
   }
 }
 
 void
 DataWriterRemoteImpl::association_complete(const RepoId& remote_id)
 {
-  DataWriterCallbacks* parent = 0;
-  DDS::DataWriter_var dwv;
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-    dwv = getDataWriter(this->parent_);
-    parent = this->parent_;
-  }
-  if (parent) {
-    parent->association_complete(remote_id);
+  // DataWriterCallbacks* parent = 0;
+  // DDS::DataWriter_var dwv;
+  // {
+  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
+  //   dwv = getDataWriter(this->parent_);
+  //   parent = this->parent_;
+  // }
+  if (parent_.in()) {
+    parent_->association_complete(remote_id);
   }
 }
 
@@ -88,15 +88,15 @@ void
 DataWriterRemoteImpl::remove_associations(const ReaderIdSeq& readers,
                                           CORBA::Boolean notify_lost)
 {
-  DataWriterCallbacks* parent = 0;
-  DDS::DataWriter_var dwv;
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-    dwv = getDataWriter(this->parent_);
-    parent = this->parent_;
-  }
-  if (parent) {
-    parent->remove_associations(readers, notify_lost);
+  // DataWriterCallbacks* parent = 0;
+  // DDS::DataWriter_var dwv;
+  // {
+  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
+  //   dwv = getDataWriter(this->parent_);
+  //   parent = this->parent_;
+  // }
+  if (parent_.in()) {
+    parent_->remove_associations(readers, notify_lost);
   }
 }
 
@@ -104,15 +104,15 @@ void
 DataWriterRemoteImpl::update_incompatible_qos(
   const IncompatibleQosStatus& status)
 {
-  DataWriterCallbacks* parent = 0;
-  DDS::DataWriter_var dwv;
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-    dwv = getDataWriter(this->parent_);
-    parent = this->parent_;
-  }
-  if (parent) {
-    parent->update_incompatible_qos(status);
+  // DataWriterCallbacks* parent = 0;
+  // DDS::DataWriter_var dwv;
+  // {
+  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
+  //   dwv = getDataWriter(this->parent_);
+  //   parent = this->parent_;
+  // }
+  if (parent_.in()) {
+    parent_->update_incompatible_qos(status);
   }
 }
 
@@ -120,15 +120,15 @@ void
 DataWriterRemoteImpl::update_subscription_params(const RepoId& readerId,
                                                  const DDS::StringSeq& params)
 {
-  DataWriterCallbacks* parent = 0;
-  DDS::DataWriter_var dwv;
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
-    dwv = getDataWriter(this->parent_);
-    parent = this->parent_;
-  }
-  if (parent) {
-    parent->update_subscription_params(readerId, params);
+  // DataWriterCallbacks* parent = 0;
+  // DDS::DataWriter_var dwv;
+  // {
+  //   ACE_GUARD(ACE_Thread_Mutex, g, this->mutex_);
+  //   dwv = getDataWriter(this->parent_);
+  //   parent = this->parent_;
+  // }
+  if (parent_.in()) {
+    parent_->update_subscription_params(readerId, params);
   }
 }
 

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
@@ -45,16 +45,20 @@ DataWriterRemoteImpl::add_association(const RepoId& yourId,
                std::string(reader_converter).c_str()));
   }
 
-  if (parent_.in()) {
-    parent_->add_association(yourId, reader, active);
+  // the local copy of parent_ is necessary to prevent race condition
+  RcHandle<DataWriterCallbacks> parent = parent_;
+  if (parent.in()) {
+    parent->add_association(yourId, reader, active);
   }
 }
 
 void
 DataWriterRemoteImpl::association_complete(const RepoId& remote_id)
 {
-  if (parent_.in()) {
-    parent_->association_complete(remote_id);
+  // the local copy of parent_ is necessary to prevent race condition
+  RcHandle<DataWriterCallbacks> parent = parent_;
+  if (parent.in()) {
+    parent->association_complete(remote_id);
   }
 }
 
@@ -62,8 +66,10 @@ void
 DataWriterRemoteImpl::remove_associations(const ReaderIdSeq& readers,
                                           CORBA::Boolean notify_lost)
 {
-  if (parent_.in()) {
-    parent_->remove_associations(readers, notify_lost);
+  // the local copy of parent_ is necessary to prevent race condition
+  RcHandle<DataWriterCallbacks> parent = parent_;
+  if (parent.in()) {
+    parent->remove_associations(readers, notify_lost);
   }
 }
 
@@ -71,8 +77,10 @@ void
 DataWriterRemoteImpl::update_incompatible_qos(
   const IncompatibleQosStatus& status)
 {
-  if (parent_.in()) {
-    parent_->update_incompatible_qos(status);
+  // the local copy of parent_ is necessary to prevent race condition
+  RcHandle<DataWriterCallbacks> parent = parent_;
+  if (parent.in()) {
+    parent->update_incompatible_qos(status);
   }
 }
 
@@ -80,8 +88,10 @@ void
 DataWriterRemoteImpl::update_subscription_params(const RepoId& readerId,
                                                  const DDS::StringSeq& params)
 {
-  if (parent_.in()) {
-    parent_->update_subscription_params(readerId, params);
+  // the local copy of parent_ is necessary to prevent race condition
+  RcHandle<DataWriterCallbacks> parent = parent_;
+  if (parent.in()) {
+    parent->update_subscription_params(readerId, params);
   }
 }
 

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.h
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.h
@@ -10,6 +10,7 @@
 
 #include "dds/DCPS/InfoRepoDiscovery/DataWriterRemoteS.h"
 #include "dds/DCPS/Definitions.h"
+#include "dds/DCPS/RcHandle_T.h"
 
 #include "ace/Thread_Mutex.h"
 
@@ -54,7 +55,7 @@ public:
   void detach_parent();
 
 private:
-  DataWriterCallbacks* parent_;
+  RcHandle<DataWriterCallbacks> parent_;
   ACE_Thread_Mutex mutex_;
 };
 

--- a/dds/DCPS/Loaner.h
+++ b/dds/DCPS/Loaner.h
@@ -9,6 +9,7 @@
 #define OPENDDS_DCPS_LOANER_H
 
 #include "dds/Versioned_Namespace.h"
+#include "dds/DdsDcpsInfrastructureC.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -19,11 +20,13 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+class ReceivedDataElement;
+
 class Loaner
 {
 public:
-  Loaner () {}
-  virtual ~Loaner () {};
+  Loaner() {}
+  virtual ~Loaner() {}
 
   /**
    * This method provides virtual access to type specific code

--- a/dds/DCPS/Loaner.h
+++ b/dds/DCPS/Loaner.h
@@ -1,0 +1,50 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_LOANER_H
+#define OPENDDS_DCPS_LOANER_H
+
+#include "dds/Versioned_Namespace.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+class Loaner
+{
+public:
+  Loaner () {}
+  virtual ~Loaner () {};
+
+  /**
+   * This method provides virtual access to type specific code
+   * that is used when loans are automatically returned.
+   * The destructor of the sequence supporting zero-copy read calls this
+   * method on the datareader that provided the loan.
+   *
+   * @param seq - The sequence of loaned values.
+   *
+   * @returns Always RETCODE_OK.
+   *
+   * thows NONE.
+   */
+  virtual DDS::ReturnCode_t auto_return_loan(void* seq) = 0;
+
+  virtual void dec_ref_data_element(ReceivedDataElement* r) = 0;
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_LOANER_H  */

--- a/dds/DCPS/MultiTopicDataReaderBase.h
+++ b/dds/DCPS/MultiTopicDataReaderBase.h
@@ -10,7 +10,7 @@
 
 #ifndef OPENDDS_NO_MULTI_TOPIC
 
-#include "dds/DdsDcpsSubscriptionC.h"
+#include "dds/DdsDcpsSubscriptionExtC.h"
 #include "dds/DCPS/ZeroCopySeq_T.h"
 #include "dds/DCPS/MultiTopicImpl.h"
 #include "dds/DCPS/PoolAllocator.h"
@@ -23,6 +23,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace DCPS {
+
+class SubscriberImpl;
 
 class OpenDDS_Dcps_Export MultiTopicDataReaderBase
   : public virtual LocalObject<DataReaderEx> {

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -234,6 +234,9 @@ private:
     void notify_connection_deleted(const DCPS::RepoId&) {}
     void remove_associations(const DCPS::WriterIdSeq&, bool) {}
 
+    virtual void _add_ref() { DCPS::RcObject<ACE_SYNCH_MUTEX>::_add_ref(); }
+    virtual void _remove_ref() { DCPS::RcObject<ACE_SYNCH_MUTEX>::_remove_ref(); }
+
     void listener_add_ref() { _add_ref(); }
     void listener_remove_ref() { _remove_ref(); }
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -33,8 +33,8 @@
 
 #include "ace/Task_Ex_T.h"
 #include "ace/Thread_Mutex.h"
+#include "ace/Condition_Thread_Mutex.h"
 #include "dds/DCPS/PoolAllocator.h"
-
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -23,6 +23,7 @@
 #include "ace/Atomic_Op.h"
 #include "ace/SOCK_Dgram.h"
 #include "ace/SOCK_Dgram_Mcast.h"
+#include "ace/Condition_Thread_Mutex.h"
 
 #include "dds/DCPS/PoolAllocator.h"
 #include "dds/DCPS/PoolAllocationBase.h"

--- a/dds/DCPS/RcHandle_T.h
+++ b/dds/DCPS/RcHandle_T.h
@@ -31,6 +31,13 @@ public:
     }
   }
 
+  template <typename U>
+  RcHandle(const RcHandle<U>& other)
+    : ptr_(other.in())
+  {
+    this->bump_up();
+  }
+
   RcHandle(const RcHandle& b)
     : ptr_(b.ptr_)
   {
@@ -42,16 +49,30 @@ public:
     this->bump_down();
   }
 
-  RcHandle& operator=(T* p)
+
+  void reset(T* p=0)
   {
     RcHandle tmp(p);
     swap(tmp);
+  }
+
+  RcHandle& operator=(T* p)
+  {
+    this->reset(p);
     return *this;
   }
 
   RcHandle& operator=(const RcHandle& b)
   {
     RcHandle tmp(b);
+    swap(tmp);
+    return *this;
+  }
+
+  template <class U>
+  RcHandle& operator=(const RcHandle<U>& b)
+  {
+    RcHandle<T> tmp(b);
     swap(tmp);
     return *this;
   }
@@ -101,14 +122,19 @@ public:
     return retval;
   }
 
-  bool operator==(const RcHandle& rhs)
+  bool operator==(const RcHandle& rhs) const
   {
     return in() == rhs.in();
   }
 
-  bool operator!=(const RcHandle& rhs)
+  bool operator!=(const RcHandle& rhs) const
   {
     return in() != rhs.in();
+  }
+
+  bool operator < (const RcHandle& rhs) const
+  {
+    return in() < rhs.in();
   }
 
 private:

--- a/dds/DCPS/RcObject_T.h
+++ b/dds/DCPS/RcObject_T.h
@@ -12,6 +12,7 @@
 #include "ace/Atomic_Op.h"
 #include "ace/Malloc_Base.h"
 #include "dds/DCPS/PoolAllocationBase.h"
+#include "dds/DCPS/RcHandle_T.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -72,6 +73,15 @@ private:
   // method instead (if needed).
   RcObject(const RcObject&);
   RcObject& operator=(const RcObject&);
+};
+
+template <class T>
+struct EnableSharedFromThis
+{
+  RcHandle<T> shared_from_this()
+  {
+    return RcHandle<T>(static_cast<T*>(this), false);
+  }
 };
 
 } // namespace DCPS

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -37,6 +37,7 @@
 
 #include "ace/Reactor.h"
 #include "ace/Auto_Ptr.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 
 #include <stdexcept>
 

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -27,7 +27,7 @@
 
 #include "ace/Event_Handler.h"
 #include "ace/OS_NS_sys_time.h"
-#include "ace/Condition_Thread_Mutex.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 
 #include <memory>
 

--- a/dds/DCPS/RepoIdGenerator.cpp
+++ b/dds/DCPS/RepoIdGenerator.cpp
@@ -12,18 +12,18 @@
 #include "ace/Log_Msg.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS {
+namespace DCPS {
 
-const unsigned RepoIdGenerator::KeyBits = 24;
+const unsigned int RepoIdGenerator::KeyBits = 24;
 
-const unsigned RepoIdGenerator::KeyMask = (1 << KeyBits) - 1;
+const unsigned int RepoIdGenerator::KeyMask = (1 << KeyBits) - 1;
 
-RepoIdGenerator::RepoIdGenerator(
-  long                      federation,
-  long                      participant,
-  OpenDDS::DCPS::EntityKind kind) : kind_(kind),
-    federation_(federation),
-    participant_(participant),
-    lastKey_(0)
+RepoIdGenerator::RepoIdGenerator(long federation, long participant, EntityKind kind)
+  : kind_(kind)
+  , federation_(federation)
+  , participant_(participant)
+  , lastKey_(0)
 {
 }
 
@@ -31,20 +31,20 @@ RepoIdGenerator::~RepoIdGenerator()
 {
 }
 
-OpenDDS::DCPS::RepoId
+RepoId
 RepoIdGenerator::next()
 {
   // Generate a new key value.
-  ++this->lastKey_;
+  ++lastKey_;
 
-  OpenDDS::DCPS::RepoIdBuilder builder;
+  RepoIdBuilder builder;
   builder.federationId(federation_);
 
   // Generate a Participant GUID value.
-  if (this->kind_ == OpenDDS::DCPS::KIND_PARTICIPANT) {
+  if (kind_ == KIND_PARTICIPANT) {
 
     // Rudimentary validity checking.
-    if (this->lastKey_ == 0) {
+    if (lastKey_ == 0) {
       // We have rolled over and there can now exist objects with
       // the same key.
       ACE_ERROR((LM_ERROR,
@@ -54,14 +54,14 @@ RepoIdGenerator::next()
     }
 
     builder.participantId(lastKey_);
-    builder.entityId(OpenDDS::DCPS::ENTITYID_PARTICIPANT);
+    builder.entityId(ENTITYID_PARTICIPANT);
 
     // Generate an Entity GUID value.
 
   } else {
 
     // Rudimentary validity checking.
-    if ((this->lastKey_ & ~KeyMask) != 0) {
+    if ((lastKey_ & ~KeyMask) != 0) {
       // We have rolled over and there can now exist objects with
       // the same key.
       ACE_ERROR((LM_ERROR,
@@ -75,15 +75,17 @@ RepoIdGenerator::next()
     builder.entityKind(kind_);
   }
 
-  return OpenDDS::DCPS::RepoId(builder);
+  return RepoId(builder);
 }
 
 void
 RepoIdGenerator::last(long key)
 {
-  if (key > this->lastKey_) {
-    this->lastKey_ = key;
+  if (key > lastKey_) {
+    lastKey_ = key;
   }
 }
 
+} // namespace DCPS
+} // namespace OpenDDS
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RepoIdGenerator.h
+++ b/dds/DCPS/RepoIdGenerator.h
@@ -18,6 +18,8 @@
 #include "dcps_export.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS {
+namespace DCPS {
 
 /**
  * @class RepoIdGenerator
@@ -89,9 +91,9 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
  */
 class OpenDDS_Dcps_Export RepoIdGenerator {
 public:
-  static const unsigned KeyBits;
+  static const unsigned int KeyBits;
 
-  static const unsigned KeyMask;
+  static const unsigned int KeyMask;
 
   /**
    * @brief construct with at least a FederationId value.
@@ -108,13 +110,13 @@ public:
   RepoIdGenerator(
     long federation,
     long participant = 0,
-    OpenDDS::DCPS::EntityKind kind = OpenDDS::DCPS::KIND_PARTICIPANT);
+    EntityKind kind = KIND_PARTICIPANT);
 
   /// Virtual destructor.
   virtual ~RepoIdGenerator();
 
   /// Obtain the next RepoId value.
-  OpenDDS::DCPS::RepoId next();
+  RepoId next();
 
   /**
    * Set the minimum of the last key (or participant) value used.
@@ -128,7 +130,7 @@ public:
 
 private:
   /// Type of Entity to generate GUID values for.
-  OpenDDS::DCPS::EntityKind kind_;
+  EntityKind kind_;
 
   /// Unique identifier for the repository.
   long federation_;
@@ -140,6 +142,8 @@ private:
   long lastKey_;
 };
 
+} // namespace DCPS
+} // namespace OpenDDS
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #endif /* REPOIDGENERATOR_H  */

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -29,6 +29,7 @@
 #include "ace/Auto_Ptr.h"
 #include "ace/Sched_Params.h"
 #include "ace/Malloc_Allocator.h"
+#include "ace/OS_NS_unistd.h"
 
 #ifdef OPENDDS_SAFETY_PROFILE
 #include <stdio.h> // <cstdio> after FaceCTS bug 623 is fixed

--- a/dds/DCPS/WaitSet.h
+++ b/dds/DCPS/WaitSet.h
@@ -20,7 +20,7 @@
 
 #include "ace/Thread_Mutex.h"
 #include "ace/Atomic_Op.h"
-#include "ace/Condition_Thread_Mutex.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -18,6 +18,7 @@
 #include "PoolAllocationBase.h"
 
 #include "ace/Synch_Traits.h"
+#include "ace/Condition_T.h"
 #include "ace/Condition_Thread_Mutex.h"
 #include "ace/Condition_Recursive_Thread_Mutex.h"
 

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -19,6 +19,7 @@
 
 #include "ace/Synch_Traits.h"
 #include "ace/Condition_Thread_Mutex.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 
 #include <memory>
 

--- a/dds/DCPS/WriterDataSampleList.cpp
+++ b/dds/DCPS/WriterDataSampleList.cpp
@@ -8,10 +8,6 @@
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
 #include "WriterDataSampleList.h"
 #include "DataSampleElement.h"
-#include "Definitions.h"
-#include "PublicationInstance.h"
-
-#include "dds/DCPS/transport/framework/TransportSendListener.h"
 
 #if !defined (__ACE_INLINE__)
 #include "WriterDataSampleList.inl"

--- a/dds/DCPS/WriterDataSampleList.h
+++ b/dds/DCPS/WriterDataSampleList.h
@@ -8,12 +8,8 @@
 #ifndef OPENDDS_DCPS_WRITERDATASAMPLELIST_H
 #define OPENDDS_DCPS_WRITERDATASAMPLELIST_H
 
-#include "dds/DdsDcpsInfoUtilsC.h"
-#include "Definitions.h"
-#include "transport/framework/TransportDefs.h"
-#include "Dynamic_Cached_Allocator_With_Overflow_T.h"
-
-#include <iterator>
+#include "dcps_export.h"
+#include <cstring>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -21,7 +17,6 @@ namespace OpenDDS {
 namespace DCPS {
 
 class DataSampleElement;
-
 
 /**
 * A list of DataSampleElement pointers to be queued by the order the

--- a/dds/DCPS/WriterInfo.h
+++ b/dds/DCPS/WriterInfo.h
@@ -9,8 +9,9 @@
 #ifndef OPENDDS_DCPS_WRITERINFO_H
 #define OPENDDS_DCPS_WRITERINFO_H
 
-#include "dds/DCPS/PoolAllocator.h"
 #include "dds/DdsDcpsInfoUtilsC.h"
+#include "dds/DdsDcpsCoreC.h"
+#include "dds/DCPS/PoolAllocator.h"
 #include "RcObject_T.h"
 #include "Definitions.h"
 #include "CoherentChangeControl.h"
@@ -78,7 +79,7 @@ public:
 
   WriterInfo(WriterInfoListener*         reader,
              const PublicationId&        writer_id,
-             const ::DDS::DataWriterQos& writer_qos);
+             const DDS::DataWriterQos& writer_qos);
 
   /// check to see if this writer is alive (called by handle_timeout).
   /// @param now next time this DataWriter will become not active (not alive)
@@ -118,8 +119,8 @@ public:
 #endif
 
   void clear_owner_evaluated ();
-  void set_owner_evaluated (::DDS::InstanceHandle_t instance, bool flag);
-  bool is_owner_evaluated (::DDS::InstanceHandle_t instance);
+  void set_owner_evaluated (DDS::InstanceHandle_t instance, bool flag);
+  bool is_owner_evaluated (DDS::InstanceHandle_t instance);
 
   //private:
 
@@ -162,16 +163,16 @@ public:
   PublicationId writer_id_;
 
   /// Writer qos
-  ::DDS::DataWriterQos writer_qos_;
+  DDS::DataWriterQos writer_qos_;
 
   /// The publication entity instance handle.
-  ::DDS::InstanceHandle_t handle_;
+  DDS::InstanceHandle_t handle_;
 
   /// Number of received coherent changes in active change set.
   ACE_Atomic_Op<ACE_Thread_Mutex, ACE_UINT32> coherent_samples_;
 
   /// Is this writer evaluated for owner ?
-  typedef OPENDDS_MAP( ::DDS::InstanceHandle_t, bool) OwnerEvaluateFlags;
+  typedef OPENDDS_MAP(DDS::InstanceHandle_t, bool) OwnerEvaluateFlags;
   OwnerEvaluateFlags owner_evaluated_;
 
   /// Data to support GROUP access scope.

--- a/dds/DCPS/ZeroCopySeq_T.h
+++ b/dds/DCPS/ZeroCopySeq_T.h
@@ -23,7 +23,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class DataReaderImpl;
+class Loaner;
 class ReceivedDataElement;
 
 } // namespace DCPS
@@ -126,7 +126,7 @@ public:
       seq_.internal_set_length(len);
     }
 
-    void set_loaner(::OpenDDS::DCPS::DataReaderImpl* loaner) {
+    void set_loaner(::OpenDDS::DCPS::Loaner* loaner) {
       seq_.set_loaner(loaner);
     }
 
@@ -176,7 +176,7 @@ private:
 
   void internal_set_length(CORBA::ULong len);
 
-  void set_loaner(OpenDDS::DCPS::DataReaderImpl* loaner);
+  void set_loaner(OpenDDS::DCPS::Loaner* loaner);
 
   void assign_ptr(CORBA::ULong ii, OpenDDS::DCPS::ReceivedDataElement* item);
 
@@ -188,8 +188,8 @@ private:
 
   void make_single_copy(CORBA::ULong maximum);
 
-  /// The datareader that loaned its samples.
-  OpenDDS::DCPS::DataReaderImpl* loaner_;
+  /// The loaner that loaned its samples.
+  OpenDDS::DCPS::Loaner* loaner_;
 
   /// the default allocator
   OpenDDS::DCPS::FirstTimeFastAllocator<OpenDDS::DCPS::ReceivedDataElement*, DEF_MAX>

--- a/dds/DCPS/ZeroCopySeq_T.inl
+++ b/dds/DCPS/ZeroCopySeq_T.inl
@@ -6,7 +6,7 @@
  */
 
 #include "dds/DCPS/ReceivedDataElementList.h"
-#include "dds/DCPS/DataReaderImpl.h"
+#include "dds/DCPS/Loaner.h"
 #include "ace/Truncate.h"
 
 #include <utility>
@@ -262,7 +262,7 @@ ZeroCopyDataSeq<Sample_T, DEF_MAX>::internal_set_length(CORBA::ULong len)
 template <class Sample_T, size_t DEF_MAX> ACE_INLINE
 void
 ZeroCopyDataSeq<Sample_T, DEF_MAX>::set_loaner(
-  OpenDDS::DCPS::DataReaderImpl* loaner)
+  OpenDDS::DCPS::Loaner* loaner)
 {
   loaner_ = loaner;
 }

--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -58,7 +58,7 @@ DataLink::DataLink(TransportImpl* impl, Priority priority, bool is_loopback,
   DBG_ENTRY_LVL("DataLink", "DataLink", 6);
 
   impl->_add_ref();
-  this->impl_ = impl;
+  this->impl_.reset(impl);
 
   datalink_release_delay_.sec(this->impl_->config_->datalink_release_delay_ / 1000);
   datalink_release_delay_.usec(this->impl_->config_->datalink_release_delay_ % 1000 * 1000);
@@ -118,6 +118,31 @@ DataLink::impl() const
   return impl_;
 }
 
+
+bool
+DataLink::add_on_start_callback(const TransportClient_rch& client, const RepoId& remote)
+{
+  GuardType guard(strategy_lock_);
+
+  if (started_ && !send_strategy_.is_nil()) {
+    return false; // link already started
+  }
+  on_start_callbacks_.push_back(std::make_pair(client, remote));
+  return true;
+}
+
+void
+DataLink::remove_on_start_callback(const TransportClient_rch& client, const RepoId& remote)
+{
+  GuardType guard(strategy_lock_);
+  on_start_callbacks_.erase(
+    std::remove(on_start_callbacks_.begin(),
+                on_start_callbacks_.end(),
+                std::make_pair(client, remote)),
+    on_start_callbacks_.end());
+}
+
+
 void
 DataLink::invoke_on_start_callbacks(bool success)
 {
@@ -132,6 +157,10 @@ DataLink::invoke_on_start_callbacks(bool success)
 
     OnStartCallback last_callback = on_start_callbacks_.back();
     on_start_callbacks_.pop_back();
+
+    // Need increment the reference count before release the lock;
+    // otherwise, the callback object may be deleted before it is used.
+    //RcHandle<TransportClient> client(last_callback.first, false);
 
     guard.release();
     last_callback.first->use_datalink(last_callback.second, link);
@@ -291,7 +320,7 @@ DataLink::make_reservation(const RepoId& remote_subscription_id,
     ReceiveListenerSet_rch& rls = assoc_by_remote_[remote_subscription_id];
 
     if (rls.is_nil())
-      rls = new ReceiveListenerSet;
+      rls.reset(new ReceiveListenerSet);
     rls->insert(local_publication_id, 0);
 
     if (send_listeners_.insert(std::make_pair(local_publication_id,
@@ -331,7 +360,7 @@ DataLink::make_reservation(const RepoId& remote_publication_id,
     ReceiveListenerSet_rch& rls = assoc_by_remote_[remote_publication_id];
 
     if (rls.is_nil())
-      rls = new ReceiveListenerSet;
+      rls.reset(new ReceiveListenerSet);
     rls->insert(local_subscription_id, receive_listener);
 
     if (recv_listeners_.insert(std::make_pair(local_subscription_id,
@@ -411,7 +440,7 @@ DataLink::release_reservations(RepoId remote_id, RepoId local_id,
   if (ris.size() == 1) {
     DataLinkSet_rch& links = released_locals[local_id];
     if (links.is_nil())
-      links = new DataLinkSet;
+      links.reset(new DataLinkSet);
     links->insert_link(this);
     {
       GuardType guard(this->released_assoc_by_local_lock_);

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -245,10 +245,10 @@ public:
 
   void default_listener(TransportReceiveListener* trl);
   TransportReceiveListener* default_listener() const;
-
-  typedef std::pair<TransportClient*, RepoId> OnStartCallback;
-  bool add_on_start_callback(TransportClient* client, const RepoId& remote);
-  void remove_on_start_callback(TransportClient* client, const RepoId& remote);
+  typedef RcHandle<TransportClient> TransportClient_rch;
+  typedef std::pair<TransportClient_rch, RepoId> OnStartCallback;
+  bool add_on_start_callback(const TransportClient_rch& client, const RepoId& remote);
+  void remove_on_start_callback(const TransportClient_rch& client, const RepoId& remote);
   void invoke_on_start_callbacks(bool success);
 
   void set_scheduling_release(bool scheduling_release);

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -159,7 +159,7 @@ DataLink::send_stop_i(RepoId repoId)
   // This one is easy.  Simply delegate to our TransportSendStrategy
   // data member.
 
-  TransportSendStrategy_rch strategy = 0;
+  TransportSendStrategy_rch strategy;
   {
     GuardType guard(this->strategy_lock_);
 
@@ -281,30 +281,6 @@ DataLink::start(const TransportSendStrategy_rch& send_strategy,
   return 0;
 }
 
-ACE_INLINE
-bool
-DataLink::add_on_start_callback(TransportClient* client, const RepoId& remote)
-{
-  GuardType guard(strategy_lock_);
-
-  if (started_ && !send_strategy_.is_nil()) {
-    return false; // link already started
-  }
-  on_start_callbacks_.push_back(std::make_pair(client, remote));
-
-  return true;
-}
-
-ACE_INLINE
-void
-DataLink::remove_on_start_callback(TransportClient* client, const RepoId& remote)
-{
-  GuardType guard(strategy_lock_);
-  on_start_callbacks_.erase(std::remove(on_start_callbacks_.begin(),
-                                        on_start_callbacks_.end(),
-                                        std::make_pair(client, remote)),
-                            on_start_callbacks_.end());
-}
 
 ACE_INLINE
 const char*

--- a/dds/DCPS/transport/framework/PerConnectionSynch.h
+++ b/dds/DCPS/transport/framework/PerConnectionSynch.h
@@ -9,9 +9,11 @@
 #define OPENDDS_DCPS_PERCONNECTIONSYNCH_H
 
 #include "ThreadSynch.h"
-#include "ace/Task.h"
+
+#include "ace/Condition_T.h"
 #include "ace/Condition_Thread_Mutex.h"
 #include "ace/Synch_Traits.h"
+#include "ace/Task.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/transport/framework/PoolSynchStrategy.h
+++ b/dds/DCPS/transport/framework/PoolSynchStrategy.h
@@ -10,9 +10,11 @@
 
 #include "dds/DCPS/dcps_export.h"
 #include "ThreadSynchStrategy.h"
-#include "ace/Task.h"
+
+#include "ace/Condition_T.h"
 #include "ace/Condition_Thread_Mutex.h"
 #include "ace/Synch_Traits.h"
+#include "ace/Task.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -16,6 +16,7 @@
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include "ace/Condition_T.h"
 #include "ace/Condition_Thread_Mutex.h"
 #include "ace/Task.h"
 #include "ace/Unbounded_Queue.h"

--- a/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.h
+++ b/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.h
@@ -14,8 +14,10 @@
 #include "dds/DCPS/PoolAllocationBase.h"
 #include "BasicQueue_T.h"
 #include "TransportDefs.h"
-#include "ace/Task.h"
+
+#include "ace/Condition_T.h"
 #include "ace/Synch_Traits.h"
+#include "ace/Task.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -49,13 +49,17 @@ class SendStateDataSampleListIterator;
  * communication mechanisms and the DataLink objects that represent the
  * currently active communication channels to peers.
  */
-class OpenDDS_Dcps_Export TransportClient {
+class OpenDDS_Dcps_Export TransportClient :
+  public EnableSharedFromThis<TransportClient>
+{
 public:
   // Used by TransportImpl to complete associate() processing:
   void use_datalink(const RepoId& remote_id, const DataLink_rch& link);
 
   // values for flags parameter of transport_assoc_done():
   enum { ASSOC_OK = 1, ASSOC_ACTIVE = 2 };
+  virtual void _add_ref(){};
+  virtual void _remove_ref(){};
 
 protected:
   TransportClient();
@@ -127,6 +131,7 @@ protected:
   virtual void add_link(const DataLink_rch& link, const RepoId& peer);
 
   void on_notification_of_connection_deletion(const RepoId& peerId);
+
 
 private:
 
@@ -302,6 +307,8 @@ private:
 
   RepoId repo_id_;
 };
+
+typedef RcHandle<TransportClient> TransportClient_rch;
 
 }
 }

--- a/dds/DCPS/transport/framework/TransportImpl.cpp
+++ b/dds/DCPS/transport/framework/TransportImpl.cpp
@@ -67,7 +67,7 @@ TransportImpl::shutdown()
 
   this->pre_shutdown_i();
 
-  OPENDDS_SET(TransportClient*) local_clients;
+  OPENDDS_SET(TransportClient_rch) local_clients;
 
   {
     GuardType guard(this->lock_);
@@ -83,7 +83,7 @@ TransportImpl::shutdown()
     // We can release our lock_ now.
   }
 
-  for (OPENDDS_SET(TransportClient*)::iterator it = local_clients.begin();
+  for (OPENDDS_SET(TransportClient_rch)::iterator it = local_clients.begin();
        it != local_clients.end(); ++it) {
     (*it)->transport_detached(this);
   }
@@ -167,10 +167,9 @@ TransportImpl::configure(TransportInst* config)
 }
 
 void
-TransportImpl::add_pending_connection(TransportClient* client, DataLink* link)
+TransportImpl::add_pending_connection(const TransportClient_rch& client, DataLink* link)
 {
-  pending_connections_.insert(std::pair<TransportClient* const, DataLink_rch>(
-    client, DataLink_rch(link, false)));
+  pending_connections_.insert( std::make_pair(client, DataLink_rch(link, false)));
 }
 
 void
@@ -187,7 +186,7 @@ TransportImpl::create_reactor_task(bool useAsyncSend)
 }
 
 void
-TransportImpl::attach_client(TransportClient* client)
+TransportImpl::attach_client(const TransportClient_rch& client)
 {
   DBG_ENTRY_LVL("TransportImpl", "attach_client", 6);
 
@@ -196,7 +195,7 @@ TransportImpl::attach_client(TransportClient* client)
 }
 
 void
-TransportImpl::detach_client(TransportClient* client)
+TransportImpl::detach_client(const TransportClient_rch& client)
 {
   DBG_ENTRY_LVL("TransportImpl", "detach_client", 6);
 

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -34,6 +34,7 @@ class TransportReceiveListener;
 class DataLink;
 class Monitor;
 struct AssociationData;
+typedef RcHandle<TransportClient> TransportClient_rch;
 
 /** The TransportImpl class includes the abstract methods that must be implemented
 *   by any implementation to provide data delivery service to the DCPS implementation.
@@ -152,7 +153,7 @@ protected:
   /// transport calls back to TransportClient::use_datalink().
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
-                                               TransportClient* client) = 0;
+                                               const TransportClient_rch& client) = 0;
 
   /// accept_datalink() is called from TransportClient to initiate an
   /// association as the passive peer.  A DataLink may be returned if
@@ -163,7 +164,7 @@ protected:
   /// transport calls back to TransportClient::use_datalink().
   virtual AcceptConnectResult accept_datalink(const RemoteTransport& remote,
                                               const ConnectionAttribs& attribs,
-                                              TransportClient* client) = 0;
+                                              const TransportClient_rch& client) = 0;
 
   /// stop_accepting_or_connecting() is called from TransportClient
   /// to terminate the accepting process begun by accept_datalink()
@@ -171,7 +172,7 @@ protected:
   /// up any resources associated with this pending connection.
   /// The TransportClient* passed in to accept or connect is not
   /// valid after this method is called.
-  virtual void stop_accepting_or_connecting(TransportClient* client,
+  virtual void stop_accepting_or_connecting(const TransportClient_rch& client,
                                             const RepoId& remote_id) = 0;
 
   /// Concrete subclass gets a shot at the config object.  The subclass
@@ -193,8 +194,9 @@ protected:
   /// returned.
   TransportReactorTask* reactor_task();
 
-  OPENDDS_MULTIMAP(TransportClient*, DataLink_rch) pending_connections_;
-  void add_pending_connection(TransportClient* client, DataLink* link);
+  typedef OPENDDS_MULTIMAP(TransportClient_rch, DataLink_rch) PendConnMap;
+  PendConnMap pending_connections_;
+  void add_pending_connection(const TransportClient_rch& client, DataLink* link);
 
 private:
   /// We have a few friends in the transport framework so that they
@@ -217,9 +219,9 @@ private:
   /// any other threads while we perform this release.
   virtual void release_datalink(DataLink* link) = 0;
 
-  void attach_client(TransportClient* client);
-  void detach_client(TransportClient* client);
-  virtual void pre_detach(TransportClient*) {}
+  void attach_client(const TransportClient_rch& client);
+  void detach_client(const TransportClient_rch& client);
+  virtual void pre_detach(const TransportClient_rch&) {}
 
   DataLink* find_connect_i(const RepoId& local_id,
                            const AssociationData& remote_association,
@@ -255,7 +257,7 @@ public:
   /// Lock to protect the config_ and reactor_task_ data members.
   mutable LockType lock_;
 
-  OPENDDS_SET(TransportClient*) clients_;
+  OPENDDS_SET(TransportClient_rch) clients_;
 
   /// A reference (via a smart pointer) to the TransportInst
   /// object that was supplied to us during our configure() method.

--- a/dds/DCPS/transport/framework/TransportReactorTask.h
+++ b/dds/DCPS/transport/framework/TransportReactorTask.h
@@ -13,6 +13,7 @@
 #include "ace/Task.h"
 #include "ace/Barrier.h"
 #include "ace/Synch_Traits.h"
+#include "ace/Condition_T.h"
 #include "ace/Condition_Thread_Mutex.h"
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -164,7 +164,7 @@ get_remote_reliability(const TransportImpl::RemoteTransport& remote)
 TransportImpl::AcceptConnectResult
 MulticastTransport::connect_datalink(const RemoteTransport& remote,
                                      const ConnectionAttribs& attribs,
-                                     TransportClient*)
+                                     const TransportClient_rch&)
 {
   // Check that the remote reliability matches.
   if (get_remote_reliability(remote) != this->config_i_->is_reliable()) {
@@ -204,7 +204,7 @@ MulticastTransport::connect_datalink(const RemoteTransport& remote,
 TransportImpl::AcceptConnectResult
 MulticastTransport::accept_datalink(const RemoteTransport& remote,
                                     const ConnectionAttribs& attribs,
-                                    TransportClient* client)
+                                    const TransportClient_rch& client)
 {
   // Check that the remote reliability matches.
   if (get_remote_reliability(remote) != this->config_i_->is_reliable()) {
@@ -250,7 +250,7 @@ MulticastTransport::accept_datalink(const RemoteTransport& remote,
   } else {
 
     this->pending_connections_[std::make_pair(remote_peer, local_peer)].
-    push_back(std::pair<TransportClient*, RepoId>(client, remote.repo_id_));
+    push_back(std::make_pair(client, remote.repo_id_));
     //can't call start session with connections_lock_ due to reactor
     //call in session->start which could deadlock with passive_connection
     guard.release();
@@ -263,7 +263,7 @@ MulticastTransport::accept_datalink(const RemoteTransport& remote,
 }
 
 void
-MulticastTransport::stop_accepting_or_connecting(TransportClient* client,
+MulticastTransport::stop_accepting_or_connecting(const TransportClient_rch& client,
                                                  const RepoId& remote_id)
 {
   VDBG((LM_DEBUG, "(%P|%t) MulticastTransport::stop_accepting_or_connecting\n"));
@@ -325,7 +325,7 @@ MulticastTransport::passive_connection(MulticastPeer local_peer, MulticastPeer r
                                                   pend->second.end(),
                                                   tmp.at(i));
         if (tmp_iter != pend->second.end()) {
-          TransportClient* pend_client = tmp.at(i).first;
+          TransportClient_rch pend_client = tmp.at(i).first;
           RepoId remote_repo = tmp.at(i).second;
           guard.release();
           pend_client->use_datalink(remote_repo, link);

--- a/dds/DCPS/transport/multicast/MulticastTransport.h
+++ b/dds/DCPS/transport/multicast/MulticastTransport.h
@@ -34,13 +34,13 @@ public:
 protected:
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
-                                               TransportClient* client);
+                                               const TransportClient_rch& client);
 
   virtual AcceptConnectResult accept_datalink(const RemoteTransport& remote,
                                               const ConnectionAttribs& attribs,
-                                              TransportClient* client);
+                                              const TransportClient_rch& client);
 
-  virtual void stop_accepting_or_connecting(TransportClient* client,
+  virtual void stop_accepting_or_connecting(const TransportClient_rch& client,
                                             const RepoId& remote_id);
 
   virtual bool configure_i(TransportInst* config);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -72,7 +72,7 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 TransportImpl::AcceptConnectResult
 RtpsUdpTransport::connect_datalink(const RemoteTransport& remote,
                                    const ConnectionAttribs& attribs,
-                                   TransportClient* client )
+                                   const TransportClient_rch& client )
 {
   GuardThreadType guard_links(this->links_lock_);
   RtpsUdpDataLink_rch link = link_;
@@ -111,7 +111,7 @@ RtpsUdpTransport::connect_datalink(const RemoteTransport& remote,
 TransportImpl::AcceptConnectResult
 RtpsUdpTransport::accept_datalink(const RemoteTransport& remote,
                                   const ConnectionAttribs& attribs,
-                                  TransportClient* )
+                                  const TransportClient_rch& )
 {
   GuardThreadType guard_links(this->links_lock_);
   RtpsUdpDataLink_rch link = link_;
@@ -129,11 +129,11 @@ RtpsUdpTransport::accept_datalink(const RemoteTransport& remote,
 
 
 void
-RtpsUdpTransport::stop_accepting_or_connecting(TransportClient* client,
+RtpsUdpTransport::stop_accepting_or_connecting(const TransportClient_rch& client,
                                                const RepoId& remote_id)
 {
   GuardType guard(connections_lock_);
-  typedef OPENDDS_MULTIMAP(TransportClient*, DataLink_rch)::iterator iter_t;
+  typedef PendConnMap::iterator iter_t;
   const std::pair<iter_t, iter_t> range =
         pending_connections_.equal_range(client);
   for (iter_t iter = range.first; iter != range.second; ++iter) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -32,13 +32,13 @@ public:
 private:
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
-                                               TransportClient* client);
+                                               const TransportClient_rch& client);
 
   virtual AcceptConnectResult accept_datalink(const RemoteTransport& remote,
                                               const ConnectionAttribs& attribs,
-                                              TransportClient* client);
+                                              const TransportClient_rch& client);
 
-  virtual void stop_accepting_or_connecting(TransportClient* client,
+  virtual void stop_accepting_or_connecting(const TransportClient_rch& client,
                                             const RepoId& remote_id);
 
   virtual bool configure_i(TransportInst* config);

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -76,7 +76,7 @@ ShmemTransport::make_datalink(const std::string& remote_address)
 TransportImpl::AcceptConnectResult
 ShmemTransport::connect_datalink(const RemoteTransport& remote,
                                  const ConnectionAttribs&,
-                                 TransportClient*)
+                                 const TransportClient_rch&)
 {
   const std::pair<std::string, std::string> key = blob_to_key(remote.blob_);
   if (key.first != this->config_i_->hostname()) {
@@ -106,13 +106,13 @@ ShmemTransport::add_datalink(const std::string& remote_address)
 TransportImpl::AcceptConnectResult
 ShmemTransport::accept_datalink(const RemoteTransport& remote,
                                 const ConnectionAttribs& attribs,
-                                TransportClient* client)
+                                const TransportClient_rch& client)
 {
   return connect_datalink(remote, attribs, client);
 }
 
 void
-ShmemTransport::stop_accepting_or_connecting(TransportClient*, const RepoId&)
+ShmemTransport::stop_accepting_or_connecting(const TransportClient_rch&, const RepoId&)
 {
   // no-op: accept and connect either complete or fail immediately
 }

--- a/dds/DCPS/transport/shmem/ShmemTransport.h
+++ b/dds/DCPS/transport/shmem/ShmemTransport.h
@@ -37,13 +37,13 @@ public:
 protected:
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
-                                               TransportClient* client);
+                                               const TransportClient_rch& client);
 
   virtual AcceptConnectResult accept_datalink(const RemoteTransport& remote,
                                               const ConnectionAttribs& attribs,
-                                              TransportClient* client);
+                                              const TransportClient_rch& client);
 
-  virtual void stop_accepting_or_connecting(TransportClient* client,
+  virtual void stop_accepting_or_connecting(const TransportClient_rch& client,
                                             const RepoId& remote_id);
 
   virtual bool configure_i(TransportInst* config);

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -23,6 +23,7 @@
 #include "dds/DCPS/debug.h"
 #include "dds/DCPS/GuidConverter.h"
 #include "dds/DCPS/Service_Participant.h"
+#include "dds/DCPS/transport/framework/TransportClient.h"
 
 #include <sstream>
 
@@ -69,7 +70,7 @@ TcpTransport::blob_to_key(const TransportBLOB& remote,
 TransportImpl::AcceptConnectResult
 TcpTransport::connect_datalink(const RemoteTransport& remote,
                                const ConnectionAttribs& attribs,
-                               TransportClient* client)
+                               const TransportClient_rch& client)
 {
   DBG_ENTRY_LVL("TcpTransport", "connect_datalink", 6);
 
@@ -187,7 +188,7 @@ TcpTransport::async_connect_failed(const PriorityKey& key)
 //Called with links_lock_ held
 bool
 TcpTransport::find_datalink_i(const PriorityKey& key, TcpDataLink_rch& link,
-                              TransportClient* client, const RepoId& remote_id)
+                              const TransportClient_rch& client, const RepoId& remote_id)
 {
   DBG_ENTRY_LVL("TcpTransport", "find_datalink_i", 6);
 
@@ -232,7 +233,7 @@ TcpTransport::find_datalink_i(const PriorityKey& key, TcpDataLink_rch& link,
 TransportImpl::AcceptConnectResult
 TcpTransport::accept_datalink(const RemoteTransport& remote,
                               const ConnectionAttribs& attribs,
-                              TransportClient* client)
+                              const TransportClient_rch& client)
 {
   GuidConverter remote_conv(remote.repo_id_);
   GuidConverter local_conv(attribs.local_id_);
@@ -312,7 +313,7 @@ TcpTransport::accept_datalink(const RemoteTransport& remote,
 }
 
 void
-TcpTransport::stop_accepting_or_connecting(TransportClient* client,
+TcpTransport::stop_accepting_or_connecting(const TransportClient_rch& client,
                                            const RepoId& remote_id)
 {
   GuidConverter remote_converted(remote_id);
@@ -321,7 +322,7 @@ TcpTransport::stop_accepting_or_connecting(TransportClient* client,
             std::string(remote_converted).c_str()), 5);
 
   GuardType guard(connections_lock_);
-  typedef std::multimap<TransportClient*, DataLink_rch>::iterator iter_t;
+  typedef PendConnMap::iterator iter_t;
   const std::pair<iter_t, iter_t> range =
     pending_connections_.equal_range(client);
 

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -59,13 +59,13 @@ public:
 private:
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
-                                               TransportClient* client);
+                                               const TransportClient_rch& client);
 
   virtual AcceptConnectResult accept_datalink(const RemoteTransport& remote,
                                               const ConnectionAttribs& attribs,
-                                              TransportClient* client);
+                                              const TransportClient_rch& client);
 
-  virtual void stop_accepting_or_connecting(TransportClient* client,
+  virtual void stop_accepting_or_connecting(const TransportClient_rch& client,
                                             const RepoId& remote_id);
 
   virtual bool configure_i(TransportInst* config);
@@ -97,7 +97,7 @@ private:
                           const TcpConnection_rch& connection);
 
   bool find_datalink_i(const PriorityKey& key, TcpDataLink_rch& link,
-                       TransportClient* client, const RepoId& remote_id);
+                       const TransportClient_rch& client, const RepoId& remote_id);
 
   /// Code common to make_active_connection() and
   /// make_passive_connection().

--- a/dds/DCPS/transport/udp/UdpTransport.cpp
+++ b/dds/DCPS/transport/udp/UdpTransport.cpp
@@ -78,7 +78,7 @@ UdpTransport::make_datalink(const ACE_INET_Addr& remote_address,
 TransportImpl::AcceptConnectResult
 UdpTransport::connect_datalink(const RemoteTransport& remote,
                                const ConnectionAttribs& attribs,
-                               TransportClient* )
+                               const TransportClient_rch& )
 {
   UdpInst_rch tmp_config(this->config_i_.in(), false);
   if (this->is_shut_down() || this->config_i_.is_nil()) {
@@ -115,7 +115,7 @@ UdpTransport::connect_datalink(const RemoteTransport& remote,
 TransportImpl::AcceptConnectResult
 UdpTransport::accept_datalink(const RemoteTransport& remote,
                               const ConnectionAttribs& attribs,
-                              TransportClient* client)
+                              const TransportClient_rch& client)
 {
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(connections_lock_);
   //GuardType guard(connections_lock_);
@@ -141,7 +141,7 @@ UdpTransport::accept_datalink(const RemoteTransport& remote,
 }
 
 void
-UdpTransport::stop_accepting_or_connecting(TransportClient* client,
+UdpTransport::stop_accepting_or_connecting(const TransportClient_rch& client,
                                            const RepoId& remote_id)
 {
   VDBG((LM_DEBUG, "(%P|%t) UdpTransport::stop_accepting_or_connecting\n"));
@@ -328,7 +328,7 @@ UdpTransport::passive_connection(const ACE_INET_Addr& remote_address,
                                                   pend->second.end(),
                                                   tmp.at(i));
         if (tmp_iter != pend->second.end()) {
-          TransportClient* pend_client = tmp.at(i).first;
+          TransportClient_rch pend_client = tmp.at(i).first;
           RepoId remote_repo = tmp.at(i).second;
           guard.release();
           pend_client->use_datalink(remote_repo, link);

--- a/dds/DCPS/transport/udp/UdpTransport.h
+++ b/dds/DCPS/transport/udp/UdpTransport.h
@@ -15,6 +15,7 @@
 
 #include "dds/DCPS/transport/framework/PriorityKey.h"
 #include "dds/DCPS/transport/framework/TransportImpl.h"
+#include "dds/DCPS/transport/framework/TransportClient.h"
 #include "dds/DCPS/PoolAllocator.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/udp/UdpTransport.h
+++ b/dds/DCPS/transport/udp/UdpTransport.h
@@ -34,13 +34,13 @@ public:
 protected:
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
-                                               TransportClient* client);
+                                               const TransportClient_rch& client);
 
   virtual AcceptConnectResult accept_datalink(const RemoteTransport& remote,
                                               const ConnectionAttribs& attribs,
-                                              TransportClient* client);
+                                              const TransportClient_rch& client);
 
-  virtual void stop_accepting_or_connecting(TransportClient* client,
+  virtual void stop_accepting_or_connecting(const TransportClient_rch& client,
                                             const RepoId& remote_id);
 
   virtual bool configure_i(TransportInst* config);

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -9,6 +9,7 @@
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/SafetyProfileStreams.h"
 #include "dds/DCPS/SafetyProfilePool.h"
+#include "dds/DCPS/GuidConverter.h"
 #include "dds/DCPS/Qos_Helper.h"
 #include "dds/DdsDcpsCoreC.h"
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
@@ -18,8 +19,6 @@
 #ifndef OPENDDS_SAFETY_PROFILE
 using OpenDDS::DCPS::operator==;
 #endif
-
-OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace FACE {
 namespace TS {
@@ -650,6 +649,8 @@ namespace {
 }
 
 }}
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace FaceTSS {

--- a/dds/FACE/OpenDDS_FACE.mpc
+++ b/dds/FACE/OpenDDS_FACE.mpc
@@ -1,6 +1,6 @@
 project: dcpslib, install {
   requires += built_in_topics
-  avoids += uses_wchar versioned_namespace
+  avoids += uses_wchar
   dynamicflags = OPENDDS_FACE_BUILD_DLL
 
   Source_Files {

--- a/dds/FACE/StringManager.cpp
+++ b/dds/FACE/StringManager.cpp
@@ -65,6 +65,8 @@ void wstring_free(WChar* str)
 #endif // DDS_HAS_WCHAR
 }
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
 namespace OpenDDS {
 namespace FaceTypes {
 
@@ -84,3 +86,5 @@ bool operator>>(DCPS::Serializer& ser, StringBase<FACE::WChar>& str)
 
 }
 }
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/FACE/config/Parser.h
+++ b/dds/FACE/config/Parser.h
@@ -11,6 +11,7 @@ class ACE_Configuration_Heap;
 class ACE_Configuration_Section_Key;
 ACE_END_VERSIONED_NAMESPACE_DECL
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS { namespace FaceTSS { namespace config {
 

--- a/dds/InfoRepo/DCPSInfoRepoServ.h
+++ b/dds/InfoRepo/DCPSInfoRepoServ.h
@@ -20,6 +20,7 @@
 #include "ShutdownInterface.h"
 
 #include "ace/Event_Handler.h"
+#include "ace/Condition_Thread_Mutex.h"
 
 class OpenDDS_DCPSInfoRepoServ_Export InfoRepo
   : public ShutdownInterface, public ACE_Event_Handler {

--- a/dds/InfoRepo/DCPSInfo_i.h
+++ b/dds/InfoRepo/DCPSInfo_i.h
@@ -415,7 +415,7 @@ private:
   CORBA::ORB_var dispatchingOrb_;
 
   const TAO_DDS_DCPSFederationId& federation_;
-  RepoIdGenerator participantIdGenerator_;
+  OpenDDS::DCPS::RepoIdGenerator participantIdGenerator_;
 
   Update::Manager* um_;
   bool reincarnate_;

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -51,7 +51,7 @@ private:
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
-DCPS_IR_Domain::DCPS_IR_Domain(DDS::DomainId_t id, RepoIdGenerator& generator)
+DCPS_IR_Domain::DCPS_IR_Domain(DDS::DomainId_t id, OpenDDS::DCPS::RepoIdGenerator& generator)
   : id_(id),
     participantIdGenerator_(generator),
     useBIT_(false)

--- a/dds/InfoRepo/DCPS_IR_Domain.h
+++ b/dds/InfoRepo/DCPS_IR_Domain.h
@@ -23,7 +23,7 @@
 
 #include "dds/DCPS/transport/framework/TransportConfig.h"
 #include "dds/DCPS/transport/tcp/TcpTransport.h"
-
+#include "dds/DCPS/transport/framework/TransportConfig_rch.h"
 #include /**/ "ace/Unbounded_Set.h"
 
 #include <set>

--- a/dds/InfoRepo/DCPS_IR_Domain.h
+++ b/dds/InfoRepo/DCPS_IR_Domain.h
@@ -60,7 +60,7 @@ class DCPS_IR_Publication;
  */
 class OpenDDS_InfoRepoLib_Export DCPS_IR_Domain {
 public:
-  DCPS_IR_Domain(DDS::DomainId_t id, RepoIdGenerator& generator);
+  DCPS_IR_Domain(DDS::DomainId_t id, OpenDDS::DCPS::RepoIdGenerator& generator);
 
   ~DCPS_IR_Domain();
 
@@ -202,7 +202,7 @@ private:
 
   // Participant GUID Id generator.  The remaining Entities have their
   // values generated within the containing Participant.
-  RepoIdGenerator& participantIdGenerator_;
+  OpenDDS::DCPS::RepoIdGenerator& participantIdGenerator_;
 
   /// all the participants
   DCPS_IR_Participant_Map participants_;

--- a/dds/InfoRepo/DCPS_IR_Participant.h
+++ b/dds/InfoRepo/DCPS_IR_Participant.h
@@ -213,9 +213,9 @@ private:
   ACE_SYNCH_MUTEX ownerLock_;
 
   // Entity GUID Id generators.
-  RepoIdGenerator topicIdGenerator_;
-  RepoIdGenerator publicationIdGenerator_;
-  RepoIdGenerator subscriptionIdGenerator_;
+  OpenDDS::DCPS::RepoIdGenerator topicIdGenerator_;
+  OpenDDS::DCPS::RepoIdGenerator publicationIdGenerator_;
+  OpenDDS::DCPS::RepoIdGenerator subscriptionIdGenerator_;
 
   DCPS_IR_Subscription_Map subscriptions_;
   DCPS_IR_Publication_Map publications_;

--- a/dds/InfoRepo/DCPS_IR_Publication.cpp
+++ b/dds/InfoRepo/DCPS_IR_Publication.cpp
@@ -21,7 +21,6 @@
 
 #include /**/ "ace/OS_NS_unistd.h"
 
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 DCPS_IR_Publication::DCPS_IR_Publication(const OpenDDS::DCPS::RepoId& id,

--- a/examples/DCPS/DistributedContent/main.cpp
+++ b/examples/DCPS/DistributedContent/main.cpp
@@ -11,9 +11,6 @@
 
 #include <string>
 
-
-
-
 int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 {
   /// return status of main

--- a/examples/DCPS/IntroductionToOpenDDS/publisher.cpp
+++ b/examples/DCPS/IntroductionToOpenDDS/publisher.cpp
@@ -11,6 +11,7 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include <ace/streams.h>
+#include <ace/OS_NS_unistd.h>
 #include <orbsvcs/Time_Utilities.h>
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/examples/DCPS/IntroductionToOpenDDS/subscriber.cpp
+++ b/examples/DCPS/IntroductionToOpenDDS/subscriber.cpp
@@ -14,6 +14,7 @@
 #include <dds/DCPS/SubscriberImpl.h>
 #include <dds/DCPS/BuiltInTopicUtils.h>
 #include <ace/streams.h>
+#include "ace/OS_NS_unistd.h"
 #include <orbsvcs/Time_Utilities.h>
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/examples/DCPS/Messenger_IOGR_Imr/subscriber.cpp
+++ b/examples/DCPS/Messenger_IOGR_Imr/subscriber.cpp
@@ -18,6 +18,7 @@
 
 #include <ace/streams.h>
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 

--- a/examples/DCPS/Messenger_Imr/publisher.cpp
+++ b/examples/DCPS/Messenger_Imr/publisher.cpp
@@ -19,6 +19,7 @@
 
 #include <ace/streams.h>
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 

--- a/examples/DCPS/Messenger_Imr/subscriber.cpp
+++ b/examples/DCPS/Messenger_Imr/subscriber.cpp
@@ -19,6 +19,7 @@
 
 #include <ace/streams.h>
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 

--- a/performance-tests/Bench/src/Process.cpp
+++ b/performance-tests/Bench/src/Process.cpp
@@ -8,7 +8,7 @@
 #include "Publication.h"
 #include "Subscription.h"
 #include "TestTypeSupportImpl.h"
-
+#include "ace/OS_NS_unistd.h"
 
 #include <iostream>
 #include <fstream>

--- a/performance-tests/Bench/src/Process.h
+++ b/performance-tests/Bench/src/Process.h
@@ -5,6 +5,7 @@
 #include "dds/DCPS/GuardCondition.h"
 #include "dds/DCPS/WaitSet.h"
 
+#include "ace/Condition_T.h"
 #include "ace/Synch_Traits.h"
 
 #include <string>

--- a/performance-tests/Bench/src/Publication.cpp
+++ b/performance-tests/Bench/src/Publication.cpp
@@ -16,6 +16,7 @@
 #include "dds/DCPS/transport/multicast/MulticastInst.h"
 
 #include "ace/High_Res_Timer.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <sstream>
 

--- a/performance-tests/DCPS/InfoRepo_population/subscriber.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/subscriber.cpp
@@ -21,6 +21,7 @@
 #include "ace/Get_Opt.h"
 #include "ace/OS_NS_sys_stat.h"
 #include "ace/High_Res_Timer.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <sstream>
 

--- a/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
@@ -6,8 +6,6 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "ace/OS_NS_unistd.h"
 
-
-
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
 
 

--- a/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
@@ -4,6 +4,8 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 #include "dds/DCPS/Service_Participant.h"
+
+#include "ace/Condition_T.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;

--- a/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/Writer.cpp
@@ -6,6 +6,7 @@
 #include "dds/DCPS/Service_Participant.h"
 
 #include "ace/Condition_T.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;

--- a/performance-tests/DCPS/MulticastListenerTest/publisher.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/publisher.cpp
@@ -18,9 +18,7 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 
 #include "ace/Arg_Shifter.h"
-
-
-
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/performance-tests/DCPS/MulticastListenerTest/subscriber.cpp
+++ b/performance-tests/DCPS/MulticastListenerTest/subscriber.cpp
@@ -19,9 +19,7 @@
 #include "dds/DCPS/transport/framework/EntryExit.h"
 
 #include "ace/Arg_Shifter.h"
-
-
-
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/performance-tests/DCPS/Priority/Publisher.cpp
+++ b/performance-tests/DCPS/Priority/Publisher.cpp
@@ -22,6 +22,7 @@
 
 // #include "ace/Null_Mutex.h"
 #include "ace/Condition_T.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <sstream>
 

--- a/performance-tests/DCPS/Priority/Writer.cpp
+++ b/performance-tests/DCPS/Priority/Writer.cpp
@@ -5,6 +5,7 @@
 #include "TestTypeSupportC.h"
 
 #include "dds/DCPS/DataWriterImpl.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <sstream>
 

--- a/performance-tests/DCPS/SimpleE2ETest/Reader.cpp
+++ b/performance-tests/DCPS/SimpleE2ETest/Reader.cpp
@@ -8,7 +8,7 @@
 #include "dds/DCPS/Serializer.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
-
+#include "ace/OS_NS_unistd.h"
 
 template<class Tseq, class R, class R_var, class R_ptr>
 ::DDS::ReturnCode_t read (TestStats* stats,

--- a/performance-tests/DCPS/SimpleE2ETest/Writer.cpp
+++ b/performance-tests/DCPS/SimpleE2ETest/Writer.cpp
@@ -7,7 +7,6 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "ace/OS_NS_unistd.h"
 
-
 template<class T, class W, class W_var, class W_ptr>
 void write (long id,
             int size,

--- a/performance-tests/DCPS/SimpleLatency/sample_pub.cpp
+++ b/performance-tests/DCPS/SimpleLatency/sample_pub.cpp
@@ -18,9 +18,9 @@
 #include <dds/DCPS/transport/framework/TransportExceptions.h>
 #include <ace/streams.h>
 
-
 #include "ace/Get_Opt.h"
 #include "ace/Sched_Params.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <iostream>
 #include <cstdio>

--- a/performance-tests/DCPS/TCPListenerTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/TCPListenerTest/DataReaderListener.cpp
@@ -4,6 +4,7 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
+#include "ace/OS_NS_unistd.h"
 
 extern long subscriber_delay_msec; // from common.h
 

--- a/performance-tests/DCPS/TCPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPListenerTest/Writer.cpp
@@ -5,6 +5,8 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 #include "dds/DCPS/Service_Participant.h"
+
+#include "ace/Condition_T.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;

--- a/performance-tests/DCPS/TCPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPListenerTest/Writer.cpp
@@ -7,6 +7,7 @@
 #include "dds/DCPS/Service_Participant.h"
 
 #include "ace/Condition_T.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;

--- a/performance-tests/DCPS/TCPListenerTest/subscriber.cpp
+++ b/performance-tests/DCPS/TCPListenerTest/subscriber.cpp
@@ -20,6 +20,7 @@
 #include "dds/DCPS/StaticIncludes.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <string>
 

--- a/performance-tests/DCPS/TCPProfilingTest/DataReaderListener.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/DataReaderListener.cpp
@@ -4,6 +4,7 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "testMessageTypeSupportC.h"
 #include "testMessageTypeSupportImpl.h"
+#include "ace/OS_NS_unistd.h"
 
 extern long subscriber_delay_msec; // from common.h
 

--- a/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
@@ -5,6 +5,8 @@
 #include "testMessageTypeSupportC.h"
 #include "testMessageTypeSupportImpl.h"
 #include "dds/DCPS/Service_Participant.h"
+
+#include "ace/Condition_T.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
@@ -138,4 +140,3 @@ Writer::is_finished () const
 {
   return finished_sending_;
 }
-

--- a/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
@@ -7,6 +7,7 @@
 #include "dds/DCPS/Service_Participant.h"
 
 #include "ace/Condition_T.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;

--- a/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/Writer.cpp
@@ -7,11 +7,7 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "ace/OS_NS_unistd.h"
 
-
-
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
-
-
 
 void write (long id,
             int size,

--- a/performance-tests/DCPS/TCPProfilingTest/subscriber.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/subscriber.cpp
@@ -19,6 +19,7 @@
 #include "testMessageTypeSupportImpl.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <string>
 

--- a/performance-tests/DCPS/UDPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/Writer.cpp
@@ -4,6 +4,8 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 #include "dds/DCPS/Service_Participant.h"
+
+#include "ace/Condition_T.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
@@ -226,4 +228,3 @@ Writer::is_finished () const
 {
   return finished_sending_;
 }
-

--- a/performance-tests/DCPS/UDPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/Writer.cpp
@@ -6,8 +6,6 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "ace/OS_NS_unistd.h"
 
-
-
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;
 
 

--- a/performance-tests/DCPS/UDPListenerTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/Writer.cpp
@@ -6,6 +6,7 @@
 #include "dds/DCPS/Service_Participant.h"
 
 #include "ace/Condition_T.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/OS_NS_unistd.h"
 
 extern ACE_Condition<ACE_Recursive_Thread_Mutex> done_condition_;

--- a/performance-tests/DCPS/UDPListenerTest/publisher.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/publisher.cpp
@@ -18,9 +18,7 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 
 #include "ace/Arg_Shifter.h"
-
-
-
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/performance-tests/DCPS/UDPListenerTest/subscriber.cpp
+++ b/performance-tests/DCPS/UDPListenerTest/subscriber.cpp
@@ -18,9 +18,7 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 
 #include "ace/Arg_Shifter.h"
-
-
-
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/performance-tests/DCPS/UDPNoKeyTest/Reader.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/Reader.cpp
@@ -8,9 +8,7 @@
 #include "dds/DCPS/Serializer.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
-
-
-
+#include "ace/OS_NS_unistd.h"
 
 template<class Tseq, class R, class R_var, class R_ptr>
 ::DDS::ReturnCode_t read (TestStats* stats,

--- a/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
@@ -5,6 +5,8 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportC.h"
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 #include "dds/DCPS/Service_Participant.h"
+
+#include "ace/Condition_T.h"
 #include "ace/OS_NS_unistd.h"
 
 // throttle by spinning;  ACE_OS::sleep() minimum sleep is 10 miliseconds
@@ -216,4 +218,3 @@ Writer::is_finished () const
 {
   return finished_sending_;
 }
-

--- a/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
@@ -7,6 +7,7 @@
 #include "dds/DCPS/Service_Participant.h"
 
 #include "ace/Condition_T.h"
+#include "ace/Condition_Recursive_Thread_Mutex.h"
 #include "ace/OS_NS_unistd.h"
 
 // throttle by spinning;  ACE_OS::sleep() minimum sleep is 10 miliseconds

--- a/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/Writer.cpp
@@ -7,8 +7,6 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "ace/OS_NS_unistd.h"
 
-
-
 // throttle by spinning;  ACE_OS::sleep() minimum sleep is 10 miliseconds
 #define THROTTLE \
   if (throttle_factor_) { \

--- a/performance-tests/DCPS/UDPNoKeyTest/publisher.cpp
+++ b/performance-tests/DCPS/UDPNoKeyTest/publisher.cpp
@@ -19,9 +19,7 @@
 #include "../TypeNoKeyBounded/PTDefTypeSupportImpl.h"
 
 #include "ace/Arg_Shifter.h"
-
-
-
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/tests/DCPS/BidirMessenger/pubsub.cpp
+++ b/tests/DCPS/BidirMessenger/pubsub.cpp
@@ -9,6 +9,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/BuiltInTopic/common.cpp
+++ b/tests/DCPS/BuiltInTopic/common.cpp
@@ -5,6 +5,7 @@
 #include "tests/DCPS/common/TestSupport.h"
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "tests/DCPS/FooType4/FooDefTypeSupportImpl.h"
+#include "ace/OS_NS_unistd.h"
 #include <string>
 
 #include <sstream>

--- a/tests/DCPS/BuiltInTopic/main.cpp
+++ b/tests/DCPS/BuiltInTopic/main.cpp
@@ -29,6 +29,7 @@
 #include "ace/Get_Opt.h"
 #include "ace/High_Res_Timer.h"
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "ace/Reactor.h"
 

--- a/tests/DCPS/BuiltInTopicTest/monitor.cpp
+++ b/tests/DCPS/BuiltInTopicTest/monitor.cpp
@@ -23,6 +23,7 @@
 
 #include <ace/streams.h>
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 #include "tests/Utils/ExceptionStreams.h"
 
 using namespace std;

--- a/tests/DCPS/CompatibilityTest/publisher.cpp
+++ b/tests/DCPS/CompatibilityTest/publisher.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 #include "ace/Reactor.h"
 
 #include "common.h"

--- a/tests/DCPS/CompatibilityTest/subscriber.cpp
+++ b/tests/DCPS/CompatibilityTest/subscriber.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/tests/DCPS/ConfigTransports/Pusher.cpp
+++ b/tests/DCPS/ConfigTransports/Pusher.cpp
@@ -6,8 +6,7 @@
 #include "../common/TestSupport.h"
 #include "../FooType4/FooDefTypeSupportImpl.h"
 #include "dds/DCPS/WaitSet.h"
-
-
+#include "ace/OS_NS_unistd.h"
 
 Pusher::Pusher(const Factory& f,
                const DDS::DomainParticipantFactory_var& factory,

--- a/tests/DCPS/ConfigTransports/common.cpp
+++ b/tests/DCPS/ConfigTransports/common.cpp
@@ -24,6 +24,7 @@
 #include "dds/DCPS/transport/udp/Udp.h"
 #include "dds/DCPS/transport/multicast/Multicast.h"
 #endif
+#include "dds/DCPS/transport/framework/TransportClient.h"
 
 ACE_Thread_Mutex shutdown_lock;
 bool shutdown_flag = false;

--- a/tests/DCPS/CorbaSeq/publisher.cpp
+++ b/tests/DCPS/CorbaSeq/publisher.cpp
@@ -14,6 +14,7 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include <ace/streams.h>
+#include "ace/OS_NS_unistd.h"
 #include "tests/Utils/ExceptionStreams.h"
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/tests/DCPS/CorbaSeq/subscriber.cpp
+++ b/tests/DCPS/CorbaSeq/subscriber.cpp
@@ -15,6 +15,7 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/SubscriberImpl.h>
 #include <ace/streams.h>
+#include <ace/OS_NS_unistd.h>
 #include "tests/Utils/ExceptionStreams.h"
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.cpp
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.cpp
@@ -109,3 +109,16 @@ TAO_DDS_DCPSDataWriter_i::update_subscription_params(
   }
   received_.received(DiscReceivedCalls::UPDATE_SUB_PARAMS);
 }
+
+
+void
+TAO_DDS_DCPSDataWriter_i::_add_ref()
+{
+  OpenDDS::DCPS::RcObject<ACE_SYNCH_MUTEX>::_add_ref();
+}
+
+void
+TAO_DDS_DCPSDataWriter_i::_remove_ref()
+{
+  OpenDDS::DCPS::RcObject<ACE_SYNCH_MUTEX>::_remove_ref();
+}

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
@@ -34,10 +34,12 @@
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #include "DiscReceivedCalls.h"
+#include "dds/DCPS/RcObject_T.h"
 
 //Class TAO_DDS_DCPSDataWriter_i
 class TAO_DDS_DCPSDataWriter_i
   : public OpenDDS::DCPS::DataWriterCallbacks
+  , public OpenDDS::DCPS::RcObject<ACE_SYNCH_MUTEX>
 {
 public:
   //Constructor
@@ -77,6 +79,9 @@ public:
     {
       return received_;
     }
+
+  void _add_ref();
+  void _remove_ref();
 private:
   DiscReceivedCalls received_;
 };

--- a/tests/DCPS/DCPSInfoRepo/pubsub.cpp
+++ b/tests/DCPS/DCPSInfoRepo/pubsub.cpp
@@ -88,7 +88,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   OpenDDS::DCPS::RepoId pubPartId = OpenDDS::DCPS::GUID_UNKNOWN;
   OpenDDS::DCPS::RepoId pubTopicId = OpenDDS::DCPS::GUID_UNKNOWN;
   OpenDDS::DCPS::RepoId pubId = OpenDDS::DCPS::GUID_UNKNOWN;
-  TAO_DDS_DCPSDataWriter_i dwImpl;
+  OpenDDS::DCPS::RcHandle<TAO_DDS_DCPSDataWriter_i> dwImpl(new TAO_DDS_DCPSDataWriter_i);
 
   TheServiceParticipant->get_domain_participant_factory();
 
@@ -151,7 +151,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
     }
 
   // Add publication
-  if (!dwImpl.received().expectNothing())
+  if (!dwImpl->received().expectNothing())
     {
       failed = true;
     }
@@ -169,7 +169,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   pubId = disc->add_publication(domain,
                                 pubPartId,
                                 pubTopicId,
-                                &dwImpl,
+                                dwImpl.in(),
                                 dwQos.in(),
                                 tii,
                                 pQos.in());
@@ -179,7 +179,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
       ACE_ERROR((LM_ERROR, ACE_TEXT("ERROR: add_publication failed!\n") ));
     }
 
-  if (!dwImpl.received().expectNothing())
+  if (!dwImpl->received().expectNothing())
     {
       failed = true;
     }
@@ -206,7 +206,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
                  ACE_TEXT("CONFLICTING_TYPENAME and returned %d"), topicStatus));
     }
 
-  if (!dwImpl.received().expectNothing())
+  if (!dwImpl->received().expectNothing())
     {
       failed = true;
     }
@@ -257,7 +257,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
       ACE_ERROR((LM_ERROR, ACE_TEXT("ERROR: Topic creation returned existing topic")));
     }
 
-  if (!dwImpl.received().expectNothing())
+  if (!dwImpl->received().expectNothing())
     {
       failed = true;
     }
@@ -299,7 +299,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
 
   if (use_rtps)
     expected.push_back(DiscReceivedCalls::ASSOC_COMPLETE);
-  if (!dwImpl.received().expect(orb, max_delay, expected))
+  if (!dwImpl->received().expect(orb, max_delay, expected))
     {
       failed = true;
     }

--- a/tests/DCPS/DPFactoryQos/subscriber.cpp
+++ b/tests/DCPS/DPFactoryQos/subscriber.cpp
@@ -19,6 +19,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/DcpsIntegration/topic.cpp
+++ b/tests/DCPS/DcpsIntegration/topic.cpp
@@ -14,6 +14,7 @@
 #endif
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 // const data declarations
 const long  TEST_DOMAIN_NUMBER   = 41;

--- a/tests/DCPS/Deadline/Writer.h
+++ b/tests/DCPS/Deadline/Writer.h
@@ -6,8 +6,10 @@
 #include <dds/DdsDcpsPublicationC.h>
 #include "MessengerTypeSupportC.h"
 #include "DataWriterListenerImpl.h"
-#include <ace/Task.h>
+
+#include <ace/Condition_T.h>
 #include <ace/Synch_Traits.h>
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {

--- a/tests/DCPS/Deadline/publisher.cpp
+++ b/tests/DCPS/Deadline/publisher.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <ace/streams.h>
+#include <ace/OS_NS_unistd.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
 

--- a/tests/DCPS/Deadline/subscriber.cpp
+++ b/tests/DCPS/Deadline/subscriber.cpp
@@ -27,6 +27,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include <ace/Time_Value.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <cassert>
 using namespace std;

--- a/tests/DCPS/DestinationOrder/TestCase.cpp
+++ b/tests/DCPS/DestinationOrder/TestCase.cpp
@@ -7,6 +7,7 @@
 
 #include <ace/Arg_Shifter.h>
 #include <ace/OS_NS_string.h>
+#include <ace/OS_NS_unistd.h>
 #include <ace/OS_main.h>
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/tests/DCPS/Dispose/main.cpp
+++ b/tests/DCPS/Dispose/main.cpp
@@ -11,7 +11,9 @@
 #include <dds/DCPS/SubscriberImpl.h>
 #include <dds/DCPS/SubscriptionInstance.h>
 #include <dds/DCPS/WaitSet.h>
+#include <dds/DCPS/DataReaderImpl.h>
 #include <dds/DCPS/transport/framework/TransportDefs.h>
+#include <ace/OS_NS_unistd.h>
 
 #include "FooTypeTypeSupportImpl.h"
 

--- a/tests/DCPS/Federation/Publisher.cpp
+++ b/tests/DCPS/Federation/Publisher.cpp
@@ -7,6 +7,7 @@
 #include "dds/DCPS/Marked_Default_Qos.h"
 #include "dds/DCPS/transport/framework/TransportImpl.h"
 #include "ace/SString.h"
+#include "ace/OS_NS_unistd.h"
 #include "tests/Utils/ExceptionStreams.h"
 
 #include <set>

--- a/tests/DCPS/FooTest3_0/SubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/SubDriver.cpp
@@ -10,9 +10,11 @@
 
 #include <ace/Arg_Shifter.h>
 #include <ace/Argv_Type_Converter.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <string>
 #include <sstream>
+#include <iostream>
 
 const long  MY_DOMAIN   = 411;
 const char* MY_TOPIC    = "foo";

--- a/tests/DCPS/FooTest3_2/SubDriver.cpp
+++ b/tests/DCPS/FooTest3_2/SubDriver.cpp
@@ -8,6 +8,7 @@
 
 #include <ace/Arg_Shifter.h>
 #include <ace/Argv_Type_Converter.h>
+#include <ace/OS_NS_unistd.h>
 #include <string>
 #include <sstream>
 

--- a/tests/DCPS/FooTest4/Writer.cpp
+++ b/tests/DCPS/FooTest4/Writer.cpp
@@ -8,6 +8,7 @@
 #include "dds/DCPS/RepoIdBuilder.h"
 #include "dds/DCPS/Service_Participant.h"
 #include "dds/DCPS/Serializer.h"
+#include "dds/DCPS/DataReaderImpl.h"
 #include "tests/DCPS/FooType4/FooDefTypeSupportC.h"
 #include "tests/DCPS/FooType4/FooDefTypeSupportImpl.h"
 

--- a/tests/DCPS/FooTest4_0/common.h
+++ b/tests/DCPS/FooTest4_0/common.h
@@ -12,6 +12,7 @@
 
 
 #include "dds/DdsDcpsInfrastructureC.h"
+#include "dds/DCPS/transport/framework/TransportImpl_rch.h"
 
 #include <map>
 

--- a/tests/DCPS/FooTest4_0/main.cpp
+++ b/tests/DCPS/FooTest4_0/main.cpp
@@ -18,10 +18,12 @@
 #include "dds/DCPS/Qos_Helper.h"
 #include "dds/DCPS/TopicDescriptionImpl.h"
 #include "tests/DCPS/FooType4/FooDefTypeSupportImpl.h"
+#include "dds/DCPS/transport/framework/TransportImpl.h"
 
 #include "dds/DCPS/StaticIncludes.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 OpenDDS::DCPS::TransportImpl_rch reader_transport_impl;
 OpenDDS::DCPS::TransportImpl_rch writer_transport_impl;

--- a/tests/DCPS/FooTest5/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest5/DataReaderListener.cpp
@@ -6,6 +6,7 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "tests/DCPS/FooType5/FooDefTypeSupportC.h"
 #include "tests/DCPS/FooType5/FooDefTypeSupportImpl.h"
+#include "ace/OS_NS_unistd.h"
 
 template <class DT, class DT_seq, class DR, class DR_ptr, class DR_var>
 int read (::DDS::DataReader_ptr reader)

--- a/tests/DCPS/FooTest5/publisher.cpp
+++ b/tests/DCPS/FooTest5/publisher.cpp
@@ -31,6 +31,7 @@
 #include "model/Sync.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/tests/DCPS/FooTest5_0/main.cpp
+++ b/tests/DCPS/FooTest5_0/main.cpp
@@ -23,6 +23,7 @@
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <string>
 

--- a/tests/DCPS/Footprint/rtpspublisher.cpp
+++ b/tests/DCPS/Footprint/rtpspublisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/Footprint/tcppublisher.cpp
+++ b/tests/DCPS/Footprint/tcppublisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/GroupPresentation/publisher.cpp
+++ b/tests/DCPS/GroupPresentation/publisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/Instances/PubDriver.h
+++ b/tests/DCPS/Instances/PubDriver.h
@@ -11,6 +11,7 @@
 #include "ace/Task.h"
 #include "ace/String_Base.h"
 #include "ace/Atomic_Op_T.h"
+#include "ace/OS_NS_unistd.h"
 #include "tests/DCPS/common/TestSupport.h"
 #include "tests/Utils/DDSApp.h"
 #include "tests/Utils/Options.h"

--- a/tests/DCPS/Instances/SubDriver.h
+++ b/tests/DCPS/Instances/SubDriver.h
@@ -5,6 +5,7 @@
 #include "tests/Utils/Options.h"
 #include "tests/Utils/ListenerRecorder.h"
 #include "model/Sync.h"
+#include "ace/OS_NS_unistd.h"
 #include <vector>
 
 // Set data reader QOS to use topic QOS

--- a/tests/DCPS/LargeSample/publisher.cpp
+++ b/tests/DCPS/LargeSample/publisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/LargeSample/subscriber.cpp
+++ b/tests/DCPS/LargeSample/subscriber.cpp
@@ -9,6 +9,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/Marked_Default_Qos.h>

--- a/tests/DCPS/LatencyBudget/DataReaderListener.cpp
+++ b/tests/DCPS/LatencyBudget/DataReaderListener.cpp
@@ -4,6 +4,7 @@
 #include "MessengerTypeSupportC.h"
 #include "MessengerTypeSupportImpl.h"
 #include <dds/DCPS/Service_Participant.h>
+#include "dds/DCPS/DataReaderImpl.h"
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 

--- a/tests/DCPS/LatencyBudget/subscriber.cpp
+++ b/tests/DCPS/LatencyBudget/subscriber.cpp
@@ -14,12 +14,13 @@
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/SubscriberImpl.h>
-
+#include "dds/DCPS/DataReaderImpl.h"
 #include "dds/DCPS/StaticIncludes.h"
 
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace std;
 

--- a/tests/DCPS/Lifespan/subscriber.cpp
+++ b/tests/DCPS/Lifespan/subscriber.cpp
@@ -20,6 +20,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace std;
 

--- a/tests/DCPS/LivelinessTest/publisher.cpp
+++ b/tests/DCPS/LivelinessTest/publisher.cpp
@@ -25,6 +25,7 @@
 
 #include "ace/Arg_Shifter.h"
 #include "ace/Reactor.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/tests/DCPS/ManualAssertLiveliness/publisher.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/publisher.cpp
@@ -25,6 +25,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/ManualAssertLiveliness/subscriber.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/subscriber.cpp
@@ -24,6 +24,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/ManyTopicTest/publisher.cpp
+++ b/tests/DCPS/ManyTopicTest/publisher.cpp
@@ -29,6 +29,7 @@
 #include "ace/Arg_Shifter.h"
 #include "ace/OS_NS_time.h"
 #include "ace/Atomic_Op_T.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/tests/DCPS/ManyTopicTest/subscriber.cpp
+++ b/tests/DCPS/ManyTopicTest/subscriber.cpp
@@ -29,6 +29,7 @@
 #endif
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "common.h"
 

--- a/tests/DCPS/Messenger/publisher.cpp
+++ b/tests/DCPS/Messenger/publisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/Monitor/monitor.cpp
+++ b/tests/DCPS/Monitor/monitor.cpp
@@ -9,6 +9,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/Marked_Default_Qos.h>

--- a/tests/DCPS/Monitor/publisher.cpp
+++ b/tests/DCPS/Monitor/publisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/NotifyTest/subscriber.cpp
+++ b/tests/DCPS/NotifyTest/subscriber.cpp
@@ -19,6 +19,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/Partition/Subscriber.cpp
+++ b/tests/DCPS/Partition/Subscriber.cpp
@@ -19,6 +19,8 @@
 
 #include "dds/DCPS/StaticIncludes.h"
 
+#include "ace/OS_NS_unistd.h"
+
 #include <vector>
 #include <algorithm>
 #include <iostream>

--- a/tests/DCPS/PersistentDurability/publisher.cpp
+++ b/tests/DCPS/PersistentDurability/publisher.cpp
@@ -20,6 +20,7 @@
 #include <ace/Atomic_Op_T.h>
 #include <ace/streams.h>
 #include <ace/Get_Opt.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <memory>
 #include <stdexcept>

--- a/tests/DCPS/PersistentDurability/subscriber.cpp
+++ b/tests/DCPS/PersistentDurability/subscriber.cpp
@@ -15,6 +15,7 @@
 #include <dds/DCPS/SubscriberImpl.h>
 
 #include "dds/DCPS/StaticIncludes.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <iostream>
 

--- a/tests/DCPS/PersistentInfoRepo/Listener.cpp
+++ b/tests/DCPS/PersistentInfoRepo/Listener.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Listener.h"
+#include "ace/OS_NS_unistd.h"
 
 Listener::Listener() :
   sample_count_(-1), expected_count_(0), expected_seq_(0)

--- a/tests/DCPS/Priority/DataReaderListener.cpp
+++ b/tests/DCPS/Priority/DataReaderListener.cpp
@@ -2,6 +2,7 @@
 #include "DataReaderListener.h"
 #include "TestTypeSupportC.h"
 #include "TestTypeSupportImpl.h"
+#include "ace/OS_NS_unistd.h"
 
 Test::DataReaderListener::DataReaderListener( const bool verbose)
  : verbose_( verbose),

--- a/tests/DCPS/Prst_delayed_subscriber/subscriber.cpp
+++ b/tests/DCPS/Prst_delayed_subscriber/subscriber.cpp
@@ -19,6 +19,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/PubScalability/SubDriver.cpp
+++ b/tests/DCPS/PubScalability/SubDriver.cpp
@@ -10,6 +10,7 @@
 #include <ace/Argv_Type_Converter.h>
 #include <string>
 #include <sstream>
+#include <iostream>
 
 const long  MY_DOMAIN   = 411;
 const char* MY_TOPIC    = "foo";

--- a/tests/DCPS/Rejects/subscriber.cpp
+++ b/tests/DCPS/Rejects/subscriber.cpp
@@ -25,6 +25,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include <ace/Time_Value.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <cassert>
 using namespace std;

--- a/tests/DCPS/Reliability/Boilerplate.cpp
+++ b/tests/DCPS/Reliability/Boilerplate.cpp
@@ -8,6 +8,7 @@
 #include "Boilerplate.h"
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/Service_Participant.h>
+#include <iostream>
 
 namespace examples { namespace boilerplate {
 

--- a/tests/DCPS/Reliability/pub/Publisher.cpp
+++ b/tests/DCPS/Reliability/pub/Publisher.cpp
@@ -9,6 +9,7 @@
 #include <dds/DCPS/Service_Participant.h>
 #include <model/Sync.h>
 #include <stdexcept>
+#include <iostream>
 
 #include "dds/DCPS/StaticIncludes.h"
 #ifdef ACE_AS_STATIC_LIBS

--- a/tests/DCPS/Reliability/sub/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Reliability/sub/DataReaderListenerImpl.cpp
@@ -7,6 +7,8 @@
 
 #include "DataReaderListenerImpl.h"
 #include "Boilerplate.h"
+#include "ace/OS_NS_unistd.h"
+#include <iostream>
 
 using namespace examples::boilerplate;
 

--- a/tests/DCPS/Reliability/sub/SeqReaderListenerImpl.cpp
+++ b/tests/DCPS/Reliability/sub/SeqReaderListenerImpl.cpp
@@ -7,6 +7,7 @@
 
 #include "SeqReaderListenerImpl.h"
 #include "Boilerplate.h"
+#include <iostream>
 
 using namespace examples::boilerplate;
 

--- a/tests/DCPS/Reliability/sub/Subscriber.cpp
+++ b/tests/DCPS/Reliability/sub/Subscriber.cpp
@@ -13,6 +13,7 @@
 #include <model/Sync.h>
 #include <stdexcept>
 #include <ctime>
+#include <iostream>
 #include <ace/Arg_Shifter.h>
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/tests/DCPS/Reliability/sub/TakeNextReaderListenerImpl.cpp
+++ b/tests/DCPS/Reliability/sub/TakeNextReaderListenerImpl.cpp
@@ -7,7 +7,7 @@
 
 #include "TakeNextReaderListenerImpl.h"
 #include "Boilerplate.h"
-
+#include <iostream>
 
 TakeNextReaderListenerImpl::TakeNextReaderListenerImpl()
 {

--- a/tests/DCPS/Reliability/sub/ZeroCopyReaderListenerImpl.cpp
+++ b/tests/DCPS/Reliability/sub/ZeroCopyReaderListenerImpl.cpp
@@ -7,6 +7,7 @@
 
 #include "ZeroCopyReaderListenerImpl.h"
 #include "Boilerplate.h"
+#include <iostream>
 
 using namespace examples::boilerplate;
 

--- a/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
+++ b/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
@@ -20,6 +20,7 @@
 
 #include "model/Sync.h"
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 class TestConfig {
 public:

--- a/tests/DCPS/Serializer_wstring/subscriber.cpp
+++ b/tests/DCPS/Serializer_wstring/subscriber.cpp
@@ -16,6 +16,7 @@
 #include <dds/DCPS/SubscriberImpl.h>
 #include <ace/OS_main.h>
 #include <ace/streams.h>
+#include <ace/OS_NS_unistd.h>
 #include "tests/Utils/ExceptionStreams.h"
 
 #include "dds/DCPS/StaticIncludes.h"

--- a/tests/DCPS/SetQosDeadline/subscriber.cpp
+++ b/tests/DCPS/SetQosDeadline/subscriber.cpp
@@ -26,6 +26,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include <ace/Time_Value.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <cassert>
 

--- a/tests/DCPS/SetQosPartition/publisher.cpp
+++ b/tests/DCPS/SetQosPartition/publisher.cpp
@@ -25,6 +25,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <memory>
 

--- a/tests/DCPS/SetQosPartition/subscriber.cpp
+++ b/tests/DCPS/SetQosPartition/subscriber.cpp
@@ -25,6 +25,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include <ace/Time_Value.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <cassert>
 using namespace std;

--- a/tests/DCPS/SharedTransport/TestCase.cpp
+++ b/tests/DCPS/SharedTransport/TestCase.cpp
@@ -8,6 +8,8 @@
 #include <ace/Arg_Shifter.h>
 #include <ace/OS_NS_string.h>
 #include <ace/OS_main.h>
+#include <iostream>
+#include <ace/OS_NS_unistd.h>
 
 #include "dds/DCPS/StaticIncludes.h"
 #if defined ACE_AS_STATIC_LIBS && !defined OPENDDS_SAFETY_PROFILE

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -20,6 +20,7 @@
 
 #include "ace/Arg_Shifter.h"
 #include "ace/OS_NS_stdlib.h"
+#include "ace/OS_NS_unistd.h"
 
 /*
   NOTE:  The messages may not be processed by the reader in this test.

--- a/tests/DCPS/StaticDiscoveryReconnect/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscoveryReconnect/StaticDiscoveryTest.cpp
@@ -19,6 +19,7 @@
 
 #include "ace/Arg_Shifter.h"
 #include "ace/OS_NS_stdlib.h"
+#include "ace/OS_NS_unistd.h"
 
 const int DOMAIN_ID = 100;
 const int SLEEP_SHORT = 11;

--- a/tests/DCPS/StringKey/publisher.cpp
+++ b/tests/DCPS/StringKey/publisher.cpp
@@ -18,6 +18,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/StringKey/subscriber.cpp
+++ b/tests/DCPS/StringKey/subscriber.cpp
@@ -19,6 +19,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace Messenger;
 using namespace std;

--- a/tests/DCPS/SubscriberCycle/ParticipantTask.cpp
+++ b/tests/DCPS/SubscriberCycle/ParticipantTask.cpp
@@ -6,6 +6,7 @@
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
 #include <ace/Thread_Mutex.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/Service_Participant.h>

--- a/tests/DCPS/SubscriberCycle/Subscriber.cpp
+++ b/tests/DCPS/SubscriberCycle/Subscriber.cpp
@@ -5,6 +5,7 @@
 #include <ace/Log_Msg.h>
 #include <ace/OS_main.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DdsDcpsTopicC.h>

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -10,6 +10,7 @@
 #include <ace/OS_NS_stdlib.h>
 #include "ace/Arg_Shifter.h"
 #include "ace/Process.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -20,6 +20,7 @@
 #include "FooTypeTypeSupportImpl.h"
 
 #include "dds/DCPS/StaticIncludes.h"
+#include "ace/OS_NS_unistd.h"
 
 namespace
 {

--- a/tests/DCPS/TransientDurability/publisher.cpp
+++ b/tests/DCPS/TransientDurability/publisher.cpp
@@ -17,6 +17,7 @@
 #include "dds/DCPS/StaticIncludes.h"
 
 #include <ace/streams.h>
+#include "ace/OS_NS_unistd.h"
 
 #include <memory>
 

--- a/tests/DCPS/TransientDurability/subscriber.cpp
+++ b/tests/DCPS/TransientDurability/subscriber.cpp
@@ -15,6 +15,7 @@
 #include <dds/DCPS/SubscriberImpl.h>
 
 #include "dds/DCPS/StaticIncludes.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <iostream>
 

--- a/tests/DCPS/TransientLocalTest/publisher.cpp
+++ b/tests/DCPS/TransientLocalTest/publisher.cpp
@@ -17,6 +17,7 @@
 #include "dds/DCPS/StaticIncludes.h"
 
 #include "ace/streams.h"
+#include "ace/OS_NS_unistd.h"
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
 

--- a/tests/DCPS/TransientLocalTest/subscriber.cpp
+++ b/tests/DCPS/TransientLocalTest/subscriber.cpp
@@ -20,6 +20,7 @@
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace std;
 

--- a/tests/DCPS/ViewState/main.cpp
+++ b/tests/DCPS/ViewState/main.cpp
@@ -18,10 +18,10 @@
 #include "SimpleTypeSupportImpl.h"
 #include "dds/DCPS/transport/framework/EntryExit.h"
 
-
 #include "dds/DCPS/StaticIncludes.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <string>
 

--- a/tests/DCPS/WaitForAck/Publisher.cpp
+++ b/tests/DCPS/WaitForAck/Publisher.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "ace/Condition_T.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <sstream>
 

--- a/tests/DCPS/WaitForAck/Writer.cpp
+++ b/tests/DCPS/WaitForAck/Writer.cpp
@@ -5,6 +5,8 @@
 
 #include "dds/DCPS/DataWriterImpl.h"
 
+#include "ace/OS_NS_unistd.h"
+
 #include <sstream>
 
 /// Control the spew.

--- a/tests/DCPS/ZeroCopyDataReaderListener/publisher.cpp
+++ b/tests/DCPS/ZeroCopyDataReaderListener/publisher.cpp
@@ -8,6 +8,7 @@
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>

--- a/tests/DCPS/ZeroCopyRead/main.cpp
+++ b/tests/DCPS/ZeroCopyRead/main.cpp
@@ -21,6 +21,7 @@
 #include "dds/DCPS/StaticIncludes.h"
 
 #include "ace/Arg_Shifter.h"
+#include "ace/OS_NS_unistd.h"
 
 #include <string.h>
 

--- a/tests/DCPS/sub_init_loop/publisher.cpp
+++ b/tests/DCPS/sub_init_loop/publisher.cpp
@@ -20,6 +20,7 @@
 #include "tests/Utils/ExceptionStreams.h"
 #include <ace/Get_Opt.h>
 #include "ace/OS_NS_sys_stat.h"
+#include "ace/OS_NS_unistd.h"
 
 using namespace std;
 

--- a/tests/DCPS/sub_init_loop/subscriber.cpp
+++ b/tests/DCPS/sub_init_loop/subscriber.cpp
@@ -18,7 +18,8 @@
 
 #include <ace/streams.h>
 #include <ace/Get_Opt.h>
-#include "ace/OS_NS_sys_stat.h"
+#include <ace/OS_NS_sys_stat.h>
+#include <ace/OS_NS_unistd.h>
 
 using namespace Messenger;
 

--- a/tests/FACE/Compiler/idl_test_fixed/TestFixed.cpp
+++ b/tests/FACE/Compiler/idl_test_fixed/TestFixed.cpp
@@ -2,6 +2,7 @@
 
 #include "ace/OS_main.h"
 #include "ace/CDR_Base.h"
+#include <sstream>
 
 int ACE_TMAIN(int, ACE_TCHAR*[])
 {

--- a/tests/FACE/Unit/QosSettingsTest.cpp
+++ b/tests/FACE/Unit/QosSettingsTest.cpp
@@ -9,6 +9,7 @@
 unsigned int assertions = 0;
 unsigned int failed = 0;
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS { namespace FaceTSS { namespace config {
 
 class QosSettingsAccessor {
@@ -25,8 +26,9 @@ private:
 };
 
 } } }
-
 using namespace OpenDDS::FaceTSS::config;
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
 
 /////// Publisher tests
 void test_set_publisher_single_partition() {

--- a/tests/transport/rtps/publisher.cpp
+++ b/tests/transport/rtps/publisher.cpp
@@ -33,6 +33,7 @@
 #include <ace/Message_Block.h>
 #include <ace/OS_NS_sys_time.h>
 #include <ace/OS_NS_time.h>
+#include "ace/OS_NS_unistd.h"
 
 #include <iostream>
 #include <sstream>

--- a/tests/transport/rtps/subscriber.cpp
+++ b/tests/transport/rtps/subscriber.cpp
@@ -20,6 +20,7 @@
 #include <ace/String_Base.h>
 #include <ace/Get_Opt.h>
 #include <ace/OS_NS_time.h>
+#include "ace/OS_NS_unistd.h"
 
 #include <cstdio>
 #include <cstring>

--- a/tests/transport/simple/PubDriver.cpp
+++ b/tests/transport/simple/PubDriver.cpp
@@ -15,6 +15,7 @@
 
 #include <ace/Arg_Shifter.h>
 #include <ace/OS_NS_sys_stat.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <fstream>
 #include <cstring>

--- a/tests/transport/simple/SimpleDataWriter.cpp
+++ b/tests/transport/simple/SimpleDataWriter.cpp
@@ -11,6 +11,7 @@
 
 #include "ace/SString.h"
 #include "ace/OS_NS_sys_time.h"
+#include "ace/OS_NS_unistd.h"
 
 #include "TestException.h"
 

--- a/tests/transport/simple/SubDriver.cpp
+++ b/tests/transport/simple/SubDriver.cpp
@@ -18,6 +18,7 @@
 
 #include <ace/Arg_Shifter.h>
 #include <ace/OS_NS_sys_stat.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <fstream>
 #include <cstring>

--- a/tools/modeling/codegen/model/Sync.h
+++ b/tools/modeling/codegen/model/Sync.h
@@ -3,6 +3,8 @@
 
 #include "model_export.h"
 #include "dds/DdsDcpsC.h"
+
+#include <ace/Condition_T.h>
 #include <ace/Condition_Thread_Mutex.h>
 
 #if defined _MSC_VER && _MSC_VER >= 1900

--- a/tools/modeling/tests/Exchange/subscriber.cpp
+++ b/tools/modeling/tests/Exchange/subscriber.cpp
@@ -1,5 +1,6 @@
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/WaitSet.h>
 

--- a/tools/modeling/tests/MessengerMC/subscriber.cpp
+++ b/tools/modeling/tests/MessengerMC/subscriber.cpp
@@ -1,5 +1,6 @@
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/WaitSet.h>
 

--- a/tools/modeling/tests/MultiTopic/subscriber.cpp
+++ b/tools/modeling/tests/MultiTopic/subscriber.cpp
@@ -1,5 +1,6 @@
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/WaitSet.h>
 

--- a/tools/modeling/tests/UDP/publisher.cpp
+++ b/tools/modeling/tests/UDP/publisher.cpp
@@ -1,5 +1,6 @@
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
 
 #include <dds/DCPS/WaitSet.h>
 


### PR DESCRIPTION
This fix the issue where a DataWriterImpl object being registered to a DataLink object for callbacks but  the reference counts do not incremented and thus causes the DataWriterImpl object being deleted while the DataLink still has reference to it. 