### PR TITLE
Convert Readme to markdown and add Travis badge

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,7 +7,7 @@ BUILDING OpenDDS
 * Supported platforms:
 
   We have built OpenDDS on number of different platforms and compilers.  See
-  $DDS_ROOT/README for a complete description of supported platforms.
+  $DDS_ROOT/README.md for a complete description of supported platforms.
 
 
 * Compiling:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ terms as ACE, TAO and MPC.  See the LICENSE file for details.
 This directory structure contains OpenDDS
 
 
-======================================================================
-* Documentation
+# Documentation
 
 The OpenDDS Developer's Guide is freely downloadable at:
 http://download.ociweb.com/OpenDDS/
@@ -27,8 +26,7 @@ The TAO Developer's Guide book set may also be purchased from:
 http://www.theaceorb.com/purchase/index.html
 
 
-======================================================================
-* Support
+# Support
 
 OCI strives to make OpenDDS as bug free as possible.  If you encounter
 any problems with this release please fill out the PROBLEM-REPORT-FORM
@@ -45,16 +43,15 @@ find out more about the support options available, please contact
 sales@ociweb.com.
 
 
-======================================================================
-* Features
+# Features
 
 This release of OpenDDS is based on the DDS Specification formal/2015-04-10
 (version 1.4).  It features the following transport protocols:
 
-** TCP/IP
-** UDP/IP
-** IP multicast
-** RTPS over UDP/IP (unicast and multicast)
+* TCP/IP
+* UDP/IP
+* IP multicast
+* RTPS over UDP/IP (unicast and multicast)
 
 RTPS (Interoperability) features are based on the DDS-RTPS Specification
 formal/2014-09-01 (version 2.2).  See the OpenDDS Developer's Guide and
@@ -76,10 +73,9 @@ found below.  If you would like have OCI add a feature to OpenDDS
 please see the Support section for contact information.
 
 
-======================================================================
-* Dependencies
+# Dependencies
 
-** TAO
+## TAO
 
 OpenDDS requires TAO for both IDL compilation as well as interaction
 with the DCPSInfoRepo.  If you will be using the "configure" script for OpenDDS
@@ -89,9 +85,9 @@ the "configure" script will download it for you.
 At a minimum, you must be at one of the following versions in order to properly
 compile OpenDDS:
 
-*** TAO 2.0a patch 7
-*** TAO 2.2a patch 10
-*** TAO 2.4.0 (DOC Group)
+* TAO 2.0a patch 7
+* TAO 2.2a patch 10
+* TAO 2.4.0 (DOC Group)
 
 Note that the 2.0a and 2.2a releases are from OCI and can be obtained
 from http://www.theaceorb.com/.  The DOC Group releases can be obtained from
@@ -99,43 +95,43 @@ http://download.dre.vanderbilt.edu/.
 
 OpenDDS Safety Profile requires TAO from the 2.2a or DOC Group release series.
 
-** GNU Make
+## GNU Make
 
 GNU Make 3.80+ was used for automating the compiling and linking of OpenDDS
 on Unix and Linux systems.
 
-** Perl
+## Perl
 
 Perl is used for running the automated tests and examples included in this
 source tree and generating Makefiles or Visual Studio project files.  On Windows
 we recommend the use of ActiveState Perl.  The configure script also uses Perl.
 
-* Operating Systems
+# Operating Systems
 
 This release of OpenDDS has been tested under the following platforms:
 
 Linux family:
-** Red Hat EL 5 and 5.3, x86_64
-** Red Hat EL and CentOS 6.6 and 6.8, x86_64
-** Red Hat EL 7, x86_64
-** Fedora Core 6, x86
-** Fedora 24 x86_64
-** Ubuntu 16.04 LTS, x86_64
-** openSUSE 42.1, x86_64
+* Red Hat EL 5 and 5.3, x86_64
+* Red Hat EL and CentOS 6.6 and 6.8, x86_64
+* Red Hat EL 7, x86_64
+* Fedora Core 6, x86
+* Fedora 24 x86_64
+* Ubuntu 16.04 LTS, x86_64
+* openSUSE 42.1, x86_64
 
 Windows family:
-** Windows 7 (32-bit, 64-bit)
-** Windows Server 2012 R2 (64-bit)
+* Windows 7 (32-bit, 64-bit)
+* Windows Server 2012 R2 (64-bit)
 
 Others:
-** SunOS 5.10 (Solaris 10) (SPARC)
-** Mac OSX 10.11 (El Capitan)
+* SunOS 5.10 (Solaris 10) (SPARC)
+* Mac OSX 10.11 (El Capitan)
 
 Embedded/Mobile/IoT:
-** LynxOS-178 (OpenDDS Safety Profile)
-** VxWorks 6.9 and 7 (see below)
-** Linux on Raspberry Pi and Intel Edison
-** Android NDK r12b (ARM)
+* LynxOS-178 (OpenDDS Safety Profile)
+* VxWorks 6.9 and 7 (see below)
+* Linux on Raspberry Pi and Intel Edison
+* Android NDK r12b (ARM)
 
 We have built OpenDDS for VxWorks 6.9 and 7 and have run basic
 system and performance tests (but not the entire regression test suite).
@@ -146,34 +142,31 @@ Marketplace at:
 https://marketplace.windriver.com/index.php?partners&on=details&id=33
 
 
-======================================================================
-* Compilers
+# Compilers
 
 This release of OpenDDS has been tested using the following compilers:
 
-** Microsoft Visual C++ 9 with SP1 (Visual Studio 2008)
-** Microsoft Visual C++ 10 with SP1 (Visual Studio 2010)
-** Microsoft Visual C++ 11 (Visual Studio 2012) - Update 4
-** Microsoft Visual C++ 12 (Visual Studio 2013) - Update 5
-** Microsoft Visual C++ 14 (Visual Studio 2015) - Update 3
-** gcc 4.1.x
-** gcc 4.4.x
-** gcc 4.8.x
-** gcc 4.9.x
-** gcc 5.4
-** gcc 6.2
-** Clang 3.8 (llvm.org) and 7.3 (Apple)
-** Sun C++ 5.9 SunOS_sparc Patch 124863-01 2007/07/25
+* Microsoft Visual C++ 9 with SP1 (Visual Studio 2008)
+* Microsoft Visual C++ 10 with SP1 (Visual Studio 2010)
+* Microsoft Visual C++ 11 (Visual Studio 2012) - Update 4
+* Microsoft Visual C++ 12 (Visual Studio 2013) - Update 5
+* Microsoft Visual C++ 14 (Visual Studio 2015) - Update 3
+* gcc 4.1.x
+* gcc 4.4.x
+* gcc 4.8.x
+* gcc 4.9.x
+* gcc 5.4
+* gcc 6.2
+* Clang 3.8 (llvm.org) and 7.3 (Apple)
+* Sun C++ 5.9 SunOS_sparc Patch 124863-01 2007/07/25
 
-* Building and Installing
+# Building and Installing
 
 For building and installation instructions
 see the INSTALL file in this directory.
 
 
-======================================================================
-* OpenDDS Compliance with the DDS Specification
+# OpenDDS Compliance with the DDS Specification
 
 See http://www.opendds.org and the OpenDDS Developer's Guide at:
 http://download.ociweb.com/OpenDDS/OpenDDS-latest.pdf
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/objectcomputing/OpenDDS.svg?branch=master)](https://travis-ci.org/objectcomputing/OpenDDS)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/objectcomputing/OpenDDS?svg=true)](https://ci.appveyor.com/project/mitza-oci/opendds/branch/master)
 <!-- [![Coverity Scan Build Status](https://scan.coverity.com/projects/opendds/badge.svg)](https://scan.coverity.com/projects/opendds) -->
 
 OpenDDS is an open-source C++ implementation of the Object Management Group's

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/objectcomputing/OpenDDS.svg?branch=master)](https://travis-ci.org/objectcomputing/OpenDDS)
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/opendds/badge.svg)](https://scan.coverity.com/projects/opendds)
 
 OpenDDS is an open-source C++ implementation of the Object Management Group's
 specification "Data Distribution Service for Real-time Systems".  Although

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/objectcomputing/OpenDDS.svg?branch=master)](https://travis-ci.org/objectcomputing/OpenDDS)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/opendds/badge.svg)](https://scan.coverity.com/projects/opendds)
+<!-- [![Coverity Scan Build Status](https://scan.coverity.com/projects/opendds/badge.svg)](https://scan.coverity.com/projects/opendds) -->
 
 OpenDDS is an open-source C++ implementation of the Object Management Group's
 specification "Data Distribution Service for Real-time Systems".  Although

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/objectcomputing/OpenDDS.svg?branch=master)](https://travis-ci.org/objectcomputing/OpenDDS)
+
 OpenDDS is an open-source C++ implementation of the Object Management Group's
 specification "Data Distribution Service for Real-time Systems".  Although
 OpenDDS is itself developed in C++, Java and JMS bindings are provided so

--- a/VERSION
+++ b/VERSION
@@ -3,6 +3,6 @@ This is OpenDDS version 3.9, released Fri Sep 30 17:48:45 UTC 2016
 This software is open source and free of licensing fees.  See the
 LICENSE file (in this directory) for license details.
 
-For information about OpenDDS support see the README file.
+For information about OpenDDS support see the README.md file.
 
 For more information about OpenDDS please visit www.opendds.org.

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -68,7 +68,7 @@ project(OpenDDS_Dcps): core, coverage_optional, \
     gendir = .
     ../MPC
     ../AUTHORS
-    ../README
+    ../README.md
     ../VERSION
     ../LICENSE
     ../NEWS.md

--- a/docs/html/guidelines/guidelines.html
+++ b/docs/html/guidelines/guidelines.html
@@ -537,7 +537,7 @@ Whenever there is similar functionality provided by ACE or system-specific libra
 Not all supported platforms have standard library support for wide characters (wchar_t) but this is rarely needed.  Preprocessor macro ~DDS_HAS_WCHAR can be used to detect those platforms.</pre>
 </div>
 <div title="C++ coding style" modifier="AdamMitz" created="201305221418" modified="201305221609" changecount="17">
-<pre>* C++ code in OpenDDS must compile under the compilers listed in the README file.
+<pre>* C++ code in OpenDDS must compile under the compilers listed in the README.md file.
 * Commit code in the proper style from the start, so follow-on commits to adjust style don't clutter history.
 * C++ source code is a plaintext file, so the guidelines in [[Text file formatting]] apply.
 * A modified [[Stroustrup|http://astyle.sourceforge.net/astyle.html#_style=stroustrup]] style is used (see tools/scripts/style).

--- a/java/FAQ
+++ b/java/FAQ
@@ -1,7 +1,7 @@
 Starting with release 1.2, OpenDDS provides Java bindings.  Java applications
 can make use of the complete OpenDDS middleware just like C++ applications.
 
-See the README file in the $DDS_ROOT directory (one level above here) for a
+See the README.md file in the $DDS_ROOT directory (one level above here) for a
 general overview of OpenDDS.  Also see the release notes, DDS_release_notes.txt
 in the $DDS_ROOT directory and the FAQ at <http://www.opendds.org/faq.html>.
 

--- a/java/INSTALL
+++ b/java/INSTALL
@@ -1,7 +1,7 @@
 Starting with release 1.2, OpenDDS provides Java bindings.  Java applications
 can make use of the complete OpenDDS middleware just like C++ applications.
 
-See the README file in the $DDS_ROOT directory (one level above here) for a
+See the README.md file in the $DDS_ROOT directory (one level above here) for a
 general overview of OpenDDS.
 
 
@@ -82,7 +82,7 @@ general overview of OpenDDS.
     From each branch only the current patch release (OCI) or beta/micro release
     (DOC) is supported.  The "current" releases are the latest public releases
     of TAO at the time of the OpenDDS release.  These are listed in the "TAO"
-    section of the OpenDDS README file (in the parent directory).
+    section of the OpenDDS README.md file (in the parent directory).
 
     For responsive support from OCI it is recommended that the latest version
     of the OCI release of TAO used for OpenDDS development and testing be used.
@@ -135,5 +135,5 @@ general overview of OpenDDS.
 ======================================================================
 * Next Steps: Developing Java applications with OpenDDS
 
-  See the README file in this directory.
+  See the README.md file in this directory.
 

--- a/java/jms/INSTALL
+++ b/java/jms/INSTALL
@@ -2,7 +2,7 @@ Starting with release 1.3, OpenDDS provides partial support for JMS 1.1.
 Enterprise Java applications can make use of the complete OpenDDS middleware
 just like standard Java and C++ applications.
 
-See the README file in the $DDS_ROOT directory (two levels above here) for a
+See the README.md file in the $DDS_ROOT directory (two levels above here) for a
 general overview of OpenDDS.
 
 See the README file in the $DDS_ROOT/java directory (one level above here) for


### PR DESCRIPTION
I started out thinking it'd be useful to show the Travis badge in the readme, like many github projects do. But then realized the readme would have to be converted into markdown format first. Hence the two commits.