### PR TITLE
Removed obsolete exception specifications, see issue #361

### DIFF
--- a/contrib/wrapper/DataReader_Listener_Base.h
+++ b/contrib/wrapper/DataReader_Listener_Base.h
@@ -34,50 +34,39 @@ public:
   /// bounds specified by a DEADLINE policy.
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   /// this callback is called when a data reader QoS policy value is
   /// incompatible with what is offered.
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   /// this callback is called when the liveliness of one or more DataWriter
   /// that were writing instances read through the DataReader has changed.
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   /// this callback is called when the DataReader has found a DataWriter
   /// that matches the topic and has compatible QoS.
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   /// this callback is called when a (received) sample has been rejected.
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   /// this callback is called when new information is available.
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   /// this callback is called when a sample has been lost (never received).
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 };
 
 #if defined (__ACE_INLINE__)

--- a/contrib/wrapper/DataReader_Listener_Base.inl
+++ b/contrib/wrapper/DataReader_Listener_Base.inl
@@ -14,7 +14,6 @@
 
 ACE_INLINE void
 DataReader_Listener_Base::on_data_available(DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   // no op
 }
@@ -23,7 +22,6 @@ ACE_INLINE void
 DataReader_Listener_Base::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   // no op
 }
@@ -32,7 +30,6 @@ ACE_INLINE void
 DataReader_Listener_Base::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   // no op
 }
@@ -41,7 +38,6 @@ ACE_INLINE void
 DataReader_Listener_Base::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   // no op
 }
@@ -50,7 +46,6 @@ ACE_INLINE void
 DataReader_Listener_Base::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   // no op
 }
@@ -59,7 +54,6 @@ ACE_INLINE void
 DataReader_Listener_Base::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   // no op
 }
@@ -68,7 +62,6 @@ ACE_INLINE void
 DataReader_Listener_Base::on_sample_lost (
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   // no op
 }

--- a/examples/DCPS/IntroductionToOpenDDS/ExchangeEventDataReaderListenerImpl.cpp
+++ b/examples/DCPS/IntroductionToOpenDDS/ExchangeEventDataReaderListenerImpl.cpp
@@ -31,7 +31,6 @@ ExchangeEventDataReaderListenerImpl::is_exchange_closed_received()
 
 
 void ExchangeEventDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   try {
     StockQuoter::ExchangeEventDataReader_var exchange_evt_dr
@@ -93,7 +92,6 @@ void ExchangeEventDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr 
 void ExchangeEventDataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "ExchangeEventDataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -101,7 +99,6 @@ void ExchangeEventDataReaderListenerImpl::on_requested_deadline_missed (
 void ExchangeEventDataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "ExchangeEventDataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -109,7 +106,6 @@ void ExchangeEventDataReaderListenerImpl::on_requested_incompatible_qos (
 void ExchangeEventDataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "ExchangeEventDataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -117,7 +113,6 @@ void ExchangeEventDataReaderListenerImpl::on_liveliness_changed (
 void ExchangeEventDataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "ExchangeEventDataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -125,7 +120,6 @@ void ExchangeEventDataReaderListenerImpl::on_subscription_matched (
 void ExchangeEventDataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "ExchangeEventDataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -133,7 +127,6 @@ void ExchangeEventDataReaderListenerImpl::on_sample_rejected(
 void ExchangeEventDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "ExchangeEventDataReaderListenerImpl::on_sample_lost" << endl;
 }

--- a/examples/DCPS/IntroductionToOpenDDS/ExchangeEventDataReaderListenerImpl.h
+++ b/examples/DCPS/IntroductionToOpenDDS/ExchangeEventDataReaderListenerImpl.h
@@ -31,41 +31,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   CORBA::Boolean is_exchange_closed_received_;

--- a/examples/DCPS/IntroductionToOpenDDS/QuoteDataReaderListenerImpl.cpp
+++ b/examples/DCPS/IntroductionToOpenDDS/QuoteDataReaderListenerImpl.cpp
@@ -22,7 +22,6 @@ QuoteDataReaderListenerImpl::~QuoteDataReaderListenerImpl ()
 }
 
 void QuoteDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   try {
     StockQuoter::QuoteDataReader_var quote_dr
@@ -65,7 +64,6 @@ void QuoteDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void QuoteDataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "QuoteDataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -73,7 +71,6 @@ void QuoteDataReaderListenerImpl::on_requested_deadline_missed (
 void QuoteDataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "QuoteDataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -81,7 +78,6 @@ void QuoteDataReaderListenerImpl::on_requested_incompatible_qos (
 void QuoteDataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "QuoteDataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -89,7 +85,6 @@ void QuoteDataReaderListenerImpl::on_liveliness_changed (
 void QuoteDataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "QuoteDataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -97,7 +92,6 @@ void QuoteDataReaderListenerImpl::on_subscription_matched (
 void QuoteDataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "QuoteDataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -105,7 +99,6 @@ void QuoteDataReaderListenerImpl::on_sample_rejected(
 void QuoteDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "QuoteDataReaderListenerImpl::on_sample_lost" << endl;
 }

--- a/examples/DCPS/IntroductionToOpenDDS/QuoteDataReaderListenerImpl.h
+++ b/examples/DCPS/IntroductionToOpenDDS/QuoteDataReaderListenerImpl.h
@@ -27,41 +27,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 };
 
 #endif /* QUOTE_DATAREADER_LISTENER_IMPL  */

--- a/examples/DCPS/Messenger_IOGR_Imr/DataReaderListener.cpp
+++ b/examples/DCPS/Messenger_IOGR_Imr/DataReaderListener.cpp
@@ -18,9 +18,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -54,7 +53,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -62,7 +60,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -70,7 +67,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -78,7 +74,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -86,7 +81,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -94,7 +88,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -102,7 +95,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -110,7 +102,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -118,7 +109,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -126,14 +116,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/examples/DCPS/Messenger_IOGR_Imr/DataReaderListener.h
+++ b/examples/DCPS/Messenger_IOGR_Imr/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/examples/DCPS/Messenger_Imr/DataReaderListener.cpp
+++ b/examples/DCPS/Messenger_Imr/DataReaderListener.cpp
@@ -18,9 +18,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -54,7 +53,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -62,7 +60,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -70,7 +67,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -78,7 +74,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -86,7 +81,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -94,7 +88,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -102,7 +95,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -110,7 +102,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -118,7 +109,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -126,14 +116,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/examples/DCPS/Messenger_Imr/DataReaderListener.h
+++ b/examples/DCPS/Messenger_Imr/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/performance-tests/Bench/src/DataReaderListener.cpp
+++ b/performance-tests/Bench/src/DataReaderListener.cpp
@@ -137,7 +137,6 @@ Test::DataReaderListener::rawData( std::ostream& str) const
 
 void
 Test::DataReaderListener::on_data_available (DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   DataDataReader_var dr = DataDataReader::_narrow (reader);
   if (CORBA::is_nil (dr.in ())) {
@@ -262,7 +261,6 @@ void
 Test::DataReaderListener::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -270,7 +268,6 @@ void
 Test::DataReaderListener::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -278,7 +275,6 @@ void
 Test::DataReaderListener::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -286,7 +282,6 @@ void
 Test::DataReaderListener::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -294,14 +289,12 @@ void
 Test::DataReaderListener::on_sample_rejected (
     DDS::DataReader_ptr,
     DDS::SampleRejectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_sample_lost (DDS::DataReader_ptr,
                                           DDS::SampleLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -309,7 +302,6 @@ void
 Test::DataReaderListener::on_subscription_disconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionDisconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -317,7 +309,6 @@ void
 Test::DataReaderListener::on_subscription_reconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionReconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -325,7 +316,6 @@ void
 Test::DataReaderListener::on_subscription_lost (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -333,13 +323,11 @@ void
 Test::DataReaderListener::on_budget_exceeded (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
 }
 

--- a/performance-tests/Bench/src/DataReaderListener.h
+++ b/performance-tests/Bench/src/DataReaderListener.h
@@ -34,58 +34,46 @@ namespace Test {
 
       virtual void on_requested_deadline_missed (
           DDS::DataReader_ptr reader,
-          const DDS::RequestedDeadlineMissedStatus & status)
-        throw (CORBA::SystemException);
+          const DDS::RequestedDeadlineMissedStatus & status);
 
       virtual void on_requested_incompatible_qos (
           DDS::DataReader_ptr reader,
-          const DDS::RequestedIncompatibleQosStatus & status)
-        throw (CORBA::SystemException);
+          const DDS::RequestedIncompatibleQosStatus & status);
 
       virtual void on_liveliness_changed (
           DDS::DataReader_ptr reader,
-          const DDS::LivelinessChangedStatus & status)
-        throw (CORBA::SystemException);
+          const DDS::LivelinessChangedStatus & status);
 
       virtual void on_subscription_matched (
           DDS::DataReader_ptr reader,
-          const DDS::SubscriptionMatchedStatus & status)
-        throw (CORBA::SystemException);
+          const DDS::SubscriptionMatchedStatus & status);
 
       virtual void on_sample_rejected(
           DDS::DataReader_ptr reader,
-          const DDS::SampleRejectedStatus& status)
-        throw (CORBA::SystemException);
+          const DDS::SampleRejectedStatus& status);
 
-      virtual void on_data_available(DDS::DataReader_ptr reader)
-        throw (CORBA::SystemException);
+      virtual void on_data_available(DDS::DataReader_ptr reader);
 
       virtual void on_sample_lost(DDS::DataReader_ptr reader,
-                                  const DDS::SampleLostStatus& status)
-        throw (CORBA::SystemException);
+                                  const DDS::SampleLostStatus& status);
 
       virtual void on_subscription_disconnected (
           DDS::DataReader_ptr reader,
-          const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status)
-        throw (CORBA::SystemException);
+          const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
       virtual void on_subscription_reconnected (
           DDS::DataReader_ptr reader,
-          const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status)
-        throw (CORBA::SystemException);
+          const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
       virtual void on_subscription_lost (
           DDS::DataReader_ptr reader,
-          const ::OpenDDS::DCPS::SubscriptionLostStatus & status)
-        throw (CORBA::SystemException);
+          const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
       virtual void on_budget_exceeded (
           DDS::DataReader_ptr reader,
-          const ::OpenDDS::DCPS::BudgetExceededStatus& status)
-        throw (CORBA::SystemException);
+          const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
-      virtual void on_connection_deleted (DDS::DataReader_ptr)
-        throw (CORBA::SystemException);
+      virtual void on_connection_deleted (DDS::DataReader_ptr);
 
       /// Establish a forwarding destination for received samples.
       void set_destination( Publication* publication);

--- a/performance-tests/DCPS/InfoRepo_population/DataReaderListener.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/DataReaderListener.cpp
@@ -17,9 +17,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr = Messenger::MessageDataReader::_narrow(reader);
@@ -53,7 +52,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -61,7 +59,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -69,7 +66,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -77,7 +73,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -85,7 +80,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -93,7 +87,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -101,7 +94,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -109,7 +101,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -117,14 +108,12 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/performance-tests/DCPS/InfoRepo_population/DataReaderListener.h
+++ b/performance-tests/DCPS/InfoRepo_population/DataReaderListener.h
@@ -20,63 +20,45 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/performance-tests/DCPS/InfoRepo_population/SyncExt_i.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/SyncExt_i.cpp
@@ -22,7 +22,6 @@ void
 SyncExt_i::publish (SyncExt::Role role
                   , ::CORBA::Long instances
                   , ::CORBA::Long msecs)
-  throw (CORBA::SystemException)
 {
   if (role > SyncExt::Subscriber) {
     return;

--- a/performance-tests/DCPS/InfoRepo_population/SyncExt_i.h
+++ b/performance-tests/DCPS/InfoRepo_population/SyncExt_i.h
@@ -15,8 +15,7 @@ class SyncExt_i : public virtual POA_SyncExt::Collector,
 
   virtual void publish (SyncExt::Role rol
                         , ::CORBA::Long instances
-                        , ::CORBA::Long msecs)
-    throw (CORBA::SystemException);
+                        , ::CORBA::Long msecs);
 
   void print_results (void);
 

--- a/performance-tests/DCPS/Priority/DataReaderListener.cpp
+++ b/performance-tests/DCPS/Priority/DataReaderListener.cpp
@@ -51,7 +51,6 @@ Test::DataReaderListener::priorities() const
 
 void
 Test::DataReaderListener::on_data_available (DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   Test::DataDataReader_var dr = Test::DataDataReader::_narrow (reader);
   if (CORBA::is_nil (dr.in ())) {
@@ -168,7 +167,6 @@ void
 Test::DataReaderListener::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -176,7 +174,6 @@ void
 Test::DataReaderListener::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -184,7 +181,6 @@ void
 Test::DataReaderListener::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   if( this->verbose_) {
     ACE_DEBUG((LM_DEBUG,
@@ -197,7 +193,6 @@ void
 Test::DataReaderListener::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -205,14 +200,12 @@ void
 Test::DataReaderListener::on_sample_rejected (
     DDS::DataReader_ptr,
     DDS::SampleRejectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_sample_lost (DDS::DataReader_ptr,
                                           DDS::SampleLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -220,7 +213,6 @@ void
 Test::DataReaderListener::on_subscription_disconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionDisconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -228,7 +220,6 @@ void
 Test::DataReaderListener::on_subscription_reconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionReconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -236,7 +227,6 @@ void
 Test::DataReaderListener::on_subscription_lost (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -244,13 +234,11 @@ void
 Test::DataReaderListener::on_budget_exceeded (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
 }
 

--- a/performance-tests/DCPS/Priority/DataReaderListener.h
+++ b/performance-tests/DCPS/Priority/DataReaderListener.h
@@ -23,58 +23,46 @@ namespace Test {
 
     virtual void on_requested_deadline_missed (
         DDS::DataReader_ptr reader,
-        const DDS::RequestedDeadlineMissedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::RequestedDeadlineMissedStatus & status);
 
     virtual void on_requested_incompatible_qos (
         DDS::DataReader_ptr reader,
-        const DDS::RequestedIncompatibleQosStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::RequestedIncompatibleQosStatus & status);
 
     virtual void on_liveliness_changed (
         DDS::DataReader_ptr reader,
-        const DDS::LivelinessChangedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::LivelinessChangedStatus & status);
 
     virtual void on_subscription_matched (
         DDS::DataReader_ptr reader,
-        const DDS::SubscriptionMatchedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::SubscriptionMatchedStatus & status);
 
     virtual void on_sample_rejected(
         DDS::DataReader_ptr reader,
-        const DDS::SampleRejectedStatus& status)
-      throw (CORBA::SystemException);
+        const DDS::SampleRejectedStatus& status);
 
-    virtual void on_data_available(DDS::DataReader_ptr reader)
-      throw (CORBA::SystemException);
+    virtual void on_data_available(DDS::DataReader_ptr reader);
 
     virtual void on_sample_lost(DDS::DataReader_ptr reader,
-                                const DDS::SampleLostStatus& status)
-      throw (CORBA::SystemException);
+                                const DDS::SampleLostStatus& status);
 
     virtual void on_subscription_disconnected (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
     virtual void on_subscription_reconnected (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
     virtual void on_subscription_lost (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionLostStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
     virtual void on_budget_exceeded (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::BudgetExceededStatus& status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
-    virtual void on_connection_deleted (DDS::DataReader_ptr)
-      throw (CORBA::SystemException);
+    virtual void on_connection_deleted (DDS::DataReader_ptr);
 
     /// Number of messages received by this listener over its lifetime.
     int total_messages() const;

--- a/performance-tests/DCPS/SimpleLatency/PubListener.cpp
+++ b/performance-tests/DCPS/SimpleLatency/PubListener.cpp
@@ -129,7 +129,6 @@ void AckDataReaderListenerImpl::init(DDS::DataReader_ptr dr,
 
 
 void AckDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
     CORBA::Long sequence_number;
     DDS::ReturnCode_t status;
@@ -232,41 +231,35 @@ void AckDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr)
 void AckDataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void AckDataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void AckDataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void AckDataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void AckDataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
 void AckDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
 }

--- a/performance-tests/DCPS/SimpleLatency/PubListener.h
+++ b/performance-tests/DCPS/SimpleLatency/PubListener.h
@@ -24,41 +24,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   int done() const {
     return this->done_;

--- a/performance-tests/DCPS/SimpleLatency/SubListener.cpp
+++ b/performance-tests/DCPS/SimpleLatency/SubListener.cpp
@@ -42,7 +42,6 @@ PubDataReaderListenerImpl::~PubDataReaderListenerImpl ()
 }
 
 void PubDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
     CORBA::Long seqnum;
 
@@ -98,41 +97,35 @@ void PubDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr)
 void PubDataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void PubDataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void PubDataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void PubDataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
 void PubDataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
 void PubDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
 }

--- a/performance-tests/DCPS/SimpleLatency/SubListener.h
+++ b/performance-tests/DCPS/SimpleLatency/SubListener.h
@@ -22,41 +22,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   int done() const {
     return this->done_;

--- a/performance-tests/DCPS/Sync/SyncClient_i.cpp
+++ b/performance-tests/DCPS/Sync/SyncClient_i.cpp
@@ -116,7 +116,6 @@ SyncClient_i::svc (void)
 
 void
 SyncClient_i::proceed (void)
-  throw (CORBA::SystemException)
 {
   ACE_GUARD( ACE_SYNCH_MUTEX, guard, this->lock_);
   notification_ = true;

--- a/performance-tests/DCPS/Sync/SyncClient_i.h
+++ b/performance-tests/DCPS/Sync/SyncClient_i.h
@@ -42,8 +42,7 @@ class Sync_Export SyncClient_i : public POA_Sync::Client, public ACE_Task_Base
   virtual int svc (void);
 
   // notification from SyncServer
-  virtual void proceed (void)
-    throw (CORBA::SystemException);
+  virtual void proceed (void);
 
   // cleans up the notification pipeline.
   // Invoke this before notifying the SyncServer.

--- a/performance-tests/DCPS/Sync/SyncServer_i.cpp
+++ b/performance-tests/DCPS/Sync/SyncServer_i.cpp
@@ -79,7 +79,6 @@ SyncServer_i::~SyncServer_i (void)
 void
 SyncServer_i::register_me (::Sync::Role role, ::Sync::Client_ptr callback,
                            ::Sync::Id_out id)
-  throw (CORBA::SystemException)
 {
   //ACE_DEBUG ((LM_DEBUG, "(%P|%t) SyncServer_i::register_me\n"));
   try{
@@ -134,7 +133,6 @@ SyncServer_i::register_me (::Sync::Role role, ::Sync::Client_ptr callback,
 
 void
 SyncServer_i::unregister (::Sync::Id id)
-  throw (CORBA::SystemException)
 {
   //ACE_DEBUG ((LM_DEBUG, "(%P|%t) SyncServer_i::unregister\n"));
   if (subs_.find (id) != subs_.end()) {
@@ -161,7 +159,6 @@ SyncServer_i::unregister (::Sync::Id id)
 void
 SyncServer_i::way_point_reached (::Sync::Id id,
                                  ::Sync::WayPoint way_point)
-  throw (CORBA::SystemException)
 {
   //ACE_DEBUG ((LM_DEBUG, "(%P|%t) SyncServer_i::way_point_reached\n"));
 

--- a/performance-tests/DCPS/Sync/SyncServer_i.h
+++ b/performance-tests/DCPS/Sync/SyncServer_i.h
@@ -27,16 +27,12 @@ class Sync_Export SyncServer_i : public virtual POA_Sync::Server, public ACE_Tas
   virtual int svc (void);
 
   virtual void register_me (::Sync::Role rol, ::Sync::Client_ptr callback,
-                            ::Sync::Id_out ide)
-    throw (CORBA::SystemException);
+                            ::Sync::Id_out ide);
 
-  virtual void unregister (::Sync::Id ide)
-    throw (CORBA::SystemException);
+  virtual void unregister (::Sync::Id ide);
 
   virtual void way_point_reached (::Sync::Id ide,
-                                  ::Sync::WayPoint way_point)
-    throw (CORBA::SystemException);
-
+                                  ::Sync::WayPoint way_point);
  private:
   typedef struct Cl
   {

--- a/tests/DCPS/BidirMessenger/DataReaderListener.cpp
+++ b/tests/DCPS/BidirMessenger/DataReaderListener.cpp
@@ -52,7 +52,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
       if (si.valid_data) {
         ACE_Guard<ACE_Mutex> guard(this->lock_);
-        num_reads_ ++;
+        ++num_reads_;
 #if 0
         std::cout << "Message: subject    = " << message.subject.in() << std::endl
                   << "         subject_id = " << message.subject_id   << std::endl

--- a/tests/DCPS/BuiltInTopicTest/DataReaderListener.cpp
+++ b/tests/DCPS/BuiltInTopicTest/DataReaderListener.cpp
@@ -26,9 +26,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     ::Messenger::MessageDataReader_var message_dr = ::Messenger::MessageDataReader::_narrow(reader);
@@ -83,7 +82,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -91,7 +89,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -99,7 +96,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -107,7 +103,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus & status)
-  throw (CORBA::SystemException)
 {
   if (this->publication_handle_ == ::DDS::HANDLE_NIL) {
     this->publication_handle_ = status.last_publication_handle;
@@ -151,7 +146,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -159,7 +153,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -167,7 +160,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -175,7 +167,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -183,14 +174,12 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/BuiltInTopicTest/DataReaderListener.h
+++ b/tests/DCPS/BuiltInTopicTest/DataReaderListener.h
@@ -20,63 +20,45 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/CorbaSeq/DataReaderListener.cpp
+++ b/tests/DCPS/CorbaSeq/DataReaderListener.cpp
@@ -20,9 +20,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -86,7 +85,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -94,7 +92,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -102,7 +99,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -110,7 +106,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -118,7 +113,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -126,7 +120,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -134,7 +127,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -142,7 +134,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -150,7 +141,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -158,15 +148,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
-    ::DDS::DataReader_ptr
-    )
-    throw (CORBA::SystemException)
+    ::DDS::DataReader_ptr)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/CorbaSeq/DataReaderListener.h
+++ b/tests/DCPS/CorbaSeq/DataReaderListener.h
@@ -20,70 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-    ::DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    ::DDS::DataReader_ptr reader);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/DPFactoryQos/DataReaderListener.cpp
+++ b/tests/DCPS/DPFactoryQos/DataReaderListener.cpp
@@ -20,9 +20,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
   try {
     ::Messenger::MessageDataReader_var message_dr =
         ::Messenger::MessageDataReader::_narrow(reader);
@@ -75,7 +74,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -83,7 +81,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -91,7 +88,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -99,7 +95,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -107,7 +102,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -115,7 +109,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }

--- a/tests/DCPS/DPFactoryQos/DataReaderListener.h
+++ b/tests/DCPS/DPFactoryQos/DataReaderListener.h
@@ -20,41 +20,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Deadline/DataReaderListener.cpp
+++ b/tests/DCPS/Deadline/DataReaderListener.cpp
@@ -20,16 +20,14 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void
 DataReaderListenerImpl::on_data_available (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
-  num_arrived_ ++;
+  ++num_arrived_;
 }
 
 void
 DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr /* reader */,
     DDS::RequestedDeadlineMissedStatus const & status)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_requested_deadline_missed:")
@@ -41,7 +39,6 @@ void
 DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -50,7 +47,6 @@ void
 DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -59,7 +55,6 @@ void
 DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -68,7 +63,6 @@ void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -77,7 +71,6 @@ void
 DataReaderListenerImpl::on_sample_lost (
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -86,7 +79,6 @@ void
 DataReaderListenerImpl::on_subscription_disconnected (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -95,7 +87,6 @@ void
 DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -104,7 +95,6 @@ void
 DataReaderListenerImpl::on_subscription_lost (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -112,14 +102,12 @@ DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void
 DataReaderListenerImpl::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/Deadline/DataReaderListener.h
+++ b/tests/DCPS/Deadline/DataReaderListener.h
@@ -19,69 +19,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_arrived() const {
     return num_arrived_;

--- a/tests/DCPS/Footprint/DataReaderListener.cpp
+++ b/tests/DCPS/Footprint/DataReaderListener.cpp
@@ -40,7 +40,7 @@ DataReaderListenerImpl::is_reliable()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =

--- a/tests/DCPS/GroupPresentation/DataReaderListener.cpp
+++ b/tests/DCPS/GroupPresentation/DataReaderListener.cpp
@@ -31,7 +31,7 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =

--- a/tests/DCPS/LatencyBudget/DataReaderListener.cpp
+++ b/tests/DCPS/LatencyBudget/DataReaderListener.cpp
@@ -22,9 +22,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -58,7 +57,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -66,7 +64,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -74,7 +71,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -82,7 +78,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -90,7 +85,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -98,7 +92,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -106,7 +99,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -114,7 +106,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -122,7 +113,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -130,7 +120,6 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr reader,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   num_late_++;
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
@@ -149,7 +138,6 @@ void DataReaderListenerImpl::on_budget_exceeded (
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/LatencyBudget/DataReaderListener.h
+++ b/tests/DCPS/LatencyBudget/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Lifespan/DataReaderListener.cpp
+++ b/tests/DCPS/Lifespan/DataReaderListener.cpp
@@ -20,9 +20,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -56,7 +55,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -64,7 +62,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -72,7 +69,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -80,7 +76,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -88,7 +83,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -96,7 +90,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -104,7 +97,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -112,7 +104,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -120,7 +111,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -128,14 +118,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/Lifespan/DataReaderListener.h
+++ b/tests/DCPS/Lifespan/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/ManualAssertLiveliness/DataReaderListener.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/DataReaderListener.cpp
@@ -23,9 +23,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
   try {
     ::Messenger::MessageDataReader_var message_dr =
         ::Messenger::MessageDataReader::_narrow(reader);
@@ -75,7 +74,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -83,7 +81,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -91,7 +88,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr reader,
     const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException)
 {
   ++ num_liveliness_change_callbacks_;
 
@@ -115,7 +111,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -123,7 +118,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -131,7 +125,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }

--- a/tests/DCPS/ManualAssertLiveliness/DataReaderListener.h
+++ b/tests/DCPS/ManualAssertLiveliness/DataReaderListener.h
@@ -20,41 +20,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -40,7 +40,7 @@ DataReaderListenerImpl::is_reliable()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =

--- a/tests/DCPS/Monitor/DataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DataReaderListener.cpp
@@ -29,7 +29,7 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =

--- a/tests/DCPS/NotifyTest/DataReaderListener.cpp
+++ b/tests/DCPS/NotifyTest/DataReaderListener.cpp
@@ -23,10 +23,9 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   if (! shutdown_)
-    num_reads_ ++;
+    ++num_reads_;
 
   try {
     ::Messenger::MessageDataReader_var message_dr =
@@ -84,7 +83,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -92,7 +90,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -100,7 +97,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -108,7 +104,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -116,7 +111,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -124,7 +118,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }

--- a/tests/DCPS/NotifyTest/DataReaderListener.h
+++ b/tests/DCPS/NotifyTest/DataReaderListener.h
@@ -20,41 +20,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Ownership/DataReaderListener.cpp
+++ b/tests/DCPS/Ownership/DataReaderListener.cpp
@@ -51,7 +51,7 @@ throw(CORBA::SystemException)
 
     DDS::ReturnCode_t status = DDS::RETCODE_OK;
     while (status == DDS::RETCODE_OK) {
-      num_reads_ ++;
+      ++num_reads_;
       Messenger::Message message;
       DDS::SampleInfo si;
 

--- a/tests/DCPS/Partition/DataReaderListener.cpp
+++ b/tests/DCPS/Partition/DataReaderListener.cpp
@@ -34,7 +34,6 @@ Test::DataReaderListener::~DataReaderListener ()
 
 void
 Test::DataReaderListener::on_data_available (DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   Test::DataDataReader_var dr = Test::DataDataReader::_narrow (reader);
   if (CORBA::is_nil (dr.in ())) {
@@ -51,7 +50,6 @@ void
 Test::DataReaderListener::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -59,7 +57,6 @@ void
 Test::DataReaderListener::on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
     const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException)
 {
   // This test only modifies the PARTITION QoS policy.
   // By design, PARTITION incompatibilities should not be reported.
@@ -76,7 +73,6 @@ void
 Test::DataReaderListener::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -84,7 +80,6 @@ void
 Test::DataReaderListener::on_subscription_matched (
     DDS::DataReader_ptr reader,
     const DDS::SubscriptionMatchedStatus& status)
-  throw (CORBA::SystemException)
 {
   if( status.total_count_change > 0) {
     this->subscription_matches_ += status.total_count_change;
@@ -101,14 +96,12 @@ void
 Test::DataReaderListener::on_sample_rejected (
     DDS::DataReader_ptr,
     DDS::SampleRejectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_sample_lost (DDS::DataReader_ptr,
                                           DDS::SampleLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -116,7 +109,6 @@ void
 Test::DataReaderListener::on_subscription_disconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionDisconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -124,7 +116,6 @@ void
 Test::DataReaderListener::on_subscription_reconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionReconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -132,7 +123,6 @@ void
 Test::DataReaderListener::on_subscription_lost (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -140,13 +130,11 @@ void
 Test::DataReaderListener::on_budget_exceeded (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
 }
 

--- a/tests/DCPS/Partition/DataReaderListener.h
+++ b/tests/DCPS/Partition/DataReaderListener.h
@@ -22,58 +22,46 @@ namespace Test
 
     virtual void on_requested_deadline_missed (
         DDS::DataReader_ptr reader,
-        const DDS::RequestedDeadlineMissedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::RequestedDeadlineMissedStatus & status);
 
     virtual void on_requested_incompatible_qos (
         DDS::DataReader_ptr reader,
-        const DDS::RequestedIncompatibleQosStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::RequestedIncompatibleQosStatus & status);
 
     virtual void on_liveliness_changed (
         DDS::DataReader_ptr reader,
-        const DDS::LivelinessChangedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::LivelinessChangedStatus & status);
 
     virtual void on_subscription_matched (
         DDS::DataReader_ptr reader,
-        const DDS::SubscriptionMatchedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::SubscriptionMatchedStatus & status);
 
     virtual void on_sample_rejected(
         DDS::DataReader_ptr reader,
-        const DDS::SampleRejectedStatus& status)
-      throw (CORBA::SystemException);
+        const DDS::SampleRejectedStatus& status);
 
-    virtual void on_data_available(DDS::DataReader_ptr reader)
-      throw (CORBA::SystemException);
+    virtual void on_data_available(DDS::DataReader_ptr reader);
 
     virtual void on_sample_lost(DDS::DataReader_ptr reader,
-                                const DDS::SampleLostStatus& status)
-      throw (CORBA::SystemException);
+                                const DDS::SampleLostStatus& status);
 
     virtual void on_subscription_disconnected (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
     virtual void on_subscription_reconnected (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
     virtual void on_subscription_lost (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionLostStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
     virtual void on_budget_exceeded (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::BudgetExceededStatus& status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
-    virtual void on_connection_deleted (DDS::DataReader_ptr)
-      throw (CORBA::SystemException);
+    virtual void on_connection_deleted (DDS::DataReader_ptr);
 
   protected:
 

--- a/tests/DCPS/PersistentDurability/DataReaderListener.cpp
+++ b/tests/DCPS/PersistentDurability/DataReaderListener.cpp
@@ -20,7 +20,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void
 DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   ++this->num_reads_;
 
@@ -57,7 +56,6 @@ void
 DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -66,7 +64,6 @@ void
 DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -75,7 +72,6 @@ void
 DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -84,7 +80,6 @@ void
 DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -93,7 +88,6 @@ void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -101,7 +95,6 @@ DataReaderListenerImpl::on_sample_rejected (
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -109,7 +102,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -117,7 +109,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -125,7 +116,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -133,13 +123,11 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/PersistentDurability/DataReaderListener.h
+++ b/tests/DCPS/PersistentDurability/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded (
     DDS::DataReader_ptr,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Priority/DataReaderListener.cpp
+++ b/tests/DCPS/Priority/DataReaderListener.cpp
@@ -7,7 +7,7 @@
 Test::DataReaderListener::DataReaderListener( const bool verbose)
  : verbose_( verbose),
    count_( 0),
-   recieved_samples_invalid_( false),
+   received_samples_invalid_( false),
    priority_sample_( NOT_RECEIVED)
 {
 }
@@ -25,12 +25,11 @@ Test::DataReaderListener::count() const
 bool
 Test::DataReaderListener::passed() const
 {
-  return !recieved_samples_invalid_ && priority_sample_ == RECEIVED_VALID;
+  return !received_samples_invalid_ && priority_sample_ == RECEIVED_VALID;
 }
 
 void
 Test::DataReaderListener::on_data_available (DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   Test::DataDataReader_var dr = Test::DataDataReader::_narrow (reader);
   if (CORBA::is_nil (dr.in ())) {
@@ -75,10 +74,10 @@ Test::DataReaderListener::on_data_available (DDS::DataReader_ptr reader)
                      ACE_TEXT("(%P|%t) ERROR: DataReaderListener::on_data_available() - ")
                      ACE_TEXT("Received multiple high priority samples.\n")));
         }
-        else if (recieved_samples_.count(data.before_value)) {
+        else if (received_samples_.count(data.before_value)) {
           priority_sample_ = RECEIVED_INVALID;
           // (there is at least one entry so rbegin is valid)
-          const long highest = *recieved_samples_.rbegin();
+          const long highest = *received_samples_.rbegin();
           ACE_ERROR((LM_ERROR,
                      ACE_TEXT("(%P|%t) ERROR: DataReaderListener::on_data_available() - ")
                      ACE_TEXT("Did not receive high priority sample before low priority ")
@@ -89,22 +88,22 @@ Test::DataReaderListener::on_data_available (DDS::DataReader_ptr reader)
         else
           priority_sample_ = RECEIVED_VALID;
       }
-      else if (!recieved_samples_.insert(data.value).second) {
-        recieved_samples_invalid_ = true;
+      else if (!received_samples_.insert(data.value).second) {
+        received_samples_invalid_ = true;
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: DataReaderListener::on_data_available() - ")
                    ACE_TEXT("Received duplicate sample %d.\n"),
                    data.value));
       }
-      else if (data.value > 1 && !recieved_samples_.count(data.value - 1)) {
-        recieved_samples_invalid_ = true;
+      else if (data.value > 1 && !received_samples_.count(data.value - 1)) {
+        received_samples_invalid_ = true;
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: DataReaderListener::on_data_available() - ")
                    ACE_TEXT("Received the sample %d before the previous sample.\n"),
                    data.value));
       }
-      else if (recieved_samples_.count(data.value + 1)) {
-        recieved_samples_invalid_ = true;
+      else if (received_samples_.count(data.value + 1)) {
+        received_samples_invalid_ = true;
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: DataReaderListener::on_data_available() - ")
                    ACE_TEXT("Received the sample %d after the next sample.\n"),
@@ -134,7 +133,6 @@ void
 Test::DataReaderListener::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -142,7 +140,6 @@ void
 Test::DataReaderListener::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -150,7 +147,6 @@ void
 Test::DataReaderListener::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   if( this->verbose_) {
     ACE_DEBUG((LM_DEBUG,
@@ -163,7 +159,6 @@ void
 Test::DataReaderListener::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -171,14 +166,12 @@ void
 Test::DataReaderListener::on_sample_rejected (
     DDS::DataReader_ptr,
     DDS::SampleRejectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_sample_lost (DDS::DataReader_ptr,
                                           DDS::SampleLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -186,7 +179,6 @@ void
 Test::DataReaderListener::on_subscription_disconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionDisconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -194,7 +186,6 @@ void
 Test::DataReaderListener::on_subscription_reconnected (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionReconnectedStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -202,7 +193,6 @@ void
 Test::DataReaderListener::on_subscription_lost (
     DDS::DataReader_ptr,
     ::OpenDDS::DCPS::SubscriptionLostStatus const &)
-  throw (CORBA::SystemException)
 {
 }
 
@@ -210,13 +200,11 @@ void
 Test::DataReaderListener::on_budget_exceeded (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
 }
 
 void
 Test::DataReaderListener::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
 }
 

--- a/tests/DCPS/Priority/DataReaderListener.h
+++ b/tests/DCPS/Priority/DataReaderListener.h
@@ -23,58 +23,46 @@ namespace Test {
 
     virtual void on_requested_deadline_missed (
         DDS::DataReader_ptr reader,
-        const DDS::RequestedDeadlineMissedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::RequestedDeadlineMissedStatus & status);
 
     virtual void on_requested_incompatible_qos (
         DDS::DataReader_ptr reader,
-        const DDS::RequestedIncompatibleQosStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::RequestedIncompatibleQosStatus & status);
 
     virtual void on_liveliness_changed (
         DDS::DataReader_ptr reader,
-        const DDS::LivelinessChangedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::LivelinessChangedStatus & status);
 
     virtual void on_subscription_matched (
         DDS::DataReader_ptr reader,
-        const DDS::SubscriptionMatchedStatus & status)
-      throw (CORBA::SystemException);
+        const DDS::SubscriptionMatchedStatus & status);
 
     virtual void on_sample_rejected(
         DDS::DataReader_ptr reader,
-        const DDS::SampleRejectedStatus& status)
-      throw (CORBA::SystemException);
+        const DDS::SampleRejectedStatus& status);
 
-    virtual void on_data_available(DDS::DataReader_ptr reader)
-      throw (CORBA::SystemException);
+    virtual void on_data_available(DDS::DataReader_ptr reader);
 
     virtual void on_sample_lost(DDS::DataReader_ptr reader,
-                                const DDS::SampleLostStatus& status)
-      throw (CORBA::SystemException);
+                                const DDS::SampleLostStatus& status);
 
     virtual void on_subscription_disconnected (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
     virtual void on_subscription_reconnected (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
     virtual void on_subscription_lost (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::SubscriptionLostStatus & status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
     virtual void on_budget_exceeded (
         DDS::DataReader_ptr reader,
-        const ::OpenDDS::DCPS::BudgetExceededStatus& status)
-      throw (CORBA::SystemException);
+        const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
-    virtual void on_connection_deleted (DDS::DataReader_ptr)
-      throw (CORBA::SystemException);
+    virtual void on_connection_deleted (DDS::DataReader_ptr);
 
     /// Current number of samples that have been received.
     unsigned int count() const;
@@ -90,8 +78,8 @@ namespace Test {
 
       /// Sample count.
       unsigned int count_;
-      std::set<long> recieved_samples_;
-      bool recieved_samples_invalid_;
+      std::set<long> received_samples_;
+      bool received_samples_invalid_;
       enum PriorityStatus { NOT_RECEIVED, RECEIVED_VALID, RECEIVED_INVALID };
       PriorityStatus priority_sample_;
   };

--- a/tests/DCPS/Prst_delayed_subscriber/DataReaderListener.cpp
+++ b/tests/DCPS/Prst_delayed_subscriber/DataReaderListener.cpp
@@ -20,9 +20,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -56,7 +55,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -64,7 +62,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -72,7 +69,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -80,7 +76,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -88,7 +83,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -96,7 +90,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -104,7 +97,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -112,7 +104,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -120,7 +111,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -128,14 +118,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/Prst_delayed_subscriber/DataReaderListener.h
+++ b/tests/DCPS/Prst_delayed_subscriber/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded (
     DDS::DataReader_ptr,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Reconnect/DataReaderListener.cpp
+++ b/tests/DCPS/Reconnect/DataReaderListener.cpp
@@ -20,13 +20,12 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   if (read_delay_ms > 0)
     ACE_OS::sleep (ACE_Time_Value (read_delay_ms/1000,
                                    read_delay_ms%1000*1000));
 
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr = Messenger::MessageDataReader::_narrow(reader);
@@ -69,7 +68,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG ,
     "(%P|%t) DataReaderListenerImpl::on_requested_deadline_missed\n"));
@@ -78,7 +76,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG ,
     "(%P|%t) DataReaderListenerImpl::on_requested_incompatible_qos\n"));
@@ -87,7 +84,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG ,
     "(%P|%t) DataReaderListenerImpl::on_liveliness_changed\n"));
@@ -96,7 +92,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG ,
     "(%P|%t) DataReaderListenerImpl::on_subscription_matched\n"));
@@ -105,7 +100,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG ,
     "(%P|%t) DataReaderListenerImpl::on_sample_rejected\n"));
@@ -114,7 +108,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG ,
     "(%P|%t) DataReaderListenerImpl::on_sample_lost\n"));
@@ -124,7 +117,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status)
-  throw (CORBA::SystemException)
 {
   CORBA::ULong len = status.publication_handles.length ();
   for (CORBA::ULong i = 0; i < len; ++i)
@@ -139,7 +131,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status)
-  throw (CORBA::SystemException)
 {
   CORBA::ULong len = status.publication_handles.length ();
   for (CORBA::ULong i = 0; i < len; ++i)
@@ -154,9 +145,8 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus & status)
-  throw (CORBA::SystemException)
 {
-  ++ actual_lost_sub_notification;
+  ++actual_lost_sub_notification;
 
   CORBA::ULong len = status.publication_handles.length ();
   for (CORBA::ULong i = 0; i < len; ++i)
@@ -171,7 +161,6 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   ::DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (::CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG, "(%P|%t) received on_budget_exceeded \n"));
 }
@@ -179,7 +168,6 @@ void DataReaderListenerImpl::on_budget_exceeded (
 
 void DataReaderListenerImpl::on_connection_deleted (
   ::DDS::DataReader_ptr)
-  throw (::CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG, "(%P|%t) received on_connection_deleted  \n"));
 }

--- a/tests/DCPS/Reconnect/DataReaderListener.h
+++ b/tests/DCPS/Reconnect/DataReaderListener.h
@@ -21,70 +21,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Rejects/DataReaderListener.cpp
+++ b/tests/DCPS/Rejects/DataReaderListener.cpp
@@ -25,16 +25,14 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void
 DataReaderListenerImpl::on_data_available (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
-  num_arrived_ ++;
+  ++num_arrived_;
 }
 
 void
 DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr /* reader */,
     DDS::RequestedDeadlineMissedStatus const & /* status */)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -43,7 +41,6 @@ void
 DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -52,7 +49,6 @@ void
 DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -61,7 +57,6 @@ void
 DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -70,7 +65,6 @@ void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus& status)
-  throw (CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_sample_rejected:")
@@ -98,7 +92,6 @@ void
 DataReaderListenerImpl::on_sample_lost (
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -107,7 +100,6 @@ void
 DataReaderListenerImpl::on_subscription_disconnected (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -116,7 +108,6 @@ void
 DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -125,7 +116,6 @@ void
 DataReaderListenerImpl::on_subscription_lost (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -133,14 +123,12 @@ DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void
 DataReaderListenerImpl::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   //cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/Rejects/DataReaderListener.h
+++ b/tests/DCPS/Rejects/DataReaderListener.h
@@ -19,69 +19,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_arrived() const {
     return num_arrived_;

--- a/tests/DCPS/RtiSerialization/DataReaderListener.cpp
+++ b/tests/DCPS/RtiSerialization/DataReaderListener.cpp
@@ -40,7 +40,7 @@ DataReaderListenerImpl::is_reliable()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =

--- a/tests/DCPS/Serializer_wstring/DataReaderListener.cpp
+++ b/tests/DCPS/Serializer_wstring/DataReaderListener.cpp
@@ -30,9 +30,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
@@ -214,7 +213,6 @@ bool DataReaderListenerImpl::verify_message (Messenger::Message& message)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -222,7 +220,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -230,7 +227,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -238,7 +234,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -246,7 +241,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -254,7 +248,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -262,7 +255,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -270,7 +262,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -278,7 +269,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -286,15 +276,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
-    ::DDS::DataReader_ptr
-    )
-    throw (CORBA::SystemException)
+  ::DDS::DataReader_ptr)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/Serializer_wstring/DataReaderListener.h
+++ b/tests/DCPS/Serializer_wstring/DataReaderListener.h
@@ -21,70 +21,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded(
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-    ::DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    ::DDS::DataReader_ptr reader);
 
   long num_reads() const {
     return num_reads_;
@@ -99,8 +78,8 @@ public:
 private:
 
   DDS::DataReader_var reader_;
-  long                  num_reads_;
-  long                  passed_count_;
+  long                num_reads_;
+  long                passed_count_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/SetQosDeadline/DataReaderListener.cpp
+++ b/tests/DCPS/SetQosDeadline/DataReaderListener.cpp
@@ -23,9 +23,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void
 DataReaderListenerImpl::on_data_available (DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     ::Messenger::MessageDataReader_var message_dr =
@@ -83,7 +82,6 @@ void
 DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr /*reader*/,
     DDS::RequestedDeadlineMissedStatus const & status)
-  throw (CORBA::SystemException)
 {
   this->num_deadline_missed_ = status.total_count;
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl
@@ -96,7 +94,6 @@ void
 DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -105,7 +102,6 @@ void
 DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -114,7 +110,6 @@ void
 DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr dr,
     const DDS::SubscriptionMatchedStatus& sms)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl[" << dr << "]::on_subscription_matched "
     "tc=" << sms.total_count << " tcc=" << sms.total_count_change << " cc=" <<
@@ -125,7 +120,6 @@ void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -134,7 +128,6 @@ void
 DataReaderListenerImpl::on_sample_lost (
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -143,7 +136,6 @@ void
 DataReaderListenerImpl::on_subscription_disconnected (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -152,7 +144,6 @@ void
 DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -161,7 +152,6 @@ void
 DataReaderListenerImpl::on_subscription_lost (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -170,13 +160,11 @@ void
 DataReaderListenerImpl::on_budget_exceeded (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 void
 DataReaderListenerImpl::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/SetQosDeadline/DataReaderListener.h
+++ b/tests/DCPS/SetQosDeadline/DataReaderListener.h
@@ -19,69 +19,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded (
     DDS::DataReader_ptr,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/SetQosPartition/DataReaderListener.cpp
+++ b/tests/DCPS/SetQosPartition/DataReaderListener.cpp
@@ -22,9 +22,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void
 DataReaderListenerImpl::on_data_available (DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     ::Messenger::MessageDataReader_var message_dr =
@@ -81,7 +80,6 @@ void
 DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr /*reader*/,
     DDS::RequestedDeadlineMissedStatus const & status)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl
        << "  total_count        = " << status.total_count << endl
@@ -93,7 +91,6 @@ void
 DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -102,7 +99,6 @@ void
 DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -111,7 +107,6 @@ void
 DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -120,7 +115,6 @@ void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -129,7 +123,6 @@ void
 DataReaderListenerImpl::on_sample_lost (
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -138,7 +131,6 @@ void
 DataReaderListenerImpl::on_subscription_disconnected (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -147,7 +139,6 @@ void
 DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -156,7 +147,6 @@ void
 DataReaderListenerImpl::on_subscription_lost (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -165,13 +155,11 @@ void
 DataReaderListenerImpl::on_budget_exceeded (
     DDS::DataReader_ptr,
     const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 void
 DataReaderListenerImpl::on_connection_deleted (DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/SetQosPartition/DataReaderListener.h
+++ b/tests/DCPS/SetQosPartition/DataReaderListener.h
@@ -19,69 +19,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded (
     DDS::DataReader_ptr,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/StringKey/DataReaderListener.cpp
+++ b/tests/DCPS/StringKey/DataReaderListener.cpp
@@ -24,9 +24,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
   try {
     ::Messenger::MessageDataReader_var message_dr =
         ::Messenger::MessageDataReader::_narrow(reader);
@@ -93,7 +92,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -101,7 +99,6 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -109,7 +106,6 @@ void DataReaderListenerImpl::on_requested_incompatible_qos (
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -117,7 +113,6 @@ void DataReaderListenerImpl::on_liveliness_changed (
 void DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -125,7 +120,6 @@ void DataReaderListenerImpl::on_subscription_matched (
 void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -133,7 +127,6 @@ void DataReaderListenerImpl::on_sample_rejected(
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }

--- a/tests/DCPS/StringKey/DataReaderListener.h
+++ b/tests/DCPS/StringKey/DataReaderListener.h
@@ -20,41 +20,30 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/TcpReconnect/DataReaderListener.cpp
+++ b/tests/DCPS/TcpReconnect/DataReaderListener.cpp
@@ -40,7 +40,7 @@ DataReaderListenerImpl::is_reliable()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -16,7 +16,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 void
 DataReaderListenerImpl::on_data_available(
     DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   FooDataReader_var reader_i = FooDataReader::_narrow(reader);
   if (CORBA::is_nil(reader_i))
@@ -48,40 +47,34 @@ void
 DataReaderListenerImpl::on_requested_deadline_missed(
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus&)
-  throw (CORBA::SystemException)
 {}
 
 void
 DataReaderListenerImpl::on_requested_incompatible_qos(
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus&)
-  throw (CORBA::SystemException)
 {}
 
 void
 DataReaderListenerImpl::on_liveliness_changed(
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus&)
-  throw (CORBA::SystemException)
 {}
 
 void
 DataReaderListenerImpl::on_subscription_matched(
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus&)
-  throw (CORBA::SystemException)
 {}
 
 void
 DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {}
 
 void
 DataReaderListenerImpl::on_sample_lost(
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {}

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.h
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.h
@@ -21,40 +21,34 @@ public:
   virtual ~DataReaderListenerImpl();
 
   virtual void on_data_available(
-      DDS::DataReader_ptr reader)
-    throw (CORBA::SystemException);
+      DDS::DataReader_ptr reader);
 
   virtual void on_requested_deadline_missed(
       DDS::DataReader_ptr reader,
-      const DDS::RequestedDeadlineMissedStatus& status)
-    throw (CORBA::SystemException);
+      const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
       DDS::DataReader_ptr reader,
-      const DDS::RequestedIncompatibleQosStatus& status)
-    throw (CORBA::SystemException);
+      const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
       DDS::DataReader_ptr reader,
-      const DDS::LivelinessChangedStatus& status)
-    throw (CORBA::SystemException);
+      const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
       DDS::DataReader_ptr reader,
-      const DDS::SubscriptionMatchedStatus& status)
-    throw (CORBA::SystemException);
+      const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
       DDS::DataReader_ptr reader,
-      const DDS::SampleRejectedStatus& status)
-    throw (CORBA::SystemException);
+      const DDS::SampleRejectedStatus& status);
 
   virtual void on_sample_lost(
       DDS::DataReader_ptr reader,
-      const DDS::SampleLostStatus& status)
-    throw (CORBA::SystemException);
+      const DDS::SampleLostStatus& status);
 
 private:
+
   std::size_t& received_samples_;
 
   ProgressIndicator progress_;

--- a/tests/DCPS/TransientDurability/DataReaderListener.cpp
+++ b/tests/DCPS/TransientDurability/DataReaderListener.cpp
@@ -20,7 +20,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void
 DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-  throw (CORBA::SystemException)
 {
   ++this->num_reads_;
 
@@ -57,7 +56,6 @@ void
 DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_deadline_missed" << endl;
 }
@@ -66,7 +64,6 @@ void
 DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_requested_incompatible_qos" << endl;
 }
@@ -75,7 +72,6 @@ void
 DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_liveliness_changed" << endl;
 }
@@ -84,7 +80,6 @@ void
 DataReaderListenerImpl::on_subscription_matched (
     DDS::DataReader_ptr,
     const DDS::SubscriptionMatchedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_matched" << endl;
 }
@@ -93,7 +88,6 @@ void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
@@ -101,7 +95,6 @@ DataReaderListenerImpl::on_sample_rejected (
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
@@ -109,7 +102,6 @@ void DataReaderListenerImpl::on_sample_lost(
 void DataReaderListenerImpl::on_subscription_disconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_disconnected" << endl;
 }
@@ -117,7 +109,6 @@ void DataReaderListenerImpl::on_subscription_disconnected (
 void DataReaderListenerImpl::on_subscription_reconnected (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionReconnectedStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_reconnected" << endl;
 }
@@ -125,7 +116,6 @@ void DataReaderListenerImpl::on_subscription_reconnected (
 void DataReaderListenerImpl::on_subscription_lost (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::SubscriptionLostStatus &)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_subscription_lost" << endl;
 }
@@ -133,14 +123,12 @@ void DataReaderListenerImpl::on_subscription_lost (
 void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 
 void DataReaderListenerImpl::on_connection_deleted (
   DDS::DataReader_ptr)
-  throw (CORBA::SystemException)
 {
   cerr << "DataReaderListenerImpl::on_connection_deleted" << endl;
 }

--- a/tests/DCPS/TransientDurability/DataReaderListener.h
+++ b/tests/DCPS/TransientDurability/DataReaderListener.h
@@ -20,69 +20,49 @@ public:
 
   virtual void on_requested_deadline_missed (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus & status)
-    throw (CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus & status);
 
   virtual void on_requested_incompatible_qos (
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus & status);
 
   virtual void on_liveliness_changed (
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus & status)
-  throw (CORBA::SystemException);
+    const DDS::LivelinessChangedStatus & status);
 
   virtual void on_subscription_matched (
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus & status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader
-  )
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status
-  )
-  throw (CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   virtual void on_subscription_disconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionDisconnectedStatus & status);
 
   virtual void on_subscription_reconnected (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionReconnectedStatus & status);
 
   virtual void on_subscription_lost (
     DDS::DataReader_ptr reader,
-    const ::OpenDDS::DCPS::SubscriptionLostStatus & status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::SubscriptionLostStatus & status);
 
   virtual void on_budget_exceeded (
     DDS::DataReader_ptr,
-    const ::OpenDDS::DCPS::BudgetExceededStatus& status
-  )
-  throw (CORBA::SystemException);
+    const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   virtual void on_connection_deleted (
-  DDS::DataReader_ptr)
-  throw (CORBA::SystemException);
+    DDS::DataReader_ptr);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.cpp
+++ b/tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.cpp
@@ -29,7 +29,7 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 throw(CORBA::SystemException)
 {
-  num_reads_ ++;
+  ++num_reads_;
 
   try {
     Messenger::MessageDataReader_var message_dr =


### PR DESCRIPTION
    * contrib/wrapper/DataReader_Listener_Base.h:
    * contrib/wrapper/DataReader_Listener_Base.inl:
    * examples/DCPS/IntroductionToOpenDDS/ExchangeEventDataReaderListenerImpl.cpp:
    * examples/DCPS/IntroductionToOpenDDS/ExchangeEventDataReaderListenerImpl.h:
    * examples/DCPS/IntroductionToOpenDDS/QuoteDataReaderListenerImpl.cpp:
    * examples/DCPS/IntroductionToOpenDDS/QuoteDataReaderListenerImpl.h:
    * examples/DCPS/Messenger_IOGR_Imr/DataReaderListener.cpp:
    * examples/DCPS/Messenger_IOGR_Imr/DataReaderListener.h:
    * examples/DCPS/Messenger_Imr/DataReaderListener.cpp:
    * examples/DCPS/Messenger_Imr/DataReaderListener.h:
    * performance-tests/Bench/src/DataReaderListener.cpp:
    * performance-tests/Bench/src/DataReaderListener.h:
    * performance-tests/DCPS/InfoRepo_population/DataReaderListener.cpp:
    * performance-tests/DCPS/InfoRepo_population/DataReaderListener.h:
    * performance-tests/DCPS/InfoRepo_population/SyncExt_i.cpp:
    * performance-tests/DCPS/InfoRepo_population/SyncExt_i.h:
    * performance-tests/DCPS/Priority/DataReaderListener.cpp:
    * performance-tests/DCPS/Priority/DataReaderListener.h:
    * performance-tests/DCPS/SimpleLatency/PubListener.cpp:
    * performance-tests/DCPS/SimpleLatency/PubListener.h:
    * performance-tests/DCPS/SimpleLatency/SubListener.cpp:
    * performance-tests/DCPS/SimpleLatency/SubListener.h:
    * performance-tests/DCPS/Sync/SyncClient_i.cpp:
    * performance-tests/DCPS/Sync/SyncClient_i.h:
    * performance-tests/DCPS/Sync/SyncServer_i.cpp:
    * performance-tests/DCPS/Sync/SyncServer_i.h:
    * tests/DCPS/BidirMessenger/DataReaderListener.cpp:
    * tests/DCPS/BuiltInTopicTest/DataReaderListener.cpp:
    * tests/DCPS/BuiltInTopicTest/DataReaderListener.h:
    * tests/DCPS/CorbaSeq/DataReaderListener.cpp:
    * tests/DCPS/CorbaSeq/DataReaderListener.h:
    * tests/DCPS/DPFactoryQos/DataReaderListener.cpp:
    * tests/DCPS/DPFactoryQos/DataReaderListener.h:
    * tests/DCPS/Deadline/DataReaderListener.cpp:
    * tests/DCPS/Deadline/DataReaderListener.h:
    * tests/DCPS/Footprint/DataReaderListener.cpp:
    * tests/DCPS/GroupPresentation/DataReaderListener.cpp:
    * tests/DCPS/LatencyBudget/DataReaderListener.cpp:
    * tests/DCPS/LatencyBudget/DataReaderListener.h:
    * tests/DCPS/Lifespan/DataReaderListener.cpp:
    * tests/DCPS/Lifespan/DataReaderListener.h:
    * tests/DCPS/ManualAssertLiveliness/DataReaderListener.cpp:
    * tests/DCPS/ManualAssertLiveliness/DataReaderListener.h:
    * tests/DCPS/Messenger/DataReaderListener.cpp:
    * tests/DCPS/Monitor/DataReaderListener.cpp:
    * tests/DCPS/NotifyTest/DataReaderListener.cpp:
    * tests/DCPS/NotifyTest/DataReaderListener.h:
    * tests/DCPS/Ownership/DataReaderListener.cpp:
    * tests/DCPS/Partition/DataReaderListener.cpp:
    * tests/DCPS/Partition/DataReaderListener.h:
    * tests/DCPS/PersistentDurability/DataReaderListener.cpp:
    * tests/DCPS/PersistentDurability/DataReaderListener.h:
    * tests/DCPS/Priority/DataReaderListener.cpp:
    * tests/DCPS/Priority/DataReaderListener.h:
    * tests/DCPS/Prst_delayed_subscriber/DataReaderListener.cpp:
    * tests/DCPS/Prst_delayed_subscriber/DataReaderListener.h:
    * tests/DCPS/Reconnect/DataReaderListener.cpp:
    * tests/DCPS/Reconnect/DataReaderListener.h:
    * tests/DCPS/Rejects/DataReaderListener.cpp:
    * tests/DCPS/Rejects/DataReaderListener.h:
    * tests/DCPS/RtiSerialization/DataReaderListener.cpp:
    * tests/DCPS/Serializer_wstring/DataReaderListener.cpp:
    * tests/DCPS/Serializer_wstring/DataReaderListener.h:
    * tests/DCPS/SetQosDeadline/DataReaderListener.cpp:
    * tests/DCPS/SetQosDeadline/DataReaderListener.h:
    * tests/DCPS/SetQosPartition/DataReaderListener.cpp:
    * tests/DCPS/SetQosPartition/DataReaderListener.h:
    * tests/DCPS/StringKey/DataReaderListener.cpp:
    * tests/DCPS/StringKey/DataReaderListener.h:
    * tests/DCPS/TcpReconnect/DataReaderListener.cpp:
    * tests/DCPS/Thrasher/DataReaderListenerImpl.cpp:
    * tests/DCPS/Thrasher/DataReaderListenerImpl.h:
    * tests/DCPS/TransientDurability/DataReaderListener.cpp:
    * tests/DCPS/TransientDurability/DataReaderListener.h:
    * tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.cpp: