### PR TITLE
Time Based Filter QoS (support for reliable readers) Issue #268

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -105,6 +105,7 @@ tests/DCPS/Reconnect/run_test.pl bp_timeout: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !
 tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/sub_init_loop/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/TimeBasedFilter/run_test.pl -r: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TcpReconnect/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/BuiltInTopic/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3345,7 +3345,7 @@ void DataReaderImpl::_remove_ref()
   CORBA::Object::_remove_ref();
 }
 
-void DataReaderImpl::accept_sample_processing(SubscriptionInstance* instance, const OpenDDS::DCPS::DataSampleHeader& header, bool is_new_instance)
+void DataReaderImpl::accept_sample_processing(SubscriptionInstance* instance, const DataSampleHeader& header, bool is_new_instance)
 {
   bool accepted = true;
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -971,29 +971,7 @@ DDS::ReturnCode_t DataReaderImpl::set_qos(
       }
     }
 
-    // Reset the deadline timer if the period has changed.
-    if (qos_.deadline.period.sec != qos.deadline.period.sec
-        || qos_.deadline.period.nanosec != qos.deadline.period.nanosec) {
-      if (qos_.deadline.period.sec == DDS::DURATION_INFINITE_SEC
-          && qos_.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
-        this->watchdog_.reset(
-            new RequestedDeadlineWatchdog(
-                this->sample_lock_,
-                qos.deadline,
-                this,
-                this->dr_local_objref_.in(),
-                this->requested_deadline_missed_status_,
-                this->last_deadline_missed_total_count_));
-
-      } else if (qos.deadline.period.sec == DDS::DURATION_INFINITE_SEC
-          && qos.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
-        this->watchdog_->cancel_all();
-        this->watchdog_.reset();
-      } else {
-        this->watchdog_->reset_interval(
-            duration_to_time_value(qos.deadline.period));
-      }
-    }
+    qos_change(qos);
 
     qos_ = qos;
 
@@ -1001,6 +979,36 @@ DDS::ReturnCode_t DataReaderImpl::set_qos(
 
   } else {
     return DDS::RETCODE_INCONSISTENT_POLICY;
+  }
+}
+
+void DataReaderImpl::qos_change(
+  const DDS::DataReaderQos & qos)
+{
+  // Reset the deadline timer if the period has changed.
+  if (qos_.deadline.period.sec != qos.deadline.period.sec
+    || qos_.deadline.period.nanosec != qos.deadline.period.nanosec) {
+    if (qos_.deadline.period.sec == DDS::DURATION_INFINITE_SEC
+      && qos_.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
+      this->watchdog_.reset(
+        new RequestedDeadlineWatchdog(
+          this->sample_lock_,
+          qos.deadline,
+          this,
+          this->dr_local_objref_.in(),
+          this->requested_deadline_missed_status_,
+          this->last_deadline_missed_total_count_));
+
+    }
+    else if (qos.deadline.period.sec == DDS::DURATION_INFINITE_SEC
+      && qos.deadline.period.nanosec == DDS::DURATION_INFINITE_NSEC) {
+      this->watchdog_->cancel_all();
+      this->watchdog_.reset();
+    }
+    else {
+      this->watchdog_->reset_interval(
+        duration_to_time_value(qos.deadline.period));
+    }
   }
 }
 
@@ -1514,66 +1522,8 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     }
 
     if (filtered) break; // sample filtered from instance
-    bool accepted = true;
-#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
-    bool verify_coherent = false;
-#endif
-    RcHandle<WriterInfo> writer;
 
-    if (header.publication_id_.entityId.entityKind
-        != OpenDDS::DCPS::ENTITYKIND_OPENDDS_NIL_WRITER) {
-      ACE_READ_GUARD(ACE_RW_Thread_Mutex, read_guard, this->writers_lock_);
-
-      WriterMapType::iterator where
-      = this->writers_.find(header.publication_id_);
-
-      if (where != this->writers_.end()) {
-        if (header.coherent_change_) {
-
-#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
-          // Received coherent change
-          where->second->group_coherent_ = header.group_coherent_;
-          where->second->publisher_id_ = header.publisher_id_;
-          ++where->second->coherent_samples_;
-          verify_coherent = true;
-#endif
-          writer = where->second;
-        }
-      } else {
-        GuidConverter subscriptionBuffer(this->subscription_id_);
-        GuidConverter publicationBuffer(header.publication_id_);
-        ACE_DEBUG((LM_WARNING,
-            ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::data_received() - ")
-            ACE_TEXT("subscription %C failed to find ")
-            ACE_TEXT("publication data for %C.\n"),
-            OPENDDS_STRING(subscriptionBuffer).c_str(),
-            OPENDDS_STRING(publicationBuffer).c_str()));
-      }
-    }
-
-#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
-    if (verify_coherent) {
-      accepted = this->verify_coherent_changes_completion(writer.in());
-    }
-#endif
-
-    if (this->watchdog_.in()) {
-      instance->last_sample_tv_ = instance->cur_sample_tv_;
-      instance->cur_sample_tv_ = ACE_OS::gettimeofday();
-
-      // Watchdog can't be called with sample_lock_ due to reactor deadlock
-      ACE_GUARD(Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
-      if (is_new_instance) {
-        this->watchdog_->schedule_timer(instance);
-
-      } else {
-        this->watchdog_->execute(instance, false);
-      }
-    }
-
-    if (accepted) {
-      this->notify_read_conditions();
-    }
+    accept_sample_processing(instance, header, is_new_instance);
   }
   break;
 
@@ -2753,8 +2703,8 @@ DataReaderImpl::filter_sample(const DataSampleHeader& header)
 }
 
 bool
-DataReaderImpl::filter_instance(SubscriptionInstance* instance,
-    const PublicationId& pubid)
+DataReaderImpl::ownership_filter_instance(SubscriptionInstance* instance,
+  const PublicationId& pubid)
 {
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   if (this->is_exclusive_ownership_) {
@@ -2769,10 +2719,10 @@ DataReaderImpl::filter_instance(SubscriptionInstance* instance,
         GuidConverter reader_converter(subscription_id_);
         GuidConverter writer_converter(pubid);
         ACE_DEBUG((LM_DEBUG,
-            ACE_TEXT("(%P|%t) DataReaderImpl::filter_instance: ")
-            ACE_TEXT("reader %C is not associated with writer %C.\n"),
-            OPENDDS_STRING(reader_converter).c_str(),
-            OPENDDS_STRING(writer_converter).c_str()));
+                   ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
+                   ACE_TEXT("reader %C is not associated with writer %C.\n"),
+                   OPENDDS_STRING(reader_converter).c_str(),
+                   OPENDDS_STRING(writer_converter).c_str()));
       }
       return true;
     }
@@ -2783,10 +2733,10 @@ DataReaderImpl::filter_instance(SubscriptionInstance* instance,
     if ( instance->instance_state_.get_owner () == GUID_UNKNOWN
         || ! iter->second->is_owner_evaluated (instance->instance_handle_)) {
       bool is_owner = this->owner_manager_->select_owner (
-          instance->instance_handle_,
-          iter->second->writer_id_,
-          iter->second->writer_qos_.ownership_strength.value,
-          &instance->instance_state_);
+        instance->instance_handle_,
+        iter->second->writer_id_,
+        iter->second->writer_qos_.ownership_strength.value,
+        &instance->instance_state_);
       iter->second->set_owner_evaluated (instance->instance_handle_, true);
 
       if (! is_owner) {
@@ -2795,11 +2745,11 @@ DataReaderImpl::filter_instance(SubscriptionInstance* instance,
           GuidConverter writer_converter(pubid);
           GuidConverter owner_converter (instance->instance_state_.get_owner ());
           ACE_DEBUG((LM_DEBUG,
-              ACE_TEXT("(%P|%t) DataReaderImpl::filter_instance: ")
-              ACE_TEXT("reader %C writer %C is not elected as owner %C\n"),
-              OPENDDS_STRING(reader_converter).c_str(),
-              OPENDDS_STRING(writer_converter).c_str(),
-              OPENDDS_STRING(owner_converter).c_str()));
+                     ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
+                     ACE_TEXT("reader %C writer %C is not elected as owner %C\n"),
+                     OPENDDS_STRING(reader_converter).c_str(),
+                     OPENDDS_STRING(writer_converter).c_str(),
+                     OPENDDS_STRING(owner_converter).c_str()));
         }
         return true;
       }
@@ -2810,11 +2760,11 @@ DataReaderImpl::filter_instance(SubscriptionInstance* instance,
         GuidConverter writer_converter(pubid);
         GuidConverter owner_converter (instance->instance_state_.get_owner ());
         ACE_DEBUG((LM_DEBUG,
-            ACE_TEXT("(%P|%t) DataReaderImpl::filter_instance: ")
-            ACE_TEXT("reader %C writer %C is not owner %C\n"),
-            OPENDDS_STRING(reader_converter).c_str(),
-            OPENDDS_STRING(writer_converter).c_str(),
-            OPENDDS_STRING(owner_converter).c_str()));
+                   ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
+                   ACE_TEXT("reader %C writer %C is not owner %C\n"),
+                   OPENDDS_STRING(reader_converter).c_str(),
+                   OPENDDS_STRING(writer_converter).c_str(),
+                   OPENDDS_STRING(owner_converter).c_str()));
       }
       return true;
     }
@@ -2822,7 +2772,13 @@ DataReaderImpl::filter_instance(SubscriptionInstance* instance,
 #else
   ACE_UNUSED_ARG(pubid);
 #endif
+  return false;
+}
 
+bool
+DataReaderImpl::time_based_filter_instance(SubscriptionInstance* instance,
+                                           ACE_Time_Value& filter_time_expired)
+{
   ACE_Time_Value now(ACE_OS::gettimeofday());
 
   // TIME_BASED_FILTER processing; expire data samples
@@ -2830,8 +2786,8 @@ DataReaderImpl::filter_instance(SubscriptionInstance* instance,
   const DDS::Duration_t zero = { DDS::DURATION_ZERO_SEC, DDS::DURATION_ZERO_NSEC };
 
   if (this->qos_.time_based_filter.minimum_separation > zero) {
-    DDS::Duration_t separation =
-        time_value_to_duration(now - instance->last_accepted_);
+    filter_time_expired = now - instance->last_accepted_;
+    DDS::Duration_t separation = time_value_to_duration(filter_time_expired);
 
     if (separation < this->qos_.time_based_filter.minimum_separation) {
       return true;  // Data filtered.
@@ -3387,6 +3343,72 @@ void DataReaderImpl::_add_ref()
 void DataReaderImpl::_remove_ref()
 {
   CORBA::Object::_remove_ref();
+}
+
+void DataReaderImpl::accept_sample_processing(SubscriptionInstance* instance, const OpenDDS::DCPS::DataSampleHeader& header, bool is_new_instance)
+{
+  bool accepted = true;
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+  bool verify_coherent = false;
+#endif
+  RcHandle<WriterInfo> writer;
+
+  if (header.publication_id_.entityId.entityKind
+    != OpenDDS::DCPS::ENTITYKIND_OPENDDS_NIL_WRITER) {
+    ACE_READ_GUARD(ACE_RW_Thread_Mutex, read_guard, this->writers_lock_);
+
+    WriterMapType::iterator where
+      = this->writers_.find(header.publication_id_);
+
+    if (where != this->writers_.end()) {
+      if (header.coherent_change_) {
+
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+        // Received coherent change
+        where->second->group_coherent_ = header.group_coherent_;
+        where->second->publisher_id_ = header.publisher_id_;
+        ++where->second->coherent_samples_;
+        verify_coherent = true;
+#endif
+        writer = where->second;
+      }
+    }
+    else {
+      GuidConverter subscriptionBuffer(this->subscription_id_);
+      GuidConverter publicationBuffer(header.publication_id_);
+      ACE_DEBUG((LM_WARNING,
+        ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::data_received() - ")
+        ACE_TEXT("subscription %C failed to find ")
+        ACE_TEXT("publication data for %C.\n"),
+        OPENDDS_STRING(subscriptionBuffer).c_str(),
+        OPENDDS_STRING(publicationBuffer).c_str()));
+    }
+  }
+
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+  if (verify_coherent) {
+    accepted = this->verify_coherent_changes_completion(writer.in());
+  }
+#endif
+
+  if (this->watchdog_.in()) {
+    instance->last_sample_tv_ = instance->cur_sample_tv_;
+    instance->cur_sample_tv_ = ACE_OS::gettimeofday();
+
+    // Watchdog can't be called with sample_lock_ due to reactor deadlock
+    ACE_GUARD(Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
+    if (is_new_instance) {
+      this->watchdog_->schedule_timer(instance);
+
+    }
+    else {
+      this->watchdog_->execute(instance, false);
+    }
+  }
+
+  if (accepted) {
+    this->notify_read_conditions();
+  }
 }
 
 

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -252,9 +252,7 @@ public:
 
   virtual void _add_ref();
   virtual void _remove_ref();
-  /**
-   * cleanup the DataWriter.
-   */
+
   virtual void cleanup();
 
   void init(
@@ -598,7 +596,7 @@ protected:
 
   void accept_sample_processing(SubscriptionInstance* instance, const DataSampleHeader& header, bool is_new_instance);
 
-  virtual void qos_change(const DDS::DataReaderQos & qos);
+  virtual void qos_change(const DDS::DataReaderQos& qos);
 
   /// Data has arrived into the cache, unblock waiting ReadConditions
   void notify_read_conditions();

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -596,7 +596,7 @@ protected:
   bool time_based_filter_instance(SubscriptionInstance* instance,
                                   ACE_Time_Value& filter_time_expired);
 
-  void accept_sample_processing(SubscriptionInstance* instance, const OpenDDS::DCPS::DataSampleHeader& header, bool is_new_instance);
+  void accept_sample_processing(SubscriptionInstance* instance, const DataSampleHeader& header, bool is_new_instance);
 
   virtual void qos_change(const DDS::DataReaderQos & qos);
 

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -255,7 +255,7 @@ public:
   /**
    * cleanup the DataWriter.
    */
-  void cleanup();
+  virtual void cleanup();
 
   void init(
     TopicDescriptionImpl* a_topic_desc,
@@ -591,8 +591,14 @@ protected:
    *       QoS policy or DataReader's TIME_BASED_FILTER QoS policy.
    */
   bool filter_sample(const DataSampleHeader& header);
-  bool filter_instance(SubscriptionInstance* instance,
-                       const PublicationId& pubid);
+  bool ownership_filter_instance(SubscriptionInstance* instance,
+                                 const PublicationId& pubid);
+  bool time_based_filter_instance(SubscriptionInstance* instance,
+                                  ACE_Time_Value& filter_time_expired);
+
+  void accept_sample_processing(SubscriptionInstance* instance, const OpenDDS::DCPS::DataSampleHeader& header, bool is_new_instance);
+
+  virtual void qos_change(const DDS::DataReaderQos & qos);
 
   /// Data has arrived into the cache, unblock waiting ReadConditions
   void notify_read_conditions();
@@ -633,7 +639,7 @@ protected:
   DDS::SubscriberQos subqos_;
 
 protected:
-    virtual void add_link(const DataLink_rch& link, const RepoId& peer);
+  virtual void add_link(const DataLink_rch& link, const RepoId& peer);
 
 private:
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -2118,7 +2118,7 @@ public:
     // sample_lock_ should already be held
 
     DataSampleHeader_ptr hdr(new OpenDDS::DCPS::DataSampleHeader(header));
-    std::pair<FilterDelayedSampleMap::iterator, bool> result =
+    std::pair<typename FilterDelayedSampleMap::iterator, bool> result =
       map_.insert(std::make_pair(instance_ptr, FilterDelayedSample(instance_data, hdr, just_registered)));
     FilterDelayedSample& sample = result.first->second;
     if (result.second)
@@ -2144,7 +2144,7 @@ public:
   {
     // sample_lock_ should already be held
 
-    FilterDelayedSampleMap::iterator sample = map_.find(instance_ptr);
+    typename FilterDelayedSampleMap::iterator sample = map_.find(instance_ptr);
     if (sample != map_.end())
     {
       // leave the entry in the container, so that the key remains valid if the reactor is waiting on this lock while this is occurring
@@ -2156,7 +2156,7 @@ public:
   {
     // sample_lock_ should already be held
 
-    FilterDelayedSampleMap::iterator sample = map_.find(instance_ptr);
+    typename FilterDelayedSampleMap::iterator sample = map_.find(instance_ptr);
     if (sample != map_.end())
     {
       clear_message(sample->second.message);
@@ -2172,7 +2172,7 @@ private:
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, dataReaderImpl_.sample_lock_);
 
     SubscriptionInstance* instance_ptr = (SubscriptionInstance *)arg;
-    FilterDelayedSampleMap::iterator data = map_.find(instance_ptr);
+    typename FilterDelayedSampleMap::iterator data = map_.find(instance_ptr);
     if (data == map_.end())
     {
       return;
@@ -2209,7 +2209,7 @@ private:
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, dataReaderImpl_.sample_lock_);
 
-    for (FilterDelayedSampleMap::iterator sample = map_.begin(); sample != map_.end(); ++sample)
+    for (typename FilterDelayedSampleMap::iterator sample = map_.begin(); sample != map_.end(); ++sample)
     {
       reset_timer_interval(sample->second.timer_id);
     }
@@ -2219,7 +2219,7 @@ private:
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, dataReaderImpl_.sample_lock_);
     // insure instance_ptrs get freed
-    for (FilterDelayedSampleMap::iterator sample = map_.begin(); sample != map_.end(); ++sample)
+    for (typename FilterDelayedSampleMap::iterator sample = map_.begin(); sample != map_.end(); ++sample)
     {
       clear_message(sample->second.message);
     }

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -2095,16 +2095,12 @@ public:
   {
   }
 
-  ~FilterDelayedHandler()
+  virtual ~FilterDelayedHandler()
   {
-    ACE_DEBUG((LM_DEBUG,
-      ACE_TEXT("OpenDDS (%P|%t) FilterDelayedHandler::~FilterDelayedHandler -")));
   }
 
   void cancel()
   {
-    ACE_DEBUG((LM_DEBUG,
-      ACE_TEXT("OpenDDS (%P|%t) FilterDelayedHandler::cancel -")));
     cancel_all();
     cleanup();
   }

--- a/dds/DCPS/Watchdog.cpp
+++ b/dds/DCPS/Watchdog.cpp
@@ -23,11 +23,14 @@ namespace {
   };
 
   struct ScheduleCommand : CommandBase {
-    ScheduleCommand(ReactorInterceptor* inter, const void* act,
+    ScheduleCommand(ReactorInterceptor* inter,
+                    const void* act,
+                    const ACE_Time_Value& delay,
                     const ACE_Time_Value& interval,
                     long* timer_id)
     : CommandBase(inter)
     , act_(act)
+    , delay_(delay)
     , interval_(interval)
     , timer_id_(timer_id)
     {}
@@ -35,10 +38,11 @@ namespace {
     void execute()
     {
       *timer_id_ = interceptor_->reactor()->schedule_timer(interceptor_, act_,
-                                                           interval_, interval_);
+                                                           delay_, interval_);
     }
 
     const void* const act_;
+    const ACE_Time_Value delay_;
     const ACE_Time_Value interval_;
     long* timer_id_;
   };
@@ -105,8 +109,13 @@ void Watchdog::reset_interval(const ACE_Time_Value& interval)
 
 long Watchdog::schedule_timer(const void* act, const ACE_Time_Value& interval)
 {
+  return schedule_timer(act, interval, interval);
+}
+
+long Watchdog::schedule_timer(const void* act, const ACE_Time_Value& delay, const ACE_Time_Value& interval)
+{
   long timer_id = -1;
-  ScheduleCommand c(this, act, interval, &timer_id);
+  ScheduleCommand c(this, act, delay, interval, &timer_id);
   execute_or_enqueue(c);
   wait();
   return timer_id;

--- a/dds/DCPS/Watchdog.h
+++ b/dds/DCPS/Watchdog.h
@@ -70,6 +70,10 @@ public:
   /// recurring timer expirations.
   long schedule_timer(const void* act, const ACE_Time_Value& interval);
 
+  /// Schedule with the @c Watchdog timer delay and timer interval,
+  /// i.e. time between recurring timer expirations.
+  long schedule_timer(const void* act, const ACE_Time_Value& delay, const ACE_Time_Value& interval);
+
   /// Cancel a specific timer.
   int cancel_timer(long timer_id);
 

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -10,6 +10,10 @@ project(OpenDDS_Dcps): core, coverage_optional, \
   pch_source   = DCPS/DdsDcps_pch.cpp
   macros      += NOMINMAX         //don't #define min and max in Win32 headers
 
+  specific (vc9, vc10, vc11, vc12, vc14, nmake) {
+    compile_flags += /bigobj
+  }
+
   //The following is only to make the PCH work, client projects should not have
   //this as an include path.
   includes += $(DDS_ROOT)/dds

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -60,7 +60,7 @@ parse_args(int& argc, ACE_TCHAR** argv)
 
 typedef std::pair<Foo, DDS::SampleInfo> FooInfo;
 typedef std::vector<FooInfo> Foos;
-typedef std::map<::CORBA::Long, Foos> SampleMap;
+typedef std::map< ::CORBA::Long, Foos> SampleMap;
 
 bool verify_unreliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES, SampleMap& samples)
 {

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -66,29 +66,19 @@ bool verify_unreliable(FooDataReader_var reader_i, const size_t expected_samples
 {
   bool valid = true;
 
-  ACE_DEBUG((LM_DEBUG,
-    ACE_TEXT("%N:%l main()")
-    ACE_TEXT(" INFO: Expecting %d instances...\n"),
-    NUM_INSTANCES));
-  for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
-  {
+  for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j) {
     const Foos& foos = samples[j];
     size_t seen = foos.size();
-    if (seen != expected_samples)
-    {
+    if (seen != expected_samples) {
       valid = false;
       ACE_ERROR((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: for key %d received %d sample(s), expected %d!\n"),
         j, seen, expected_samples));
-    }
-    else
-    {
-      for (size_t i = 0; i < expected_samples; ++i)
-      {
+    } else {
+      for (size_t i = 0; i < expected_samples; ++i) {
         const FooInfo& fooInfo = foos[i];
-        if (fooInfo.first.x != 0.0f)
-        {
+        if (fooInfo.first.x != 0.0f) {
           ACE_ERROR((LM_ERROR,
             ACE_TEXT("%N:%l main()")
             ACE_TEXT(" ERROR: for key %d received x=%f, expected 0.0!\n"),
@@ -104,28 +94,22 @@ bool verify_unreliable(FooDataReader_var reader_i, const size_t expected_samples
 bool verify_reliable(FooDataReader_var reader_i, const size_t expected_samples, SampleMap& samples)
 {
   bool valid = true;
-  for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
-  {
+  for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j) {
     const Foos& foos = samples[j];
     size_t seen = foos.size();
     // each delay should result in 2 samples being seen, the first one and the last one in the filter window
-    if (seen != expected_samples * 2)
-    {
+    if (seen != expected_samples * 2) {
       valid = false;
       ACE_ERROR((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: for key %d received %d sample(s), expected %d!\n"),
         j, seen, expected_samples));
-    }
-    else
-    {
-      for (size_t i = 0; i < expected_samples * 2; ++i)
-      {
+    } else {
+      for (size_t i = 0; i < expected_samples * 2; ++i) {
         const FooInfo& fooInfo = foos[i];
         // each successive sample was sent with x = 0.0 to x = (SAMPLES_PER_CYCLE - 1)
         const float expected = (i % 2) == 0 ? 0.0f : (float)(SAMPLES_PER_CYCLE - 1);
-        if (fooInfo.first.x != expected)
-        {
+        if (fooInfo.first.x != expected) {
           ACE_ERROR((LM_ERROR,
             ACE_TEXT("%N:%l main()")
             ACE_TEXT(" ERROR: for key %d received x=%f, expected %f!\n"),
@@ -142,16 +126,14 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
 {
   parse_args(argc, argv);
 
-  if (minimum_separation.sec < 1)
-  {
+  if (minimum_separation.sec < 1) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("%N:%l main()")
                       ACE_TEXT(" ERROR: minimum_separation must be non-zero!\n")), -1);
   }
 
   bool valid = true;
-  try
-  {
+  try {
     DDS::DomainParticipantFactory_var dpf =
       TheParticipantFactoryWithArgs(argc, argv);
 
@@ -162,8 +144,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
         DDS::DomainParticipantListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (CORBA::is_nil(participant.in()))
-    {
+    if (CORBA::is_nil(participant.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_participant failed!\n")), -1);
@@ -175,8 +156,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
         DDS::SubscriberListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (CORBA::is_nil(subscriber.in()))
-    {
+    if (CORBA::is_nil(subscriber.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_subscriber failed!\n")), -1);
@@ -188,8 +168,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
         DDS::PublisherListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (CORBA::is_nil(publisher.in()))
-    {
+    if (CORBA::is_nil(publisher.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_publisher failed!\n")), -1);
@@ -197,8 +176,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     // Register Type (FooType)
     FooTypeSupport_var ts = new FooTypeSupportImpl;
-    if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK)
-    {
+    if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: register_type failed!\n")), -1);
@@ -212,8 +190,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
         DDS::TopicListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (CORBA::is_nil(topic.in()))
-    {
+    if (CORBA::is_nil(topic.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_topic failed!\n")), -1);
@@ -222,8 +199,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     // Create DataReader
     DDS::DataReaderQos dr_qos;
 
-    if (subscriber->get_default_datareader_qos(dr_qos) != DDS::RETCODE_OK)
-    {
+    if (subscriber->get_default_datareader_qos(dr_qos) != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_datareader failed!\n")), -1);
@@ -232,8 +208,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     dr_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
     dr_qos.time_based_filter.minimum_separation = minimum_separation;
 
-    if (reliable)
-    {
+    if (reliable) {
       dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
       dr_qos.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
       dr_qos.history.depth = 50;
@@ -245,16 +220,14 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
         DDS::DataReaderListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (CORBA::is_nil(reader.in()))
-    {
+    if (CORBA::is_nil(reader.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_datareader failed!\n")), -1);
     }
 
     FooDataReader_var reader_i = FooDataReader::_narrow(reader);
-    if (CORBA::is_nil(reader_i))
-    {
+    if (CORBA::is_nil(reader_i)) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: _narrow failed!\n")), -1);
@@ -262,8 +235,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     DDS::DataWriterQos dw_qos;
     publisher->get_default_datawriter_qos(dw_qos);
-    if (reliable)
-    {
+    if (reliable) {
       dw_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
       dw_qos.reliability.max_blocking_time.sec = 1;
       dw_qos.reliability.max_blocking_time.nanosec = 0;
@@ -279,16 +251,14 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
         DDS::DataWriterListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (CORBA::is_nil(writer.in()))
-    {
+    if (CORBA::is_nil(writer.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: create_datawriter failed!\n")), -1);
     }
 
     FooDataWriter_var writer_i = FooDataWriter::_narrow(writer);
-    if (CORBA::is_nil(writer_i))
-    {
+    if (CORBA::is_nil(writer_i)) {
       ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: _narrow failed!\n")), -1);
@@ -301,22 +271,18 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     DDS::WaitSet_var ws = new DDS::WaitSet;
     ws->attach_condition(cond);
 
-    DDS::Duration_t timeout =
-    { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+    DDS::Duration_t timeout = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
 
     DDS::ConditionSeq conditions;
     DDS::PublicationMatchedStatus matches = { 0, 0, 0, 0, 0 };
-    do
-    {
-      if (ws->wait(conditions, timeout) != DDS::RETCODE_OK)
-      {
+    do {
+      if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
           ACE_TEXT("%N:%l main()")
           ACE_TEXT(" ERROR: wait failed!\n")), -1);
       }
 
-      if (writer->get_publication_matched_status(matches) != ::DDS::RETCODE_OK)
-      {
+      if (writer->get_publication_matched_status(matches) != ::DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
           ACE_TEXT("%N:%l main()")
           ACE_TEXT(" ERROR: Failed to get publication match status!\n")), -1);
@@ -342,16 +308,12 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     // We expect to receive up to one sample per
     // cycle (all others should be filtered).
-    for (size_t i = 0; i < EXPECTED_SAMPLES; ++i)
-    {
-      for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
-      {
-        for (size_t k = 0; k < SAMPLES_PER_CYCLE; ++k)
-        {
+    for (size_t i = 0; i < EXPECTED_SAMPLES; ++i) {
+      for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j) {
+        for (size_t k = 0; k < SAMPLES_PER_CYCLE; ++k) {
           ::CORBA::Float x = (CORBA::Float)k;
           Foo foo = { j, x, 0, 0 }; // same instance required for repeated samples
-          if (writer_i->write(foo, DDS::HANDLE_NIL) != DDS::RETCODE_OK)
-          {
+          if (writer_i->write(foo, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("%N:%l main()")
               ACE_TEXT(" ERROR: Unable to write sample!\n")), -1);
@@ -364,24 +326,18 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     }
 
     SampleMap samples;
-    for (;;)
-    {
+    for (;;) {
       Foo foo;
       DDS::SampleInfo info;
 
       DDS::ReturnCode_t error = reader_i->take_next_sample(foo, info);
-      if (error == DDS::RETCODE_OK)
-      {
+      if (error == DDS::RETCODE_OK) {
         if (info.valid_data) {
           samples[foo.key].push_back(std::make_pair(foo, info));
         }
-      }
-      else if (error == DDS::RETCODE_NO_DATA)
-      {
+      } else if (error == DDS::RETCODE_NO_DATA) {
         break; // done!
-      }
-      else
-      {
+      } else {
         ACE_ERROR_RETURN((
           LM_ERROR,
           ACE_TEXT("%N:%l main()")
@@ -389,13 +345,10 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
       }
     }
 
-    if (!reliable)
-    {
-      valid = verify_unreliable(reader_i, EXPECTED_SAMPLES, samples);
-    }
-    else
-    {
+    if (reliable) {
       valid = verify_reliable(reader_i, EXPECTED_SAMPLES, samples);
+    } else {
+      valid = verify_unreliable(reader_i, EXPECTED_SAMPLES, samples);
     }
 
     // Clean-up!

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -25,8 +25,9 @@
 namespace
 {
 static DDS::Duration_t minimum_separation = { 5, 0 };
+static bool reliable = false;
 
-static const size_t EXPECTED_SAMPLES = 2;
+static const size_t NUM_INSTANCES = 2;
 static const size_t SAMPLES_PER_CYCLE = 5;
 
 void
@@ -43,6 +44,11 @@ parse_args(int& argc, ACE_TCHAR** argv)
       minimum_separation.sec = ACE_OS::atoi(arg);
       shifter.consume_arg();
     }
+    else if (strcmp(shifter.get_current(), (ACE_TEXT("-r"))) == 0)
+    {
+      reliable = true;
+      shifter.consume_arg();
+    }
     else
     {
       shifter.ignore_arg();
@@ -51,6 +57,85 @@ parse_args(int& argc, ACE_TCHAR** argv)
 }
 
 } // namespace
+
+typedef std::pair<Foo, DDS::SampleInfo> FooInfo;
+typedef std::vector<FooInfo> Foos;
+typedef std::map<::CORBA::Long, Foos> SampleMap;
+
+bool verify_unreliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES, SampleMap& samples)
+{
+  bool valid = true;
+
+  ACE_DEBUG((LM_DEBUG,
+    ACE_TEXT("%N:%l main()")
+    ACE_TEXT(" INFO: Expecting %d instances...\n"),
+    NUM_INSTANCES));
+  for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
+  {
+    const Foos& foos = samples[j];
+    size_t seen = foos.size();
+    if (seen != EXPECTED_SAMPLES)
+    {
+      valid = false;
+      ACE_ERROR((LM_ERROR,
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: for key %d received %d sample(s), expected %d!\n"),
+        j, seen, EXPECTED_SAMPLES));
+    }
+    else
+    {
+      for (size_t i = 0; i < EXPECTED_SAMPLES; ++i)
+      {
+        const FooInfo& fooInfo = foos[i];
+        if (fooInfo.first.x != 0.0f)
+        {
+          ACE_ERROR((LM_ERROR,
+            ACE_TEXT("%N:%l main()")
+            ACE_TEXT(" ERROR: for key %d received x=%f, expected 0.0!\n"),
+            j, fooInfo.first.x));
+        }
+      }
+    }
+  }
+  return valid;
+}
+
+
+bool verify_reliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES, SampleMap& samples)
+{
+  bool valid = true;
+  for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
+  {
+    const Foos& foos = samples[j];
+    size_t seen = foos.size();
+    // each delay should result in 2 samples being seen, the first one and the last one in the filter window
+    if (seen != EXPECTED_SAMPLES * 2)
+    {
+      valid = false;
+      ACE_ERROR((LM_ERROR,
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: for key %d received %d sample(s), expected %d!\n"),
+        j, seen, EXPECTED_SAMPLES));
+    }
+    else
+    {
+      for (size_t i = 0; i < EXPECTED_SAMPLES * 2; ++i)
+      {
+        const FooInfo& fooInfo = foos[i];
+        // each successive sample was sent with x = 0.0 to x = (SAMPLES_PER_CYCLE - 1)
+        const float expected = (i % 2) == 0 ? 0.0f : (float)(SAMPLES_PER_CYCLE - 1);
+        if (fooInfo.first.x != expected)
+        {
+          ACE_ERROR((LM_ERROR,
+            ACE_TEXT("%N:%l main()")
+            ACE_TEXT(" ERROR: for key %d received x=%f, expected %f!\n"),
+            j, fooInfo.first.x, expected));
+        }
+      }
+    }
+  }
+  return valid;
+}
 
 int
 ACE_TMAIN(int argc, ACE_TCHAR** argv)
@@ -64,6 +149,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
                       ACE_TEXT(" ERROR: minimum_separation must be non-zero!\n")), -1);
   }
 
+  bool valid = true;
   try
   {
     DDS::DomainParticipantFactory_var dpf =
@@ -72,41 +158,41 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     // Create Participant
     DDS::DomainParticipant_var participant =
       dpf->create_participant(42,
-                              PARTICIPANT_QOS_DEFAULT,
-                              DDS::DomainParticipantListener::_nil(),
-                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        PARTICIPANT_QOS_DEFAULT,
+        DDS::DomainParticipantListener::_nil(),
+        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(participant.in()))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_participant failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_participant failed!\n")), -1);
     }
 
     // Create Subscriber
     DDS::Subscriber_var subscriber =
       participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT,
-                                     DDS::SubscriberListener::_nil(),
-                                     OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        DDS::SubscriberListener::_nil(),
+        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(subscriber.in()))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_subscriber failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_subscriber failed!\n")), -1);
     }
 
     // Create Publisher
     DDS::Publisher_var publisher =
       participant->create_publisher(PUBLISHER_QOS_DEFAULT,
-                                    DDS::PublisherListener::_nil(),
-                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        DDS::PublisherListener::_nil(),
+        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(publisher.in()))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_publisher failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_publisher failed!\n")), -1);
     }
 
     // Register Type (FooType)
@@ -114,79 +200,98 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK)
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: register_type failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: register_type failed!\n")), -1);
     }
 
     // Create Topic (FooTopic)
     DDS::Topic_var topic =
       participant->create_topic("FooTopic",
-                                ts->get_type_name(),
-                                TOPIC_QOS_DEFAULT,
-                                DDS::TopicListener::_nil(),
-                                OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        ts->get_type_name(),
+        TOPIC_QOS_DEFAULT,
+        DDS::TopicListener::_nil(),
+        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(topic.in()))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_topic failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_topic failed!\n")), -1);
     }
 
     // Create DataReader
-    DDS::DataReaderQos qos;
+    DDS::DataReaderQos dr_qos;
 
-    if (subscriber->get_default_datareader_qos(qos) != DDS::RETCODE_OK)
+    if (subscriber->get_default_datareader_qos(dr_qos) != DDS::RETCODE_OK)
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_datareader failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_datareader failed!\n")), -1);
     }
 
-    qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
-    qos.time_based_filter.minimum_separation = minimum_separation;
+    dr_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+    dr_qos.time_based_filter.minimum_separation = minimum_separation;
+
+    if (reliable)
+    {
+      dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+      dr_qos.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
+      dr_qos.history.depth = 50;
+    }
 
     DDS::DataReader_var reader =
       subscriber->create_datareader(topic.in(),
-                                    qos,
-                                    DDS::DataReaderListener::_nil(),
-                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        dr_qos,
+        DDS::DataReaderListener::_nil(),
+        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(reader.in()))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_datareader failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_datareader failed!\n")), -1);
     }
 
     FooDataReader_var reader_i = FooDataReader::_narrow(reader);
     if (CORBA::is_nil(reader_i))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: _narrow failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: _narrow failed!\n")), -1);
+    }
+
+    DDS::DataWriterQos dw_qos;
+    publisher->get_default_datawriter_qos(dw_qos);
+    if (reliable)
+    {
+      dw_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+      dw_qos.reliability.max_blocking_time.sec = 1;
+      dw_qos.reliability.max_blocking_time.nanosec = 0;
+      dw_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+      dw_qos.resource_limits.max_samples = 100;
+      dw_qos.resource_limits.max_samples_per_instance = 50;
     }
 
     // Create DataWriter
     DDS::DataWriter_var writer =
       publisher->create_datawriter(topic.in(),
-                                   DATAWRITER_QOS_DEFAULT,
-                                   DDS::DataWriterListener::_nil(),
-                                   OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        dw_qos,
+        DDS::DataWriterListener::_nil(),
+        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(writer.in()))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: create_datawriter failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: create_datawriter failed!\n")), -1);
     }
 
     FooDataWriter_var writer_i = FooDataWriter::_narrow(writer);
     if (CORBA::is_nil(writer_i))
     {
       ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: _narrow failed!\n")), -1);
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: _narrow failed!\n")), -1);
     }
 
     // Block until Subscriber is associated
@@ -197,7 +302,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     ws->attach_condition(cond);
 
     DDS::Duration_t timeout =
-      { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+    { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
 
     DDS::ConditionSeq conditions;
     DDS::PublicationMatchedStatus matches = { 0, 0, 0, 0, 0 };
@@ -206,18 +311,17 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
       if (ws->wait(conditions, timeout) != DDS::RETCODE_OK)
       {
         ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l main()")
-                          ACE_TEXT(" ERROR: wait failed!\n")), -1);
+          ACE_TEXT("%N:%l main()")
+          ACE_TEXT(" ERROR: wait failed!\n")), -1);
       }
 
       if (writer->get_publication_matched_status(matches) != ::DDS::RETCODE_OK)
       {
         ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l main()")
-                          ACE_TEXT(" ERROR: Failed to get publication match status!\n")), -1);
+          ACE_TEXT("%N:%l main()")
+          ACE_TEXT(" ERROR: Failed to get publication match status!\n")), -1);
       }
-    }
-    while (matches.current_count < 1);
+    } while (matches.current_count < 1);
 
     ws->detach_condition(cond);
 
@@ -227,32 +331,39 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     // time, and then verify we receive the expected number
     // of samples.
     //
-    size_t seen = 0;
 
     ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("%N:%l main()")
-               ACE_TEXT(" INFO: Testing %d second minimum separation...\n"),
-               minimum_separation.sec));
+      ACE_TEXT("%N:%l main()")
+      ACE_TEXT(" INFO: Testing %d second minimum separation...\n"),
+      minimum_separation.sec));
+
+    const size_t EXPECTED_SAMPLES = reliable ? 5 : 2;
+    const size_t SEPARATION_MULTIPLIER = reliable ? 4 : 2;
 
     // We expect to receive up to one sample per
     // cycle (all others should be filtered).
     for (size_t i = 0; i < EXPECTED_SAMPLES; ++i)
     {
-      for (size_t j = 0; j < SAMPLES_PER_CYCLE; ++j)
+      for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
       {
-        Foo foo = { 0, 0, 0, 0 }; // same instance required!
-        if (writer_i->write(foo, DDS::HANDLE_NIL) != DDS::RETCODE_OK)
+        for (size_t k = 0; k < SAMPLES_PER_CYCLE; ++k)
         {
+          ::CORBA::Float x = (CORBA::Float)k;
+          Foo foo = { j, x, 0, 0 }; // same instance required for repeated samples
+          if (writer_i->write(foo, DDS::HANDLE_NIL) != DDS::RETCODE_OK)
+          {
             ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("%N:%l main()")
-                              ACE_TEXT(" ERROR: Unable to write sample!\n")), -1);
+              ACE_TEXT("%N:%l main()")
+              ACE_TEXT(" ERROR: Unable to write sample!\n")), -1);
+          }
         }
       }
 
       // Wait for at least two minimum_separation cycles
-      ACE_OS::sleep(2 * minimum_separation.sec);
+      ACE_OS::sleep(SEPARATION_MULTIPLIER * minimum_separation.sec);
     }
 
+    SampleMap samples;
     for (;;)
     {
       Foo foo;
@@ -262,7 +373,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
       if (error == DDS::RETCODE_OK)
       {
         if (info.valid_data) {
-          seen++;
+          samples[foo.key].push_back(std::make_pair(foo, info));
         }
       }
       else if (error == DDS::RETCODE_NO_DATA)
@@ -278,12 +389,13 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
       }
     }
 
-    if (seen != EXPECTED_SAMPLES)
+    if (!reliable)
     {
-      ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("%N:%l main()")
-                        ACE_TEXT(" ERROR: received %d sample(s), expected %d!\n"),
-                        seen, EXPECTED_SAMPLES), -1);
+      valid = verify_unreliable(reader_i, EXPECTED_SAMPLES, samples);
+    }
+    else
+    {
+      valid = verify_reliable(reader_i, EXPECTED_SAMPLES, samples);
     }
 
     // Clean-up!
@@ -294,8 +406,8 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
   catch (const CORBA::Exception& e)
   {
     e._tao_print_exception("Caught in main()");
-    return -1;
+    valid = false;
   }
 
-  return 0;
+  return valid ? 0 : -1;
 }

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -78,6 +78,8 @@ bool verify_unreliable(FooDataReader_var reader_i, const size_t expected_samples
     } else {
       for (size_t i = 0; i < expected_samples; ++i) {
         const FooInfo& fooInfo = foos[i];
+        // NOTE: spec does not enforce ordering, but relying on the fact that this is TCP and that the first sent
+        // message will also be the first received message in the data reader
         if (fooInfo.first.x != 0.0f) {
           ACE_ERROR((LM_ERROR,
             ACE_TEXT("%N:%l main()")
@@ -108,6 +110,8 @@ bool verify_reliable(FooDataReader_var reader_i, const size_t expected_samples, 
       for (size_t i = 0; i < expected_samples * 2; ++i) {
         const FooInfo& fooInfo = foos[i];
         // each successive sample was sent with x = 0.0 to x = (SAMPLES_PER_CYCLE - 1)
+        // NOTE: spec does not enforce ordering, but relying on the fact that this is TCP and that the first and last sent
+        // message will also be the first and last received message in the data reader
         const float expected = (i % 2) == 0 ? 0.0f : (float)(SAMPLES_PER_CYCLE - 1);
         if (fooInfo.first.x != expected) {
           ACE_ERROR((LM_ERROR,
@@ -183,9 +187,10 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     }
 
     // Create Topic (FooTopic)
+    CORBA::String_var type_name = ts->get_type_name();
     DDS::Topic_var topic =
       participant->create_topic("FooTopic",
-        ts->get_type_name(),
+        type_name,
         TOPIC_QOS_DEFAULT,
         DDS::TopicListener::_nil(),
         OpenDDS::DCPS::DEFAULT_STATUS_MASK);

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -62,7 +62,7 @@ typedef std::pair<Foo, DDS::SampleInfo> FooInfo;
 typedef std::vector<FooInfo> Foos;
 typedef std::map< ::CORBA::Long, Foos> SampleMap;
 
-bool verify_unreliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES, SampleMap& samples)
+bool verify_unreliable(FooDataReader_var reader_i, const size_t expected_samples, SampleMap& samples)
 {
   bool valid = true;
 
@@ -74,17 +74,17 @@ bool verify_unreliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES
   {
     const Foos& foos = samples[j];
     size_t seen = foos.size();
-    if (seen != EXPECTED_SAMPLES)
+    if (seen != expected_samples)
     {
       valid = false;
       ACE_ERROR((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: for key %d received %d sample(s), expected %d!\n"),
-        j, seen, EXPECTED_SAMPLES));
+        j, seen, expected_samples));
     }
     else
     {
-      for (size_t i = 0; i < EXPECTED_SAMPLES; ++i)
+      for (size_t i = 0; i < expected_samples; ++i)
       {
         const FooInfo& fooInfo = foos[i];
         if (fooInfo.first.x != 0.0f)
@@ -101,7 +101,7 @@ bool verify_unreliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES
 }
 
 
-bool verify_reliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES, SampleMap& samples)
+bool verify_reliable(FooDataReader_var reader_i, const size_t expected_samples, SampleMap& samples)
 {
   bool valid = true;
   for (::CORBA::Long j = 0; j < NUM_INSTANCES; ++j)
@@ -109,17 +109,17 @@ bool verify_reliable(FooDataReader_var reader_i, const size_t EXPECTED_SAMPLES, 
     const Foos& foos = samples[j];
     size_t seen = foos.size();
     // each delay should result in 2 samples being seen, the first one and the last one in the filter window
-    if (seen != EXPECTED_SAMPLES * 2)
+    if (seen != expected_samples * 2)
     {
       valid = false;
       ACE_ERROR((LM_ERROR,
         ACE_TEXT("%N:%l main()")
         ACE_TEXT(" ERROR: for key %d received %d sample(s), expected %d!\n"),
-        j, seen, EXPECTED_SAMPLES));
+        j, seen, expected_samples));
     }
     else
     {
-      for (size_t i = 0; i < EXPECTED_SAMPLES * 2; ++i)
+      for (size_t i = 0; i < expected_samples * 2; ++i)
       {
         const FooInfo& fooInfo = foos[i];
         // each successive sample was sent with x = 0.0 to x = (SAMPLES_PER_CYCLE - 1)


### PR DESCRIPTION
Time Based Filter Qos support is currently just filtering samples to prevent more than 1 sample for an instance being delivered by the data reader in the time based filter period.  Need to add support for Data readers with a Reliability Qos of Reliable, to deliver the last filtered sample after the time based filter period has expired.