### PR TITLE
Java dependencies

### DIFF
--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -80,6 +80,9 @@ project: idl2jni, dcpslib, optional_jni_check, dcps_java_optional, dcps_tcp, dcp
     OpenDDS/DCPS/transport/TransportConfig.java
     OpenDDS/DCPS/transport/TransportException.java
     OpenDDS/DCPS/transport/UnableToCreateException.java
+    
+    // Forcing java files to be generated to satisfy interdependency of DdsDcpsTopic and DdsDcpsDomain
+    DDS/TopicDescriptionOperations.java << DDS/DomainParticipant.java
   }
 
   // This list should match the Java_Files list above, but these are the .class

--- a/java/tests/hello/hello_java_client.mpc
+++ b/java/tests/hello/hello_java_client.mpc
@@ -11,6 +11,10 @@ project: idl2jni, conditional_idlflags {
     $(TAO_ROOT)/tests/Hello/Test.idl
   }
 
+  Java_Files {
+      Client.java << Test/Hello.java
+  }
+
   specific {
     jarname  = hello_java_client
   }


### PR DESCRIPTION
Fixing java dependencies that are not setup correctly to compile after a clean build.  Redmine Task #3245.