### PR TITLE
Revert previous java_dependencies commit

### DIFF
--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -80,9 +80,6 @@ project: idl2jni, dcpslib, optional_jni_check, dcps_java_optional, dcps_tcp, dcp
     OpenDDS/DCPS/transport/TransportConfig.java
     OpenDDS/DCPS/transport/TransportException.java
     OpenDDS/DCPS/transport/UnableToCreateException.java
-    
-    // Forcing java files to be generated to satisfy interdependency of DdsDcpsTopic and DdsDcpsDomain
-    DDS/TopicDescriptionOperations.java << DDS/DomainParticipant.java
   }
 
   // This list should match the Java_Files list above, but these are the .class


### PR DESCRIPTION
Reverted "Ensure java files are generated to satisfy interdependency of DdsDcpsTopic and DdsDcpsDomain."
This reverts commit 5ccbac1041c6b0fe0fd0755b9ae4841ffc0eafee.