### PR TITLE
Fixing issue causing FooTest5 blocking variant to fail.  Now that 'st…

### DIFF
--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1490,7 +1490,7 @@ WriteDataContainer::sequence_acknowledged(const SequenceNumber sequence)
 void
 WriteDataContainer::wakeup_blocking_writers (DataSampleElement* stale)
 {
-  if (stale && waiting_on_release_) {
+  if (!stale && waiting_on_release_) {
     waiting_on_release_ = false;
 
     condition_.broadcast();


### PR DESCRIPTION
…ale' is being reset to 0, make sure this is the case before broadcasting to wakeup_blocking_writers.