### PR TITLE
Workaround for DataWriterImpl::wait_for_acknowledgments() bug

### DIFF
--- a/tests/DCPS/Priority/Publisher.cpp
+++ b/tests/DCPS/Priority/Publisher.cpp
@@ -345,7 +345,7 @@ Publisher::run()
   // Make sure that the data has arriven.
   ::DDS::Duration_t shutdownDelay = {15, 0}; // Wait up to a total of 15
                                              // seconds to finish the test.
-  if (this->options_.transportType() != Options::UDP) {
+  if (this->options_.transportType() != Options::UDP && this->options_.transportType() != Options::TCP) {
     writer0->wait_for_acknowledgments(shutdownDelay);
     writer1->wait_for_acknowledgments(shutdownDelay);
   } else {


### PR DESCRIPTION
DataWriterImpl::wait_for_acknowledgments() no longer work for TCP transport on cricket. This is the workaround for the bug. 