### PR TITLE
Fix transport receive buffer allocator synchronization problem

### DIFF
--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -541,7 +541,7 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
 
   if (DCPS_debug_level >= 2) {
     ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered")
-                          ACE_TEXT(" %X \n"), sample));
+                          ACE_TEXT(" %@\n"), sample));
   }
 
   ACE_GUARD(ACE_Recursive_Thread_Mutex,

--- a/dds/DCPS/transport/framework/TransportDefs.h
+++ b/dds/DCPS/transport/framework/TransportDefs.h
@@ -24,8 +24,12 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 /**
  * Guard the allocations for the underlying memory management of the
  * receive processing with the following:
+ *
+ * Notice that even we have only one thread for receiving per transport, the underly message blocks
+ * would interact with the threads from EndHistoricSamplesMissedSweeper which are different from the
+ * receiving threads. Therefore, we cannot use ACE_SYNCH_NULL_MUTEX here.
  */
-#define RECEIVE_SYNCH ACE_SYNCH_NULL_MUTEX
+#define RECEIVE_SYNCH ACE_SYNCH_MUTEX
 
 /// Macro to get the individual configuration value
 ///  from ACE_Configuration_Heap and cast to the specific

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -347,8 +347,9 @@ bool
 OpenDDS::DCPS::TcpDataLink::handle_send_request_ack(TransportQueueElement* element)
 {
   if (Transport_debug_level >= 1) {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpDataLink::handle_send_request_ack() sequence number %q\n",
-      element->sequence().getValue()));
+    const GuidConverter converter(element->publication_id());
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::handle_send_request_ack() sequence number %q, publication_id=%s\n"),
+      element->sequence().getValue(), OPENDDS_STRING(converter).c_str()));
   }
 
   ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
@@ -358,13 +359,14 @@ OpenDDS::DCPS::TcpDataLink::handle_send_request_ack(TransportQueueElement* eleme
 
 
 void
-OpenDDS::DCPS::TcpDataLink::ack_received(ReceivedDataSample& sample)
+OpenDDS::DCPS::TcpDataLink::ack_received(const ReceivedDataSample& sample)
 {
   SequenceNumber sequence = sample.header_.sequence_;
 
   if (Transport_debug_level >= 1) {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpDataLink::ack_received() received sequence number %q\n",
-      sequence.getValue()));
+    const GuidConverter converter(sample.header_.publication_id_);
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::ack_received() received sequence number %q, publiction_id=%s\n"),
+      sequence.getValue(), OPENDDS_STRING(converter).c_str()));
   }
 
   TransportQueueElement* elem=0;
@@ -373,7 +375,7 @@ OpenDDS::DCPS::TcpDataLink::ack_received(ReceivedDataSample& sample)
     ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
     PendingRequestAcks::iterator it;
     for (it = pending_request_acks_.begin(); it != pending_request_acks_.end(); ++it){
-      if ((*it)->sequence() == sequence) {
+      if ((*it)->sequence() == sequence && (*it)->publication_id() == sample.header_.publication_id_) {
         elem = *it;
         pending_request_acks_.erase(it);
         break;
@@ -382,16 +384,20 @@ OpenDDS::DCPS::TcpDataLink::ack_received(ReceivedDataSample& sample)
   }
 
   if (elem) {
+    if (Transport_debug_level >= 1) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::ack_received() found matching element %@\n"),
+        elem));
+    }
     static_cast<TcpSendStrategy*>(this->send_strategy_.in())->add_delayed_notification_on_ack_received(elem);
   }
   else {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpDataLink::ack_received() received unknown sequence number %q\n",
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::ack_received() received unknown sequence number %q\n"),
       sequence.getValue()));
   }
 }
 
 void
-OpenDDS::DCPS::TcpDataLink::request_ack_received(ReceivedDataSample& sample)
+OpenDDS::DCPS::TcpDataLink::request_ack_received(const ReceivedDataSample& sample)
 {
   DataSampleHeader header_data;
   // The message_id_ is the most important value for the DataSampleHeader.
@@ -403,6 +409,8 @@ OpenDDS::DCPS::TcpDataLink::request_ack_received(ReceivedDataSample& sample)
   header_data.byte_order_  = ACE_CDR_BYTE_ORDER;
   header_data.message_length_ = 0;
   header_data.sequence_ = sample.header_.sequence_;
+  header_data.publication_id_ = sample.header_.publication_id_;
+  header_data.publisher_id_ = sample.header_.publisher_id_;
 
   ACE_Message_Block* message;
   size_t max_marshaled_size = header_data.max_marshaled_size();

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -13,6 +13,7 @@
 #include "dds/DCPS/transport/framework/TransportControlElement.h"
 #include "dds/DCPS/transport/framework/EntryExit.h"
 #include "dds/DCPS/DataSampleHeader.h"
+#include "dds/DCPS/GuidConverter.h"
 #include "ace/Log_Msg.h"
 
 #if !defined (__ACE_INLINE__)

--- a/dds/DCPS/transport/tcp/TcpDataLink.h
+++ b/dds/DCPS/transport/tcp/TcpDataLink.h
@@ -56,8 +56,8 @@ public:
   /// Get release pending flag.
   bool is_release_pending() const;
 
-  void ack_received(ReceivedDataSample& sample);
-  void request_ack_received(ReceivedDataSample& sample);
+  void ack_received(const ReceivedDataSample& sample);
+  void request_ack_received(const ReceivedDataSample& sample);
   void drop_pending_request_acks();
 
 protected:

--- a/tests/DCPS/Thrasher/run_test.pl
+++ b/tests/DCPS/Thrasher/run_test.pl
@@ -14,6 +14,7 @@ use PerlDDS::Run_Test;
 
 PerlDDS::add_lib_path('../FooType');
 
+my $debug_level = 0;
 my $pub_opts = "";
 my $sub_opts = "";
 # $pub_opts .= "-DCPSChunks 1 ";
@@ -42,6 +43,12 @@ if ($arg eq 'low') {
 } else { # default (i.e. lazy)
   $pub_opts .= "-t 1 -s 1024";
   $sub_opts .= "-t 1 -n 1024";
+}
+
+if ($debug_level) {
+  unlink 'publisher.log' , 'subscriber.log';
+  $pub_opts .= " -DCPSDebugLevel $debug_level -DCPSTransportDebugLevel $debug_level -ORBLogFile publisher.log";
+  $sub_opts .= " -DCPSDebugLevel $debug_level -DCPSTransportDebugLevel $debug_level -ORBLogFile subscriber.log";
 }
 
 my $ini_file = "thrasher.ini";


### PR DESCRIPTION
Even though only one thread is created for receiving data per transport, the underly message blocks may be passed up to DataReaderImpl and then processed by EndHistoricSamplesMissedSweeper from another thread. Therefore, the receive buffer allocators must be properly synchronized. 