### PR TITLE
Fix generating IPv6 text representation

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -73,7 +73,7 @@ public:
       return true;
     }
     else {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) TcpInst::local_address_set_port():")
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) RtpsUdpInst::local_address_set_port():")
                            ACE_TEXT(" failure to convert local IP address to text representation\n")));
       return false;
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -64,11 +64,19 @@ public:
     local_address_config_str_ += ":" + to_dds_string(port_number);
     local_address_.set(port_number, host_name);
   }
-  void local_address_set_port(u_short port_number) {
+  bool local_address_set_port(u_short port_number) {
+
     local_address_.set_port_number(port_number);
-    size_t pos = local_address_config_str_.find_last_of(":");
-    OPENDDS_STRING host_name = local_address_config_str_.substr(0, pos);
-    local_address_config_str_ = host_name + ":" + to_dds_string(port_number);
+    ACE_TCHAR buf[1024];
+    if (local_address_.addr_to_string(buf, 1024) == 0) {
+      local_address_config_str_ = ACE_TEXT_ALWAYS_CHAR(buf);
+      return true;
+    }
+    else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) TcpInst::local_address_set_port():")
+                           ACE_TEXT(" failure to convert local IP address to text representation\n")));
+      return false;
+    }
   }
 
 private:

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -283,7 +283,8 @@ RtpsUdpTransport::configure_i(TransportInst* config)
         ACE_TEXT("(%P|%t) ERROR: RtpsUdpDataLink::configure_i - %p\n"),
         ACE_TEXT("cannot get local addr")), false);
     }
-    conf->local_address_set_port(address.get_port_number());
+    if (!conf->local_address_set_port(address.get_port_number()))
+      return false;
   }
 
   create_reactor_task();

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -104,9 +104,9 @@ public:
   }
   void local_address_set_port(u_short port_number) {
     local_address_.set_port_number(port_number);
-    char buf[1024];
+    ACE_TCHAR buf[1024];
     local_address_.addr_to_string(buf, 1024);
-    local_address_str_ = buf;
+    local_address_str_ = ACE_Wide_To_Ascii(buf).char_rep();
   }
 
 private:

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -105,8 +105,13 @@ public:
   void local_address_set_port(u_short port_number) {
     local_address_.set_port_number(port_number);
     ACE_TCHAR buf[1024];
-    local_address_.addr_to_string(buf, 1024);
-    local_address_str_ = ACE_TEXT_ALWAYS_CHAR(buf);
+    if (local_address_.addr_to_string(buf, 1024) == 0) {
+      local_address_str_ = ACE_TEXT_ALWAYS_CHAR(buf);
+    }
+    else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) TcpInst::local_address_set_port():")
+                           ACE_TEXT(" failure to convert local IP address to text representation\n")));
+    }
   }
 
 private:

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -104,9 +104,9 @@ public:
   }
   void local_address_set_port(u_short port_number) {
     local_address_.set_port_number(port_number);
-    size_t pos = local_address_str_.find_last_of(":");
-    OPENDDS_STRING host_name = local_address_str_.substr(0, pos);
-    local_address_str_ = host_name + ":" + to_dds_string(port_number);
+    char buf[1024];
+    local_address_.addr_to_string(buf, 1024);
+    local_address_str_ = buf;
   }
 
 private:

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -106,7 +106,7 @@ public:
     local_address_.set_port_number(port_number);
     ACE_TCHAR buf[1024];
     local_address_.addr_to_string(buf, 1024);
-    local_address_str_ = ACE_Wide_To_Ascii(buf).char_rep();
+    local_address_str_ = ACE_TEXT_ALWAYS_CHAR(buf);
   }
 
 private:

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -102,15 +102,17 @@ public:
     local_address_str_ += ":" + to_dds_string(port_number);
     local_address_.set(port_number, host_name);
   }
-  void local_address_set_port(u_short port_number) {
+  bool local_address_set_port(u_short port_number) {
     local_address_.set_port_number(port_number);
     ACE_TCHAR buf[1024];
     if (local_address_.addr_to_string(buf, 1024) == 0) {
       local_address_str_ = ACE_TEXT_ALWAYS_CHAR(buf);
+      return true;
     }
     else {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) TcpInst::local_address_set_port():")
                            ACE_TEXT(" failure to convert local IP address to text representation\n")));
+      return false;
     }
   }
 

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -417,7 +417,7 @@ TcpTransport::configure_i(TransportInst* config)
   // Now we got the actual listening port. Update the port number in the configuration
   // if it's 0 originally.
   else if (tcp_config->local_address().get_port_number() == 0) {
-    tcp_config->local_address_set_port(port);
+    return tcp_config->local_address_set_port(port);
   }
 
   // Ahhh...  The sweet smell of success!

--- a/dds/DCPS/transport/udp/UdpDataLink.cpp
+++ b/dds/DCPS/transport/udp/UdpDataLink.cpp
@@ -97,7 +97,8 @@ UdpDataLink::open(const ACE_INET_Addr& remote_address)
     VDBG_LVL((LM_DEBUG,
               ACE_TEXT("(%P|%t) UdpDataLink::open listening on port %hu\n"),
               port), 2);
-    this->config_->local_address_set_port(port);
+    if (!this->config_->local_address_set_port(port))
+      return false;
   }
 
   if (this->config_->send_buffer_size_ > 0) {

--- a/dds/DCPS/transport/udp/UdpInst.h
+++ b/dds/DCPS/transport/udp/UdpInst.h
@@ -57,7 +57,7 @@ public:
       return true;
     }
     else {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) TcpInst::local_address_set_port():")
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) UdpInst::local_address_set_port():")
                            ACE_TEXT(" failure to convert local IP address to text representation\n")));
       return false;
     }

--- a/dds/DCPS/transport/udp/UdpInst.h
+++ b/dds/DCPS/transport/udp/UdpInst.h
@@ -49,11 +49,18 @@ public:
     local_address_config_str_ += ":" + to_dds_string(port_number);
     local_address_.set(port_number, host_name);
   }
-  void local_address_set_port(u_short port_number) {
+  bool local_address_set_port(u_short port_number) {
     local_address_.set_port_number(port_number);
-    size_t pos = local_address_config_str_.find_last_of(":");
-    OPENDDS_STRING host_name = local_address_config_str_.substr(0, pos);
-    local_address_config_str_ = host_name + ":" + to_dds_string(port_number);
+    ACE_TCHAR buf[1024];
+    if (local_address_.addr_to_string(buf, 1024) == 0) {
+      local_address_config_str_ = ACE_TEXT_ALWAYS_CHAR(buf);
+      return true;
+    }
+    else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) TcpInst::local_address_set_port():")
+                           ACE_TEXT(" failure to convert local IP address to text representation\n")));
+      return false;
+    }
   }
 
 private:


### PR DESCRIPTION
The old code uses the last ":" to check if the port is available in the text representation; however, it's not correct for IPv6 IP address without port.