### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_script:
     fi
 
 script:
-  - travis_wait make -s -j 6
+  - travis_wait 40 make -s -j 6
   - if [ "$SAFETY_PROFILE" == "1" ]; then
         cd build/target/tests/DCPS/Messenger && ./run_test.pl rtps_disc;
         cd $DDS_ROOT/build/target/tests/FACE/Messenger;

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ before_script:
     fi
 
 script:
-  - make -s -j 6
+  - travis_wait make -s -j 6
   - if [ "$SAFETY_PROFILE" == "1" ]; then
         cd build/target/tests/DCPS/Messenger && ./run_test.pl rtps_disc;
         cd $DDS_ROOT/build/target/tests/FACE/Messenger;


### PR DESCRIPTION
Try to use travis_wait to mitigate failures on the java build in particular, where failures are being because travis kills the build if the process goes longer than 10 minutes without producing any output.  travis_wait increases the wait time to 20 min by producing output every 1 min, if needing longer than 20 min you can append the minutes to wait (i.e. travis_wait 30).