### PR TITLE
Check typed_sample before we pass it to the filter, it is check for n…

### DIFF
--- a/dds/DCPS/RakeResults_T.cpp
+++ b/dds/DCPS/RakeResults_T.cpp
@@ -86,7 +86,7 @@ bool RakeResults<SampleSeq>::insert_sample(ReceivedDataElement* sample,
     const QueryConditionImpl* qci = dynamic_cast<QueryConditionImpl*>(cond_);
     typedef typename SampleSeq::value_type VT;
     const VT* typed_sample = static_cast<VT*>(sample->registered_data_);
-    if (!qci || !qci->filter(*typed_sample)) return false;
+    if (!qci || !typed_sample || !qci->filter(*typed_sample)) return false;
   }
 
 #endif


### PR DESCRIPTION
…il further down in the operation

    * dds/DCPS/RakeResults_T.cpp: