### PR TITLE
DataReader and DataWriter are local objects so we can just pass this …

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -222,12 +222,12 @@ DataReaderImpl::cleanup()
 }
 
 void DataReaderImpl::init(
-    TopicDescriptionImpl*       a_topic_desc,
-    const DDS::DataReaderQos &  qos,
+    TopicDescriptionImpl* a_topic_desc,
+    const DDS::DataReaderQos &qos,
     DDS::DataReaderListener_ptr a_listener,
-    const DDS::StatusMask &     mask,
-    DomainParticipantImpl*      participant,
-    SubscriberImpl*             subscriber)
+    const DDS::StatusMask & mask,
+    DomainParticipantImpl* participant,
+    SubscriberImpl* subscriber)
 {
   topic_desc_ = DDS::TopicDescription::_duplicate(a_topic_desc);
   if (TopicImpl* a_topic = dynamic_cast<TopicImpl*>(a_topic_desc)) {

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -195,8 +195,6 @@ DataReaderImpl::cleanup()
     topic_servant_->_remove_ref();
   }
 
-  dr_local_objref_ = DDS::DataReader::_nil();
-
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
   if (!CORBA::is_nil(content_filtered_topic_.in())) {
     ContentFilteredTopicImpl* cft =
@@ -224,13 +222,12 @@ DataReaderImpl::cleanup()
 }
 
 void DataReaderImpl::init(
-    TopicDescriptionImpl* a_topic_desc,
+    TopicDescriptionImpl*       a_topic_desc,
     const DDS::DataReaderQos &  qos,
     DDS::DataReaderListener_ptr a_listener,
     const DDS::StatusMask &     mask,
-    DomainParticipantImpl*        participant,
-    SubscriberImpl*               subscriber,
-    DDS::DataReader_ptr         dr_objref)
+    DomainParticipantImpl*      participant,
+    SubscriberImpl*             subscriber)
 {
   topic_desc_ = DDS::TopicDescription::_duplicate(a_topic_desc);
   if (TopicImpl* a_topic = dynamic_cast<TopicImpl*>(a_topic_desc)) {
@@ -273,7 +270,6 @@ void DataReaderImpl::init(
   // Only store the subscriber pointer, since it is our parent, we
   // will exist as long as it does.
   subscriber_servant_ = subscriber;
-  dr_local_objref_    = DDS::DataReader::_duplicate(dr_objref);
 
   if (this->subscriber_servant_->get_qos(this->subqos_) != ::DDS::RETCODE_OK) {
     ACE_DEBUG((LM_WARNING,
@@ -482,8 +478,7 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
           listener_for(DDS::SUBSCRIPTION_MATCHED_STATUS);
 
       if (!CORBA::is_nil(listener)) {
-        listener->on_subscription_matched(dr_local_objref_,
-            subscription_match_status_);
+        listener->on_subscription_matched(this, subscription_match_status_);
 
         // TBD - why does the spec say to change this but not change
         //       the ChangeFlagStatus after a listener call?
@@ -715,9 +710,7 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
       = listener_for(DDS::SUBSCRIPTION_MATCHED_STATUS);
 
       if (!CORBA::is_nil(listener.in())) {
-        listener->on_subscription_matched(
-            dr_local_objref_.in(),
-            this->subscription_match_status_);
+        listener->on_subscription_matched(this, this->subscription_match_status_);
 
         // Client will look at it so next time it looks the change should be 0
         this->subscription_match_status_.total_count_change = 0;
@@ -810,8 +803,7 @@ DataReaderImpl::update_incompatible_qos(const IncompatibleQosStatus& status)
   requested_incompatible_qos_status_.policies = status.policies;
 
   if (!CORBA::is_nil(listener.in())) {
-    listener->on_requested_incompatible_qos(dr_local_objref_.in(),
-        requested_incompatible_qos_status_);
+    listener->on_requested_incompatible_qos(this, requested_incompatible_qos_status_);
 
     // TBD - why does the spec say to change total_count_change but not
     // change the ChangeFlagStatus after a listener call?
@@ -997,7 +989,6 @@ void DataReaderImpl::qos_change(const DDS::DataReaderQos & qos)
                   ref(this->sample_lock_),
                   qos.deadline,
                   this,
-                  this->dr_local_objref_.in(),
                   ref(this->requested_deadline_missed_status_),
                   ref(this->last_deadline_missed_total_count_));
 
@@ -1300,7 +1291,6 @@ DataReaderImpl::enable()
             ref(this->sample_lock_),
             this->qos_.deadline,
             this,
-            this->dr_local_objref_.in(),
             ref(this->requested_deadline_missed_status_),
             ref(this->last_deadline_missed_total_count_));
   }
@@ -2434,9 +2424,7 @@ void DataReaderImpl::notify_latency(PublicationId writer)
     ++this->budget_exceeded_status_.total_count;
     ++this->budget_exceeded_status_.total_count_change;
 
-    listener->on_budget_exceeded(
-        this->dr_local_objref_.in(),
-        this->budget_exceeded_status_);
+    listener->on_budget_exceeded(this, this->budget_exceeded_status_);
 
     this->budget_exceeded_status_.total_count_change = 0;
   }
@@ -2538,8 +2526,7 @@ DataReaderImpl::notify_subscription_disconnected(const WriterIdSeq& pubids)
     // Since this callback may come after remove_association which removes
     // the writer from id_to_handle map, we can ignore this error.
     this->lookup_instance_handles(pubids, status.publication_handles);
-    the_listener->on_subscription_disconnected(this->dr_local_objref_.in(),
-        status);
+    the_listener->on_subscription_disconnected(this, status);
   }
 }
 
@@ -2564,8 +2551,7 @@ DataReaderImpl::notify_subscription_reconnected(const WriterIdSeq& pubids)
             "lookup_instance_handles failed.\n"));
       }
 
-      the_listener->on_subscription_reconnected(this->dr_local_objref_.in(),
-          status);
+      the_listener->on_subscription_reconnected(this,  status);
     }
   }
 }
@@ -2591,8 +2577,7 @@ DataReaderImpl::notify_subscription_lost(const DDS::InstanceHandleSeq& handles)
         status.publication_handles[i] = handles[i];
       }
 
-      the_listener->on_subscription_lost(this->dr_local_objref_.in(),
-          status);
+      the_listener->on_subscription_lost(this, status);
     }
   }
 }
@@ -2613,8 +2598,7 @@ DataReaderImpl::notify_subscription_lost(const WriterIdSeq& pubids)
     // Since this callback may come after remove_association which removes
     // the writer from id_to_handle map, we can ignore this error.
     this->lookup_instance_handles(pubids, status.publication_handles);
-    the_listener->on_subscription_lost(this->dr_local_objref_.in(),
-        status);
+    the_listener->on_subscription_lost(this, status);
   }
 }
 
@@ -2627,8 +2611,9 @@ DataReaderImpl::notify_connection_deleted(const RepoId& peerId)
   // is given to this DataWriter then narrow() fails.
   DataReaderListener_var the_listener = DataReaderListener::_narrow(this->listener_.in());
 
-  if (!CORBA::is_nil(the_listener.in()))
-    the_listener->on_connection_deleted(this->dr_local_objref_.in());
+  if (!CORBA::is_nil(the_listener.in())) {
+    the_listener->on_connection_deleted(this);
+  }
 }
 
 bool
@@ -2847,8 +2832,7 @@ void DataReaderImpl::notify_liveliness_change()
   = listener_for(DDS::LIVELINESS_CHANGED_STATUS);
 
   if (!CORBA::is_nil(listener.in())) {
-    listener->on_liveliness_changed(dr_local_objref_.in(),
-        liveliness_changed_status_);
+    listener->on_liveliness_changed(this, liveliness_changed_status_);
 
     liveliness_changed_status_.alive_count_change = 0;
     liveliness_changed_status_.not_alive_count_change = 0;
@@ -2989,7 +2973,7 @@ bool DataReaderImpl::verify_coherent_changes_completion (WriterInfo* writer)
   if (this->subqos_.presentation.access_scope == ::DDS::INSTANCE_PRESENTATION_QOS
       || ! this->subqos_.presentation.coherent_access) {
     this->accept_coherent (writer->writer_id_, writer->publisher_id_);
-    this->coherent_changes_completed (this);
+    this->coherent_changes_completed ();
     return true;
   }
 
@@ -2999,7 +2983,7 @@ bool DataReaderImpl::verify_coherent_changes_completion (WriterInfo* writer)
     if (state != NOT_COMPLETED_YET) {
       // verify if all readers received complete coherent changes in a group.
       this->subscriber_servant_->coherent_change_received (
-          writer->publisher_id_, this, state);
+          writer->publisher_id_, state);
     }
   }
   else {  // TOPIC coherent
@@ -3115,7 +3099,7 @@ DataReaderImpl::coherent_change_received (RepoId publisher_id, Coherent_State& r
 
 
 void
-DataReaderImpl::coherent_changes_completed (DataReaderImpl* reader)
+DataReaderImpl::coherent_changes_completed ()
 {
   this->subscriber_servant_->set_status_changed_flag(::DDS::DATA_ON_READERS_STATUS, true);
   this->set_status_changed_flag(::DDS::DATA_AVAILABLE_STATUS, true);
@@ -3124,7 +3108,7 @@ DataReaderImpl::coherent_changes_completed (DataReaderImpl* reader)
       this->subscriber_servant_->listener_for(::DDS::DATA_ON_READERS_STATUS);
   if (!CORBA::is_nil(sub_listener.in()))
   {
-    if (reader == this) {
+    {
       // Release the sample_lock before listener callback.
       ACE_GUARD (Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
       sub_listener->on_data_on_readers(this->subscriber_servant_);
@@ -3142,13 +3126,10 @@ DataReaderImpl::coherent_changes_completed (DataReaderImpl* reader)
 
     if (!CORBA::is_nil(listener.in()))
     {
-      if (reader == this) {
+      {
         // Release the sample_lock before listener callback.
         ACE_GUARD(Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
-        listener->on_data_available(dr_local_objref_.in ());
-      }
-      else {
-        listener->on_data_available(dr_local_objref_.in ());
+        listener->on_data_available(this);
       }
 
       set_status_changed_flag(::DDS::DATA_AVAILABLE_STATUS, false);

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -261,8 +261,7 @@ public:
     DDS::DataReaderListener_ptr a_listener,
     const DDS::StatusMask &     mask,
     DomainParticipantImpl*        participant,
-    SubscriberImpl*               subscriber,
-    DDS::DataReader_ptr         dr_objref);
+    SubscriberImpl*               subscriber);
 
   virtual DDS::ReadCondition_ptr create_readcondition(
     DDS::SampleStateMask sample_states,
@@ -366,8 +365,6 @@ public:
   virtual bool check_transport_qos(const TransportInst& inst);
 
   RepoId get_subscription_id() const;
-
-  DDS::DataReader_ptr get_dr_obj_ref();
 
   char *get_topic_name() const;
 
@@ -510,7 +507,7 @@ public:
                         RepoId& publisher_id);
   void coherent_change_received (RepoId publisher_id, Coherent_State& result);
 
-  void coherent_changes_completed (DataReaderImpl* reader);
+  void coherent_changes_completed ();
 
   void reset_coherent_info (const PublicationId& writer_id,
                             const RepoId& publisher_id);
@@ -684,7 +681,6 @@ private:
   DDS::DataReaderListener_var  listener_;
   DDS::DomainId_t              domain_id_;
   SubscriberImpl*              subscriber_servant_;
-  DDS::DataReader_var          dr_local_objref_;
   RcHandle<EndHistoricSamplesMissedSweeper> end_historic_sweeper_;
   RcHandle<RemoveAssociationSweeper<DataReaderImpl> > remove_association_sweeper_;
 

--- a/dds/DCPS/DataReaderImpl.inl
+++ b/dds/DCPS/DataReaderImpl.inl
@@ -8,15 +8,6 @@
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_INLINE
-DDS::DataReader_ptr
-OpenDDS::DCPS::DataReaderImpl::get_dr_obj_ref()
-{
-  return DDS::DataReader::_duplicate(dr_local_objref_.in()) ;
-}
-
-
-
-ACE_INLINE
 const OpenDDS::DCPS::DataReaderImpl::StatsMapType&
 OpenDDS::DCPS::DataReaderImpl::raw_latency_statistics() const
 {

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1657,13 +1657,11 @@ void store_instance_data(
       ++sample_rejected_status_.total_count_change;
       sample_rejected_status_.last_instance_handle = handle;
 
-      DDS::DataReader_var dr = get_dr_obj_ref();
       if (!CORBA::is_nil(listener.in()))
       {
         ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
 
-        listener->on_sample_rejected(dr.in (),
-                                     sample_rejected_status_);
+        listener->on_sample_rejected(this, sample_rejected_status_);
       }  // do we want to do something if listener is nil???
       notify_status_condition_no_sample_lock();
 
@@ -1863,13 +1861,11 @@ void finish_store_instance_data(MessageType* instance_data, const DataSampleHead
       ++sample_rejected_status_.total_count_change;
       sample_rejected_status_.last_instance_handle = instance_ptr->instance_handle_;
 
-      DDS::DataReader_var dr = get_dr_obj_ref();
       if (!CORBA::is_nil(listener.in()))
       {
         ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
 
-        listener->on_sample_rejected(dr.in(),
-          sample_rejected_status_);
+        listener->on_sample_rejected(this, sample_rejected_status_);
       }  // do we want to do something if listener is nil???
       notify_status_condition_no_sample_lock();
 
@@ -1927,13 +1923,11 @@ void finish_store_instance_data(MessageType* instance_data, const DataSampleHead
         ++sample_rejected_status_.total_count;
         ++sample_rejected_status_.total_count_change;
         sample_rejected_status_.last_instance_handle = instance_ptr->instance_handle_;
-        DDS::DataReader_var dr = get_dr_obj_ref();
         if (!CORBA::is_nil(listener.in()))
         {
           ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
 
-          listener->on_sample_rejected(dr.in(),
-            sample_rejected_status_);
+          listener->on_sample_rejected(this, sample_rejected_status_);
         }  // do we want to do something if listener is nil???
         notify_status_condition_no_sample_lock();
 
@@ -2018,12 +2012,11 @@ void finish_store_instance_data(MessageType* instance_data, const DataSampleHead
 
           set_status_changed_flag(DDS::SAMPLE_LOST_STATUS, true);
 
-          DDS::DataReader_var dr = get_dr_obj_ref();
           if (!CORBA::is_nil(listener.in()))
             {
               ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
 
-              listener->on_sample_lost(dr.in (), sample_lost_status_);
+              listener->on_sample_lost(this, sample_lost_status_);
             }
 
           notify_status_condition_no_sample_lock();
@@ -2056,12 +2049,11 @@ void finish_store_instance_data(MessageType* instance_data, const DataSampleHead
         DDS::DataReaderListener_var listener =
             listener_for (DDS::DATA_AVAILABLE_STATUS);
 
-        DDS::DataReader_var dr = get_dr_obj_ref();
         if (!CORBA::is_nil(listener.in()))
           {
             ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
 
-            listener->on_data_available(dr.in ());
+            listener->on_data_available(this);
             set_status_changed_flag(DDS::DATA_AVAILABLE_STATUS, false);
             sub->set_status_changed_flag(DDS::DATA_ON_READERS_STATUS, false);
           }

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -202,15 +202,14 @@ public:
   /**
    * Initialize the data members.
    */
-  virtual void init(
+  void init(
     DDS::Topic_ptr                        topic,
     TopicImpl*                            topic_servant,
     const DDS::DataWriterQos &            qos,
     DDS::DataWriterListener_ptr           a_listener,
     const DDS::StatusMask &               mask,
     OpenDDS::DCPS::DomainParticipantImpl* participant_servant,
-    OpenDDS::DCPS::PublisherImpl*         publisher_servant,
-    DDS::DataWriter_ptr                   dw_local);
+    OpenDDS::DCPS::PublisherImpl*         publisher_servant);
 
   void send_all_to_flush_control(ACE_Guard<ACE_Recursive_Thread_Mutex>& guard);
 
@@ -610,8 +609,6 @@ private:
   DDS::DomainId_t                 domain_id_;
   /// The publisher servant which creates this datawriter.
   PublisherImpl*                  publisher_servant_;
-  /// the object reference of the local datawriter
-  DDS::DataWriter_var             dw_local_objref_;
   /// The repository id of this datawriter/publication.
   PublicationId                   publication_id_;
   /// The sequence number unique in DataWriter scope.

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -46,6 +46,20 @@ namespace OpenDDS {
       , mb_allocator_ (0)
       , db_allocator_ (0)
     {
+      MessageType data;
+      if (MarshalTraitsType::gen_is_bounded_size()) {
+        marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(data, true);
+        // worst case: CDR encapsulation (4 bytes) + Padding for alignment (4 bytes)
+      } else {
+        marshaled_size_ = 0; // should use gen_find_size when marshaling
+      }
+      if (MarshalTraitsType::gen_is_bounded_key_size()) {
+        OpenDDS::DCPS::KeyOnly<const MessageType > ko(data);
+        key_marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(ko, true);
+        // worst case: CDR Encapsulation (4 bytes) + Padding for alignment (4 bytes)
+      } else {
+        key_marshaled_size_ = 0; // should use gen_find_size when marshaling
+      }
     }
 
     virtual ~DataWriterImpl_T (void)
@@ -290,44 +304,6 @@ namespace OpenDDS {
         }
     }
 
-
-  /**
-   * Initialize the DataWriter object.
-   * Called as part of create_datawriter.
-   */
-    virtual void init (DDS::Topic_ptr                       topic,
-                       OpenDDS::DCPS::TopicImpl*              topic_servant,
-                       const DDS::DataWriterQos &           qos,
-                       DDS::DataWriterListener_ptr          a_listener,
-                       const DDS::StatusMask &              mask,
-                       OpenDDS::DCPS::DomainParticipantImpl*  participant_servant,
-                       OpenDDS::DCPS::PublisherImpl*          publisher_servant,
-                       DDS::DataWriter_ptr                  dw_objref)
-    {
-      OpenDDS::DCPS::DataWriterImpl::init (topic,
-                                           topic_servant,
-                                           qos,
-                                           a_listener,
-                                           mask,
-                                           participant_servant,
-                                           publisher_servant,
-                                           dw_objref);
-
-      MessageType data;
-      if (MarshalTraitsType::gen_is_bounded_size()) {
-        marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(data, true);
-        // worst case: CDR encapsulation (4 bytes) + Padding for alignment (4 bytes)
-      } else {
-        marshaled_size_ = 0; // should use gen_find_size when marshaling
-      }
-      if (MarshalTraitsType::gen_is_bounded_key_size()) {
-        OpenDDS::DCPS::KeyOnly<const MessageType > ko(data);
-        key_marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(ko, true);
-        // worst case: CDR Encapsulation (4 bytes) + Padding for alignment (4 bytes)
-      } else {
-        key_marshaled_size_ = 0; // should use gen_find_size when marshaling
-      }
-    }
 
   /**
    * Do parts of enable specific to the datatype.

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1506,8 +1506,7 @@ namespace OpenDDS {
         DDS::DataReader_var dr = type_support->create_datareader();
         OpenDDS::DCPS::DataReaderImpl* dri = dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(dr.in());
 
-        dri->init(bit_topic_i, qos, 0 /*listener*/, 0 /*mask*/,
-                  participant_i, sub, dr);
+        dri->init(bit_topic_i, qos, 0 /*listener*/, 0 /*mask*/, participant_i, sub);
         dri->disable_transport();
         dri->enable();
       }

--- a/dds/DCPS/MultiTopicDataReaderBase.cpp
+++ b/dds/DCPS/MultiTopicDataReaderBase.cpp
@@ -103,8 +103,7 @@ void MultiTopicDataReaderBase::init(const DDS::DataReaderQos& dr_qos,
 
   DDS::DomainParticipant_var participant = parent->get_participant();
   resulting_impl->init(multitopic, dr_qos, a_listener, mask,
-    dynamic_cast<DomainParticipantImpl*>(participant.in()), parent,
-    resulting_reader_);
+    dynamic_cast<DomainParticipantImpl*>(participant.in()), parent);
 
   init_typed(resulting_reader_);
 

--- a/dds/DCPS/OfferedDeadlineWatchdog.cpp
+++ b/dds/DCPS/OfferedDeadlineWatchdog.cpp
@@ -18,14 +18,13 @@ OpenDDS::DCPS::OfferedDeadlineWatchdog::OfferedDeadlineWatchdog(
   lock_type & lock,
   DDS::DeadlineQosPolicy qos,
   OpenDDS::DCPS::DataWriterImpl * writer_impl,
-  DDS::DataWriter_ptr writer,
   DDS::OfferedDeadlineMissedStatus & status,
   CORBA::Long & last_total_count)
   : Watchdog(duration_to_time_value(qos.period))
   , status_lock_(lock)
   , reverse_status_lock_(status_lock_)
   , writer_impl_(writer_impl)
-  , writer_(DDS::DataWriter::_duplicate(writer))
+  , writer_(DDS::DataWriter::_duplicate(writer_impl))
   , status_(status)
   , last_total_count_(last_total_count)
 {

--- a/dds/DCPS/OfferedDeadlineWatchdog.h
+++ b/dds/DCPS/OfferedDeadlineWatchdog.h
@@ -46,7 +46,6 @@ public:
     lock_type & lock,
     DDS::DeadlineQosPolicy qos,
     OpenDDS::DCPS::DataWriterImpl * writer_impl,
-    DDS::DataWriter_ptr writer,
     DDS::OfferedDeadlineMissedStatus & status,
     CORBA::Long & last_total_count);
 

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -122,14 +122,21 @@ PublisherImpl::create_datawriter(
   DataWriterImpl* dw_servant =
       dynamic_cast <DataWriterImpl*>(dw_obj.in());
 
+  if (dw_servant == 0) {
+    ACE_ERROR((LM_ERROR,
+        ACE_TEXT("(%P|%t) ERROR: ")
+        ACE_TEXT("PublisherImpl::create_datawriter, ")
+        ACE_TEXT("servant is nil.\n")));
+    return DDS::DataWriter::_nil();
+  }
+
   dw_servant->init(a_topic,
       topic_servant,
       dw_qos,
       a_listener,
       mask,
       participant_,
-      this,
-      dw_obj.in());
+      this);
 
   if ((this->enabled_ == true) && (qos_.entity_factory.autoenable_created_entities)) {
     const DDS::ReturnCode_t ret = dw_servant->enable();

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -800,7 +800,7 @@ RecorderImpl::update_incompatible_qos(const IncompatibleQosStatus& status)
   requested_incompatible_qos_status_.policies = status.policies;
 
   // if (!CORBA::is_nil(listener.in())) {
-  //   listener->on_requested_incompatible_qos(dr_local_objref_.in(),
+  //   listener->on_requested_incompatible_qos(this,
   //                                           requested_incompatible_qos_status_);
   //
   //   // TBD - why does the spec say to change total_count_change but not

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -251,7 +251,7 @@ DDS::ReturnCode_t ReplayerImpl::set_qos (const DDS::PublisherQos &  publisher_qo
       //                          this->lock_,
       //                          qos.deadline,
       //                          this,
-      //                          this->dw_local_objref_.in(),
+      //                          this,
       //                          this->offered_deadline_missed_status_,
       //                          this->last_deadline_missed_total_count_));
       //

--- a/dds/DCPS/RequestedDeadlineWatchdog.cpp
+++ b/dds/DCPS/RequestedDeadlineWatchdog.cpp
@@ -20,14 +20,13 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::RequestedDeadlineWatchdog(
   lock_type & lock,
   DDS::DeadlineQosPolicy qos,
   OpenDDS::DCPS::DataReaderImpl * reader_impl,
-  DDS::DataReader_ptr reader,
   DDS::RequestedDeadlineMissedStatus & status,
   CORBA::Long & last_total_count)
   : Watchdog(duration_to_time_value(qos.period))
   , status_lock_(lock)
   , reverse_status_lock_(status_lock_)
   , reader_impl_(reader_impl)
-  , reader_(DDS::DataReader::_duplicate(reader))
+  , reader_(DDS::DataReader::_duplicate(reader_impl))
   , status_(status)
   , last_total_count_(last_total_count)
 {

--- a/dds/DCPS/RequestedDeadlineWatchdog.h
+++ b/dds/DCPS/RequestedDeadlineWatchdog.h
@@ -46,7 +46,6 @@ public:
     lock_type & lock,
     DDS::DeadlineQosPolicy qos,
     OpenDDS::DCPS::DataReaderImpl * reader_impl,
-    DDS::DataReader_ptr reader,
     DDS::RequestedDeadlineMissedStatus & status,
     CORBA::Long & last_total_count);
 

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -194,6 +194,14 @@ SubscriberImpl::create_datareader(
   DataReaderImpl* dr_servant =
     dynamic_cast<DataReaderImpl*>(dr_obj.in());
 
+  if (dr_servant == 0) {
+    ACE_ERROR((LM_ERROR,
+        ACE_TEXT("(%P|%t) ERROR: ")
+        ACE_TEXT("SubscriberImpl::create_datareader, ")
+        ACE_TEXT("servant is nil.\n")));
+    return DDS::DataReader::_nil();
+  }
+
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
   if (cft) {
     dr_servant->enable_filtering(cft);
@@ -211,8 +219,7 @@ SubscriberImpl::create_datareader(
                    a_listener,
                    mask,
                    participant_,
-                   this,
-                   dr_obj.in());
+                   this);
 
   if ((this->enabled_ == true) && (qos_.entity_factory.autoenable_created_entities)) {
     const DDS::ReturnCode_t ret = dr_servant->enable();
@@ -498,7 +505,7 @@ SubscriberImpl::get_datareaders(
     if ((*pos)->have_sample_states(sample_states) &&
         (*pos)->have_view_states(view_states) &&
         (*pos)->have_instance_states(instance_states)) {
-      push_back(readers, (*pos)->get_dr_obj_ref());
+      push_back(readers, DDS::DataReader::_duplicate(*pos));
     }
   }
 
@@ -918,7 +925,6 @@ SubscriberImpl::update_ownership_strength (const PublicationId& pub_id,
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
 void
 SubscriberImpl::coherent_change_received (RepoId&         publisher_id,
-                                          DataReaderImpl* reader,
                                           Coherent_State& group_state)
 {
   // Verify if all readers complete the coherent changes. The result
@@ -953,7 +959,7 @@ SubscriberImpl::coherent_change_received (RepoId&         publisher_id,
   if (group_state == COMPLETED) {
     for (DataReaderSet::const_iterator iter = datareader_set_.begin();
          iter != endIter; ++iter) {
-      (*iter)->coherent_changes_completed (reader);
+      (*iter)->coherent_changes_completed ();
       (*iter)->reset_coherent_info (writerId, publisher_id);
     }
   }

--- a/dds/DCPS/SubscriberImpl.h
+++ b/dds/DCPS/SubscriberImpl.h
@@ -148,7 +148,6 @@ public:
 
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
   void coherent_change_received(RepoId& publisher_id,
-                                DataReaderImpl* reader,
                                 Coherent_State& group_state);
 #endif
 

--- a/tests/DCPS/TransientLocalTest/DataReaderListener.cpp
+++ b/tests/DCPS/TransientLocalTest/DataReaderListener.cpp
@@ -37,9 +37,8 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     DDS::SampleInfo si;
     DDS::ReturnCode_t status = message_dr->take_next_sample(message, si);
 
-    if (si.valid_data) {
-      if (status == DDS::RETCODE_OK) {
-
+    if (status == DDS::RETCODE_OK) {
+      if (si.valid_data) {
         if (durable) ++num_reads_;
 
         ACE_DEBUG((LM_INFO, "(%P|%t) DataReaderListenerImpl[%@]::on_data_available - %C count = %d\n", this,
@@ -54,13 +53,13 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
           }
           last_non_durable_ = message.count;
         }
-      } else if (status == DDS::RETCODE_NO_DATA) {
-        cerr << "ERROR: reader received DDS::RETCODE_NO_DATA!" << endl;
-        ok_ = false;
-      } else {
-        cerr << "ERROR: read Message: Error: " <<  status << endl;
-        ok_ = false;
       }
+    } else if (status == DDS::RETCODE_NO_DATA) {
+      cerr << "ERROR: reader received DDS::RETCODE_NO_DATA!" << endl;
+      ok_ = false;
+    } else {
+      cerr << "ERROR: read Message: Error: " <<  status << endl;
+      ok_ = false;
     }
   } catch (CORBA::Exception& e) {
     cerr << "Exception caught in read:" << endl << e << endl;


### PR DESCRIPTION
…when we need a reference to a reader/writer, no need to store a seperate _var/_ptr for the reader/writer

    * dds/DCPS/DataReaderImpl.cpp:
    * dds/DCPS/DataReaderImpl.h:
    * dds/DCPS/DataReaderImpl.inl:
    * dds/DCPS/DataReaderImpl_T.h:
    * dds/DCPS/DataWriterImpl.cpp:
    * dds/DCPS/DataWriterImpl.h:
    * dds/DCPS/DataWriterImpl_T.h:
    * dds/DCPS/DiscoveryBase.h:
    * dds/DCPS/MultiTopicDataReaderBase.cpp:
    * dds/DCPS/OfferedDeadlineWatchdog.cpp:
    * dds/DCPS/OfferedDeadlineWatchdog.h:
    * dds/DCPS/PublisherImpl.cpp:
    * dds/DCPS/RecorderImpl.cpp:
    * dds/DCPS/ReplayerImpl.cpp:
    * dds/DCPS/RequestedDeadlineWatchdog.cpp:
    * dds/DCPS/RequestedDeadlineWatchdog.h:
    * dds/DCPS/SubscriberImpl.cpp:
    * dds/DCPS/SubscriberImpl.h: