### PR TITLE
Simplify topic implementation, store the number of entities used in t…

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -202,7 +202,7 @@ DataReaderImpl::cleanup()
     ContentFilteredTopicImpl* cft =
         dynamic_cast<ContentFilteredTopicImpl*>(content_filtered_topic_.in());
     cft->remove_reader(*this);
-    cft->update_reader_count(false);
+    cft->remove_entity_ref();
     content_filtered_topic_ = DDS::ContentFilteredTopic::_nil ();
   }
 #endif
@@ -3216,7 +3216,7 @@ DataReaderImpl::set_subscriber_qos(
 void
 DataReaderImpl::enable_filtering(ContentFilteredTopicImpl* cft)
 {
-  cft->update_reader_count(true);
+  cft->add_entity_ref();
   cft->add_reader(*this);
   content_filtered_topic_ = DDS::ContentFilteredTopic::_duplicate(cft);
 }

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -155,7 +155,7 @@ DataWriterImpl::cleanup()
 void
 DataWriterImpl::init(
   DDS::Topic_ptr                       topic,
-  TopicImpl *                            topic_servant,
+  TopicImpl *                          topic_servant,
   const DDS::DataWriterQos &           qos,
   DDS::DataWriterListener_ptr          a_listener,
   const DDS::StatusMask &              mask,

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -774,7 +774,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_contentfilteredtopic(
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
         ACE_TEXT("can't delete a content-filtered topic \"%C\" ")
-        ACE_TEXT("because it still is used.\n"), name.in ()));
+        ACE_TEXT("because it is used by a datareader\n"), name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
@@ -853,7 +853,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_multitopic, ")
         ACE_TEXT("can't delete a multitopic topic \"%C\" ")
-        ACE_TEXT("because it still is used.\n"), mt_name.in ()));
+        ACE_TEXT("because it is used by a datareader.\n"), mt_name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -764,7 +764,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_contentfilteredtopic(
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
-        ACE_TEXT("can't delete contentfiltered topic \"%C\" ")
+        ACE_TEXT("can't delete a contentfiltered topic \"%C\" ")
         ACE_TEXT("because it is not in the set.\n"), name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
@@ -837,14 +837,14 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, topics_protector_,
                    DDS::RETCODE_OUT_OF_RESOURCES);
   DDS::MultiTopic_var mt = DDS::MultiTopic::_duplicate(a_multitopic);
-  CORBA::String_var name = mt->get_name();
-  TopicDescriptionMap::iterator iter = topic_descrs_.find(name.in());
+  CORBA::String_var mt_name = mt->get_name();
+  TopicDescriptionMap::iterator iter = topic_descrs_.find(mt_name.in());
   if (iter == topic_descrs_.end()) {
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_multitopic, ")
         ACE_TEXT("can't delete multitopic \"%C\" ")
-        ACE_TEXT("because it is not in the set.\n"), name.in ()));
+        ACE_TEXT("because it is not in the set.\n"), mt_name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
@@ -853,7 +853,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
         ACE_TEXT("can't delete contentfiltered topic \"%C\" ")
-        ACE_TEXT("because it still is used.\n"), name.in ()));
+        ACE_TEXT("because it still is used.\n"), mt_name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -851,7 +851,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
   if (dynamic_cast<TopicDescriptionImpl*>(iter->second.in())->has_entity_refs()) {
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
-        ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
+        ACE_TEXT("DomainParticipantImpl::delete_multitopic, ")
         ACE_TEXT("can't delete a multitopic topic \"%C\" ")
         ACE_TEXT("because it still is used.\n"), mt_name.in ()));
     }

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -509,7 +509,6 @@ DomainParticipantImpl::delete_topic_i(
     }
 
     {
-
       ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                        tao_mon,
                        this->topics_protector_,

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -764,7 +764,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_contentfilteredtopic(
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
-        ACE_TEXT("can't delete a contentfiltered topic \"%C\" ")
+        ACE_TEXT("can't delete a content-filtered topic \"%C\" ")
         ACE_TEXT("because it is not in the set.\n"), name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
@@ -773,7 +773,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_contentfilteredtopic(
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
-        ACE_TEXT("can't delete contentfiltered topic \"%C\" ")
+        ACE_TEXT("can't delete a content-filtered topic \"%C\" ")
         ACE_TEXT("because it still is used.\n"), name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;
@@ -852,7 +852,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
-        ACE_TEXT("can't delete contentfiltered topic \"%C\" ")
+        ACE_TEXT("can't delete a content-filtered topic \"%C\" ")
         ACE_TEXT("because it still is used.\n"), mt_name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -852,7 +852,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_contentfilteredtopic, ")
-        ACE_TEXT("can't delete a content-filtered topic \"%C\" ")
+        ACE_TEXT("can't delete a multitopic topic \"%C\" ")
         ACE_TEXT("because it still is used.\n"), mt_name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -843,7 +843,7 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_multitopic(
     if (DCPS_debug_level > 3) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("DomainParticipantImpl::delete_multitopic, ")
-        ACE_TEXT("can't delete multitopic \"%C\" ")
+        ACE_TEXT("can't delete a multitopic \"%C\" ")
         ACE_TEXT("because it is not in the set.\n"), mt_name.in ()));
     }
     return DDS::RETCODE_PRECONDITION_NOT_MET;

--- a/dds/DCPS/TopicDescriptionImpl.cpp
+++ b/dds/DCPS/TopicDescriptionImpl.cpp
@@ -23,19 +23,13 @@ TopicDescriptionImpl::TopicDescriptionImpl(const char*            topic_name,
   : topic_name_(topic_name),
     type_name_(type_name),
     participant_(participant),
-    type_support_(type_support)
+    type_support_(OpenDDS::DCPS::TypeSupport::_duplicate(type_support)),
+    entity_refs_(0)
 {
-  // make sure the type_support doesn't get deleted while
-  // were still using it.
-  if (type_support_)
-    type_support_->_add_ref();
 }
 
 TopicDescriptionImpl::~TopicDescriptionImpl()
 {
-  // were finished with the type_support
-  if (type_support_)
-    type_support_->_remove_ref();
 }
 
 char *

--- a/dds/DCPS/TopicDescriptionImpl.h
+++ b/dds/DCPS/TopicDescriptionImpl.h
@@ -81,10 +81,8 @@ protected:
   /// The type_support for this topic.
   OpenDDS::DCPS::TypeSupport_var type_support_;
 
-#if !defined(OPENDDS_NO_CONTENT_FILTERED_TOPIC) || !defined(OPENDDS_NO_MULTI_TOPIC)
   /// The number of entities using this topic
   ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> entity_refs_;
-#endif
 };
 
 } // namespace DCPS

--- a/dds/DCPS/TopicDescriptionImpl.h
+++ b/dds/DCPS/TopicDescriptionImpl.h
@@ -57,18 +57,17 @@ public:
   */
   OpenDDS::DCPS::TypeSupport_ptr get_type_support();
 
-#if !defined(OPENDDS_NO_CONTENT_FILTERED_TOPIC) || !defined(OPENDDS_NO_MULTI_TOPIC)
-
-  bool has_reader() const {
-    return reader_count_ > 0;
+  bool has_entity_refs() const {
+    return entity_refs_ > 0;
   }
 
-  void update_reader_count(bool increment) {
-    if (increment) ++reader_count_;
-    else --reader_count_;
+  void add_entity_ref() {
+    ++entity_refs_;
   }
 
-#endif
+  void remove_entity_ref() {
+    --entity_refs_;
+  }
 
 protected:
   /// The name of the topic.
@@ -80,10 +79,11 @@ protected:
   DomainParticipantImpl*         participant_;
 
   /// The type_support for this topic.
-  OpenDDS::DCPS::TypeSupport_ptr type_support_;
+  OpenDDS::DCPS::TypeSupport_var type_support_;
 
 #if !defined(OPENDDS_NO_CONTENT_FILTERED_TOPIC) || !defined(OPENDDS_NO_MULTI_TOPIC)
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> reader_count_;
+  /// The number of entities using this topic
+  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> entity_refs_;
 #endif
 };
 

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -36,7 +36,6 @@ TopicImpl::TopicImpl(const RepoId                   topic_id,
     listener_mask_(mask),
     listener_(DDS::TopicListener::_duplicate(a_listener)),
     id_(topic_id),
-    entity_refs_(0),
     monitor_(0)
 {
   inconsistent_topic_status_.total_count = 0;
@@ -68,19 +67,17 @@ TopicImpl::set_qos(const DDS::TopicQos & qos)
 
     } else {
       qos_ = qos;
-      DomainParticipantImpl* part =
-        dynamic_cast<DomainParticipantImpl*>(this->participant_);
 
       Discovery_rch disco =
-        TheServiceParticipant->get_discovery(part->get_domain_id());
+        TheServiceParticipant->get_discovery(this->participant_->get_domain_id());
       const bool status =
-        disco->update_topic_qos(this->id_, part->get_domain_id(),
-                               part->get_id(), qos_);
+        disco->update_topic_qos(this->id_, this->participant_->get_domain_id(),
+                               this->participant_->get_id(), qos_);
 
       if (!status) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("(%P|%t) TopicImpl::set_qos, ")
-                          ACE_TEXT("failed on compatiblity check. \n")),
+                          ACE_TEXT("failed on compatibility check. \n")),
                          DDS::RETCODE_ERROR);
       }
     }
@@ -136,10 +133,7 @@ TopicImpl::enable()
     return DDS::RETCODE_OK;
   }
 
-  DomainParticipantImpl* part =
-    dynamic_cast<DomainParticipantImpl*>(this->participant_);
-
-  if (part->is_enabled() == false) {
+  if (this->participant_->is_enabled() == false) {
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -69,10 +69,10 @@ TopicImpl::set_qos(const DDS::TopicQos & qos)
       qos_ = qos;
 
       Discovery_rch disco =
-        TheServiceParticipant->get_discovery(this->participant_->get_domain_id());
+        TheServiceParticipant->get_discovery(participant_->get_domain_id());
       const bool status =
-        disco->update_topic_qos(this->id_, this->participant_->get_domain_id(),
-                               this->participant_->get_id(), qos_);
+        disco->update_topic_qos(this->id_, participant_->get_domain_id(),
+                               participant_->get_id(), qos_);
 
       if (!status) {
         ACE_ERROR_RETURN((LM_ERROR,

--- a/dds/DCPS/TopicImpl.h
+++ b/dds/DCPS/TopicImpl.h
@@ -72,18 +72,8 @@ public:
   */
   RepoId get_id() const;
 
-  CORBA::Long entity_refs() const {
-    return entity_refs_;
-  }
-
-  void add_entity_ref() {
-    entity_refs_++;
-  }
-
-  void remove_entity_ref() {
-    entity_refs_--;
-  }
-
+  // OpenDDS extension which doesn't duplicate the string to prevent
+  // the runtime costs of making a copy
   const char* type_name() const;
 
   virtual void transport_config(const TransportConfig_rch& cfg);
@@ -103,11 +93,8 @@ private:
   /// The id given by discovery.
   RepoId                       id_;
 
-  /// The number of DataReaders and DataWriters using this Topic.
-  CORBA::Long                  entity_refs_;
-
-  /// count of discovered (readers/writers using) topics with the same
-  ///  topic name but different characteristics (typename)
+  /// Count of discovered (readers/writers using) topics with the same
+  /// topic name but different characteristics (typename)
   DDS::InconsistentTopicStatus inconsistent_topic_status_;
 
   /// Pointer to the monitor object for this entity


### PR DESCRIPTION
…he topic description, removed not necessary dynamic casts, use _var

    * dds/DCPS/DataReaderImpl.cpp:
    * dds/DCPS/DataWriterImpl.cpp:
    * dds/DCPS/DomainParticipantImpl.cpp:
    * dds/DCPS/TopicDescriptionImpl.cpp:
    * dds/DCPS/TopicDescriptionImpl.h:
    * dds/DCPS/TopicImpl.cpp:
    * dds/DCPS/TopicImpl.h: