### PR TITLE
Remove datawriter pending_control operation, not used

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -2628,12 +2628,6 @@ DataWriterImpl::reschedule_deadline()
   }
 }
 
-bool
-DataWriterImpl::pending_control()
-{
-  return controlTracker.pending_messages();
-}
-
 void
 DataWriterImpl::wait_control_pending()
 {

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -544,11 +544,6 @@ protected:
                                          ACE_Message_Block* msg/*,
                                          void* extra = 0*/);
 
-  /**
-   * Answer if transport of all control messages is pending.
-   */
-  bool pending_control();
-
 private:
 
   void track_sequence_number(GUIDSeq* filter_out);

--- a/dds/DCPS/MessageTracker.h
+++ b/dds/DCPS/MessageTracker.h
@@ -42,6 +42,11 @@ namespace DCPS {
     void message_dropped();
 
     /**
+     * Answer if there are any messages that have not been accounted for.
+     */
+    bool pending_messages();
+
+    /**
      * Block until all messages have been account for.
      */
     void wait_messages_pending(OPENDDS_STRING& caller_message);
@@ -52,11 +57,6 @@ namespace DCPS {
     int dropped_count();
 
   private:
-    /**
-     * Answer if there are any messages that have not been accounted for.
-     */
-    bool pending_messages();
-
     const OPENDDS_STRING msg_src_;         // Source of tracked messages
     int                  dropped_count_;
     int                  delivered_count_; // Messages transmitted by transport layer

--- a/dds/DCPS/MessageTracker.h
+++ b/dds/DCPS/MessageTracker.h
@@ -42,11 +42,6 @@ namespace DCPS {
     void message_dropped();
 
     /**
-     * Answer if there are any messages that have not been accounted for.
-     */
-    bool pending_messages();
-
-    /**
      * Block until all messages have been account for.
      */
     void wait_messages_pending(OPENDDS_STRING& caller_message);
@@ -57,6 +52,10 @@ namespace DCPS {
     int dropped_count();
 
   private:
+    /**
+     * Answer if there are any messages that have not been accounted for.
+     */
+    bool pending_messages();
 
     const OPENDDS_STRING msg_src_;         // Source of tracked messages
     int                  dropped_count_;


### PR DESCRIPTION
    * dds/DCPS/DataWriterImpl.cpp:
    * dds/DCPS/DataWriterImpl.h:
    * dds/DCPS/MessageTracker.h: