### PR TITLE
FooTest3_0: check count of disposed instances

### DIFF
--- a/tests/DCPS/FooTest3_0/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.cpp
@@ -18,7 +18,8 @@
 #include <iostream>
 
 DataReaderListenerImpl::DataReaderListenerImpl()
-  : samples_read_(0)
+  : samples_read_(0),
+    samples_disposed_(0)
 {
 }
 
@@ -46,7 +47,7 @@ throw(CORBA::SystemException)
     DDS::ReturnCode_t status = foo_dr->take_next_sample(foo, si) ;
 
     if (status == DDS::RETCODE_OK) {
-      samples_read_++;
+      ++samples_read_;
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
       std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
 
@@ -54,6 +55,7 @@ throw(CORBA::SystemException)
         std::cout << "Foo sample processed" << std::endl;
       } else if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is disposed\n")));
+        ++samples_disposed_;
 
       } else if (si.instance_state == DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is unregistered\n")));

--- a/tests/DCPS/FooTest3_0/DataReaderListener.h
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.h
@@ -59,9 +59,14 @@ public:
     return samples_read_;
   }
 
+  long samples_disposed() const {
+    return samples_disposed_;
+  }
+
 private:
   DDS::DataReader_var  reader_;
   long                 samples_read_;
+  long                 samples_disposed_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/FooTest3_0/SubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/SubDriver.cpp
@@ -24,6 +24,7 @@ using namespace ::OpenDDS::DCPS;
 
 SubDriver::SubDriver()
   : num_writes_ (0),
+    num_disposed_ (0),
     shutdown_pub_ (1),
     add_new_subscription_ (0),
     shutdown_delay_secs_ (10),
@@ -81,6 +82,11 @@ SubDriver::parse_args(int& argc, ACE_TCHAR* argv[])
       else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-f"))) != 0)
         {
           sub_ready_filename_ = current_arg;
+          arg_shifter.consume_arg ();
+        }
+      else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-i"))) != 0)
+        {
+          num_disposed_ = ACE_OS::atoi (current_arg);;
           arg_shifter.consume_arg ();
         }
       else if (arg_shifter.cur_arg_strncasecmp(ACE_TEXT("-?")) == 0)
@@ -203,6 +209,8 @@ SubDriver::run()
     ACE_ERROR ((LM_ERROR,
       ACE_TEXT("(%P|%t) ERROR: participant_ should indicated it contains datareader_\n")));
   }
+
+  TEST_CHECK (this->listener_->samples_disposed() == num_disposed_);
 
   ::DDS::DomainParticipantFactory_var dpf = TheParticipantFactory;
   participant_->delete_contained_entities();

--- a/tests/DCPS/FooTest3_0/SubDriver.h
+++ b/tests/DCPS/FooTest3_0/SubDriver.h
@@ -32,6 +32,7 @@ class SubDriver
     void run();
 
     int               num_writes_;
+    int               num_disposed_;
 
     int               shutdown_pub_;
     int               add_new_subscription_;

--- a/tests/DCPS/FooTest3_0/run_test.pl
+++ b/tests/DCPS/FooTest3_0/run_test.pl
@@ -20,6 +20,7 @@ my $status = 0;
 # Configuration for default test - register test.
 my $test_to_run = 0;
 my $num_writes = 2;
+my $num_disposed = 0;
 my $n_chunks = 20; # Number of pre-allocated chunks for Dynamic_Cached_Allocator
 my $shutdown_pub = 1;
 my $add_new_subscription = 0;
@@ -32,6 +33,7 @@ if ($ARGV[0] eq 'unregister') {
 }
 elsif ($ARGV[0] eq 'dispose') {
     $test_to_run = 2;
+    $num_disposed = 1;
     $num_writes = 11;  # 1 dispose and 10 writes.
 }
 elsif ($ARGV[0] eq 'resume') {
@@ -84,7 +86,7 @@ my $subscriber = PerlDDS::create_process ("FooTest3_subscriber",
                                           " -DCPSInfoRepo file://$dcpsrepo_ior "
                                           . "$app_bit_conf -n $num_writes "
                                           . "-x $shutdown_pub "
-                                          . "-a $add_new_subscription -d $shutdown_delay_secs "
+                                          . "-a $add_new_subscription -d $shutdown_delay_secs -i $num_disposed"
                                           . "-f $sub_ready_file");
 
 print $subscriber->CommandLine(), "\n";


### PR DESCRIPTION
… correct number of disposed instance states in the listener

    * tests/DCPS/FooTest3_0/DataReaderListener.cpp:
    * tests/DCPS/FooTest3_0/DataReaderListener.h:
    * tests/DCPS/FooTest3_0/SubDriver.cpp:
    * tests/DCPS/FooTest3_0/SubDriver.h:
    * tests/DCPS/FooTest3_0/run_test.pl: