### PR TITLE
Test extension for reproducing issue with query condition

### DIFF
--- a/bin/dcps_short_tests.lst
+++ b/bin/dcps_short_tests.lst
@@ -24,6 +24,7 @@ tests/DCPS/Dispose/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl: !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl unregister: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl dispose: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
+tests/DCPS/FooTest3_0/run_test.pl dispose_qc: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_QUERY_CONDITION
 tests/DCPS/FooTest3_0/run_test.pl resume: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl listener: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl allocator: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -24,6 +24,7 @@ tests/DCPS/Dispose/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl: !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl unregister: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl dispose: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
+tests/DCPS/FooTest3_0/run_test.pl dispose_qc: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_QUERY_CONDITION
 tests/DCPS/FooTest3_0/run_test.pl resume: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl listener: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest3_0/run_test.pl allocator: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -894,7 +894,7 @@ namespace OpenDDS {
       DataSampleHeader header;
       header.message_id_ = i ? SAMPLE_DATA : INSTANCE_REGISTRATION;
       bool just_registered;
-      MessageType* data;
+      MessageType* data = 0;
       ACE_NEW_MALLOC_NORETURN(data,
                               static_cast< MessageType*>(data_allocator_->malloc(sizeof(MessageType))),
                               MessageType(sample));
@@ -1983,7 +1983,7 @@ void finish_store_instance_data(MessageType* instance_data, const DataSampleHead
     return;
   }
 
-  OpenDDS::DCPS::ReceivedDataElement *ptr;
+  OpenDDS::DCPS::ReceivedDataElement *ptr = 0;
   ACE_NEW_MALLOC (ptr,
                   static_cast<OpenDDS::DCPS::ReceivedDataElement *> (
                                                                       rd_allocator_->malloc (

--- a/tests/DCPS/FooTest3_0/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.cpp
@@ -18,7 +18,8 @@
 #include <iostream>
 
 DataReaderListenerImpl::DataReaderListenerImpl()
-  : samples_read_(0)
+  : samples_read_(0),
+    samples_disposed_(0)
 {
 }
 
@@ -46,7 +47,7 @@ throw(CORBA::SystemException)
     DDS::ReturnCode_t status = foo_dr->take_next_sample(foo, si) ;
 
     if (status == DDS::RETCODE_OK) {
-      samples_read_++;
+      ++samples_read_;
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
       std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
 
@@ -54,6 +55,7 @@ throw(CORBA::SystemException)
         std::cout << "Foo sample processed" << std::endl;
       } else if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is disposed\n")));
+        ++samples_disposed_;
 
       } else if (si.instance_state == DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is unregistered\n")));

--- a/tests/DCPS/FooTest3_0/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.cpp
@@ -43,7 +43,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     Xyz::Foo foo;
     DDS::SampleInfo si;
 
-    DDS::ReturnCode_t status = foo_dr->take_next_sample(foo, si) ;
+    const DDS::ReturnCode_t status = foo_dr->take_next_sample(foo, si) ;
 
     if (status == DDS::RETCODE_OK) {
       ++samples_read_;

--- a/tests/DCPS/FooTest3_0/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.cpp
@@ -28,7 +28,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     Xyz::FooDataReader_var foo_dr =
@@ -48,6 +47,7 @@ throw(CORBA::SystemException)
 
     if (status == DDS::RETCODE_OK) {
       ++samples_read_;
+      std::cout << "SampleInfo.valid_data = " << si.valid_data << std::endl;
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
       std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
 
@@ -83,7 +83,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -91,7 +90,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -99,7 +97,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -107,7 +104,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -115,7 +111,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -123,7 +118,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/FooTest3_0/DataReaderListener.h
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.h
@@ -59,9 +59,14 @@ public:
     return samples_read_;
   }
 
+  long samples_disposed() const {
+    return samples_disposed_;
+  }
+
 private:
   DDS::DataReader_var  reader_;
   long                 samples_read_;
+  long                 samples_disposed_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/FooTest3_0/DataReaderListener.h
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long samples_read() const {
     return samples_read_;
@@ -63,8 +56,7 @@ public:
     return samples_disposed_;
   }
 
-private:
-  DDS::DataReader_var  reader_;
+protected:
   long                 samples_read_;
   long                 samples_disposed_;
 };

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
@@ -18,8 +18,7 @@
 #include <iostream>
 
 DataReaderQCListenerImpl::DataReaderQCListenerImpl()
-  : samples_read_(0),
-    samples_disposed_(0)
+  : DataReaderListenerImpl()
 {
 }
 
@@ -28,7 +27,6 @@ DataReaderQCListenerImpl::~DataReaderQCListenerImpl()
 }
 
 void DataReaderQCListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     Xyz::FooDataReader_var foo_dr =
@@ -50,6 +48,7 @@ throw(CORBA::SystemException)
       for (CORBA::ULong index = 0; index < si.length(); index++)
         {
           ++samples_read_;
+          std::cout << "SampleInfo.valid_data = " << si[index].valid_data << std::endl;
           std::cout << "SampleInfo.sample_rank = " << si[index].sample_rank << std::endl;
           std::cout << "SampleInfo.instance_state = " << si[index].instance_state << std::endl;
 
@@ -80,54 +79,6 @@ throw(CORBA::SystemException)
     e._tao_print_exception("Exception caught in on_data_available():");
     ACE_OS::exit(-1);
   }
-}
-
-void DataReaderQCListenerImpl::on_requested_deadline_missed(
-  DDS::DataReader_ptr,
-  const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
-{
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
-}
-
-void DataReaderQCListenerImpl::on_requested_incompatible_qos(
-  DDS::DataReader_ptr,
-  const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
-{
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
-}
-
-void DataReaderQCListenerImpl::on_liveliness_changed(
-  DDS::DataReader_ptr,
-  const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
-{
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
-}
-
-void DataReaderQCListenerImpl::on_subscription_matched(
-  DDS::DataReader_ptr,
-  const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
-{
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
-}
-
-void DataReaderQCListenerImpl::on_sample_rejected(
-  DDS::DataReader_ptr,
-  const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
-{
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
-}
-
-void DataReaderQCListenerImpl::on_sample_lost(
-  DDS::DataReader_ptr,
-  const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
-{
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }
 
 void DataReaderQCListenerImpl::set_qc (

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
@@ -17,6 +17,8 @@
 
 #include <iostream>
 
+#ifndef OPENDDS_NO_QUERY_CONDITION
+
 DataReaderQCListenerImpl::DataReaderQCListenerImpl()
   : DataReaderListenerImpl()
 {
@@ -86,3 +88,5 @@ void DataReaderQCListenerImpl::set_qc (
 {
   qc_ = DDS::QueryCondition::_duplicate (qc);
 }
+
+#endif

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
@@ -1,0 +1,137 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_stdlib.h>
+
+#include <dds/DdsDcpsSubscriptionC.h>
+#include <dds/DCPS/Service_Participant.h>
+
+#include "DataReaderQCListener.h"
+#include "tests/DCPS/FooType3/FooDefTypeSupportC.h"
+#include "tests/DCPS/FooType3/FooDefTypeSupportImpl.h"
+
+#include <iostream>
+
+DataReaderQCListenerImpl::DataReaderQCListenerImpl()
+  : samples_read_(0),
+    samples_disposed_(0)
+{
+}
+
+DataReaderQCListenerImpl::~DataReaderQCListenerImpl()
+{
+}
+
+void DataReaderQCListenerImpl::on_data_available(DDS::DataReader_ptr reader)
+throw(CORBA::SystemException)
+{
+  try {
+    Xyz::FooDataReader_var foo_dr =
+      Xyz::FooDataReader::_narrow(reader);
+
+    if (CORBA::is_nil(foo_dr.in())) {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("%N:%l: on_data_available()")
+                 ACE_TEXT(" ERROR: _narrow failed!\n")));
+      ACE_OS::exit(-1);
+    }
+
+    Xyz::FooSeq foo;
+    DDS::SampleInfoSeq si;
+
+    DDS::ReturnCode_t status = foo_dr->take_w_condition(foo, si, 1, qc_.in ()) ;
+
+    if (status == DDS::RETCODE_OK) {
+      for (CORBA::ULong index = 0; index < si.length(); index++)
+        {
+          ++samples_read_;
+          std::cout << "SampleInfo.sample_rank = " << si[index].sample_rank << std::endl;
+          std::cout << "SampleInfo.instance_state = " << si[index].instance_state << std::endl;
+
+          if (si[index].valid_data) {
+            std::cout << "Foo sample processed" << std::endl;
+          } else if (si[index].instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is disposed\n")));
+            ++samples_disposed_;
+
+          } else if (si[index].instance_state == DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is unregistered\n")));
+
+          } else {
+            ACE_ERROR((LM_ERROR,
+                      ACE_TEXT("%N:%l: on_data_available()")
+                      ACE_TEXT(" ERROR: unknown instance state: %d\n"),
+                      si[index].instance_state));
+          }
+        }
+    } else {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("%N:%l: on_data_available()")
+                 ACE_TEXT(" ERROR: unexpected status: %d\n"),
+                 status));
+    }
+
+  } catch (const CORBA::Exception& e) {
+    e._tao_print_exception("Exception caught in on_data_available():");
+    ACE_OS::exit(-1);
+  }
+}
+
+void DataReaderQCListenerImpl::on_requested_deadline_missed(
+  DDS::DataReader_ptr,
+  const DDS::RequestedDeadlineMissedStatus &)
+throw(CORBA::SystemException)
+{
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
+}
+
+void DataReaderQCListenerImpl::on_requested_incompatible_qos(
+  DDS::DataReader_ptr,
+  const DDS::RequestedIncompatibleQosStatus &)
+throw(CORBA::SystemException)
+{
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
+}
+
+void DataReaderQCListenerImpl::on_liveliness_changed(
+  DDS::DataReader_ptr,
+  const DDS::LivelinessChangedStatus &)
+throw(CORBA::SystemException)
+{
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
+}
+
+void DataReaderQCListenerImpl::on_subscription_matched(
+  DDS::DataReader_ptr,
+  const DDS::SubscriptionMatchedStatus &)
+throw(CORBA::SystemException)
+{
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
+}
+
+void DataReaderQCListenerImpl::on_sample_rejected(
+  DDS::DataReader_ptr,
+  const DDS::SampleRejectedStatus&)
+throw(CORBA::SystemException)
+{
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
+}
+
+void DataReaderQCListenerImpl::on_sample_lost(
+  DDS::DataReader_ptr,
+  const DDS::SampleLostStatus&)
+throw(CORBA::SystemException)
+{
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
+}
+
+void DataReaderQCListenerImpl::set_qc (
+  DDS::QueryCondition_ptr qc)
+{
+  qc_ = DDS::QueryCondition::_duplicate (qc);
+}

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.cpp
@@ -42,7 +42,7 @@ void DataReaderQCListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     Xyz::FooSeq foo;
     DDS::SampleInfoSeq si;
 
-    DDS::ReturnCode_t status = foo_dr->take_w_condition(foo, si, 1, qc_.in ()) ;
+    const DDS::ReturnCode_t status = foo_dr->take_w_condition(foo, si, 1, qc_.in ()) ;
 
     if (status == DDS::RETCODE_OK) {
       for (CORBA::ULong index = 0; index < si.length(); index++)

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.h
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.h
@@ -14,6 +14,8 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#ifndef OPENDDS_NO_QUERY_CONDITION
+
 class DataReaderQCListenerImpl
   : public virtual DataReaderListenerImpl {
 public:
@@ -29,5 +31,7 @@ public:
 private:
   DDS::QueryCondition_var qc_;
 };
+
+#endif
 
 #endif /* DATAREADER_QCLISTENER_IMPL  */

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.h
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.h
@@ -8,67 +8,25 @@
 #ifndef DATAREADER_QCLISTENER_IMPL
 #define DATAREADER_QCLISTENER_IMPL
 
-#include <dds/DdsDcpsSubscriptionC.h>
+#include "DataReaderListener.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 class DataReaderQCListenerImpl
-  : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
+  : public virtual DataReaderListenerImpl {
 public:
   DataReaderQCListenerImpl();
 
   virtual ~DataReaderQCListenerImpl();
 
-  virtual void on_requested_deadline_missed(
-    DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
-
-  virtual void on_requested_incompatible_qos(
-    DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
-
-  virtual void on_liveliness_changed(
-    DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
-
-  virtual void on_subscription_matched(
-    DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
-
-  virtual void on_sample_rejected(
-    DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
-
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
-
-  virtual void on_sample_lost(
-    DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
-
-  long samples_read() const {
-    return samples_read_;
-  }
-
-  long samples_disposed() const {
-    return samples_disposed_;
-  }
+    DDS::DataReader_ptr reader);
 
   void set_qc (DDS::QueryCondition_ptr qc);
 
 private:
-  DDS::DataReader_var  reader_;
-  long                 samples_read_;
-  long                 samples_disposed_;
   DDS::QueryCondition_var qc_;
 };
 

--- a/tests/DCPS/FooTest3_0/DataReaderQCListener.h
+++ b/tests/DCPS/FooTest3_0/DataReaderQCListener.h
@@ -1,0 +1,75 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef DATAREADER_QCLISTENER_IMPL
+#define DATAREADER_QCLISTENER_IMPL
+
+#include <dds/DdsDcpsSubscriptionC.h>
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+class DataReaderQCListenerImpl
+  : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
+public:
+  DataReaderQCListenerImpl();
+
+  virtual ~DataReaderQCListenerImpl();
+
+  virtual void on_requested_deadline_missed(
+    DDS::DataReader_ptr reader,
+    const DDS::RequestedDeadlineMissedStatus& status)
+  throw(CORBA::SystemException);
+
+  virtual void on_requested_incompatible_qos(
+    DDS::DataReader_ptr reader,
+    const DDS::RequestedIncompatibleQosStatus& status)
+  throw(CORBA::SystemException);
+
+  virtual void on_liveliness_changed(
+    DDS::DataReader_ptr reader,
+    const DDS::LivelinessChangedStatus& status)
+  throw(CORBA::SystemException);
+
+  virtual void on_subscription_matched(
+    DDS::DataReader_ptr reader,
+    const DDS::SubscriptionMatchedStatus& status)
+  throw(CORBA::SystemException);
+
+  virtual void on_sample_rejected(
+    DDS::DataReader_ptr reader,
+    const DDS::SampleRejectedStatus& status)
+  throw(CORBA::SystemException);
+
+  virtual void on_data_available(
+    DDS::DataReader_ptr reader)
+  throw(CORBA::SystemException);
+
+  virtual void on_sample_lost(
+    DDS::DataReader_ptr reader,
+    const DDS::SampleLostStatus& status)
+  throw(CORBA::SystemException);
+
+  long samples_read() const {
+    return samples_read_;
+  }
+
+  long samples_disposed() const {
+    return samples_disposed_;
+  }
+
+  void set_qc (DDS::QueryCondition_ptr qc);
+
+private:
+  DDS::DataReader_var  reader_;
+  long                 samples_read_;
+  long                 samples_disposed_;
+  DDS::QueryCondition_var qc_;
+};
+
+#endif /* DATAREADER_QCLISTENER_IMPL  */

--- a/tests/DCPS/FooTest3_0/FooTest3_0.mpc
+++ b/tests/DCPS/FooTest3_0/FooTest3_0.mpc
@@ -23,5 +23,6 @@ project(*Subscriber): dcpsexe, dcps_transports_for_test {
     sub_main.cpp
     SubDriver.cpp
     DataReaderListener.cpp
+    DataReaderQCListener.cpp
   }
 }

--- a/tests/DCPS/FooTest3_0/SubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/SubDriver.cpp
@@ -24,6 +24,7 @@ using namespace ::OpenDDS::DCPS;
 
 SubDriver::SubDriver()
   : num_writes_ (0),
+    num_disposed_ (0),
     shutdown_pub_ (1),
     add_new_subscription_ (0),
     shutdown_delay_secs_ (10),
@@ -81,6 +82,11 @@ SubDriver::parse_args(int& argc, ACE_TCHAR* argv[])
       else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-f"))) != 0)
         {
           sub_ready_filename_ = current_arg;
+          arg_shifter.consume_arg ();
+        }
+      else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-i"))) != 0)
+        {
+          num_disposed_ = ACE_OS::atoi (current_arg);;
           arg_shifter.consume_arg ();
         }
       else if (arg_shifter.cur_arg_strncasecmp(ACE_TEXT("-?")) == 0)
@@ -203,6 +209,8 @@ SubDriver::run()
     ACE_ERROR ((LM_ERROR,
       ACE_TEXT("(%P|%t) ERROR: participant_ should indicated it contains datareader_\n")));
   }
+
+  TEST_CHECK (this->listener_->samples_disposed() == num_disposed_);
 
   ::DDS::DomainParticipantFactory_var dpf = TheParticipantFactory;
   participant_->delete_contained_entities();

--- a/tests/DCPS/FooTest3_0/SubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/SubDriver.cpp
@@ -206,7 +206,7 @@ SubDriver::init(int& argc, ACE_TCHAR* argv[])
 
     DDS::QueryCondition_var qc =
       datareader_->create_querycondition (DDS::NOT_READ_SAMPLE_STATE,
-                                          DDS::NEW_VIEW_STATE | DDS::NOT_NEW_VIEW_STATE,
+                                          DDS::ANY_VIEW_STATE,
                                           DDS::ANY_INSTANCE_STATE,
                                           "a_long_value = %0",
                                           params);

--- a/tests/DCPS/FooTest3_0/SubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/SubDriver.cpp
@@ -176,6 +176,7 @@ SubDriver::init(int& argc, ACE_TCHAR* argv[])
   std::cout << std::hex << "0x" << subscriber_->get_instance_handle() << std::endl;
 
   // Create datareader to test copy_from_topic_qos.
+#ifndef OPENDDS_NO_QUERY_CONDITION
   DataReaderQCListenerImpl* qc_listener = 0;
   if (qc_usage_)
   {
@@ -183,6 +184,7 @@ SubDriver::init(int& argc, ACE_TCHAR* argv[])
     listener_ = qc_listener;
   }
   else
+#endif
   {
     listener_ = new DataReaderListenerImpl;
   }
@@ -195,6 +197,7 @@ SubDriver::init(int& argc, ACE_TCHAR* argv[])
                                      ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   TEST_CHECK (! CORBA::is_nil (datareader_.in ()));
 
+#ifndef OPENDDS_NO_QUERY_CONDITION
   if (qc_usage_)
   {
     DDS::StringSeq params(1);
@@ -211,6 +214,7 @@ SubDriver::init(int& argc, ACE_TCHAR* argv[])
 
     qc_listener->set_qc (qc.in ());
   }
+#endif
 
   // Indicate that the subscriber is ready to accept connection
   FILE* readers_ready = ACE_OS::fopen (sub_ready_filename_.c_str (), ACE_TEXT("w"));

--- a/tests/DCPS/FooTest3_0/SubDriver.h
+++ b/tests/DCPS/FooTest3_0/SubDriver.h
@@ -32,6 +32,7 @@ class SubDriver
     void run();
 
     int               num_writes_;
+    int               num_disposed_;
 
     int               shutdown_pub_;
     int               add_new_subscription_;

--- a/tests/DCPS/FooTest3_0/SubDriver.h
+++ b/tests/DCPS/FooTest3_0/SubDriver.h
@@ -48,7 +48,6 @@ class SubDriver
     ::Xyz::FooDataReader_var     foo_datareader_;
 
     DataReaderListenerImpl*      listener_;
-    DataReaderQCListenerImpl*    qc_listener_;
     // Are we going to use the QueryCondition version of the listener
     bool                         qc_usage_;
 };

--- a/tests/DCPS/FooTest3_0/SubDriver.h
+++ b/tests/DCPS/FooTest3_0/SubDriver.h
@@ -12,7 +12,6 @@
 #include <vector>
 
 class DataReaderListenerImpl;
-class DataReaderQCListenerImpl;
 
 class SubDriver
 {

--- a/tests/DCPS/FooTest3_0/SubDriver.h
+++ b/tests/DCPS/FooTest3_0/SubDriver.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class DataReaderListenerImpl;
+class DataReaderQCListenerImpl;
 
 class SubDriver
 {
@@ -47,7 +48,9 @@ class SubDriver
     ::Xyz::FooDataReader_var     foo_datareader_;
 
     DataReaderListenerImpl*      listener_;
-
+    DataReaderQCListenerImpl*    qc_listener_;
+    // Are we going to use the QueryCondition version of the listener
+    bool                         qc_usage_;
 };
 
 #endif

--- a/tests/DCPS/FooTest3_0/run_test.pl
+++ b/tests/DCPS/FooTest3_0/run_test.pl
@@ -26,6 +26,7 @@ my $shutdown_pub = 1;
 my $add_new_subscription = 0;
 my $shutdown_delay_secs=10;
 my $sub_ready_file = "sub_ready.txt";
+my $use_qc = 0;
 
 if ($ARGV[0] eq 'unregister') {
     $test_to_run = 1;
@@ -34,6 +35,12 @@ if ($ARGV[0] eq 'unregister') {
 elsif ($ARGV[0] eq 'dispose') {
     $test_to_run = 2;
     $num_disposed = 1;
+    $num_writes = 11;  # 1 dispose and 10 writes.
+}
+elsif ($ARGV[0] eq 'dispose_qc') {
+    $test_to_run = 2;
+    $num_disposed = 1;
+    $use_qc = 1;
     $num_writes = 11;  # 1 dispose and 10 writes.
 }
 elsif ($ARGV[0] eq 'resume') {
@@ -86,7 +93,7 @@ my $subscriber = PerlDDS::create_process ("FooTest3_subscriber",
                                           " -DCPSInfoRepo file://$dcpsrepo_ior "
                                           . "$app_bit_conf -n $num_writes "
                                           . "-x $shutdown_pub "
-                                          . "-a $add_new_subscription -d $shutdown_delay_secs -i $num_disposed"
+                                          . "-a $add_new_subscription -d $shutdown_delay_secs -i $num_disposed -q $use_qc"
                                           . "-f $sub_ready_file");
 
 print $subscriber->CommandLine(), "\n";

--- a/tests/DCPS/FooTest3_0/run_test.pl
+++ b/tests/DCPS/FooTest3_0/run_test.pl
@@ -20,6 +20,7 @@ my $status = 0;
 # Configuration for default test - register test.
 my $test_to_run = 0;
 my $num_writes = 2;
+my $num_disposed = 0;
 my $n_chunks = 20; # Number of pre-allocated chunks for Dynamic_Cached_Allocator
 my $shutdown_pub = 1;
 my $add_new_subscription = 0;
@@ -32,6 +33,7 @@ if ($ARGV[0] eq 'unregister') {
 }
 elsif ($ARGV[0] eq 'dispose') {
     $test_to_run = 2;
+    $num_disposed = 1;
     $num_writes = 11;  # 1 dispose and 10 writes.
 }
 elsif ($ARGV[0] eq 'resume') {
@@ -84,7 +86,7 @@ my $subscriber = PerlDDS::create_process ("FooTest3_subscriber",
                                           " -DCPSInfoRepo file://$dcpsrepo_ior "
                                           . "$app_bit_conf -n $num_writes "
                                           . "-x $shutdown_pub "
-                                          . "-a $add_new_subscription -d $shutdown_delay_secs "
+                                          . "-a $add_new_subscription -d $shutdown_delay_secs -i $num_disposed"
                                           . "-f $sub_ready_file");
 
 print $subscriber->CommandLine(), "\n";


### PR DESCRIPTION
Extended test with new dispose_qc commandline option that uses a query condition to read the data in the listener. This should be similar to the dispose test case where we get one dispose but in case of a query condition we don't get a dispose but a no data when we try to read the dispose data. Not fixed yet, this is just the test extension for the moment