### PR TITLE
Removed deprecated throw exception specification in tests

### DIFF
--- a/tests/DCPS/FooTest3_2/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest3_2/DataReaderListener.cpp
@@ -28,7 +28,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     Xyz::FooDataReader_var foo_dr =
@@ -81,7 +80,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -89,7 +87,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -97,7 +94,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -105,7 +101,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -113,7 +108,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -121,7 +115,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/FooTest3_2/DataReaderListener.h
+++ b/tests/DCPS/FooTest3_2/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long samples_read() const {
     return samples_read_;

--- a/tests/DCPS/Footprint/DataReaderListener.cpp
+++ b/tests/DCPS/Footprint/DataReaderListener.cpp
@@ -38,7 +38,6 @@ DataReaderListenerImpl::is_reliable()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -122,7 +121,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -130,7 +128,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -138,7 +135,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -146,7 +142,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -154,7 +149,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -162,7 +156,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Footprint/DataReaderListener.h
+++ b/tests/DCPS/Footprint/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/GroupPresentation/DataReaderListener.cpp
+++ b/tests/DCPS/GroupPresentation/DataReaderListener.cpp
@@ -29,7 +29,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -92,7 +91,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -100,7 +98,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -108,7 +105,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -116,7 +112,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -124,7 +119,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -132,7 +126,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/GroupPresentation/DataReaderListener.h
+++ b/tests/DCPS/GroupPresentation/DataReaderListener.h
@@ -25,37 +25,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/LargeSample/DataReaderListener.cpp
+++ b/tests/DCPS/LargeSample/DataReaderListener.cpp
@@ -29,7 +29,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     Messenger::MessageDataReader_var message_dr =
@@ -154,7 +153,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -162,7 +160,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -170,7 +167,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus& status)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed() alive=%d, not alive=%d\n"),
              status.alive_count, status.not_alive_count));
@@ -179,7 +175,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -187,7 +182,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -195,7 +189,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/LargeSample/DataReaderListener.h
+++ b/tests/DCPS/LargeSample/DataReaderListener.h
@@ -25,37 +25,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_samples() const {
     return num_samples_;

--- a/tests/DCPS/ManyToMany/DataReaderListener.cpp
+++ b/tests/DCPS/ManyToMany/DataReaderListener.cpp
@@ -50,7 +50,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     Messenger::MessageDataReader_var message_dr =
@@ -146,7 +145,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T %N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -154,7 +152,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T %N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -162,7 +159,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus& status)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T %N:%l: INFO: on_liveliness_changed() alive=%d, not alive=%d\n"),
              status.alive_count, status.not_alive_count));
@@ -171,7 +167,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T %N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -179,7 +174,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T %N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -187,7 +181,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T %N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/ManyToMany/DataReaderListener.h
+++ b/tests/DCPS/ManyToMany/DataReaderListener.h
@@ -30,37 +30,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   bool done() const;
   void report_errors() const;

--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -38,7 +38,6 @@ DataReaderListenerImpl::is_reliable()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -122,7 +121,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -130,7 +128,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -138,7 +135,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -146,7 +142,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -154,7 +149,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -162,7 +156,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Messenger/DataReaderListener.h
+++ b/tests/DCPS/Messenger/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Monitor/DPMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DPMDataReaderListener.cpp
@@ -29,7 +29,6 @@ DPMDataReaderListenerImpl::~DPMDataReaderListenerImpl()
 }
 
 void DPMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::DomainParticipantReportDataReader_var dpm_dr =
@@ -90,7 +89,6 @@ throw(CORBA::SystemException)
 void DPMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -98,7 +96,6 @@ throw(CORBA::SystemException)
 void DPMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -106,7 +103,6 @@ throw(CORBA::SystemException)
 void DPMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -114,7 +110,6 @@ throw(CORBA::SystemException)
 void DPMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -122,7 +117,6 @@ throw(CORBA::SystemException)
 void DPMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -130,7 +124,6 @@ throw(CORBA::SystemException)
 void DPMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/DPMDataReaderListener.h
+++ b/tests/DCPS/Monitor/DPMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/DRMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DRMDataReaderListener.cpp
@@ -29,7 +29,6 @@ DRMDataReaderListenerImpl::~DRMDataReaderListenerImpl()
 }
 
 void DRMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::DataReaderReportDataReader_var drm_dr =
@@ -96,7 +95,6 @@ throw(CORBA::SystemException)
 void DRMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -104,7 +102,6 @@ throw(CORBA::SystemException)
 void DRMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -112,7 +109,6 @@ throw(CORBA::SystemException)
 void DRMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -120,7 +116,6 @@ throw(CORBA::SystemException)
 void DRMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -128,7 +123,6 @@ throw(CORBA::SystemException)
 void DRMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -136,7 +130,6 @@ throw(CORBA::SystemException)
 void DRMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/DRMDataReaderListener.h
+++ b/tests/DCPS/Monitor/DRMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/DRPerMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DRPerMDataReaderListener.cpp
@@ -29,7 +29,6 @@ DRPerMDataReaderListenerImpl::~DRPerMDataReaderListenerImpl()
 }
 
 void DRPerMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::DataReaderPeriodicReportDataReader_var drperm_dr =
@@ -90,7 +89,6 @@ throw(CORBA::SystemException)
 void DRPerMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -98,7 +96,6 @@ throw(CORBA::SystemException)
 void DRPerMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -106,7 +103,6 @@ throw(CORBA::SystemException)
 void DRPerMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -114,7 +110,6 @@ throw(CORBA::SystemException)
 void DRPerMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -122,7 +117,6 @@ throw(CORBA::SystemException)
 void DRPerMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -130,7 +124,6 @@ throw(CORBA::SystemException)
 void DRPerMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/DRPerMDataReaderListener.h
+++ b/tests/DCPS/Monitor/DRPerMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/DWMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DWMDataReaderListener.cpp
@@ -29,7 +29,6 @@ DWMDataReaderListenerImpl::~DWMDataReaderListenerImpl()
 }
 
 void DWMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::DataWriterReportDataReader_var dwm_dr =
@@ -95,7 +94,6 @@ throw(CORBA::SystemException)
 void DWMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -103,7 +101,6 @@ throw(CORBA::SystemException)
 void DWMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -111,7 +108,6 @@ throw(CORBA::SystemException)
 void DWMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -119,7 +115,6 @@ throw(CORBA::SystemException)
 void DWMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -127,7 +122,6 @@ throw(CORBA::SystemException)
 void DWMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -135,7 +129,6 @@ throw(CORBA::SystemException)
 void DWMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/DWMDataReaderListener.h
+++ b/tests/DCPS/Monitor/DWMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/DWPerMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DWPerMDataReaderListener.cpp
@@ -29,7 +29,6 @@ DWPerMDataReaderListenerImpl::~DWPerMDataReaderListenerImpl()
 }
 
 void DWPerMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::DataWriterPeriodicReportDataReader_var dwperm_dr =
@@ -94,7 +93,6 @@ throw(CORBA::SystemException)
 void DWPerMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -102,7 +100,6 @@ throw(CORBA::SystemException)
 void DWPerMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -110,7 +107,6 @@ throw(CORBA::SystemException)
 void DWPerMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -118,7 +114,6 @@ throw(CORBA::SystemException)
 void DWPerMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -126,7 +121,6 @@ throw(CORBA::SystemException)
 void DWPerMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -134,7 +128,6 @@ throw(CORBA::SystemException)
 void DWPerMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/DWPerMDataReaderListener.h
+++ b/tests/DCPS/Monitor/DWPerMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/DataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DataReaderListener.cpp
@@ -27,7 +27,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -87,7 +86,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -95,7 +93,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -103,7 +100,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -111,7 +107,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -119,7 +114,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -127,7 +121,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/DataReaderListener.h
+++ b/tests/DCPS/Monitor/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/Monitor/PublisherMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/PublisherMDataReaderListener.cpp
@@ -26,7 +26,6 @@ PublisherMDataReaderListenerImpl::~PublisherMDataReaderListenerImpl()
 }
 
 void PublisherMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::PublisherReportDataReader_var pubm_dr =
@@ -87,7 +86,6 @@ throw(CORBA::SystemException)
 void PublisherMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -95,7 +93,6 @@ throw(CORBA::SystemException)
 void PublisherMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -103,7 +100,6 @@ throw(CORBA::SystemException)
 void PublisherMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -111,7 +107,6 @@ throw(CORBA::SystemException)
 void PublisherMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -119,7 +114,6 @@ throw(CORBA::SystemException)
 void PublisherMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -127,7 +121,6 @@ throw(CORBA::SystemException)
 void PublisherMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/PublisherMDataReaderListener.h
+++ b/tests/DCPS/Monitor/PublisherMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/SPMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/SPMDataReaderListener.cpp
@@ -26,7 +26,6 @@ SPMDataReaderListenerImpl::~SPMDataReaderListenerImpl()
 }
 
 void SPMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::ServiceParticipantReportDataReader_var spm_dr =
@@ -91,7 +90,6 @@ throw(CORBA::SystemException)
 void SPMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -99,7 +97,6 @@ throw(CORBA::SystemException)
 void SPMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -107,7 +104,6 @@ throw(CORBA::SystemException)
 void SPMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -115,7 +111,6 @@ throw(CORBA::SystemException)
 void SPMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -123,7 +118,6 @@ throw(CORBA::SystemException)
 void SPMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -131,7 +125,6 @@ throw(CORBA::SystemException)
 void SPMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/SPMDataReaderListener.h
+++ b/tests/DCPS/Monitor/SPMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/SubscriberMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/SubscriberMDataReaderListener.cpp
@@ -26,7 +26,6 @@ SubscriberMDataReaderListenerImpl::~SubscriberMDataReaderListenerImpl()
 }
 
 void SubscriberMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::SubscriberReportDataReader_var subm_dr =
@@ -87,7 +86,6 @@ throw(CORBA::SystemException)
 void SubscriberMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -95,7 +93,6 @@ throw(CORBA::SystemException)
 void SubscriberMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -103,7 +100,6 @@ throw(CORBA::SystemException)
 void SubscriberMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -111,7 +107,6 @@ throw(CORBA::SystemException)
 void SubscriberMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -119,7 +114,6 @@ throw(CORBA::SystemException)
 void SubscriberMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -127,7 +121,6 @@ throw(CORBA::SystemException)
 void SubscriberMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/SubscriberMDataReaderListener.h
+++ b/tests/DCPS/Monitor/SubscriberMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/TopicMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/TopicMDataReaderListener.cpp
@@ -29,7 +29,6 @@ TopicMDataReaderListenerImpl::~TopicMDataReaderListenerImpl()
 }
 
 void TopicMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::TopicReportDataReader_var topicm_dr =
@@ -87,7 +86,6 @@ throw(CORBA::SystemException)
 void TopicMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -95,7 +93,6 @@ throw(CORBA::SystemException)
 void TopicMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -103,7 +100,6 @@ throw(CORBA::SystemException)
 void TopicMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -111,7 +107,6 @@ throw(CORBA::SystemException)
 void TopicMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -119,7 +114,6 @@ throw(CORBA::SystemException)
 void TopicMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -127,7 +121,6 @@ throw(CORBA::SystemException)
 void TopicMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/TopicMDataReaderListener.h
+++ b/tests/DCPS/Monitor/TopicMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Monitor/TransportMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/TransportMDataReaderListener.cpp
@@ -29,7 +29,6 @@ TransportMDataReaderListenerImpl::~TransportMDataReaderListenerImpl()
 }
 
 void TransportMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     OpenDDS::DCPS::TransportReportDataReader_var transportm_dr =
@@ -87,7 +86,6 @@ throw(CORBA::SystemException)
 void TransportMDataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -95,7 +93,6 @@ throw(CORBA::SystemException)
 void TransportMDataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -103,7 +100,6 @@ throw(CORBA::SystemException)
 void TransportMDataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -111,7 +107,6 @@ throw(CORBA::SystemException)
 void TransportMDataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -119,7 +114,6 @@ throw(CORBA::SystemException)
 void TransportMDataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -127,7 +121,6 @@ throw(CORBA::SystemException)
 void TransportMDataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Monitor/TransportMDataReaderListener.h
+++ b/tests/DCPS/Monitor/TransportMDataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
 private:
   DDS::DataReader_var  reader_;

--- a/tests/DCPS/Ownership/DataReaderListener.cpp
+++ b/tests/DCPS/Ownership/DataReaderListener.cpp
@@ -35,7 +35,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
 
   try {
@@ -101,7 +100,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus & status)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %s: on_requested_deadline_missed(): ")
           ACE_TEXT(" handle %d total_count_change %d \n"),
@@ -111,7 +109,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -119,7 +116,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus & status)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %s: on_liveliness_changed(): ")
           ACE_TEXT(" last pub handle %d alive_count %d change %d; not_alive_count %d change %d \n"),
@@ -131,7 +127,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -139,7 +134,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -147,7 +141,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/Ownership/DataReaderListener.h
+++ b/tests/DCPS/Ownership/DataReaderListener.h
@@ -32,37 +32,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/PubScalability/DataReaderListener.cpp
+++ b/tests/DCPS/PubScalability/DataReaderListener.cpp
@@ -28,7 +28,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   try {
     Xyz::SampleTypeDataReader_var foo_dr =
@@ -81,7 +80,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -89,7 +87,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -97,7 +94,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -105,7 +101,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -113,7 +108,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -121,7 +115,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/PubScalability/DataReaderListener.h
+++ b/tests/DCPS/PubScalability/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long samples_read() const {
     return samples_read_;

--- a/tests/DCPS/RtiSerialization/DataReaderListener.cpp
+++ b/tests/DCPS/RtiSerialization/DataReaderListener.cpp
@@ -38,7 +38,6 @@ DataReaderListenerImpl::is_reliable()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -116,7 +115,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -124,7 +122,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -132,7 +129,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -140,7 +136,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -148,7 +143,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -156,7 +150,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/RtiSerialization/DataReaderListener.h
+++ b/tests/DCPS/RtiSerialization/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/SubscriberCycle/SubscriberListenerImpl.cpp
+++ b/tests/DCPS/SubscriberCycle/SubscriberListenerImpl.cpp
@@ -81,19 +81,16 @@ SubscriberListenerImpl::on_data_on_readers(::DDS::Subscriber_ptr sub)
 void
 SubscriberListenerImpl::on_liveliness_changed(::DDS::DataReader_ptr,
                                               const ::DDS::LivelinessChangedStatus&)
-  throw(CORBA::SystemException)
 {
 }
 
 void
 SubscriberListenerImpl::on_subscription_matched(::DDS::DataReader_ptr ,
                                                 const ::DDS::SubscriptionMatchedStatus& )
-  throw(CORBA::SystemException)
 {
 }
 
 void SubscriberListenerImpl::on_data_available(::DDS::DataReader_ptr )
-  throw(CORBA::SystemException)
 {
 }
 
@@ -101,7 +98,6 @@ void
 SubscriberListenerImpl::on_requested_deadline_missed (::DDS::DataReader_ptr /*reader*/,
                                                       const ::DDS::RequestedDeadlineMissedStatus& /*status*/
                                                       )
-  throw(CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT("(%P|%t) Subscriber deadline missed\n")));
@@ -112,7 +108,6 @@ SubscriberListenerImpl::on_requested_deadline_missed (::DDS::DataReader_ptr /*re
 void
 SubscriberListenerImpl::on_requested_incompatible_qos(::DDS::DataReader_ptr ,
                                                       const ::DDS::RequestedIncompatibleQosStatus&)
-  throw(CORBA::SystemException)
 {
   ACE_DEBUG ((LM_DEBUG,
               ACE_TEXT("(%P|%t) Subscriber incompatible QoS\n")));
@@ -121,13 +116,11 @@ SubscriberListenerImpl::on_requested_incompatible_qos(::DDS::DataReader_ptr ,
 void
 SubscriberListenerImpl::on_sample_rejected(::DDS::DataReader_ptr,
                                            const ::DDS::SampleRejectedStatus&)
-  throw(CORBA::SystemException)
 {
 }
 
 void
 SubscriberListenerImpl::on_sample_lost(::DDS::DataReader_ptr,
                                        const ::DDS::SampleLostStatus&)
-  throw(CORBA::SystemException)
 {
 }

--- a/tests/DCPS/SubscriberCycle/SubscriberListenerImpl.h
+++ b/tests/DCPS/SubscriberCycle/SubscriberListenerImpl.h
@@ -24,36 +24,28 @@ class SubscriberListenerImpl
   virtual void on_data_on_readers(::DDS::Subscriber_ptr sub);
 
   virtual void on_liveliness_changed(::DDS::DataReader_ptr,
-                                     const ::DDS::LivelinessChangedStatus&)
-    throw(CORBA::SystemException);
+                                     const ::DDS::LivelinessChangedStatus&);
 
   virtual void on_subscription_matched(::DDS::DataReader_ptr ,
-                                       const ::DDS::SubscriptionMatchedStatus& )
-    throw(CORBA::SystemException);
+                                       const ::DDS::SubscriptionMatchedStatus& );
 
-  virtual void on_data_available(::DDS::DataReader_ptr )
-    throw(CORBA::SystemException);
+  virtual void on_data_available(::DDS::DataReader_ptr );
 
   virtual void
     on_requested_deadline_missed (::DDS::DataReader_ptr reader,
-                                  const ::DDS::RequestedDeadlineMissedStatus& status
-                                  )
-    throw(CORBA::SystemException);
+                                  const ::DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void
     on_requested_incompatible_qos(::DDS::DataReader_ptr ,
-                                  const ::DDS::RequestedIncompatibleQosStatus&)
-    throw(CORBA::SystemException);
+                                  const ::DDS::RequestedIncompatibleQosStatus&);
 
   virtual void
     on_sample_rejected(::DDS::DataReader_ptr,
-                       const ::DDS::SampleRejectedStatus&)
-    throw(CORBA::SystemException);
+                       const ::DDS::SampleRejectedStatus&);
 
   virtual void
     on_sample_lost(::DDS::DataReader_ptr,
-                   const ::DDS::SampleLostStatus&)
-    throw(CORBA::SystemException);
+                   const ::DDS::SampleLostStatus&);
 
  private:
   std::size_t& received_samples_;

--- a/tests/DCPS/TcpReconnect/DataReaderListener.cpp
+++ b/tests/DCPS/TcpReconnect/DataReaderListener.cpp
@@ -38,7 +38,6 @@ DataReaderListenerImpl::is_reliable()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -125,7 +124,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -133,7 +131,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -141,7 +138,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -149,7 +145,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -157,7 +152,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -165,7 +159,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/TcpReconnect/DataReaderListener.h
+++ b/tests/DCPS/TcpReconnect/DataReaderListener.h
@@ -23,37 +23,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;

--- a/tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.cpp
+++ b/tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.cpp
@@ -27,7 +27,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
-throw(CORBA::SystemException)
 {
   ++num_reads_;
 
@@ -92,7 +91,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_deadline_missed(
   DDS::DataReader_ptr,
   const DDS::RequestedDeadlineMissedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
 }
@@ -100,7 +98,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_requested_incompatible_qos(
   DDS::DataReader_ptr,
   const DDS::RequestedIncompatibleQosStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
 }
@@ -108,7 +105,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_liveliness_changed(
   DDS::DataReader_ptr,
   const DDS::LivelinessChangedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
 }
@@ -116,7 +112,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
   const DDS::SubscriptionMatchedStatus &)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
 }
@@ -124,7 +119,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_rejected(
   DDS::DataReader_ptr,
   const DDS::SampleRejectedStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
 }
@@ -132,7 +126,6 @@ throw(CORBA::SystemException)
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
-throw(CORBA::SystemException)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
 }

--- a/tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.h
+++ b/tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.h
@@ -24,37 +24,30 @@ public:
 
   virtual void on_requested_deadline_missed(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedDeadlineMissedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedDeadlineMissedStatus& status);
 
   virtual void on_requested_incompatible_qos(
     DDS::DataReader_ptr reader,
-    const DDS::RequestedIncompatibleQosStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::RequestedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_changed(
     DDS::DataReader_ptr reader,
-    const DDS::LivelinessChangedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::LivelinessChangedStatus& status);
 
   virtual void on_subscription_matched(
     DDS::DataReader_ptr reader,
-    const DDS::SubscriptionMatchedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SubscriptionMatchedStatus& status);
 
   virtual void on_sample_rejected(
     DDS::DataReader_ptr reader,
-    const DDS::SampleRejectedStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleRejectedStatus& status);
 
   virtual void on_data_available(
-    DDS::DataReader_ptr reader)
-  throw(CORBA::SystemException);
+    DDS::DataReader_ptr reader);
 
   virtual void on_sample_lost(
     DDS::DataReader_ptr reader,
-    const DDS::SampleLostStatus& status)
-  throw(CORBA::SystemException);
+    const DDS::SampleLostStatus& status);
 
   long num_reads() const {
     return num_reads_;


### PR DESCRIPTION
…hat is changed on another branch already

    * tests/DCPS/FooTest3_2/DataReaderListener.cpp:
    * tests/DCPS/FooTest3_2/DataReaderListener.h:
    * tests/DCPS/Footprint/DataReaderListener.cpp:
    * tests/DCPS/Footprint/DataReaderListener.h:
    * tests/DCPS/GroupPresentation/DataReaderListener.cpp:
    * tests/DCPS/GroupPresentation/DataReaderListener.h:
    * tests/DCPS/LargeSample/DataReaderListener.cpp:
    * tests/DCPS/LargeSample/DataReaderListener.h:
    * tests/DCPS/ManyToMany/DataReaderListener.cpp:
    * tests/DCPS/ManyToMany/DataReaderListener.h:
    * tests/DCPS/Messenger/DataReaderListener.cpp:
    * tests/DCPS/Messenger/DataReaderListener.h:
    * tests/DCPS/Monitor/DPMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DPMDataReaderListener.h:
    * tests/DCPS/Monitor/DRMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DRMDataReaderListener.h:
    * tests/DCPS/Monitor/DRPerMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DRPerMDataReaderListener.h:
    * tests/DCPS/Monitor/DWMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DWMDataReaderListener.h:
    * tests/DCPS/Monitor/DWPerMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DWPerMDataReaderListener.h:
    * tests/DCPS/Monitor/DataReaderListener.cpp:
    * tests/DCPS/Monitor/DataReaderListener.h:
    * tests/DCPS/Monitor/PublisherMDataReaderListener.cpp:
    * tests/DCPS/Monitor/PublisherMDataReaderListener.h:
    * tests/DCPS/Monitor/SPMDataReaderListener.cpp:
    * tests/DCPS/Monitor/SPMDataReaderListener.h:
    * tests/DCPS/Monitor/SubscriberMDataReaderListener.cpp:
    * tests/DCPS/Monitor/SubscriberMDataReaderListener.h:
    * tests/DCPS/Monitor/TopicMDataReaderListener.cpp:
    * tests/DCPS/Monitor/TopicMDataReaderListener.h:
    * tests/DCPS/Monitor/TransportMDataReaderListener.cpp:
    * tests/DCPS/Monitor/TransportMDataReaderListener.h:
    * tests/DCPS/Ownership/DataReaderListener.cpp:
    * tests/DCPS/Ownership/DataReaderListener.h:
    * tests/DCPS/PubScalability/DataReaderListener.cpp:
    * tests/DCPS/PubScalability/DataReaderListener.h:
    * tests/DCPS/RtiSerialization/DataReaderListener.cpp:
    * tests/DCPS/RtiSerialization/DataReaderListener.h:
    * tests/DCPS/SubscriberCycle/SubscriberListenerImpl.cpp:
    * tests/DCPS/SubscriberCycle/SubscriberListenerImpl.h:
    * tests/DCPS/TcpReconnect/DataReaderListener.cpp:
    * tests/DCPS/TcpReconnect/DataReaderListener.h:
    * tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.cpp:
    * tests/DCPS/ZeroCopyDataReaderListener/DataReaderListener.h: