### PR TITLE
Sample lost test extension

### DIFF
--- a/dds/DdsDcpsSubscriptionExt.idl
+++ b/dds/DdsDcpsSubscriptionExt.idl
@@ -44,38 +44,38 @@ module OpenDDS
 
     local interface DataReaderListener : ::DDS::DataReaderListener {
 
-      // Called when a connection failure has been detected
-      // and there are still associations using the connection
-      // after the configurable graceful_disconnected_period.
-      // When connection is gracefully disconnected, this callback
-      // is also triggered.
+      /// Called when a connection failure has been detected
+      /// and there are still associations using the connection
+      /// after the configurable graceful_disconnected_period.
+      /// When connection is gracefully disconnected, this callback
+      /// is also triggered.
       void on_subscription_disconnected(
         in ::DDS::DataReader reader,
         in SubscriptionDisconnectedStatus status);
 
-      // Called when a disconnected connection
-      // has been reconnected.
+      /// Called when a disconnected connection
+      /// has been reconnected.
       void on_subscription_reconnected(
         in ::DDS::DataReader reader,
         in SubscriptionReconnectedStatus status);
 
-      // called when a connection is lost and hence one
-      // or more associations from this subscription to
-      // some publishers have been lost.
-      // A connection is "lost" when the retry attempts
-      // have been exhausted.
+      /// Called when a connection is lost and hence one
+      /// or more associations from this subscription to
+      /// some publishers have been lost.
+      /// A connection is "lost" when the retry attempts
+      /// have been exhausted.
       void on_subscription_lost(
         in ::DDS::DataReader reader,
         in SubscriptionLostStatus status);
 
-      // called when the connection object is cleaned up and
-      // the reconnect thread exits.
-      // This hook is added for testing the reconnect thread
-      // leaking problem when the subscriber crashes.
+      /// Called when the connection object is cleaned up and
+      /// the reconnect thread exits.
+      /// This hook is added for testing the reconnect thread
+      /// leaking problem when the subscriber crashes.
       void on_connection_deleted(
         in ::DDS::DataReader reader);
 
-      // Called when the latency budget has been exceeded.
+      /// Called when the latency budget has been exceeded.
       void on_budget_exceeded(
         in ::DDS::DataReader reader,
         in BudgetExceededStatus status);

--- a/tests/DCPS/SampleLost/DataReaderListener.cpp
+++ b/tests/DCPS/SampleLost/DataReaderListener.cpp
@@ -10,7 +10,8 @@
 using namespace Messenger;
 
 DataReaderListenerImpl::DataReaderListenerImpl()
-  : num_reads_(0)
+  : num_reads_(0),
+    num_samples_lost_ (0)
 {
 }
 
@@ -98,6 +99,8 @@ void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
 {
+  ++this->num_samples_lost_;
+
   cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
 }
 

--- a/tests/DCPS/SampleLost/DataReaderListener.cpp
+++ b/tests/DCPS/SampleLost/DataReaderListener.cpp
@@ -11,7 +11,9 @@ using namespace Messenger;
 
 DataReaderListenerImpl::DataReaderListenerImpl()
   : num_reads_(0),
-    num_samples_lost_ (0)
+    num_samples_lost_ (0),
+    num_samples_rejected_ (0),
+    num_budget_exceeded_ (0)
 {
 }
 
@@ -92,6 +94,8 @@ DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
 {
+  ++this->num_samples_rejected_;
+
   cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
 }
 
@@ -129,6 +133,8 @@ void DataReaderListenerImpl::on_budget_exceeded (
   DDS::DataReader_ptr,
   const ::OpenDDS::DCPS::BudgetExceededStatus&)
 {
+  ++this->num_budget_exceeded_;
+
   cerr << "DataReaderListenerImpl::on_budget_exceeded" << endl;
 }
 

--- a/tests/DCPS/SampleLost/DataReaderListener.cpp
+++ b/tests/DCPS/SampleLost/DataReaderListener.cpp
@@ -92,20 +92,30 @@ DataReaderListenerImpl::on_subscription_matched (
 void
 DataReaderListenerImpl::on_sample_rejected (
     DDS::DataReader_ptr,
-    const DDS::SampleRejectedStatus&)
+    const DDS::SampleRejectedStatus& status)
 {
   ++this->num_samples_rejected_;
 
-  cerr << "DataReaderListenerImpl::on_sample_rejected" << endl;
+  cerr << "DataReaderListenerImpl::on_sample_rejected, "
+       << " total_count <" << status.total_count
+       << "> total_count_change <" << status.total_count_change
+       << "> last_reason <" << status.last_reason
+       << "> last_instance_handle <" << status.last_instance_handle
+       << ">"
+       << endl;
 }
 
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
-  const DDS::SampleLostStatus&)
+  const DDS::SampleLostStatus& status)
 {
   ++this->num_samples_lost_;
 
-  cerr << "DataReaderListenerImpl::on_sample_lost" << endl;
+  cerr << "DataReaderListenerImpl::on_sample_lost, "
+       << " total_count <" << status.total_count
+       << "> total_count_change <" << status.total_count_change
+       << ">"
+       << endl;
 }
 
 void DataReaderListenerImpl::on_subscription_disconnected (

--- a/tests/DCPS/SampleLost/DataReaderListener.h
+++ b/tests/DCPS/SampleLost/DataReaderListener.h
@@ -68,10 +68,15 @@ public:
     return num_reads_;
   }
 
+  long num_samples_lost () const {
+    return num_samples_lost_;
+  }
+
 private:
 
   DDS::DataReader_var reader_;
-  long                  num_reads_;
+  long num_reads_;
+  long num_samples_lost_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/SampleLost/DataReaderListener.h
+++ b/tests/DCPS/SampleLost/DataReaderListener.h
@@ -71,12 +71,19 @@ public:
   long num_samples_lost () const {
     return num_samples_lost_;
   }
-
+  long num_samples_rejected () const {
+    return num_samples_rejected_;
+  }
+  long num_budget_exceeded () const {
+    return num_budget_exceeded_;
+  }
 private:
 
   DDS::DataReader_var reader_;
   long num_reads_;
   long num_samples_lost_;
+  long num_samples_rejected_;
+  long num_budget_exceeded_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/SampleLost/subscriber.cpp
+++ b/tests/DCPS/SampleLost/subscriber.cpp
@@ -117,14 +117,13 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       int const expected = 10;
       while (listener_servant->num_reads() < expected)
       {
-        cerr << "Got " << listener_servant->num_reads() << endl;
+        cerr << "Got " << listener_servant->num_reads() << " number of reads" << endl;
         ACE_OS::sleep (1);
       }
 
-      if (listener_servant->num_samples_lost () == 0)
-      {
-        cerr << "ERROR: Did not got sample lost callbacks" << endl;
-      }
+      cerr << "Got " << listener_servant->num_samples_lost() << " sample lost callbacks" << endl;
+      cerr << "Got " << listener_servant->num_samples_rejected() << " sample rejected callbacks" << endl;
+      cerr << "Got " << listener_servant->num_budget_exceeded() << " budget exceeded callbacks" << endl;
 
       if (!CORBA::is_nil (participant.in ())) {
         participant->delete_contained_entities();

--- a/tests/DCPS/SampleLost/subscriber.cpp
+++ b/tests/DCPS/SampleLost/subscriber.cpp
@@ -123,7 +123,9 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
       cerr << "Got " << listener_servant->num_samples_lost() << " sample lost callbacks" << endl;
       cerr << "Got " << listener_servant->num_samples_rejected() << " sample rejected callbacks" << endl;
-      cerr << "Got " << listener_servant->num_budget_exceeded() << " budget exceeded callbacks" << endl;
+      if (listener_servant->num_budget_exceeded() > 0) {
+        cerr << "ERROR: Got " << listener_servant->num_budget_exceeded() << " budget exceeded callbacks" << endl;
+      }
 
       if (!CORBA::is_nil (participant.in ())) {
         participant->delete_contained_entities();

--- a/tests/DCPS/SampleLost/subscriber.cpp
+++ b/tests/DCPS/SampleLost/subscriber.cpp
@@ -121,6 +121,11 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         ACE_OS::sleep (1);
       }
 
+      if (listener_servant->num_samples_lost () == 0)
+      {
+        cerr << "ERROR: Did not got sample lost callbacks" << endl;
+      }
+
       if (!CORBA::is_nil (participant.in ())) {
         participant->delete_contained_entities();
       }


### PR DESCRIPTION
Extend the test to log the number of sample lost, sample rejected, and budget exceeded callbacks