### PR TITLE
According to the DDS specification get_key_value should return RETCOD…

### DIFF
--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -663,7 +663,7 @@ namespace OpenDDS {
           }
       }
 
-    return DDS::RETCODE_ERROR;
+    return DDS::RETCODE_BAD_PARAMETER;
   }
 
   virtual DDS::InstanceHandle_t lookup_instance (const MessageType & instance_data)

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -267,7 +267,7 @@ namespace OpenDDS {
             }
         }
 
-      return DDS::RETCODE_ERROR;
+      return DDS::RETCODE_BAD_PARAMETER;
     }
 
   virtual DDS::InstanceHandle_t lookup_instance (

--- a/tests/DCPS/FooTest3_0/PubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/PubDriver.cpp
@@ -480,6 +480,9 @@ PubDriver::register_test ()
   TEST_CHECK(key_holder.sample_sequence == foo1.sample_sequence);
   TEST_CHECK(key_holder.writer_id == foo1.writer_id);
 
+  ret = foo_datawriter_->get_key_value(key_holder, ::DDS::HANDLE_NIL);
+  TEST_CHECK(ret == ::DDS::RETCODE_BAD_PARAMETER);
+
   for (CORBA::Long i = 1; i <= 2; i ++)
   {
     foo2.a_long_value = 101010;

--- a/tests/DCPS/FooTest4/Reader.cpp
+++ b/tests/DCPS/FooTest4/Reader.cpp
@@ -4,6 +4,7 @@
 #include "Reader.h"
 #include "../common/SampleInfo.h"
 #include "../common/TestException.h"
+#include "../common/TestSupport.h"
 #include "dds/DCPS/transport/framework/ReceivedDataSample.h"
 #include "dds/DCPS/Service_Participant.h"
 #include "dds/DCPS/Serializer.h"
@@ -177,7 +178,8 @@ Reader::start1 ()
 
       PrintSampleInfo(si[0]);
 
-      foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+      status = foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+      TEST_CHECK(status == ::DDS::RETCODE_OK);
 
       PrintSampleInfo(si[0]) ;
 
@@ -212,7 +214,11 @@ Reader::start1 ()
 
               PrintSampleInfo(si[0]);
 
-              foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+              status = foo_dr->get_key_value(key_holder, ::DDS::HANDLE_NIL) ;
+              TEST_CHECK(status == ::DDS::RETCODE_BAD_PARAMETER);
+
+              status = foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+              TEST_CHECK(status == ::DDS::RETCODE_OK);
               ACE_OS::printf (
                   "get_key_value: handle = %d foo.x = %f foo.y = %f, foo.key = %d\n",
                   si[0].instance_handle,
@@ -255,7 +261,11 @@ Reader::start1 ()
 
       PrintSampleInfo(si[0]);
 
-      foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+      status = foo_dr->get_key_value(key_holder, ::DDS::HANDLE_NIL) ;
+      TEST_CHECK(status == ::DDS::RETCODE_BAD_PARAMETER);
+
+      status = foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+      TEST_CHECK(status == ::DDS::RETCODE_OK);
 
       ACE_OS::printf (
           "get_key_value: handle = %d foo.x = %f foo.y = %f, foo.key = %d\n",
@@ -291,7 +301,11 @@ Reader::start1 ()
 
               PrintSampleInfo(si[0]);
 
-              foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+              status = foo_dr->get_key_value(key_holder, ::DDS::HANDLE_NIL) ;
+              TEST_CHECK(status == ::DDS::RETCODE_BAD_PARAMETER);
+
+              status = foo_dr->get_key_value(key_holder, si[0].instance_handle) ;
+              TEST_CHECK(status == ::DDS::RETCODE_OK);
               ACE_OS::printf (
                   "get_key_value: handle = %d foo.x = %f foo.y = %f, foo.key = %d\n",
                   si[0].instance_handle,

--- a/tests/DCPS/MultiTopic/MultiTopicTest.cpp
+++ b/tests/DCPS/MultiTopic/MultiTopicTest.cpp
@@ -187,6 +187,11 @@ bool run_multitopic_test(const Publisher_var& pub, const Subscriber_var& sub)
         strcmp(data[0].misc, ui.misc)) {
       return false;
     }
+    // Check return get_key_value
+    Resulting resulting_value;
+    ret = res_dr->get_key_value(resulting_value, DDS::HANDLE_NIL);
+    if (ret != RETCODE_BAD_PARAMETER) return false;
+
     data.length(0);
     info.length(0);
     ret = res_dr->read_w_condition(data, info, LENGTH_UNLIMITED, rc);


### PR DESCRIPTION
…E_BAD_PARAMETER at the moment an unknown handle is passed. This fixes issue #592

    * dds/DCPS/DataReaderImpl_T.h:
    * dds/DCPS/DataWriterImpl_T.h:
    * tests/DCPS/FooTest3_0/PubDriver.cpp:
    * tests/DCPS/FooTest4/Reader.cpp:
    * tests/DCPS/MultiTopic/MultiTopicTest.cpp: