### PR TITLE
Removed initialized_ flag, was only used to check if some points need…

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -77,7 +77,6 @@ DataReaderImpl::DataReaderImpl()
     last_deadline_missed_total_count_(0),
     watchdog_(),
     is_bit_(false),
-    initialized_(false),
     always_get_history_(false),
     statistics_enabled_(false),
     raw_latency_buffer_size_(0),
@@ -153,9 +152,7 @@ DataReaderImpl::~DataReaderImpl()
   liveliness_timer_->cancel_timer();
   liveliness_timer_->wait();
 
-  if (initialized_) {
-    delete rd_allocator_;
-  }
+  delete rd_allocator_;
 }
 
 // this method is called when delete_datareader is called.
@@ -276,8 +273,6 @@ void DataReaderImpl::init(
         ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::init() - ")
         ACE_TEXT("failed to get SubscriberQos\n")));
   }
-
-  initialized_ = true;
 }
 
 DDS::InstanceHandle_t

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -802,8 +802,6 @@ private:
   /// datareader.
   bool is_bit_;
 
-  /// Flag indicates that the init() is called.
-  bool initialized_;
   bool always_get_history_;
 
   /// Flag indicating status of statistics gathering.

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -83,7 +83,6 @@ DataWriterImpl::DataWriterImpl()
     watchdog_(),
     cancel_timer_(false),
     is_bit_(false),
-    initialized_(false),
     min_suspended_transaction_id_(0),
     max_suspended_transaction_id_(0),
     monitor_(0),
@@ -123,12 +122,10 @@ DataWriterImpl::~DataWriterImpl()
 {
   DBG_ENTRY_LVL("DataWriterImpl","~DataWriterImpl",6);
 
-  if (initialized_) {
-    delete data_container_;
-    delete mb_allocator_;
-    delete db_allocator_;
-    delete header_allocator_;
-  }
+  delete data_container_;
+  delete mb_allocator_;
+  delete db_allocator_;
+  delete header_allocator_;
   delete db_lock_pool_;
 }
 
@@ -192,8 +189,6 @@ DataWriterImpl::init(
   publisher_servant_ = publisher_servant;
 
   this->reactor_ = TheServiceParticipant->timer();
-
-  initialized_ = true;
 }
 
 DDS::InstanceHandle_t

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -671,9 +671,6 @@ private:
   /// datawriter.
   bool                       is_bit_;
 
-  /// Flag indicates that the init() is called.
-  bool                       initialized_;
-
   RepoIdSet pending_readers_, assoc_complete_readers_;
 
   /// The cached available data while suspending and associated transaction ids.

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -316,9 +316,6 @@ private:
   /// datawriter.
   bool is_bit_;
 
-  /// Flag indicates that the init() is called.
-  // bool                       initialized_;
-
   typedef OPENDDS_MAP_CMP(RepoId, SequenceNumber, GUID_tKeyLessThan)
   RepoIdToSequenceMap;
 


### PR DESCRIPTION
… to be deleted, but at the moment we haven't allocated them they are zero which is not a problem when calling delete on them

    * dds/DCPS/DataReaderImpl.cpp:
    * dds/DCPS/DataReaderImpl.h:
    * dds/DCPS/DataWriterImpl.cpp:
    * dds/DCPS/DataWriterImpl.h:
    * dds/DCPS/ReplayerImpl.h: