### PR TITLE
Added missing includes for static builds

### DIFF
--- a/tests/DCPS/DPFactoryQos/publisher.cpp
+++ b/tests/DCPS/DPFactoryQos/publisher.cpp
@@ -14,6 +14,10 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include "dds/DCPS/StaticIncludes.h"
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"

--- a/tests/DCPS/DPFactoryQos/subscriber.cpp
+++ b/tests/DCPS/DPFactoryQos/subscriber.cpp
@@ -16,6 +16,10 @@
 #include <dds/DCPS/SubscriberImpl.h>
 #include <dds/DCPS/Qos_Helper.h>
 #include "dds/DCPS/StaticIncludes.h"
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"

--- a/tests/DCPS/Lifespan/publisher.cpp
+++ b/tests/DCPS/Lifespan/publisher.cpp
@@ -15,6 +15,10 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include "dds/DCPS/StaticIncludes.h"
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 #include "dds/DCPS/scoped_ptr.h"
 
 #include <ace/streams.h>

--- a/tests/DCPS/Lifespan/subscriber.cpp
+++ b/tests/DCPS/Lifespan/subscriber.cpp
@@ -16,6 +16,10 @@
 #include <dds/DCPS/SubscriberImpl.h>
 
 #include "dds/DCPS/StaticIncludes.h"
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include <ace/streams.h>
 #include "tests/Utils/ExceptionStreams.h"

--- a/tests/DCPS/LivelinessTimeout/publisher.cpp
+++ b/tests/DCPS/LivelinessTimeout/publisher.cpp
@@ -20,6 +20,10 @@
 #include "DataWriterListenerImpl.h"
 
 #include "dds/DCPS/StaticIncludes.h"
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include "ace/Arg_Shifter.h"
 #include "ace/Reactor.h"

--- a/tests/DCPS/LivelinessTimeout/subscriber.cpp
+++ b/tests/DCPS/LivelinessTimeout/subscriber.cpp
@@ -21,6 +21,10 @@
 #include "dds/DCPS/transport/framework/EntryExit.h"
 
 #include "dds/DCPS/StaticIncludes.h"
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include "ace/Arg_Shifter.h"
 


### PR DESCRIPTION
    * tests/DCPS/DPFactoryQos/publisher.cpp:
    * tests/DCPS/DPFactoryQos/subscriber.cpp:
    * tests/DCPS/Lifespan/publisher.cpp:
    * tests/DCPS/Lifespan/subscriber.cpp:
    * tests/DCPS/LivelinessTimeout/publisher.cpp:
    * tests/DCPS/LivelinessTimeout/subscriber.cpp: