### PR TITLE
Fixed typo in repoctl console output

### DIFF
--- a/tools/repoctl/repoctl.cpp
+++ b/tools/repoctl/repoctl.cpp
@@ -70,7 +70,7 @@ usage_and_exit(int value = 0)
             << "              will then failover to another repository within the" << std::endl
             << "              federation." << std::endl
             << std::endl
-            << "   Any unrecongnized commands or no command will result in the same" << std::endl
+            << "   Any unrecognized commands or no command will result in the same" << std::endl
             << "   action as the '-h' option." << std::endl
             << std::endl;
 


### PR DESCRIPTION
    * tools/repoctl/repoctl.cpp: