### PR TITLE
fix problem with multiple transports in configuration file

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -179,6 +179,7 @@ tests/DCPS/Messenger/run_test.pl rtps_unicast: !DCPS_MIN RTPS !OPENDDS_SAFETY_PR
 tests/DCPS/Messenger/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl rtps_disc_tcp: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl rtps_disc_tcp thread_per: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Messenger/run_test.pl rtps_disc_tcp_udp: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/Messenger/run_corbaloc_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_corbaloc_test.pl host_port_only: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -353,10 +353,14 @@ TransportClient::associate(const AssociationData& data, bool active)
             return true;
           }
 
-          if (res.success_ && !res.link_.is_nil()) {
-
-            use_datalink_i(data.remote_id_, res.link_, guard);
-
+          if (res.success_) {
+            if (res.link_.is_nil()) {
+                // In this case, it may be waiting for the TCP connection to be established.  Just wait without trying other transports.
+                pending_assoc_timer_->schedule_timer(this, iter->second);
+            }
+            else {
+                use_datalink_i(data.remote_id_, res.link_, guard);
+            }
             return true;
           }
         }

--- a/tests/DCPS/Messenger/rtps_disc_tcp_udp.ini
+++ b/tests/DCPS/Messenger/rtps_disc_tcp_udp.ini
@@ -1,0 +1,8 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[transport/the_rtps_tcp_transport]
+transport_type=tcp
+
+[transport/the_rtps_transport]
+transport_type=rtps_udp

--- a/tests/DCPS/Messenger/run_test.pl
+++ b/tests/DCPS/Messenger/run_test.pl
@@ -83,6 +83,11 @@ elsif ($test->flag('rtps_disc_tcp')) {
     $sub_opts .= " -DCPSConfigFile rtps_disc_tcp.ini";
     $is_rtps_disc = 1;
 }
+elsif ($test->flag('rtps_disc_tcp_udp')) {
+    $pub_opts .= " -DCPSConfigFile rtps_disc_tcp_udp.ini";
+    $sub_opts .= " -DCPSConfigFile rtps_disc_tcp_udp.ini";
+    $is_rtps_disc = 1;
+}
 elsif ($test->flag('rtps_unicast')) {
     $test->{nobits} = 1;
     $pub_opts .= " -DCPSConfigFile rtps_uni.ini";


### PR DESCRIPTION
This fix the data reader listener not found issue when both tcp and rtps_udp transports are listed in the configuration file.