### PR TITLE
Removed throw exception specification, results in a compile error whe…

### DIFF
--- a/performance-tests/DCPS/InfoRepo_population/SyncClientExt_i.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/SyncClientExt_i.cpp
@@ -6,7 +6,6 @@
 
 SyncClientExt_i::SyncClientExt_i (const std::string& sync_server
                                   , CORBA::ORB_ptr orb, Role role)
-  throw (SyncClient_i::InitError)
   : SyncClient_i (sync_server, orb, role)
 { }
 

--- a/performance-tests/DCPS/InfoRepo_population/SyncClientExt_i.h
+++ b/performance-tests/DCPS/InfoRepo_population/SyncClientExt_i.h
@@ -8,8 +8,7 @@ class SyncClientExt_i : public SyncClient_i
 {
  public:
   SyncClientExt_i (const std::string& sync_server, CORBA::ORB_ptr orb
-                   , Role role)
-    throw (SyncClient_i::InitError);
+                   , Role role);
   virtual ~SyncClientExt_i (void);
 
   void publish (SyncExt::Role role, int instances

--- a/performance-tests/DCPS/InfoRepo_population/SyncServer.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/SyncServer.cpp
@@ -12,7 +12,7 @@ class SyncServer
 public:
   typedef std::string InitError;
 
-  SyncServer (int argc, ACE_TCHAR *argv[]) throw (InitError);
+  SyncServer (int argc, ACE_TCHAR *argv[]);
 
   bool run ();
 
@@ -57,7 +57,6 @@ SyncServer::parse_args (int argc, ACE_TCHAR *argv[])
 }
 
 SyncServer::SyncServer (int argc, ACE_TCHAR* argv[])
-  throw (SyncServer::InitError)
   : pub_count_ (1), sub_count_ (1)
 {
   try

--- a/performance-tests/DCPS/InfoRepo_population/publisher.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/publisher.cpp
@@ -31,7 +31,7 @@ class Publisher
 public:
   typedef std::string InitError;
 
-  Publisher (int argc, ACE_TCHAR *argv[]) throw (InitError);
+  Publisher (int argc, ACE_TCHAR *argv[]);
 
   bool run ();
 
@@ -101,7 +101,7 @@ Publisher::parse_args (int argc, ACE_TCHAR *argv[])
   return true;
 }
 
-Publisher::Publisher (int argc, ACE_TCHAR *argv[]) throw (Publisher::InitError)
+Publisher::Publisher (int argc, ACE_TCHAR *argv[])
   : topic_count_ (1), participant_count_ (1), writer_count_ (1)
   , control_file_ ("barrier_file"), subscriber_count_(1)
 {

--- a/performance-tests/DCPS/InfoRepo_population/subscriber.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/subscriber.cpp
@@ -31,7 +31,7 @@ class Subscriber
 public:
   typedef std::string InitError;
 
-  Subscriber (int argc, ACE_TCHAR *argv[]) throw (InitError);
+  Subscriber (int argc, ACE_TCHAR *argv[]);
 
   bool run ();
 
@@ -102,7 +102,7 @@ Subscriber::parse_args (int argc, ACE_TCHAR *argv[])
   return true;
 }
 
-Subscriber::Subscriber (int argc, ACE_TCHAR *argv[]) throw (Subscriber::InitError)
+Subscriber::Subscriber (int argc, ACE_TCHAR *argv[])
   : topic_count_ (1), participant_count_ (1), reader_count_(1)
   , control_file_ ("barrier_file"), publisher_count_ (1)
 {

--- a/performance-tests/DCPS/Sync/SyncClient_i.cpp
+++ b/performance-tests/DCPS/Sync/SyncClient_i.cpp
@@ -7,7 +7,6 @@
 
 SyncClient_i::SyncClient_i (const std::string& sync_server
                             , CORBA::ORB_ptr orb, Role role)
-  throw (SyncClient_i::InitError)
   : shutdown_ (false), notification_ (false)
 {
   try

--- a/performance-tests/DCPS/Sync/SyncClient_i.h
+++ b/performance-tests/DCPS/Sync/SyncClient_i.h
@@ -23,8 +23,7 @@ class Sync_Export SyncClient_i : public POA_Sync::Client, public ACE_Task_Base
   enum Role {Pub, Sub};
 
   SyncClient_i (const std::string& sync_server, CORBA::ORB_ptr orb
-                , Role role)
-    throw (InitError);
+                , Role role);
   virtual ~SyncClient_i (void);
 
   void way_point_reached (int way_point);

--- a/performance-tests/DCPS/Sync/SyncServer.cpp
+++ b/performance-tests/DCPS/Sync/SyncServer.cpp
@@ -13,7 +13,7 @@ class SyncServer
 public:
   typedef std::string InitError;
 
-  SyncServer (int argc, ACE_TCHAR *argv[]) throw (InitError);
+  SyncServer (int argc, ACE_TCHAR *argv[]);
 
   bool run ();
 
@@ -59,7 +59,6 @@ SyncServer::parse_args (int argc, ACE_TCHAR *argv[])
 }
 
 SyncServer::SyncServer (int argc, ACE_TCHAR* argv[])
-  throw (SyncServer::InitError)
   : pub_count_ (1), sub_count_ (1)
 {
   try

--- a/performance-tests/DCPS/Sync/SyncServer_i.cpp
+++ b/performance-tests/DCPS/Sync/SyncServer_i.cpp
@@ -10,7 +10,6 @@
 
 SyncServer_i::SyncServer_i (size_t pub_count, size_t sub_count
                             , CORBA::ORB_ptr orb, bool write_ior)
-  throw (SyncServer_i::InitError, CORBA::ORB::InvalidName)
   : count_ (0), pub_count_(pub_count), sub_count_(sub_count)
   , shutdown_ (false), ior_file_("sync.ior")
 {

--- a/performance-tests/DCPS/Sync/SyncServer_i.h
+++ b/performance-tests/DCPS/Sync/SyncServer_i.h
@@ -16,7 +16,7 @@ class Sync_Export SyncServer_i : public virtual POA_Sync::Server, public ACE_Tas
   typedef std::string InitError;
 
   SyncServer_i (size_t pub_count, size_t sub_count
-                , CORBA::ORB_ptr orb, bool write_ior=true) throw (InitError, CORBA::ORB::InvalidName);
+                , CORBA::ORB_ptr orb, bool write_ior=true);
   virtual ~SyncServer_i (void);
 
   // synchrously wait for session completion.


### PR DESCRIPTION
…n C++17 is enabled

    * performance-tests/DCPS/InfoRepo_population/SyncClientExt_i.cpp:
    * performance-tests/DCPS/InfoRepo_population/SyncClientExt_i.h:
    * performance-tests/DCPS/InfoRepo_population/SyncServer.cpp:
    * performance-tests/DCPS/InfoRepo_population/publisher.cpp:
    * performance-tests/DCPS/InfoRepo_population/subscriber.cpp:
    * performance-tests/DCPS/Sync/SyncClient_i.cpp:
    * performance-tests/DCPS/Sync/SyncClient_i.h:
    * performance-tests/DCPS/Sync/SyncServer.cpp:
    * performance-tests/DCPS/Sync/SyncServer_i.cpp:
    * performance-tests/DCPS/Sync/SyncServer_i.h: