### PR TITLE
Disable std::(w)string insertion/extraction when using safety profile

### DIFF
--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -183,12 +183,14 @@ public:
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, ACE_OutputCDR::from_wstring x);
 
+#ifndef OPENDDS_SAFETY_PROFILE
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, const std::string& x);
 #ifdef DDS_HAS_WCHAR
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, const std::wstring& x);
 #endif /* DDS_HAS_WCHAR */
+#endif /* !OPENDDS_SAFETYP_PROFILE */
 
   // Extraction operators.
   friend OpenDDS_Dcps_Export
@@ -230,12 +232,14 @@ public:
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, ACE_InputCDR::to_wstring x);
 
+#ifndef OPENDDS_SAFETY_PROFILE
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, std::string& x);
 #ifdef DDS_HAS_WCHAR
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, std::wstring& x);
 #endif /* DDS_HAS_WCHAR */
+#endif /* !OPENDDS_SAFETY_PROFILE */
 
   /// Read from the chain into a destination buffer.
   // This method doesn't respect alignment, so use with care.

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -741,6 +741,7 @@ operator<<(Serializer& s, ACE_OutputCDR::from_wchar x)
   return s.good_bit();
 }
 
+#ifndef OPENDDS_SAFETY_PROFILE
 ACE_INLINE bool
 operator<<(Serializer& s, const std::string& x)
 {
@@ -754,6 +755,7 @@ operator<<(Serializer& s, const std::wstring& x)
   return s << x.c_str();
 }
 #endif /* DDS_HAS_WCHAR */
+#endif /* !OPENDDS_SAFETY_PROFILE */
 
 ACE_INLINE bool
 operator<<(Serializer& s, ACE_OutputCDR::from_octet x)
@@ -946,6 +948,7 @@ operator>>(Serializer& s, ACE_InputCDR::to_wstring x)
          && ((x.bound_ == 0) || (length <= x.bound_));
 }
 
+#ifndef OPENDDS_SAFETY_PROFILE
 ACE_INLINE bool
 operator>>(Serializer& s, std::string& x)
 {
@@ -965,6 +968,7 @@ operator>>(Serializer& s, std::wstring& x)
   return s.good_bit();
 }
 #endif /* DDS_HAS_WCHAR */
+#endif /* !OPENDDS_SAFETY_PROFILE */
 
 //----------------------------------------------------------------------------
 // predefined type gen_max_marshaled_size methods

--- a/tests/DCPS/Serializer/SerializerTest.cpp
+++ b/tests/DCPS/Serializer/SerializerTest.cpp
@@ -29,10 +29,14 @@ struct Values {
   ACE_CDR::Char       charValue;
   ACE_CDR::WChar      wcharValue;
   ACE_CDR::Char*      stringValue;
+#ifndef OPENDDS_SAFETY_PROFILE
   std::string         stdstringValue;
+#endif
 #ifdef DDS_HAS_WCHAR
   ACE_CDR::WChar*     wstringValue;
+#ifndef OPENDDS_SAFETY_PROFILE
   std::wstring        stdwstringValue;
+#endif
 #endif
 };
 
@@ -70,10 +74,14 @@ insertions(ACE_Message_Block* chain, const Values& values,
   serializer << values.charValue;
   serializer << ACE_OutputCDR::from_wchar(values.wcharValue);
   serializer << ACE_OutputCDR::from_string(values.stringValue, 0);
+#ifndef OPENDDS_SAFETY_PROFILE
   serializer << values.stdstringValue;
+#endif
 #ifdef DDS_HAS_WCHAR
   serializer << ACE_OutputCDR::from_wstring(values.wstringValue, 0);
+#ifndef OPENDDS_SAFETY_PROFILE
   serializer << values.stdwstringValue;
+#endif
 #endif
 }
 
@@ -116,10 +124,14 @@ extractions(ACE_Message_Block* chain, Values& values,
   serializer >> values.charValue;
   serializer >> ACE_InputCDR::to_wchar(values.wcharValue);
   serializer >> ACE_InputCDR::to_string(values.stringValue, 0);
+#ifndef OPENDDS_SAFETY_PROFILE
   serializer >> values.stdstringValue;
+#endif
 #ifdef DDS_HAS_WCHAR
   serializer >> ACE_InputCDR::to_wstring(values.wstringValue, 0);
+#ifndef OPENDDS_SAFETY_PROFILE
   serializer >> values.stdwstringValue;
+#endif
 #endif
 }
 
@@ -256,6 +268,7 @@ checkValues(const Values& expected, const Values& observed)
     std::cout << ")." << std::endl;
     failed = true;
   }
+#ifndef OPENDDS_SAFETY_PROFILE
   if(expected.stdstringValue != observed.stdstringValue) {
     ACE::format_hexdump(expected.stdstringValue.c_str(), expected.stdstringValue.length(), ebuffer, sizeof(ebuffer));
     ACE::format_hexdump(observed.stdstringValue.c_str(), observed.stdstringValue.length(), obuffer, sizeof(obuffer));
@@ -265,6 +278,7 @@ checkValues(const Values& expected, const Values& observed)
     std::cout << ")." << std::endl;
     failed = true;
   }
+#endif
 #ifdef DDS_HAS_WCHAR
   if((expected.wstringValue != 0) && (0 != ACE_OS::strcmp(expected.wstringValue, observed.wstringValue))) {
     ACE::format_hexdump(reinterpret_cast<char*>(expected.wstringValue), ACE_OS::strlen(expected.wstringValue), ebuffer, sizeof(ebuffer));
@@ -275,12 +289,14 @@ checkValues(const Values& expected, const Values& observed)
     std::cout << ")." << std::endl;
     failed = true;
   }
+#ifndef OPENDDS_SAFETY_PROFILE
   if(expected.stdwstringValue != observed.stdwstringValue) {
     ACE::format_hexdump(reinterpret_cast<const char*>(expected.stdwstringValue.c_str()), expected.stdwstringValue.length(), ebuffer, sizeof(ebuffer));
     ACE::format_hexdump(reinterpret_cast<const char*>(observed.stdwstringValue.c_str()), observed.stdwstringValue.length(), obuffer, sizeof(obuffer));
     std::cout << "wstring values not correct after insertion and extraction." << std::endl;
     failed = true;
   }
+#endif
 #endif
 }
 
@@ -458,9 +474,11 @@ ACE_TMAIN(int, ACE_TCHAR*[])
 #ifdef DDS_HAS_WCHAR
   const ACE_CDR::WChar wstring[] = L"This is a test of the wstring serialization.";
 #endif
+#ifndef OPENDDS_SAFETY_PROFILE
   std::string stdstring = "This is a test of the std string serialization.";
 #ifdef DDS_HAS_WCHAR
   std::wstring stdwstring = L"This is a test of the std wstring serialization.";
+#endif
 #endif
 
   Values expected = { 0x01,
@@ -480,10 +498,14 @@ ACE_TMAIN(int, ACE_TCHAR*[])
                       0x1a,
                       0xb2,
                       const_cast<ACE_CDR::Char*>(string),
+#ifndef OPENDDS_SAFETY_PROFILE
                       stdstring,
+#endif
 #ifdef DDS_HAS_WCHAR
                       const_cast<ACE_CDR::WChar*>(wstring),
+#ifndef OPENDDS_SAFETY_PROFILE
                       stdwstring
+#endif
 #endif
   };
 

--- a/tests/DCPS/Serializer/SerializerTest.cpp
+++ b/tests/DCPS/Serializer/SerializerTest.cpp
@@ -434,9 +434,15 @@ runTest(const Values& expected, const ArrayValues& expectedArray,
   displayChain(testchain);
   std::cout << "EXTRACTING SINGLE VALUES WITH" << out << " SWAPPING" << std::endl;
   Values observed = {0, 0, 0, 0, 0, 0, 0, 0, 0,
-                     ACE_CDR_LONG_DOUBLE_INITIALIZER, 0, 0, 0, ""
+                     ACE_CDR_LONG_DOUBLE_INITIALIZER, 0, 0, 0
+#ifndef OPENDDS_SAFETY_PROFILE
+                     , ""
+#endif
 #ifdef DDS_HAS_WCHAR
-                     , 0, L""
+                     , 0
+#ifndef OPENDDS_SAFETY_PROFILE
+                     , L""
+#endif
 #endif
                     };
   extractions(testchain, observed, swap, align);
@@ -497,14 +503,14 @@ ACE_TMAIN(int, ACE_TCHAR*[])
 #endif
                       0x1a,
                       0xb2,
-                      const_cast<ACE_CDR::Char*>(string),
+                      const_cast<ACE_CDR::Char*>(string)
 #ifndef OPENDDS_SAFETY_PROFILE
-                      stdstring,
+                      , stdstring
 #endif
 #ifdef DDS_HAS_WCHAR
-                      const_cast<ACE_CDR::WChar*>(wstring),
+                      , const_cast<ACE_CDR::WChar*>(wstring)
 #ifndef OPENDDS_SAFETY_PROFILE
-                      stdwstring
+                      , stdwstring
 #endif
 #endif
   };


### PR DESCRIPTION
    * dds/DCPS/Serializer.h:
    * dds/DCPS/Serializer.inl: