### PR TITLE
Fix dcps_tests.lst errors

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -123,9 +123,9 @@ tests/DCPS/CorbaSeq/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ViewState/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/NotifyTest/run_test.pl: !DCPS_MIN
-tests/DCPS/Reliability/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Reliability/run_test.pl: rtps !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Reliability/run_test.pl keep-last-one: !DCPS_MIN
+tests/DCPS/Reliability/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Reliability/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Reliability/run_test.pl keep-last-one: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Reliability/run_test.pl rtps keep-last-one: !DCPS_MIN
 
 tests/DCPS/WriteDataContainer/run_test.pl: !DCPS_MIN
@@ -247,7 +247,7 @@ tests/DCPS/Priority/run_test.pl --instances: !DCPS_MIN !QNX !OPENDDS_SAFETY_PROF
 tests/DCPS/LatencyBudget/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/LatencyBudget/run_test.pl late: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/WaitForAck/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/WaitForAck/run_test.pl: rtps !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/WaitForAck/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/WaitForAck/run_test.pl --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/WaitForAck/run_test.pl rtps --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl single: !DCPS_MIN !LYNXOS

--- a/tests/DCPS/Reliability/rtps.ini
+++ b/tests/DCPS/Reliability/rtps.ini
@@ -1,5 +1,6 @@
 [common]
 DCPSGlobalTransportConfig=$file
+pool_size=83886080
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp


### PR DESCRIPTION
This fixes the problem where the tests/DCPS/Reliability/run_test.pl and tests/DCPS/WaitForAck/run_test.pl tests not running problem.