### PR TITLE
Avoid running Inconsistent_Qos Test for static build

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -46,7 +46,7 @@ tests/DCPS/LivelinessTest/run_test.pl udp: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !
 tests/DCPS/LivelinessTest/run_test.pl rtps_disc: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE RTPS
 tests/DCPS/LivelinessTest/run_test.pl rtps_disc take: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE RTPS
 
-tests/DCPS/Inconsistent_Qos/run_test.pl: RTPS DDS4CCM_OPENDDS !STATIC
+tests/DCPS/Inconsistent_Qos/run_test.pl: RTPS XERCES3 !STATIC
 tests/DCPS/TopicReuse/run_test.pl: RTPS
 tests/DCPS/DpShutdown/run_test.pl: RTPS
 tests/DCPS/Serializer/run_test.pl: !DCPS_MIN
@@ -318,7 +318,7 @@ tests/DCPS/ManyTopicTest/run_test.pl rtps: !DCPS_MIN RTPS
 
 tests/DCPS/ManyTopicMultiProcess/run_test.pl: !DCPS_MIN
 
-tests/DCPS/QoS_XML/dump/run_test.pl: DDS4CCM_OPENDDS
+tests/DCPS/QoS_XML/dump/run_test.pl: XERCES3
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS
 tests/DCPS/ManyToMany/run_test.pl multicast 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -46,7 +46,7 @@ tests/DCPS/LivelinessTest/run_test.pl udp: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !
 tests/DCPS/LivelinessTest/run_test.pl rtps_disc: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE RTPS
 tests/DCPS/LivelinessTest/run_test.pl rtps_disc take: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE RTPS
 
-tests/DCPS/Inconsistent_Qos/run_test.pl: RTPS DDS4CCM_OPENDDS
+tests/DCPS/Inconsistent_Qos/run_test.pl: RTPS DDS4CCM_OPENDDS !STATIC
 tests/DCPS/TopicReuse/run_test.pl: RTPS
 tests/DCPS/DpShutdown/run_test.pl: RTPS
 tests/DCPS/Serializer/run_test.pl: !DCPS_MIN


### PR DESCRIPTION
Inconsistenct_Qos test uses RTPS discovery while the executable only links the default discovery. Therefore, it won't run on static build.