### PR TITLE
Coverity Scan updates

### DIFF
--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -652,7 +652,9 @@ namespace {
         if (config.is_nil()) return INVALID_PARAM;
         try {
           TheTransportRegistry->bind_config(config, pub);
-        } catch (const OpenDDS::DCPS::Transport::MiscProblem& mp) {
+        } catch (const OpenDDS::DCPS::Transport::MiscProblem&) {
+          return INVALID_PARAM;
+        } catch (const OpenDDS::DCPS::Transport::NotFound&) {
           return INVALID_PARAM;
         }
       }

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -92,6 +92,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       if (options.command_line(command_line.c_str()) != 0)
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT ("%p\n"), ACE_TEXT("set options")) ,-1);
 
+      if (stub_ready_filename.empty())
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%p\n"), ACE_TEXT("-stub_ready_file required.")), -1);
+
 #ifdef ACE_WIN32
       options.creation_flags(CREATE_NEW_PROCESS_GROUP);
 #endif


### PR DESCRIPTION
Initially to address 1454919 and 1454912 having to do with further exceptions not being caught from the bind_config call.