### PR TITLE
Fix persistent Inforepo memory leak

### DIFF
--- a/dds/InfoRepo/DCPSInfo_i.cpp
+++ b/dds/InfoRepo/DCPSInfo_i.cpp
@@ -57,6 +57,10 @@ TAO_DDS_DCPSInfo_i::TAO_DDS_DCPSInfo_i(CORBA::ORB_ptr orb
 
 TAO_DDS_DCPSInfo_i::~TAO_DDS_DCPSInfo_i()
 {
+  DCPS_IR_Domain_Map::iterator where;
+  for (where = this->domains_.begin(); where != this->domains_.end(); ++where) {
+    delete where->second;
+  }
 }
 
 int

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -60,6 +60,19 @@ DCPS_IR_Domain::DCPS_IR_Domain(DDS::DomainId_t id, OpenDDS::DCPS::RepoIdGenerato
 
 DCPS_IR_Domain::~DCPS_IR_Domain()
 {
+
+
+  for (DCPS_IR_Topic_Description_Set::iterator itr = topicDescriptions_.begin(); itr != topicDescriptions_.end(); ++ itr) {
+    delete *itr;
+  }
+
+  for (DCPS_IR_Participant_Map::iterator where = this->participants_.begin(); where != this->participants_.end(); ++where) {
+    delete where->second;
+  }
+
+  for (IdToTopicMap::iterator itr = idToTopicMap_.begin(); itr != idToTopicMap_.end(); ++ itr) {
+    delete itr->second;
+  }
 }
 
 const DCPS_IR_Participant_Map&

--- a/dds/InfoRepo/DCPS_IR_Participant.cpp
+++ b/dds/InfoRepo/DCPS_IR_Participant.cpp
@@ -58,43 +58,15 @@ DCPS_IR_Participant::~DCPS_IR_Participant()
   for (DCPS_IR_Subscription_Map::const_iterator current = this->subscriptions_.begin();
        current != this->subscriptions_.end();
        ++current) {
-    OpenDDS::DCPS::RepoIdConverter part_converter(id_);
-    OpenDDS::DCPS::RepoIdConverter sub_converter(current->first);
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Participant::~DCPS_IR_Participant: ")
-               ACE_TEXT("domain %d participant %C removing subscription %C.\n"),
-               this->domain_->get_id(),
-               std::string(part_converter).c_str(),
-               std::string(sub_converter).c_str()));
-    remove_subscription(current->first);
+    delete current->second;
   }
 
   for (DCPS_IR_Publication_Map::const_iterator current = this->publications_.begin();
        current != this->publications_.end();
        ++current) {
-    OpenDDS::DCPS::RepoIdConverter part_converter(id_);
-    OpenDDS::DCPS::RepoIdConverter pub_converter(current->first);
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Participant::~DCPS_IR_Participant: ")
-               ACE_TEXT("domain %d participant %C removing publication %C.\n"),
-               this->domain_->get_id(),
-               std::string(part_converter).c_str(),
-               std::string(pub_converter).c_str()));
-    remove_publication(current->first);
+    delete current->second;
   }
 
-  for (DCPS_IR_Topic_Map::const_iterator current = this->topicRefs_.begin();
-       current != this->topicRefs_.end();
-       ++current) {
-    OpenDDS::DCPS::RepoIdConverter part_converter(id_);
-    OpenDDS::DCPS::RepoIdConverter topic_converter(current->first);
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Participant::~DCPS_IR_Participant: ")
-               ACE_TEXT("domain %d participant %C retained topic %C.\n"),
-               this->domain_->get_id(),
-               std::string(part_converter).c_str(),
-               std::string(topic_converter).c_str()));
-  }
 }
 
 const DCPS_IR_Publication_Map&

--- a/dds/InfoRepo/DCPS_IR_Publication.cpp
+++ b/dds/InfoRepo/DCPS_IR_Publication.cpp
@@ -47,10 +47,6 @@ DCPS_IR_Publication::DCPS_IR_Publication(const OpenDDS::DCPS::RepoId& id,
 
 DCPS_IR_Publication::~DCPS_IR_Publication()
 {
-  if (0 != associations_.size()) {
-    CORBA::Boolean dont_notify_lost = 0;
-    remove_associations(dont_notify_lost);
-  }
 }
 
 int DCPS_IR_Publication::add_associated_subscription(DCPS_IR_Subscription* sub,

--- a/dds/InfoRepo/DCPS_IR_Subscription.cpp
+++ b/dds/InfoRepo/DCPS_IR_Subscription.cpp
@@ -52,10 +52,6 @@ DCPS_IR_Subscription::DCPS_IR_Subscription(const OpenDDS::DCPS::RepoId& id,
 
 DCPS_IR_Subscription::~DCPS_IR_Subscription()
 {
-  if (0 != associations_.size()) {
-    CORBA::Boolean dont_notify_lost = 0;
-    remove_associations(dont_notify_lost);
-  }
 }
 
 int DCPS_IR_Subscription::add_associated_publication(DCPS_IR_Publication* pub,

--- a/dds/InfoRepo/DCPS_IR_Topic.cpp
+++ b/dds/InfoRepo/DCPS_IR_Topic.cpp
@@ -40,54 +40,6 @@ DCPS_IR_Topic::DCPS_IR_Topic(const OpenDDS::DCPS::RepoId& id,
 
 DCPS_IR_Topic::~DCPS_IR_Topic()
 {
-  // check for remaining publication references
-  if (0 != publicationRefs_.size()) {
-    DCPS_IR_Publication* pub = 0;
-    DCPS_IR_Publication_Set::ITERATOR iter = publicationRefs_.begin();
-    DCPS_IR_Publication_Set::ITERATOR end = publicationRefs_.end();
-
-    OpenDDS::DCPS::RepoIdConverter topic_converter(id_);
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic::~DCPS_IR_Topic: ")
-               ACE_TEXT("id %C has retained publications.\n"),
-               std::string(topic_converter).c_str()));
-
-    while (iter != end) {
-      pub = *iter;
-      ++iter;
-
-      OpenDDS::DCPS::RepoIdConverter pub_converter(pub->get_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic::~DCPS_IR_Topic: ")
-                 ACE_TEXT("topic %C retains publication id %C.\n"),
-                 std::string(topic_converter).c_str(),
-                 std::string(pub_converter).c_str()));
-    }
-  }
-
-  if (0 != subscriptionRefs_.size()) {
-    DCPS_IR_Subscription* sub = 0;
-    DCPS_IR_Subscription_Set::ITERATOR iter = subscriptionRefs_.begin();
-    DCPS_IR_Subscription_Set::ITERATOR end = subscriptionRefs_.end();
-
-    OpenDDS::DCPS::RepoIdConverter topic_converter(id_);
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic::~DCPS_IR_Topic: ")
-               ACE_TEXT("id %C has retained subscriptions.\n"),
-               std::string(topic_converter).c_str()));
-
-    while (iter != end) {
-      sub = *iter;
-      ++iter;
-
-      OpenDDS::DCPS::RepoIdConverter sub_converter(sub->get_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic::~DCPS_IR_Topic: ")
-                 ACE_TEXT("topic %C retains subscription id %C.\n"),
-                 std::string(topic_converter).c_str(),
-                 std::string(sub_converter).c_str()));
-    }
-  }
 }
 
 void DCPS_IR_Topic::release(bool removing)

--- a/dds/InfoRepo/DCPS_IR_Topic_Description.cpp
+++ b/dds/InfoRepo/DCPS_IR_Topic_Description.cpp
@@ -33,54 +33,6 @@ DCPS_IR_Topic_Description::DCPS_IR_Topic_Description(DCPS_IR_Domain* domain,
 
 DCPS_IR_Topic_Description::~DCPS_IR_Topic_Description()
 {
-  // check for any subscriptions still referencing this description.
-  if (0 != subscriptionRefs_.size()) {
-    DCPS_IR_Subscription* subscription = 0;
-    DCPS_IR_Subscription_Set::ITERATOR iter = subscriptionRefs_.begin();
-    DCPS_IR_Subscription_Set::ITERATOR end = subscriptionRefs_.end();
-
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic_Description::~DCPS_IR_Topic_Description: ")
-               ACE_TEXT("topic description name %C data type name %C has retained subscriptions.\n"),
-               name_.c_str(),
-               dataTypeName_.c_str()));
-
-    while (iter != end) {
-      subscription = *iter;
-      ++iter;
-
-      OpenDDS::DCPS::RepoIdConverter converter(subscription->get_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic_Description::~DCPS_IR_Topic_Description: ")
-                 ACE_TEXT("topic description %C retains subscription %C.\n"),
-                 this->name_.c_str(),
-                 std::string(converter).c_str()));
-    }
-  }
-
-  if (0 != topics_.size()) {
-    DCPS_IR_Topic* topic = 0;
-    DCPS_IR_Topic_Set::ITERATOR iter = topics_.begin();
-    DCPS_IR_Topic_Set::ITERATOR end = topics_.end();
-
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic_Description::~DCPS_IR_Topic_Description: ")
-               ACE_TEXT("topic description name %C data type name %C has retained topics.\n"),
-               name_.c_str(),
-               dataTypeName_.c_str()));
-
-    while (iter != end) {
-      topic = *iter;
-      ++iter;
-
-      OpenDDS::DCPS::RepoIdConverter converter(topic->get_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: DCPS_IR_Topic_Description::~DCPS_IR_Topic_Description: ")
-                 ACE_TEXT("topic description %C retains topic %C.\n"),
-                 this->name_.c_str(),
-                 std::string(converter).c_str()));
-    }
-  }
 }
 
 int DCPS_IR_Topic_Description::add_subscription_reference(DCPS_IR_Subscription* subscription


### PR DESCRIPTION
This would fix the memory leak for persistent inforepo. However, it won't fix the corruption of persistent file for asan build. I don't see any persistent file corruption for non-asan build.  