### PR TITLE
Service_Participant: re-init the MonitorFactory

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -439,6 +439,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
 
       if (this->monitor_factory_ == 0) {
         // Use the stubbed factory
+        MonitorFactory::service_initialize();
         this->monitor_factory_ =
           ACE_Dynamic_Service<MonitorFactory>::instance ("OpenDDS_Monitor_Default");
       }


### PR DESCRIPTION
supports the scenario where OpenDDS is completely shutdown then restarted within a process