### PR TITLE
Dissector macOS support, configure script, fixed throw spec problem

### DIFF
--- a/configure
+++ b/configure
@@ -154,7 +154,7 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'java:s', 'Java development kit (use JAVA_HOME)',
     'jboss:s', 'JBoss application server (use JBOSS_HOME)',
     'ant:s', 'Ant for JBoss (use ANT_HOME or system pkg)',
-    'wireshark:s', 'Wireshark source (use WIRESHARK_SRC)',
+    'wireshark:s', 'Wireshark source, "non-CMake" based (use WIRESHARK_SRC)',
     'wireshark_cmake:s', 'Wireshark built with CMake, requires wireshark_build and wireshark_lib (use WIRESHARK_SRC)',
     'wireshark_build:s', 'Wireshark CMake Build Location',
     'wireshark_lib:s', 'Wireshark CMake libraries location, relative to wireshark_build',
@@ -855,6 +855,31 @@ if (exists $opts{'java'}) {
 $opts{'qt'} = '' if exists $opts{'qt-include'} && !exists $opts{'qt'};
 $opts{'boost'} = '' if exists $opts{'boost-version'} && !exists $opts{'boost'};
 
+# Default to Wireshark Development Package if installed
+my $wireshark_install = '/usr/include/wireshark';
+if (exists $opts{'wireshark'} && $opts{'wireshark'} eq '') {
+  if (-d $wireshark_install) {
+    $opts{'wireshark'} = $wireshark_install;
+  } else {
+    die "ERROR: --wireshark must be given a value because there is not a " .
+        "development package installed at " . $wireshark_install;
+  }
+}
+
+my $wireshark_lib_defaulted = 0;
+if (exists $opts{'wirehshark_cmake'} && !exists $opts{'wireshark_lib'}) {
+  if ($^O =~ /MSWin32/) {
+    $opts{'wirehshark_lib'} = "run\\RelWithDebInfo";
+  } elsif ($^O =~ /darwin/) {
+    $opts{'wirehshark_lib'} = "run/Wireshark.app/Contents/Frameworks";
+  } elsif ($^O =~ /linux/) {
+    $opts{'wirehshark_lib'} = "";
+  } else {
+    die "ERROR: --wireshark_lib is needed because we couldn't decide on a default value";
+  }
+  $wireshark_lib_defaulted = 1;
+}
+
 my %use_system_pkg = map {$_, 1} qw/ant glib qt boost xerces3/;
 my %use_win_default = ('boost' => 'c:\\Boost');
 my %need_platform_macros = map {$_, 1} qw/xerces3/;
@@ -979,18 +1004,35 @@ if (exists $opts{'wireshark'} || exists $opts{'wireshark_cmake'}) {
     die "ERROR: --glib is required for --wireshark and --wireshark_cmake\n";
   }
   
-  if (exists $opts{'wireshark'} && exists $opts{'wireshark_cmake'}) {
-    die "ERROR: --wireshark and --wireshark_cmake can not be used at the same time.\n";
-  }
-
   if (exists $opts{'wireshark_cmake'}) {
-    if (!exists $opts{'wireshark_build'} || !exists $opts{'wireshark_lib'}) {
-      die "ERROR: --wireshark_build and --wireshark_lib are required with --wireshark_cmake\n";
+
+    if (exists $opts{'wireshark'}) {
+      die "ERROR: --wireshark and --wireshark_cmake can not be used at the same time.\n";
     }
-  } elsif (exists $opts{'wireshark_build'} || exists $opts{'wireshark_lib'}) {
-    die "ERROR: --wireshark_cmake is required for --wireshark_build and --wireshark_lib\n";
+
+    if (! -d ($opts{'wireshark_build'} . '/' . $opts{'wireshark_lib'})) {
+      if ($wireshark_lib_defaulted) {
+        die "ERROR: The default value for wireshark_lib: " . $opts{'wireshark_lib'} .
+            " does not exist, please sypply wireshark_lib with the correct value";
+      } else {
+        die "ERROR: The supplied wireshark_lib: " . $opts{'wireshark_lib'} . " does not exist.";
+      }
+    }
   }
 }
+
+if (exists $opts{'wireshark_cmake'} && !exists $opts{'wireshark_build'}) {
+  die "ERROR: --wireshark_build are required with --wireshark_cmake\n";
+}
+
+if (exists $opts{'wireshark_lib'} && !exists $opts{'wireshark_cmake'}) {
+  die "ERROR: --wireshark_cmake and --wireshark_build is required for --wireshark_lib\n";
+}
+
+if (exists $opts{'wireshark_build'} && !exists $opts{'wireshark_cmake'}) {
+  die "ERROR: --wireshark_cmake is required for --wireshark_build\n";
+}
+
 
 if ($opts{'glib'}) {
   if (!-r "$opts{'glib'}/lib/glib-2.0/include/glibconfig.h") {

--- a/configure
+++ b/configure
@@ -154,10 +154,10 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'java:s', 'Java development kit (use JAVA_HOME)',
     'jboss:s', 'JBoss application server (use JBOSS_HOME)',
     'ant:s', 'Ant for JBoss (use ANT_HOME or system pkg)',
-    'wireshark:s', 'Wireshark 1.x Source (use WIRESHARK_SRC)',
-    'wireshark2:s', 'Wireshark 2.x Source (use WIRESHARK_SRC)',
-    'wireshark2_build:s', 'Wireshark 2 Build Location on Windows',
-    'wireshark2_bin:s', 'Folder with Wireshark 2 libraries on Windows (default: $WIRESHARK2_BUILD\\run\\RelWithDebInfo)',
+    'wireshark:s', 'Wireshark source (use WIRESHARK_SRC)',
+    'wireshark_cmake:s', 'Wireshark built with CMake, requires wireshark_build and wireshark_lib (use WIRESHARK_SRC)',
+    'wireshark_build:s', 'Wireshark CMake Build Location',
+    'wireshark_lib:s', 'Wireshark CMake libraries location, relative to wireshark_build',
     'glib:s', 'GLib for Wireshark (use GLIB_ROOT or system pkg)',
     'rapidjson', 'RapidJSON for Wireshark Sample Dissection(optional)',
     'qt:s', 'Qt (use QTDIR or system pkg)',
@@ -831,11 +831,11 @@ my %optdep =
    'jboss' =>     ['JBOSS_HOME',    'lib/jboss-common.jar'],
    'ant' =>       ['ANT_HOME',      'bin/ant'],
    'wireshark' => ['WIRESHARK_SRC', 'epan/packet.h',               'wireshark'],
-   'wireshark2' =>['WIRESHARK_SRC', 'epan/packet.h',               'wireshark2'],
-   'wireshark2_build' =>
-                  ['WIRESHARK2_BUILD', 'config.h'],
-   'wireshark2_bin' =>
-                  ['WIRESHARK2_BIN'],
+   'wireshark_cmake' =>['WIRESHARK_SRC', 'epan/packet.h',          'wireshark_cmake'],
+   'wireshark_build' =>
+                  ['WIRESHARK_BUILD', 'config.h'],
+   'wireshark_lib' =>
+                  ['WIRESHARK_LIB'],
    'glib' =>      ['GLIB_ROOT',     'include/glib-2.0/glib.h'],
    'rapidjson' => [undef,           undef,                         'no_itl=0'],
    'qt' =>        ['QTDIR',         '',                            'qt4'],
@@ -974,23 +974,21 @@ if (exists $opts{'jboss'} && !exists $opts{'ant'}) {
   die "ERROR: --ant is required for --jboss (OpenDDS JMS Provider)\n";
 }
 
-if (exists $opts{'wireshark'} || exists $opts{'wireshark2'}) {
+if (exists $opts{'wireshark'} || exists $opts{'wireshark_cmake'}) {
   if (!exists $opts{'glib'}) {
-    die "ERROR: --glib is required for --wireshark and --wireshark2\n";
+    die "ERROR: --glib is required for --wireshark and --wireshark_cmake\n";
   }
   
-  if (exists $opts{'wireshark'} && exists $opts{'wireshark2'}) {
-    die "ERROR: --wireshark and --wireshark2 can not be used at the same time.\n";
+  if (exists $opts{'wireshark'} && exists $opts{'wireshark_cmake'}) {
+    die "ERROR: --wireshark and --wireshark_cmake can not be used at the same time.\n";
   }
 
-  if ($^O eq 'MSWin32') {
-    if (exists $opts{'wireshark2'}) {
-      if (!exists $opts{'wireshark2_build'}) {
-        die "ERROR: --wireshark2_build is required on Windows with --wireshark2\n";
-      }
-    } elsif (exists $opts{'wireshark2_build'}) {
-      die "ERROR: --wireshark2 is required for --wireshark2_build\n";
+  if (exists $opts{'wireshark_cmake'}) {
+    if (!exists $opts{'wireshark_build'} || !exists $opts{'wireshark_lib'}) {
+      die "ERROR: --wireshark_build and --wireshark_lib are required with --wireshark_cmake\n";
     }
+  } elsif (exists $opts{'wireshark_build'} || exists $opts{'wireshark_lib'}) {
+    die "ERROR: --wireshark_cmake is required for --wireshark_build and --wireshark_lib\n";
   }
 }
 

--- a/tools/IntermediateTypeLang/cpp/itl/itl.hpp
+++ b/tools/IntermediateTypeLang/cpp/itl/itl.hpp
@@ -115,6 +115,12 @@ namespace itl {
   };
 
   class Fixed : public Type, public ConstrainedType {
+
+  public:
+    unsigned int base() { return base_; }
+    unsigned int digits() { return digits_; }
+    unsigned int scale() { return scale_; }
+
   private:
     Fixed(const rapidjson::Value* note,
           unsigned int base,

--- a/tools/dissector/README
+++ b/tools/dissector/README
@@ -1,8 +1,8 @@
-Starting with release 2.1.1, OpenDDS provides support for Wireshark.
-The OpenDDS DCPS dissector provides a Wireshark 1.2.x/1.3.x compatible
-dissector which supports the TCP/IP, UDP/IP, and IP multicast transports.
-Dissection of transport headers and encapsulated sample headers are fully
-supported.
+The OpenDDS DCPS Wireshark dissector supports the TCP/IP, UDP/IP, and IP
+multicast transports. Dissection of transport headers and encapsulated sample
+headers are fully supported. Optional dissection of sample payloads is also
+supported from Wireshark 1.12 on. The dissector is compatible with Wireshark
+1.2 up to at least 2.4 and has been tested with Windows, macOS, and, Linux.
 
 
 ======================================================================
@@ -29,51 +29,67 @@ Follow the steps in the INSTALL file in the root of OpenDDS directory, along
 with the steps here.
 
 In addition, the Wireshark sources must be available and built locally
-according to the Wireshark Developer's Guide (see above).
+according to the Wireshark Developer's Guide (see above) or the headers and
+libraries must be installed through a development package like:
+ - "wireshark-devel" on Fedora derived Linux distribution.
+ - "wireshark-dev" on Debian derived Linux distribution.
 
 1. Set up the Build System to Build the Dissector
 
-   Run the DDS_ROOT/configure script, passing these arguments:
+   There are two ways to build against Wireshark depending on how Wireshark
+   was built or was acquired:
 
-     --wireshark=WIRESHARK_SRC
-       If buidling against Wireshark 1.x, else:
-     --wireshark2=WIRESHARK_SRC
-       If building against Wireshark 2.x, where WIRESHARK_SRC is the location
-       of the Wireshark source.
+    - The older method, "--wireshark" passed with the location of the
+      Wireshark headers and libraries. This should be used with:
 
-     --glib
-       On systems where Glib installed is the same used by the Wireshark
-       build.
-     --glib=GLIB_ROOT
-       Where GLIB_ROOT is the install prefix for Glib. If building on Windows,
-       GLIB_ROOT is the location of gtk2 folder Wireshark creates in the
-       wireshark-win32-libs or wireshark-win64-libs folder when it is built.
-       Can be also be used on systems where the Glib installed is different
-       than what was used to build Wireshark.
+       - Any version of Wireshark built with autoconf, which is try if you
+         ran autogen.sh. This is the recommended way to build on Linux as
+         of Wireshark 2.4.
 
-     --rapidjson
-       If using Wireshark 1.12 or later and sample payload data dissection is
-       desired. If RapidJSON is not installed on the system, it must be downloaded
-       using:
-         git submodule update --init --recursive
-       This can also be done manunally by putting rapidjson at:
-         DDS_ROOT/tools/IntermediateTypeLang/cpp/rapidjson
+       - Wireshark 1.x built on Windows. Also %WIRETAP_VERSION% should also
+         be set to the version of wiretap in the build.
 
-   If using Wireshark 1.x on Windows, then this must be specified:
-     set WIRETAP_VERSION=<version of the wiretap DLL built by Wireshark>
+       - If there is a development package available for your system
+         and you want to use it to avoid having to build Wireshark.
+         This option defaults to /usr/include/wireshark if it exists, so
+         supplying the path isn't necessary.
 
-   If using Wireshark 2.x on Windows, then the Wireshark Developer's Guide will
-   have you build Wireshark outside the Wireshark source folder. You will need
-   to pass the full path to the build folder you created, which should contain
-   config.h:
-     --wireshark2_build WIRESHARK2_BUILD
+    - The newer out-of-source method, "--wireshark_cmake", should be used if
+      Wireshark was built using CMake, which can put "config.h" header and
+      the Wireshark libraries somewhere other than the source tree. This is
+      Wireshark's recommended method for Windows and macOS and can optionally
+      be used on Linux. This method has two more parameters:
 
-   As of writing (Wireshark 2.4) building Wireshark 2 on Windows puts libraries
-   in WIRESHARK2_BUILD\run\RelWithDebInfo along with the application itself.
-   This is handled by default, but if this is not true for some reason,
-   the library location can be defined manually:
-     --wireshark2_bin WIRESHARK2_BIN
+       --wireshark_build
+         Is the build directory the user choose before building Wireshark.
+         This is required and an absolute path.
 
+       --wireshark_lib
+         Is the location of the Wireshark libraries RELATIVE to the build
+         location. It's optional but it might have to be supplied depending
+         on the version of Wireshark as these defaults are based on
+         Wireshark 2.4:
+           - On Windows the default is "run\RelWithDebInfo".
+           - On macOS the default is "run\Wireshark.app\Contents\Frameworks".
+           - On Linux the default is "" (They are in the build directory).
+
+   Glib is also required to build the dissector, so "--glib" must be passed.
+   If Wireshark was not built with the system Glib or Glib is not installed,
+   the install prefix of Glib must be passed as well:
+    - On Windows this will be something like: wireshark-win(32|64)-libs-*\gtk2
+    - On macOS it depends on if the built-in dependency script or a package
+      manager like Homebrew was used to install Wireshark's dependencies.
+    - On the average Linux, it shouldn't be necessary unless you needed to use
+      a Glib that is not installed to build Wireshark.
+
+   For optional sample payload dissection support, RapidJSON must be available
+   and "--rapidjson" must be passed. It might already be available if OpenDDS
+   was recursively cloned by a git client or RapidJSON is installed in a
+   default include location (RapidJSON is header only library).
+   If RapidJSON is not installed on the system, it must be downloaded using:
+     git submodule update --init --recursive
+   or equivalent for your git client or manually downloading and placing the
+   library at DDS_ROOT/tools/IntermediateTypeLang/cpp/rapidjson.
 
 2. Build
 
@@ -98,7 +114,7 @@ according to the Wireshark Developer's Guide (see above).
    libraries are not installed system-wide.
 
    You may verify the plugin is installed correctly by looking at the
-   Supported Protocols list.  Depending on the wireshark version, this
+   Supported Protocols list.  Depending on the Wireshark version, this
    can usually be found somewhere under the Help or Internals menus.
    The OpenDDS_Dissector library we created above should appear in the
    list of plugins or protocols.
@@ -263,7 +279,7 @@ Notes:
 
       opendds.sample.payload.Messenger.Message.seq < 3
 
-      This will show all OpenDD packets with a payload of type
+      This will show all OpenDDS packets with a payload of type
       "Messenger::Message" where it's "seq" member has less than 3 elements.
 
     To filter the items inside use "_e" (element). Items can not be

--- a/tools/dissector/README
+++ b/tools/dissector/README
@@ -2,7 +2,7 @@ The OpenDDS DCPS Wireshark dissector supports the TCP/IP, UDP/IP, and IP
 multicast transports. Dissection of transport headers and encapsulated sample
 headers are fully supported. Optional dissection of sample payloads is also
 supported from Wireshark 1.12 on. The dissector is compatible with Wireshark
-1.2 up to at least 2.4 and has been tested with Windows, macOS, and, Linux.
+1.2 up to at least 2.4 and has been tested with Windows, macOS, and Linux.
 
 
 ======================================================================
@@ -31,8 +31,8 @@ with the steps here.
 In addition, the Wireshark sources must be available and built locally
 according to the Wireshark Developer's Guide (see above) or the headers and
 libraries must be installed through a development package like:
- - "wireshark-devel" on Fedora derived Linux distribution.
- - "wireshark-dev" on Debian derived Linux distribution.
+ - "wireshark-devel" on Fedora derived Linux distributions.
+ - "wireshark-dev" on Debian derived Linux distributions.
 
 1. Set up the Build System to Build the Dissector
 

--- a/tools/dissector/README
+++ b/tools/dissector/README
@@ -70,7 +70,7 @@ libraries must be installed through a development package like:
          on the version of Wireshark as these defaults are based on
          Wireshark 2.4:
            - On Windows the default is "run\RelWithDebInfo".
-           - On macOS the default is "run\Wireshark.app\Contents\Frameworks".
+           - On macOS the default is "run/Wireshark.app/Contents/Frameworks".
            - On Linux the default is "" (They are in the build directory).
 
    Glib is also required to build the dissector, so "--glib" must be passed.

--- a/tools/dissector/dissector.mpc
+++ b/tools/dissector/dissector.mpc
@@ -28,4 +28,9 @@ project : dcpslib, wireshark, itl {
     LIB_UNCHECKED   = $(LIB_NAME).$(LIBEXT)
     SHLIB_UNCHECKED = $(LIB_NAME).$(SOEXT)
   }
+
+  // Make corrections for macOS, see macos_postbuild.sh for details
+  specific(!prop:windows) {
+    postbuild += bash macos_postbuild.sh
+  }
 }

--- a/tools/dissector/macos_postbuild.sh
+++ b/tools/dissector/macos_postbuild.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This script takes care of two problems with the dissector file on macOS:
 #
 #   $DYLD_LIBRARY_PATH is not persevered between processes after

--- a/tools/dissector/macos_postbuild.sh
+++ b/tools/dissector/macos_postbuild.sh
@@ -1,0 +1,25 @@
+# This script takes care of two problems with the dissector file on macOS:
+#
+#   $DYLD_LIBRARY_PATH is not persevered between processes after
+#   v10.11 "El Capitan" for security reasons and the rpath for the OpenDDS
+#   libraries is relative. To remedy this we add a absolute rpath to
+#   $DDS_ROOT/lib.
+#
+#   It produces dylib files which Wireshark will except but only if they have
+#   a "so" file extention. To remedy this we just make a copy with the "so"
+#   extension.
+#
+# These are probably are possible with MPC alone, but it was easier to do it
+# here.
+
+filename="OpenDDS_Dissector"
+d="$filename.dylib"
+s="$filename.so"
+
+# if there is a dylib file and either no so file or the dylib file is newer:
+if [ -f "$d" -a \( \( ! -f "$s" \) -o \( "$d" -nt "$s" \) \) ]; then
+  # then produce a so file:
+  # (Since only macOS will produce dylib files other unixes will skip this)
+  install_name_tool -add_rpath "$DDS_ROOT/lib" "$d"
+  cp "$d" "$s"
+fi

--- a/tools/dissector/macos_postbuild.sh
+++ b/tools/dissector/macos_postbuild.sh
@@ -7,12 +7,9 @@
 #   libraries is relative. To remedy this we add a absolute rpath to
 #   $DDS_ROOT/lib.
 #
-#   It produces dylib files which Wireshark will except but only if they have
+#   It produces dylib files which Wireshark will accept but only if they have
 #   a "so" file extention. To remedy this we just make a copy with the "so"
 #   extension.
-#
-# These are probably are possible with MPC alone, but it was easier to do it
-# here.
 
 filename="OpenDDS_Dissector"
 d="$filename.dylib"

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -58,7 +58,7 @@ namespace OpenDDS
       GError * error = NULL;
       char * utf8 = g_convert(
         from_, length * sizeof(ACE_CDR::WChar),
-        "UTF-8", "UTF-16", NULL, NULL, &error
+        "UTF-8", "UTF-16LE", NULL, NULL, &error
       );
 
       if (utf8 != NULL) {

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -161,6 +161,7 @@ namespace OpenDDS
         Float,
         Double,
         LongDouble,
+        Fixed,
         String,  // not fixed, but pre-defined in IDL
         WString,
         Enumeration,

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -51,7 +51,7 @@ namespace OpenDDS
       {
       }
 
-      ~Sample_Dissector_Error() {}
+      ~Sample_Dissector_Error() throw() {}
 
       const char* what() const throw() {
         return message_.c_str();

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -154,12 +154,13 @@ namespace OpenDDS
         }
       }
 
-      void visit (itl::Fixed&) {
-        // TODO Fixed types are supported in OpenDDS now, and the dissector
-        // should handle them.
+      void visit (itl::Fixed& fixed) {
+#ifndef ACE_HAS_CDR_FIXED
         dissector = new Sample_Dissector();
-        dissector->add_field(new Sample_Field(Sample_Field::Undefined, ""));
-        ACE_DEBUG ((LM_WARNING, ACE_TEXT ("Fixed-point types are not supported\n")));
+        dissector->add_field(new Sample_Field(Sample_Field::Fixed, ""));
+#else
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("ACE is missing Fixed support.\n")));
+#endif
       }
 
       Sample_Dissector* do_array(std::vector<unsigned int>::const_iterator pos,

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -155,10 +155,9 @@ namespace OpenDDS
       }
 
       void visit (itl::Fixed& fixed) {
-#ifndef ACE_HAS_CDR_FIXED
         dissector = new Sample_Dissector();
         dissector->add_field(new Sample_Field(Sample_Field::Fixed, ""));
-#else
+#ifndef ACE_HAS_CDR_FIXED
         ACE_DEBUG((LM_WARNING, ACE_TEXT("ACE is missing Fixed support.\n")));
 #endif
       }


### PR DESCRIPTION
Dissector macOS support as well as changing the configure script to reflect [MPC#48](https://github.com/DOCGroup/MPC/pull/48) and the dissector/README to reflect both of these.

Also:
 - Some bits of the `Fixed` type support for the sample payload dissector are in here, but nowhere near done.
 - The loose throw error that I failed to fix in the scoreboards.
 - Default to `/usr/include/wireshark` if it exists and `--wireshark` was left blank to support wireshark development packages installed there.