### PR TITLE
dissector: Fixed Type Support and expert changes

### DIFF
--- a/dds/idl/itl_generator.cpp
+++ b/dds/idl/itl_generator.cpp
@@ -269,8 +269,8 @@ bool itl_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* /*name*/,
         << Indent(this) << "\"type\" : { "
           << "\"kind\" : \"fixed\", "
           << "\"digits\" : " << digits << ", "
-          << "\"scale\" : " << scale
-          << " }\n"
+          << "\"scale\" : " << scale << ", "
+          << "\"base\" : 10 }\n"
         << Close(this) << Indent(this) << "}\n" << Close(this);
       break;
     }

--- a/dds/idl/itl_generator.cpp
+++ b/dds/idl/itl_generator.cpp
@@ -12,6 +12,8 @@
 #include "utl_identifier.h"
 #include "utl_labellist.h"
 
+#include <ast_fixed.h>
+
 using namespace AstTypeClassification;
 
 std::ostream&
@@ -253,6 +255,23 @@ bool itl_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* /*name*/,
                       << Close(this)
                       << Indent(this) << "}\n"
                       << Close(this);
+      break;
+    }
+  case AST_Decl::NT_fixed:
+    {
+      AST_Fixed* fixed = AST_Fixed::narrow_from_decl(base);
+      unsigned digits = fixed->digits()->ev()->u.ulval;
+      unsigned scale = fixed->scale()->ev()->u.ulval;
+      be_global->itl_
+        << Open(this) << Indent(this) << "{\n" << Open(this)
+        << Indent(this) << "\"kind\" : \"alias\",\n"
+        << Indent(this) << "\"name\" : \"" << repoid << "\",\n"
+        << Indent(this) << "\"type\" : { "
+          << "\"kind\" : \"fixed\", "
+          << "\"digits\" : " << digits << ", "
+          << "\"scale\" : " << scale
+          << " }\n"
+        << Close(this) << Indent(this) << "}\n" << Close(this);
       break;
     }
   default:

--- a/tools/IntermediateTypeLang/cpp/itl/itl.hpp
+++ b/tools/IntermediateTypeLang/cpp/itl/itl.hpp
@@ -606,13 +606,15 @@ namespace itl {
       std::map<std::string, std::string> values;
       bool isConstrained = false;
 
-      if (!extractUint("base", value, base)) throw std::runtime_error("No base for fixed");
+      // if (!extractUint("base", value, base)) throw std::runtime_error("No base for fixed");
       if (!extractUint("digits", value, digits)) throw std::runtime_error("No digits for fixed");
       if (!extractUint("scale", value, scale)) throw std::runtime_error("No scale for fixed");
 
+      /*
       if (base == 0) {
         throw std::runtime_error("Illegal base for fixed");
       }
+      */
 
       if (scale > digits) {
         throw std::runtime_error("Scale exceeds digits in fixed");

--- a/tools/IntermediateTypeLang/cpp/itl/itl.hpp
+++ b/tools/IntermediateTypeLang/cpp/itl/itl.hpp
@@ -606,15 +606,13 @@ namespace itl {
       std::map<std::string, std::string> values;
       bool isConstrained = false;
 
-      // if (!extractUint("base", value, base)) throw std::runtime_error("No base for fixed");
+      if (!extractUint("base", value, base)) throw std::runtime_error("No base for fixed");
       if (!extractUint("digits", value, digits)) throw std::runtime_error("No digits for fixed");
       if (!extractUint("scale", value, scale)) throw std::runtime_error("No scale for fixed");
 
-      /*
       if (base == 0) {
         throw std::runtime_error("Illegal base for fixed");
       }
-      */
 
       if (scale > digits) {
         throw std::runtime_error("Scale exceeds digits in fixed");

--- a/tools/dissector/packet-opendds.cpp
+++ b/tools/dissector/packet-opendds.cpp
@@ -92,11 +92,16 @@ int hf_sample_flags_more_frags  = -1;
 int hf_sample_flags2            = -1;
 int hf_sample_flags2_cdr_encap  = -1;
 int hf_sample_flags2_key_only   = -1;
+
 // Payload IDL Type, ex "Messenger::Message"
 int hf_sample_payload = -1;
+
 #ifndef NO_EXPERT
-// Payload "Expert" Error Field
-expert_field ei_sample_payload = EI_INIT;
+// This signifies a problem with the structure of the payload
+expert_field ei_sample_payload_error = EI_INIT;
+// All other problems that are considered less serious, like missing
+// dissector ITL file or problems with individual fields of payload.
+expert_field ei_sample_payload_warning = EI_INIT;
 #endif
 
 const int sample_flags_bits = 8;
@@ -514,7 +519,7 @@ namespace OpenDDS
         proto_tree_add_expert_format(
           ltree,
           pinfo_,
-          &ei_sample_payload,
+          &ei_sample_payload_warning,
           tvb_,
           offset,
           (gint) header.message_length_,
@@ -540,7 +545,7 @@ namespace OpenDDS
         proto_tree_add_expert_format(
           ltree,
           pinfo_,
-          &ei_sample_payload,
+          &ei_sample_payload_warning,
           tvb_,
           offset,
           (gint) header.message_length_,
@@ -574,7 +579,7 @@ namespace OpenDDS
         proto_tree_add_expert_format(
           ltree,
           pinfo_,
-          &ei_sample_payload,
+          &ei_sample_payload_warning,
           tvb_,
           offset,
           (gint) header.message_length_,
@@ -622,6 +627,7 @@ namespace OpenDDS
         params.info = pinfo_;
         params.tree = contents_tree;
         params.offset = offset;
+        params.warning_ef = &ei_sample_payload_warning;
 
         /*
          * Handle Seg Faults that might be caused by incorrect ITL file
@@ -698,7 +704,7 @@ namespace OpenDDS
             } catch (Sample_Dissector_Error & e) {
 #ifndef NO_EXPERT
               proto_tree_add_expert_format(
-                trans_tree, pinfo_, &ei_sample_payload,
+                trans_tree, pinfo_, &ei_sample_payload_error,
                 tvb_, offset, -1, e.what()
               );
 #endif
@@ -978,12 +984,18 @@ namespace OpenDDS
       // Expert Information
 #ifndef NO_EXPERT
       static ei_register_info ei[] = {
-        { &ei_sample_payload, {
-          "opendds.sample.dissect_error",
+        {&ei_sample_payload_warning, {
+          "opendds.sample.dissect_warning",
           PI_UNDECODED, PI_WARN,
-          "Unable to Dissect Sample Payload",
+          "Unable dissect a field in the sample payload successfully.",
           EXPFILL
         }},
+        {&ei_sample_payload_error, {
+          "opendds.sample.dissect_error",
+          PI_MALFORMED, PI_ERROR,
+          "Unable to dissect sample payload because data not match ITL file.",
+          EXPFILL
+        }}
       };
 #endif
 

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -1316,7 +1316,7 @@ namespace OpenDDS
 #ifdef ACE_HAS_CDR_FIXED
         // Extract a ACE_CDR::Fixed, give it to WS as a double, and display
         // it using Fixed.to_string().
-        FACE::Octet raw[len];
+        FACE::Octet raw[(ACE_CDR::Fixed::MAX_DIGITS + 2) / 2];
         if (params.serializer.read_octet_array(raw, len)) {
           ACE_CDR::Fixed fixed_value = ACE_CDR::Fixed::from_octets(
             raw, len, scale_);

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -1342,13 +1342,12 @@ namespace OpenDDS
 #else
         // Place Dummy value and inform user
         const char * missing_fixed = "Fixed Type Support is missing from ACE";
-        proto_item * item;
         if (params.use_index) {
-          item = proto_tree_add_double_format(
+          proto_tree_add_double_format(
             ADD_FIELD_PARAMS, 0, "[%u]: %s", params.index, missing_fixed
           );
         } else {
-          item = proto_tree_add_double_format_value(
+          proto_tree_add_double_format_value(
             ADD_FIELD_PARAMS, 0, "%s", missing_fixed
           );
         }

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -27,6 +27,12 @@
 #include <string>
 #include <vector>
 
+#ifndef NO_EXPERT
+extern "C" {
+#include <epan/expert.h>
+}
+#endif
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS
@@ -34,10 +40,14 @@ namespace OpenDDS
   namespace DCPS
   {
 
-    std::string utf16_to_utf8(
-       const ACE_CDR::WChar* from, const size_t length = 1
+    /*
+     * To make it easy to pass to Wireshark, we should convert DDS wide chars
+     * and strings to UTF-8. Returns true if there was an error and sets
+     * result to the reason it failed.
+     */
+    bool utf16_to_utf8(
+       std::string &result, const ACE_CDR::WChar* from, const size_t length = 1
     ) {
-      std::string result;
 
       const gchar* from_;
 #if ACE_SIZEOF_WCHAR == 4
@@ -64,6 +74,7 @@ namespace OpenDDS
       if (utf8 != NULL) {
         result = utf8;
         g_free(utf8);
+        return false;
       } else {
         const char * error_msg = "UTF-16 to UTF-8 conversion failed: ";
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%C%C\n"),
@@ -73,9 +84,8 @@ namespace OpenDDS
         result = error_msg;
         result += error->message;
         g_clear_error(&error);
+        return true;
       }
-
-      return result;
     }
 
     Wireshark_Bundle::Wireshark_Bundle(
@@ -104,6 +114,7 @@ namespace OpenDDS
       offset = other.offset;
       use_index = other.use_index;
       index = other.index;
+      warning_ef = other.warning_ef;
     }
 
     size_t Wireshark_Bundle::buffer_pos() {
@@ -249,6 +260,7 @@ namespace OpenDDS
       TAO::String_Manager string_value;
       size_t wstring_length;
       TAO::WString_Manager wstring_value;
+      std::string converted;
 
       switch (this->type_id_) {
       case Char:
@@ -275,7 +287,8 @@ namespace OpenDDS
       case WChar:
         ACE_CDR::WChar wchar_value;
         p.serializer >> ACE_InputCDR::to_wchar(wchar_value);
-        s << utf16_to_utf8(&wchar_value);
+        utf16_to_utf8(converted, &wchar_value);
+        s << converted;
         break;
 
       case Short:
@@ -339,7 +352,8 @@ namespace OpenDDS
 
       case WString:
         wstring_length = p.serializer.read_string(wstring_value.inout());
-        s << utf16_to_utf8(wstring_value, wstring_length);
+        utf16_to_utf8(converted, wstring_value, wstring_length);
+        s << converted;
         break;
 
       case Enumeration:
@@ -419,7 +433,15 @@ namespace OpenDDS
             len = params.buffer_pos() - location;
             if (!params.get_size_only) {
               std::string s;
-              s = utf16_to_utf8(&wchar_value);
+              bool utf_fail = utf16_to_utf8(s, &wchar_value);
+#ifndef NO_EXPERT
+              if (utf_fail) {
+                proto_tree_add_expert_format(
+                    params.tree, params.info, params.warning_ef, params.tvb,
+                    params.offset, len, s.c_str()
+                );
+              }
+#endif
               if (params.use_index) {
                 proto_tree_add_string_format(
                   ADD_FIELD_PARAMS, s.c_str(),
@@ -627,7 +649,15 @@ namespace OpenDDS
             if (!params.get_size_only) {
               // Get UTF8 Version of the String
               std::string s;
-              s = utf16_to_utf8(wstring_value, wstring_length);
+              bool utf_fail = utf16_to_utf8(s, wstring_value, wstring_length);
+#ifndef NO_EXPERT
+              if (utf_fail) {
+                proto_tree_add_expert_format(
+                    params.tree, params.info, params.warning_ef, params.tvb,
+                    params.offset, len, s.c_str()
+                );
+              }
+#endif
 
               if (params.use_index) {
                 proto_tree_add_string_format(
@@ -1254,6 +1284,83 @@ namespace OpenDDS
 
     void Sample_Alias::init_ws_fields() {
       base_->init_ws_fields();
+    }
+
+    //-----------------------------------------------------------------------
+
+    Sample_Fixed::Sample_Fixed(unsigned digits, unsigned scale)
+    :
+      Sample_Dissector(""),
+      digits_(digits),
+      scale_(scale)
+    {
+    }
+
+    void Sample_Fixed::init_ws_fields() {
+      add_protocol_field(FT_DOUBLE);
+    }
+
+    size_t Sample_Fixed::dissect_i(Wireshark_Bundle &params) {
+      // Based on FACE/Fixed.h
+      // Fixed_T could not be used here because it is a templated class
+      size_t len = (digits_ + 2) / 2;
+
+      if (!params.get_size_only) {
+        int hf = get_hf();
+        if (hf == -1) {
+          throw Sample_Dissector_Error(
+            get_ns()  + " is not a registered wireshark field."
+          );
+        }
+
+#ifdef ACE_HAS_CDR_FIXED
+        // Extract a ACE_CDR::Fixed, give it to WS as a double, and display
+        // it using Fixed.to_string().
+        FACE::Octet raw[len];
+        if (params.serializer.read_octet_array(raw, len)) {
+          ACE_CDR::Fixed fixed_value = ACE_CDR::Fixed::from_octets(
+            raw, len, scale_);
+          char string_value[ACE_CDR::Fixed::MAX_STRING_SIZE];
+          fixed_value.to_string(
+            &string_value[0], ACE_CDR::Fixed::MAX_STRING_SIZE);
+          double double_value = static_cast<ACE_CDR::LongDouble>(
+            fixed_value);
+          if (params.use_index) {
+            proto_tree_add_double_format(
+              ADD_FIELD_PARAMS, double_value,
+              "[%u]: %s", params.index, &string_value[0]
+            );
+          } else {
+            proto_tree_add_double_format_value(
+              ADD_FIELD_PARAMS, double_value,
+              "%s", &string_value[0]
+            );
+          }
+        } else {
+          throw Sample_Dissector_Error("Error Reading Fixed Type");
+        }
+#else
+        // Place Dummy value and inform user
+        const char * missing_fixed = "Fixed Type Support is missing from ACE";
+        proto_item * item;
+        if (params.use_index) {
+          item = proto_tree_add_double_format(
+            ADD_FIELD_PARAMS, 0, "[%u]: %s", params.index, missing_fixed
+          );
+        } else {
+          item = proto_tree_add_double_format_value(
+            ADD_FIELD_PARAMS, 0, "%s", missing_fixed
+          );
+        }
+#ifndef NO_EXPERT
+        proto_tree_add_expert(
+            params.tree, params.info, params.warning_ef, params.tvb,
+            params.offset, len, missing_fixed
+        );
+#endif
+#endif
+      }
+      return len;
     }
 
   }

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -32,6 +32,7 @@ extern "C" {
 #include "tools/dissector/dissector_export.h"
 #include "ws_common.h"
 
+#include "FACE/Fixed.h"
 #include "dds/DCPS/Serializer.h"
 #include "dds/DCPS/DataSampleHeader.h"
 
@@ -73,6 +74,7 @@ namespace OpenDDS
       packet_info* info;
       proto_tree* tree;
       size_t offset;
+      expert_field * warning_ef;
 
       bool use_index;
       guint32 index;
@@ -161,7 +163,6 @@ namespace OpenDDS
         Float,
         Double,
         LongDouble,
-        Fixed,
         String,  // not fixed, but pre-defined in IDL
         WString,
         Enumeration,
@@ -194,7 +195,6 @@ namespace OpenDDS
       /// Sample_Dissector object for further evaluation.
       size_t dissect_i (Wireshark_Bundle &params, bool recur = true);
 
-      /// Compute the size of the field in bytes
       size_t compute_length(const Wireshark_Bundle & p);
 
       void to_stream(std::stringstream &s, Wireshark_Bundle & p);
@@ -413,6 +413,24 @@ namespace OpenDDS
       Sample_Dissector *base_;
     };
 
+    /*
+     * A Dissector for Fixed Point Types (FACE/Fixed.h)
+     */
+    class dissector_Export Sample_Fixed : public Sample_Dissector
+    {
+    public:
+      Sample_Fixed(unsigned digits, unsigned scale);
+
+      unsigned digits() { return digits_; }
+      unsigned scale() { return scale_; }
+
+    protected:
+      virtual void init_ws_fields();
+      virtual size_t dissect_i(Wireshark_Bundle &params);
+
+    private:
+      unsigned digits_, scale_;
+    };
   }
 }
 

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -155,11 +155,12 @@ namespace OpenDDS
       }
 
       void visit (itl::Fixed& fixed) {
-        dissector = new Sample_Dissector();
-        dissector->add_field(new Sample_Field(Sample_Field::Fixed, ""));
 #ifndef ACE_HAS_CDR_FIXED
-        ACE_DEBUG((LM_WARNING, ACE_TEXT("ACE is missing Fixed support.\n")));
+        ACE_DEBUG((LM_WARNING, ACE_TEXT(
+          "A Fixed type has been specified but ACE is missing Fixed.\n"
+        )));
 #endif
+        dissector = new Sample_Fixed(fixed.digits(), fixed.scale());
       }
 
       Sample_Dissector* do_array(std::vector<unsigned int>::const_iterator pos,


### PR DESCRIPTION
Added support for dissection of OpenDDS fixed-point numbers which are
converted to doubles for numerical comparisons within Wireshark.
If ACE_CDR::Fixed is missing, a message will be displayed that this is so.

Also started marking some packets with a warning instead of marking it
as malformed. For example, when an individual field fails for some
reason or non essential information is unavailable, like the dissector
ITL file or Fixed type is missing like above.