### PR TITLE
Dissector Fixes for Fixed Type Support, Expert, and configure

### DIFF
--- a/configure
+++ b/configure
@@ -855,9 +855,10 @@ if (exists $opts{'java'}) {
 $opts{'qt'} = '' if exists $opts{'qt-include'} && !exists $opts{'qt'};
 $opts{'boost'} = '' if exists $opts{'boost-version'} && !exists $opts{'boost'};
 
-# Default to Wireshark Development Package if installed
+# Default to Wireshark Development Package if installed and a path wasn't
+# supplied.
 my $wireshark_install = '/usr/include/wireshark';
-if (exists $opts{'wireshark'} && $opts{'wireshark'} eq '') {
+if (exists $opts{'wireshark'} && !defined $ENV{'WIRESHARK_SRC'} && $opts{'wireshark'} eq '') {
   if (-d $wireshark_install) {
     $opts{'wireshark'} = $wireshark_install;
   } else {
@@ -1013,7 +1014,7 @@ if (exists $opts{'wireshark'} || exists $opts{'wireshark_cmake'}) {
     if (! -d ($opts{'wireshark_build'} . '/' . $opts{'wireshark_lib'})) {
       if ($wireshark_lib_defaulted) {
         die "ERROR: The default value for wireshark_lib: " . $opts{'wireshark_lib'} .
-            " does not exist, please sypply wireshark_lib with the correct value";
+            " does not exist, please supply wireshark_lib with the correct value";
       } else {
         die "ERROR: The supplied wireshark_lib: " . $opts{'wireshark_lib'} . " does not exist.";
       }

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -1305,7 +1305,9 @@ namespace OpenDDS
       // Fixed_T could not be used here because it is a templated class
       size_t len = (digits_ + 2) / 2;
 
-      if (!params.get_size_only) {
+      if (params.get_size_only) {
+        params.serializer.skip(len);
+      } else {
         int hf = get_hf();
         if (hf == -1) {
           throw Sample_Dissector_Error(
@@ -1356,9 +1358,15 @@ namespace OpenDDS
             params.tree, params.info, params.warning_ef, params.tvb,
             params.offset, len, missing_fixed
         );
-#endif
-#endif
+#endif // NO_EXPERT
+
+        // and skip it.
+        params.serializer.skip(len);
+
+#endif // ACE_HAS_CDR_FIXED
+
       }
+
       return len;
     }
 

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -74,7 +74,9 @@ namespace OpenDDS
       packet_info* info;
       proto_tree* tree;
       size_t offset;
+#ifndef NO_EXPERT
       expert_field * warning_ef;
+#endif
 
       bool use_index;
       guint32 index;


### PR DESCRIPTION
- Missing Macro Guard for older Wiresharks.
- Fix for configure script "wireshark" value being passed through $WIRESHARK_SRC.
- Missing serializer skips when we are going over but not extracting a Fixed data type.