### PR TITLE
Link Doxygen to a Built-In Copy of ACE/TAO Documentation

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+doxygen_ace_tao_generated_links.h

--- a/docs/doxygen_main_page.h
+++ b/docs/doxygen_main_page.h
@@ -1,0 +1,17 @@
+/*! \mainpage OpenDDS
+ *
+ * \section intro_sec Introduction
+ *
+ * <a href="http://opendds.org/">OpenDDS</a> is an open source C++
+ * implementation of the Object Management Group (OMG) Data Distribution
+ * Service (%DDS).
+ * Java applications can use %OpenDDS through JNI bindings.
+ * %OpenDDS was developed and open sourced by
+ * <a href="https://objectcomputing.com/">OCI</a>.
+ *
+ * \section ace_tao_sec Built-In ACE/TAO Documentation
+ * If this documentation was built using \c generate_combined_doxygen.pl, then
+ * you can browse directly: \ref ace_tao_links or through the ACE/TAO
+ * references throughout this documentation.
+ *
+ */

--- a/etc/dds.doxygen
+++ b/etc/dds.doxygen
@@ -1073,7 +1073,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = 
+TAGFILES = $(ace_tao_tagfiles)
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.

--- a/etc/dds.doxygen
+++ b/etc/dds.doxygen
@@ -463,7 +463,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories 
 # with spaces.
 
-INPUT                  = dds
+INPUT = dds docs/doxygen_main_page.h docs/doxygen_ace_tao_generated_links.h
 
 # This tag can be used to specify the character encoding of the source files that 
 # doxygen parses. Internally doxygen uses the UTF-8 encoding, which is also the default 

--- a/tools/scripts/generate_combined_doxygen.pl
+++ b/tools/scripts/generate_combined_doxygen.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+# Script that wraps around generate_doxygen.pl to generate OpenDDS Doxygen
+# documentation with ACE/TAO documentation built-in.
+
+use strict;
+use File::Path qw(make_path);
+use File::Copy qw(move);
+use File::Spec;
+use File::Find;
+use File::Basename;
+
+# Parse Arguments
+my $usage = "usage: generate_combined_doxygen.pl [-h|--help] DESTINATION ...\n";
+my $argc = $#ARGV + 1;
+if (!(defined $ENV{"ACE_ROOT"} && defined $ENV{"DDS_ROOT"})) {
+  die "ERROR: \$ACE_ROOT and \$DDS_ROOT must be defined\n";
+}
+if ($argc == 0) {
+  die "ERROR: $usage";
+}
+if ($ARGV[0] eq "-h" || $ARGV[0] eq "--help") {
+  print $usage;
+  print "\nGenerates OpenDDS Doxygen documentation with ACE/TAO documentation built-in.\n";
+  print "Extra arguments are passed to generate_doxygen.pl.\n";
+
+  exit 0;
+}
+if (! -d $ARGV[0]) {
+  die "ERROR: destination directory $ARGV[0] does not exist!\n";
+}
+
+# Set up paths
+my $dest = File::Spec->rel2abs(shift);
+my @doxygen = (
+  "perl", $ENV{"ACE_ROOT"} . "/bin/generate_doxygen.pl", "-html_output", $dest
+);
+for (my $i = 0; $i <= $#ARGV; $i++) {
+  push(@doxygen, $ARGV[$i]);
+}
+my $ace_dest = "$dest/html/dds/ace_tao";
+if (! -d $ace_dest) {
+  make_path($ace_dest) or die "ERROR: $!";
+}
+
+# Build ACE/TAO Documentation
+chdir $ENV{"ACE_ROOT"};
+system(@doxygen) == 0 or die "ERROR: ACE/TAO Doxygen failed ($!)\n";
+move("$dest/html/libace-doc", "$ace_dest/libace-doc") or die $!;
+move("$dest/html/libacexml-doc", "$ace_dest/libacexml-doc") or die $!;
+move("$dest/html/libtao-doc", "$ace_dest/libtao-doc") or die $!;
+
+# Find Tagfiles and Inject into dds.doxygen using $ace_tao_tagfiles
+my $ace_tao_tagfiles = "";
+my (@tagfiles)=();
+find (\&check_if_tag, $ace_dest);
+sub check_if_tag {
+  push (@tagfiles, $File::Find::name) if (!-d && $File::Find::name =~ /.*\.tag$/);
+}
+foreach $a (@tagfiles) {
+  my $file = "ace_tao" . dirname(substr($a, (length $ace_dest)));
+  $ace_tao_tagfiles = sprintf(
+    "%s \"%s = %s\"", $ace_tao_tagfiles, $a, $file
+  );
+}
+$ENV{ace_tao_tagfiles} = $ace_tao_tagfiles;
+
+# Build OpenDDS Documentation
+chdir $ENV{"DDS_ROOT"};
+system(@doxygen) == 0 or die "ERROR: DDS Doxygen failed ($!)\n";
+

--- a/tools/scripts/generate_combined_doxygen.pl
+++ b/tools/scripts/generate_combined_doxygen.pl
@@ -4,7 +4,7 @@
 # documentation with ACE/TAO documentation built-in.
 
 use strict;
-use File::Path qw(make_path rmtree);
+use File::Path qw(mkpath rmtree);
 use File::Copy qw(move);
 use File::Find;
 use File::Basename;
@@ -42,7 +42,7 @@ my $ace_dest = "$dest/html/dds/ace_tao";
 if (-d "$dest/html") {
   rmtree("$dest/html");
 }
-make_path($ace_dest) or die "ERROR: $!";
+mkpath($ace_dest) or die "ERROR: $!";
 
 # Build ACE/TAO Documentation
 chdir $ENV{"ACE_ROOT"};

--- a/tools/scripts/generate_combined_doxygen.pl
+++ b/tools/scripts/generate_combined_doxygen.pl
@@ -39,9 +39,6 @@ for (my $i = 0; $i <= $#ARGV; $i++) {
   push(@doxygen, $ARGV[$i]);
 }
 my $ace_dest = "$dest/html/dds/ace_tao";
-if (-d "$dest/html") {
-  rmtree("$dest/html");
-}
 mkpath($ace_dest) or die "ERROR: $!";
 
 # Build ACE/TAO Documentation

--- a/tools/scripts/gitrelease.pl
+++ b/tools/scripts/gitrelease.pl
@@ -924,7 +924,7 @@ sub remedy_gen_doxygen {
     my $curdir = getcwd;
     chdir($settings->{clone_dir});
     $ENV{DDS_ROOT} = getcwd;
-    my $result = system("$ENV{ACE_ROOT}/bin/generate_doxygen.pl -exclude_ace -include_dds -is_release");
+    my $result = system("$ENV{DDS_ROOT}/tools/scripts/generate_combined_doxygen.pl . -is_release");
     chdir($curdir);
     if (!$result) {
       $generated = 1;


### PR DESCRIPTION
- Added `generate_combined_doxygen.pl`, which builds ACE/TAO Doxygen docs based on `$ACE_ROOT`, and builds OpenDDS Doxygen docs based on `$DDS_ROOT`. The script calls `generate_doxygen.pl` internally. The DDS docs will be linked to the ACE/TAO docs reference wise. It also generates a list of the ACE/TAO Doxygens included.

- Also updated `gitrelease.pl` to use `generate_combined_doxygen.pl` instead of `generate_doxygen.pl`.