### PR TITLE
Fix Reconnect Test and DataLink Leaks

### DIFF
--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -111,7 +111,9 @@ DataLink::send(TransportQueueElement* element)
   }
 
   if (this->thr_per_con_send_task_ != 0) {
-    this->thr_per_con_send_task_->add_request(SEND, element);
+    if (this->thr_per_con_send_task_->add_request(SEND, element) == -1) {
+      element->data_dropped(true);
+    }
 
   } else {
     this->send_i(element);
@@ -135,6 +137,8 @@ DataLink::send_i(TransportQueueElement* element, bool relink)
 
   if (strategy) {
     strategy->send(element, relink);
+  } else {
+    element->data_dropped(true);
   }
 }
 

--- a/tests/DCPS/Reconnect/.gitignore
+++ b/tests/DCPS/Reconnect/.gitignore
@@ -24,3 +24,4 @@
 /subscriber1.log
 /subscriber2.log
 /repo.log
+/core*

--- a/tests/DCPS/Reconnect/.gitignore
+++ b/tests/DCPS/Reconnect/.gitignore
@@ -19,9 +19,8 @@
 /subscriber_ready.txt
 /publisher_finished.txt
 /publisher_ready.txt
-/test.log
 /publisher1.log
 /publisher2.log
 /subscriber1.log
 /subscriber2.log
-
+/repo.log

--- a/tests/DCPS/Reconnect/Writer.cpp
+++ b/tests/DCPS/Reconnect/Writer.cpp
@@ -47,6 +47,9 @@ Writer::svc ()
 
   ::DDS::InstanceHandleSeq handles;
   try {
+
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT(
+      "(%P|%t) Writer::svc wait for get_matched_subscriptions()\n")));
     while (1)
     {
       writer_->get_matched_subscriptions(handles);
@@ -55,6 +58,9 @@ Writer::svc ()
       else
         ACE_OS::sleep(ACE_Time_Value(0,200000));
     }
+    ACE_DEBUG((LM_DEBUG,
+      ACE_TEXT("(%P|%t) Writer::svc get_matched_subscriptions() got %lu\n"),
+      handles.length()));
 
     Messenger::MessageDataWriter_var message_dw
       = Messenger::MessageDataWriter::_narrow(writer_.in());

--- a/tests/DCPS/Reconnect/Writer.cpp
+++ b/tests/DCPS/Reconnect/Writer.cpp
@@ -59,7 +59,7 @@ Writer::svc ()
         ACE_OS::sleep(ACE_Time_Value(0,200000));
     }
     ACE_DEBUG((LM_DEBUG,
-      ACE_TEXT("(%P|%t) Writer::svc get_matched_subscriptions() got %lu\n"),
+      ACE_TEXT("(%P|%t) Writer::svc get_matched_subscriptions() got %u\n"),
       handles.length()));
 
     Messenger::MessageDataWriter_var message_dw

--- a/tests/DCPS/Reconnect/run_test.pl
+++ b/tests/DCPS/Reconnect/run_test.pl
@@ -232,11 +232,23 @@ if ($num_writes_before_crash > 0) {
 
 if ($sub_init_crash) {
   # Make sure publisher has started
-  if (PerlACE::waitforfile_timed($publisher_ready, 10) == -1) {
-    print STDERR "ERROR: waiting for publisher to be ready\n";
-    $status = 1;
+  # Did not use PerlACE::waitforfile_timed because it tests for a
+  # nonemtpy file.
+  my $i = 0;
+  while (1) {
+    if (-e $publisher_ready) {
+      last;
+    }
+    if ($i >= 60) {
+      print STDERR "ERROR: timedout waiting for publisher to be ready\n";
+      $status = 1;
+      last;
+    }
+    $i++;
+    sleep (1);
   }
-  # Kill or else it will timeout waiting for subscribers
+  # Kill the publisher or else it will just wait for subscribers
+  # that will never come.
   $Publisher->Kill(0);
 
 } else {

--- a/tests/DCPS/Reconnect/run_test.pl
+++ b/tests/DCPS/Reconnect/run_test.pl
@@ -13,6 +13,10 @@ use strict;
 
 my $status = 0;
 
+# Debug Levels
+my $dcps_dbl = 2;
+my $transport_dbl = 0;
+
 my $num_reads_before_crash = 0;
 my $num_writes_before_crash = 0;
 my $num_writes = 10;
@@ -23,7 +27,7 @@ my $read_delay_ms=0;
 my $lost_publication_callback = 0;
 my $lost_subscription_callback = 0;
 my $end_with_publisher = 0;
-my $kill_subscriber = 0;
+my $sub_init_crash = 0;
 my $expected_total_publication_count = 1;
 my $verify_lost_sub_notification = 1;
 
@@ -79,7 +83,7 @@ elsif ($ARGV[0] eq 'bp_timeout') {
   $end_with_publisher = 1;
 }
 elsif ($ARGV[0] eq 'sub_init_crash') {
-    $kill_subscriber = 1;
+  $sub_init_crash = 1;
 }
 elsif ($ARGV[0] eq '') {
   #default test - no reconnect
@@ -89,57 +93,71 @@ else {
   exit 1;
 }
 
+my $common_args = "";
+$common_args .= "-DCPSDebugLevel $dcps_dbl" if $dcps_dbl;
+$common_args .= " " if $dcps_dbl && $transport_dbl;
+$common_args .= "-TransportDebugLevel $transport_dbl" if $transport_dbl;
+my $client_args = "-DCPSConfigFile opendds.ini $common_args";
+
 my $dcpsrepo_ior = "repo.ior";
 my $subscriber_completed = "subscriber_finished.txt";
 my $subscriber_ready = "subscriber_ready.txt";
 my $publisher_completed = "publisher_finished.txt";
 my $publisher_ready = "publisher_ready.txt";
-my $testoutputfilename = "test.log";
+my $repo_log = 'repo.log';
+my $pub1_log = 'publisher1.log';
+my $pub2_log = 'publisher2.log';
+my $sub1_log = 'subscriber1.log';
+my $sub2_log = 'subscriber2.log';
 
 unlink $dcpsrepo_ior;
 unlink $subscriber_completed;
 unlink $subscriber_ready;
 unlink $publisher_completed;
 unlink $publisher_ready;
-unlink 'publisher1.log';
-unlink 'publisher2.log';
-unlink 'subscriber1.log';
-unlink 'subscriber2.log';
-
+unlink $repo_log;
+unlink $pub1_log;
+unlink $pub2_log;
+unlink $sub1_log;
+unlink $sub2_log;
 
 my $DCPSREPO = PerlDDS::create_process
-      ("$ENV{DDS_ROOT}/bin/DCPSInfoRepo", "-o $dcpsrepo_ior");
+      ("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
+       "-o $dcpsrepo_ior"
+       . " $common_args -ORBLogFile $repo_log");
 my $Subscriber = PerlDDS::create_process
       ("subscriber"
        , "-a $num_reads_before_crash"
        . " -n $num_expected_reads -i $read_delay_ms -l $lost_subscription_callback"
-       . " -c $verify_lost_sub_notification -e $end_with_publisher -DCPSConfigFile opendds.ini"
-       . " -DCPSDebugLevel 2 -ORBLogFile subscriber1.log");
+       . " -c $verify_lost_sub_notification -e $end_with_publisher"
+       . " $client_args -ORBLogFile $sub1_log");
 my $Publisher = PerlDDS::create_process
       ("publisher"
        , "-a $num_writes_before_crash"
        . " -n $num_writes -i $write_delay_ms -l $lost_publication_callback"
-       . " -d $expected_total_publication_count -DCPSConfigFile opendds.ini"
-       . " -DCPSDebugLevel 2 -ORBLogFile publisher1.log");
+       . " -d $expected_total_publication_count"
+       . " $client_args -ORBLogFile $pub1_log");
 
 print $DCPSREPO->CommandLine () . "\n";
 $DCPSREPO->Spawn ();
 if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
-    exit 1;
+  print STDERR "ERROR: waiting for Info Repo IOR file\n";
+  $DCPSREPO->Kill ();
+  PerlDDS::print_file($repo_log);
+  print STDERR "test FAILED.\n";
+  exit 1;
 }
 
 print $Subscriber->CommandLine () . "\n";
 $Subscriber->Spawn ();
 
-if ($kill_subscriber > 0)
+if ($sub_init_crash > 0)
 {
-    # Simulate a crashed subscriber by killing it.
-    sleep (5); # Let subscriber initialize
-    $Subscriber->Kill (0); # Crash it.
+  # Simulate a crashed subscriber by killing it.
+  sleep (5); # Let subscriber initialize
+  $Subscriber->Kill (0); # Crash it.
 
-    print STDOUT "Subscriber crash before Publisher initialization.\n\n";
+  print STDOUT "Subscriber crash before Publisher initialization.\n\n";
 }
 
 print $Publisher->CommandLine () . "\n";
@@ -150,11 +168,15 @@ my($PublisherResult, $SubscriberResult);
 # The subscriber crashes and we need restart the subscriber.
 if ($num_reads_before_crash > 0)
 {
-  if (PerlACE::waitforfileoutput_timed ("subscriber1.log", "Subscriber crash after", 90) == -1) {
+  if (PerlACE::waitforfileoutput_timed ($sub1_log, "Subscriber crash after", 90) == -1) {
     print STDERR "ERROR: waiting for 'Subscriber crash after' output.\n";
     $Subscriber->Kill ();
     $Publisher->Kill ();
     $DCPSREPO->Kill ();
+    PerlDDS::print_file($repo_log);
+    PerlDDS::print_file($sub1_log);
+    PerlDDS::print_file($pub1_log);
+    print STDERR "test FAILED.\n";
     exit 1;
   }
 
@@ -180,7 +202,8 @@ if ($num_reads_before_crash > 0)
   $Subscriber = PerlDDS::create_process
         ("subscriber"
          , "-n $num_expected_reads_restart_sub"
-         . " -r $num_reads_deviation -DCPSConfigFile opendds.ini -ORBLogFile subscriber2.log");
+         . " -r $num_reads_deviation"
+         . " $client_args -ORBLogFile $sub2_log");
 
   print "\n\n!!! Restart subscriber !!! \n\n";;
   print $Subscriber->CommandLine () . "\n";
@@ -196,8 +219,9 @@ if ($num_writes_before_crash > 0) {
   print "Publisher crashed and returned $PublisherResult. \n";
 
   $Publisher = PerlDDS::create_process
-        ("publisher"
-         , "-DCPSConfigFile opendds.ini -ORBLogFile publisher2.log -n $num_writes");
+        ("publisher",
+         "-n $num_writes"
+         . " $client_args -ORBLogFile $pub2_log");
 
   sleep($restart_delay);
 
@@ -206,33 +230,34 @@ if ($num_writes_before_crash > 0) {
   $Publisher->Spawn ();
 }
 
-if ($kill_subscriber == 0)
-{
-    my $SubscriberResult = $Subscriber->WaitKill (300);
-    if ($SubscriberResult != 0) {
-        print STDERR "ERROR: subscriber returned $SubscriberResult \n";
-        $status = 1;
-    }
-}
-
-$PublisherResult = $Publisher->WaitKill (60);
-if ($kill_subscriber != 0 && $PublisherResult == 0) {
-    # writing out to STDOUT as these tests redirect STDERR to a log file.
-    # The nightly script parses STDERR to detect test failures.
-    print STDOUT "ERROR: Publisher crashed\n";
+if ($sub_init_crash) {
+  # Make sure publisher has started
+  if (PerlACE::waitforfile_timed($publisher_ready, 10) == -1) {
+    print STDERR "ERROR: waiting for publisher to be ready\n";
     $status = 1;
-}
-elsif ($kill_subscriber == 0 &&  $PublisherResult != 0) {
+  }
+  # Kill or else it will timeout waiting for subscribers
+  $Publisher->Kill(0);
+
+} else {
+  my $SubscriberResult = $Subscriber->WaitKill (300);
+  if ($SubscriberResult != 0) {
+    print STDERR "ERROR: subscriber returned $SubscriberResult \n";
+    $status = 1;
+  }
+
+  if ($Publisher->WaitKill (60)) {
     print STDERR "ERROR: publisher returned $PublisherResult \n";
     $status = 1;
+  }
 }
 
 # give InfoRepo a chance to digest the publisher crash.
 sleep (5);
 my $ir = $DCPSREPO->TerminateWaitKill(5);
 if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
+  print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
+  $status = 1;
 }
 
 unlink $dcpsrepo_ior;
@@ -245,10 +270,11 @@ if ($status == 0) {
   print "test PASSED.\n";
 } else {
   print STDERR "test FAILED.\n";
-  PerlDDS::print_file('subscriber1.log');
-  PerlDDS::print_file('publisher1.log');
-  PerlDDS::print_file('subscriber2.log') if -f 'subscriber2.log';
-  PerlDDS::print_file('publisher2.log') if -f 'publisher2.log';
+  PerlDDS::print_file($repo_log);
+  PerlDDS::print_file($sub1_log);
+  PerlDDS::print_file($pub1_log);
+  PerlDDS::print_file($sub2_log) if -f $sub2_log;
+  PerlDDS::print_file($pub2_log) if -f $pub2_log;
 }
 
 exit $status;


### PR DESCRIPTION
- Re-added the `element->data_dropped()`s in `DataLink`, except for the one after `customize_element()`. `customize_element()` calls `data_dropped` or passes it to `TransportCustomizedElement` which drops it when it's no longer needed.

- The Reconnect test hides the program output. Huangming had changed it in 373f41c
from collecting individual program output in a single file to having one
for each program, except the InfoRepo. I added an InfoRepo log file and did
some cleanup/small improvements.

- For the Reconnect sub_init_crash test the publisher has always (or at least in the commit
before the WeakRcHandle PR) waited for subscribers until the test script
timedout, killed it and reported it as an error. The fact that no more
subscribers are spawned seems to be intentional, as it just tries to see
if the publisher will crash but it was also hidden before the PR.
Now it is killed and it shouldn't report an error unless
the publisher returns a non zero status.