### PR TITLE
Adjust and simplify FACE/SingleProcessMessenger test.

### DIFF
--- a/tests/FACE/SingleProcessMessenger/face_config.ini
+++ b/tests/FACE/SingleProcessMessenger/face_config.ini
@@ -24,15 +24,8 @@ direction=source
 topic=Message
 datawriterqos=durable_writer
 
-[connection/suba]
+[connection/sub]
 id=2
-domain=3
-direction=destination
-topic=Message
-datareaderqos=durable_reader
-
-[connection/subb]
-id=3
 domain=3
 direction=destination
 topic=Message

--- a/tests/FACE/SingleProcessMessenger/face_config_static.ini
+++ b/tests/FACE/SingleProcessMessenger/face_config_static.ini
@@ -9,21 +9,13 @@ local_address=127.0.0.1:21074
 [config/pub]
 transports=rtps_pub
 
-[transport/rtps_suba]
+[transport/rtps_sub]
 transport_type=rtps_udp
 use_multicast=0
 local_address=127.0.0.1:21075
 
-[config/suba]
-transports=rtps_suba
-
-[transport/rtps_subb]
-transport_type=rtps_udp
-use_multicast=0
-local_address=127.0.0.1:21076
-
-[config/subb]
-transports=rtps_subb
+[config/sub]
+transports=rtps_sub
 
 [topic/Message]
 platform_view_guid=1
@@ -39,23 +31,14 @@ topic=Message
 datawriterqos=durable_writer
 config=pub
 
-[connection/suba]
+[connection/sub]
 id=2
 participantid=22222
 domain=3
 direction=destination
 topic=Message
 datareaderqos=durable_reader
-config=suba
-
-[connection/subb]
-id=3
-participantid=33333
-domain=3
-direction=destination
-topic=Message
-datareaderqos=durable_reader
-config=subb
+config=sub
 
 [datawriterqos/durable_writer]
 durability.kind=TRANSIENT_LOCAL


### PR DESCRIPTION
Collapse unnecessary suba/subb connections to a single sub connection.
Register any callbacks before sending the message designed to trigger the callback.
Mark shared variables as volatile to prevent compiler optimization shenanigans.

Fixes #833