### PR TITLE
Partially revert "Make TransportRegistry the owner of TransportInst Objects"

### DIFF
--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -268,7 +268,7 @@ InfoRepoDiscovery::bit_config()
 
     const std::string inst_name = TransportRegistry::DEFAULT_INST_PREFIX +
                                   std::string("_BITTCPTransportInst_") + key();
-    TransportInst* inst =
+    TransportInst_rch inst =
       TransportRegistry::instance()->create_inst(inst_name, "tcp");
     bit_config_->instances_.push_back(inst);
 
@@ -278,7 +278,7 @@ InfoRepoDiscovery::bit_config()
     }
 
     // Use a static cast to avoid dependency on the Tcp library
-    TcpInst* tcp_inst = static_cast<TcpInst*>(inst);
+    TcpInst_rch tcp_inst = static_rchandle_cast<TcpInst>(inst);
 
     tcp_inst->datalink_release_delay_ = 0;
     if (!bit_transport_ip_.empty()) {

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -217,8 +217,8 @@ Sedp::init(const RepoId& guid, const RtpsDiscovery& disco,
                        OPENDDS_STRING("_SEDPTransportInst_") + key.c_str() + domainStr,
                        "rtps_udp");
   // Use a static cast to avoid dependency on the RtpsUdp library
-  DCPS::RtpsUdpInst* rtps_inst =
-      static_cast<DCPS::RtpsUdpInst*>(transport_inst_);
+  DCPS::RtpsUdpInst_rch rtps_inst =
+      DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
   // The SEDP endpoints may need to wait at least one resend period before
   // the handshake completes (allows time for our SPDP multicast to be
   // received by the other side).  Arbitrary constant of 5 to account for
@@ -282,8 +282,8 @@ Sedp::init(const RepoId& guid, const RtpsDiscovery& disco,
 void
 Sedp::unicast_locators(OpenDDS::DCPS::LocatorSeq& locators) const
 {
-  DCPS::RtpsUdpInst* rtps_inst =
-    static_cast<DCPS::RtpsUdpInst*>(transport_inst_);
+  DCPS::RtpsUdpInst_rch rtps_inst =
+    DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
   using namespace OpenDDS::RTPS;
 
   CORBA::ULong idx = 0;
@@ -330,16 +330,16 @@ Sedp::unicast_locators(OpenDDS::DCPS::LocatorSeq& locators) const
 const ACE_INET_Addr&
 Sedp::local_address() const
 {
-  DCPS::RtpsUdpInst* rtps_inst =
-      static_cast<DCPS::RtpsUdpInst*>(transport_inst_);
+  DCPS::RtpsUdpInst_rch rtps_inst =
+      DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
   return rtps_inst->local_address_;
 }
 
 const ACE_INET_Addr&
 Sedp::multicast_group() const
 {
-  DCPS::RtpsUdpInst* rtps_inst =
-      static_cast<DCPS::RtpsUdpInst*>(transport_inst_);
+  DCPS::RtpsUdpInst_rch rtps_inst =
+      DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
   return rtps_inst->multicast_group_address_;
 }
 bool

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -29,6 +29,7 @@
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include "dds/DCPS/transport/framework/TransportSendListener.h"
 #include "dds/DCPS/transport/framework/TransportClient.h"
+#include "dds/DCPS/transport/framework/TransportInst_rch.h"
 
 #include "ace/Task_Ex_T.h"
 #include "ace/Thread_Mutex.h"
@@ -267,7 +268,7 @@ private:
   } task_;
 
   // Transport
-  DCPS::TransportInst* transport_inst_;
+  DCPS::TransportInst_rch transport_inst_;
 
 #ifndef DDS_HAS_MINIMUM_BIT
   OpenDDS::DCPS::TopicBuiltinTopicDataDataReaderImpl* topic_bit();

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -133,7 +133,7 @@ TransportClient::enable_transport_using_config(bool reliable, bool durable,
   const size_t n = tc->instances_.size();
 
   for (size_t i = 0; i < n; ++i) {
-    TransportInst* inst = tc->instances_[i];
+    TransportInst_rch inst = tc->instances_[i];
 
     if (check_transport_qos(*inst)) {
       TransportImpl* impl = inst->impl();

--- a/dds/DCPS/transport/framework/TransportConfig.cpp
+++ b/dds/DCPS/transport/framework/TransportConfig.cpp
@@ -24,7 +24,7 @@ TransportConfig::~TransportConfig()
 {}
 
 void
-TransportConfig::sorted_insert(TransportInst* inst)
+TransportConfig::sorted_insert(const TransportInst_rch& inst)
 {
   const OPENDDS_STRING name = inst->name();
   InstancesType::iterator it = instances_.begin();

--- a/dds/DCPS/transport/framework/TransportConfig.h
+++ b/dds/DCPS/transport/framework/TransportConfig.h
@@ -17,6 +17,7 @@
 #include "dds/DCPS/RcObject.h"
 #include "dds/DCPS/PoolAllocator.h"
 #include "TransportInst.h"
+#include "TransportInst_rch.h"
 #include "ace/Synch_Traits.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -31,7 +32,7 @@ public:
 
   OPENDDS_STRING name() const { return name_; }
 
-  typedef OPENDDS_VECTOR(TransportInst*) InstancesType;
+  typedef OPENDDS_VECTOR(TransportInst_rch) InstancesType;
   InstancesType instances_;
 
   bool swap_bytes_;
@@ -44,7 +45,7 @@ public:
   /// Insert the TransportInst in sorted order (by name) in the instances_ list.
   /// Use when the names of the TransportInst objects are specifically assigned
   /// to have the sorted order make sense.
-  void sorted_insert(TransportInst* inst);
+  void sorted_insert(const TransportInst_rch& inst);
 
   void populate_locators(OpenDDS::DCPS::TransportLocatorSeq& trans_info) const;
 

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -58,7 +58,7 @@ public:
                    ACE_Configuration_Section_Key& sect);
 
   /// Diagnostic aid.
-  void dump() const ;
+  void dump() const;
   virtual OPENDDS_STRING dump_to_str() const;
 
   /// Format name of transport configuration parameter for use in

--- a/dds/DCPS/transport/framework/TransportInst_rch.h
+++ b/dds/DCPS/transport/framework/TransportInst_rch.h
@@ -1,0 +1,44 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_TRANSPORTINST_RCH_H
+#define OPENDDS_DCPS_TRANSPORTINST_RCH_H
+
+#include "dds/DCPS/RcHandle_T.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+/**
+ * This file instantiates a smart-pointer type (rch) to a specific
+ * underlying "pointed-to" type.
+ *
+ * This type definition is in its own header file so that the
+ * smart-pointer type can be defined without causing the inclusion
+ * of the underlying "pointed-to" type header file.  Instead, the
+ * underlying "pointed-to" type is forward-declared.  This is analogous
+ * to the inclusion requirements that would be imposed if the
+ * "pointed-to" type was being referenced via a raw pointer type.
+ * Holding the raw pointer indirectly via a smart pointer doesn't
+ * change the inclusion requirements (ie, the underlying type doesn't
+ * need to be included in either case).
+ */
+
+// Forward declaration of the underlying type.
+class TransportInst;
+
+/// The type definition for the smart-pointer to the underlying type.
+typedef RcHandle<TransportInst> TransportInst_rch;
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_TRANSPORTINST_RCH_H */

--- a/dds/DCPS/transport/framework/TransportRegistry.h
+++ b/dds/DCPS/transport/framework/TransportRegistry.h
@@ -14,6 +14,7 @@
 #include "TransportReactorTask_rch.h"
 #include "TransportType.h"
 #include "TransportType_rch.h"
+#include "TransportInst_rch.h"
 #include "TransportConfig_rch.h"
 #include "TransportConfig.h"
 #include "dds/DCPS/PoolAllocator.h"
@@ -54,9 +55,10 @@ public:
   /// framework.
   void release();
 
-  TransportInst* create_inst(const OPENDDS_STRING& name,
-                             const OPENDDS_STRING& transport_type);
-  TransportInst* get_inst(const OPENDDS_STRING& name) const;
+  TransportInst_rch create_inst(const OPENDDS_STRING& name,
+                                const OPENDDS_STRING& transport_type);
+  TransportInst_rch get_inst(const OPENDDS_STRING& name) const;
+  void remove_inst(const TransportInst_rch& inst);
 
   static const char DEFAULT_CONFIG_NAME[];
   static const char DEFAULT_INST_PREFIX[];

--- a/dds/DCPS/transport/framework/TransportRegistry.inl
+++ b/dds/DCPS/transport/framework/TransportRegistry.inl
@@ -60,6 +60,14 @@ TransportRegistry::domain_default_config(DDS::DomainId_t domain) const
 
 ACE_INLINE
 void
+TransportRegistry::remove_inst(const TransportInst_rch& inst)
+{
+  GuardType guard(this->lock_);
+  this->inst_map_.erase(inst->name());
+}
+
+ACE_INLINE
+void
 TransportRegistry::remove_config(const TransportConfig_rch& cfg)
 {
   GuardType guard(this->lock_);

--- a/dds/DCPS/transport/multicast/MulticastLoader.cpp
+++ b/dds/DCPS/transport/multicast/MulticastLoader.cpp
@@ -42,11 +42,11 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   TransportConfig_rch cfg =
     registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME);
 
-  TransportInst* default_unrel =
+  TransportInst_rch default_unrel =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
                           + std::string("0410_MCAST_UNRELIABLE"),
                           MULTICAST_NAME);
-  MulticastInst* mi = dynamic_cast<MulticastInst*>(default_unrel);
+  MulticastInst* mi = dynamic_cast<MulticastInst*>(default_unrel.in());
   if (!mi) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) MulticastLoader::init:")
       ACE_TEXT(" failed to obtain MulticastInst.\n")), -1);
@@ -54,7 +54,7 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   mi->reliable_ = false;
   cfg->sorted_insert(default_unrel);
 
-  TransportInst* default_rel =
+  TransportInst_rch default_rel =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
                           + std::string("0420_MCAST_RELIABLE"), MULTICAST_NAME);
   cfg->sorted_insert(default_rel);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
@@ -43,7 +43,7 @@ RtpsUdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   // the user needs to explicitly configure it...
 #ifdef OPENDDS_SAFETY_PROFILE
   // ...except for Safety Profile where RTPS is the only option.
-  TransportInst* default_inst =
+  TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           OPENDDS_STRING("0600_RTPS_UDP"),
                           RTPS_UDP_NAME);

--- a/dds/DCPS/transport/tcp/TcpLoader.cpp
+++ b/dds/DCPS/transport/tcp/TcpLoader.cpp
@@ -58,7 +58,7 @@ TcpLoader::init(int, ACE_TCHAR*[])
 
   TransportRegistry* registry = TheTransportRegistry;
   registry->register_type(make_rch<TcpType>());
-  TransportInst* default_inst =
+  TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           std::string("0500_TCP"), TCP_NAME);
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)

--- a/dds/DCPS/transport/udp/UdpLoader.cpp
+++ b/dds/DCPS/transport/udp/UdpLoader.cpp
@@ -39,7 +39,7 @@ UdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
   TransportRegistry* registry = TheTransportRegistry;
   registry->register_type(make_rch<UdpType>());
-  TransportInst* default_inst =
+  TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           std::string("0300_UDP"), UDP_NAME);
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)

--- a/dds/InfoRepo/DCPSInfo_i.cpp
+++ b/dds/InfoRepo/DCPSInfo_i.cpp
@@ -15,6 +15,7 @@
 #include "dds/DCPS/transport/tcp/TcpInst.h"
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include "dds/DCPS/transport/framework/TransportInst.h"
+#include "dds/DCPS/transport/framework/TransportInst_rch.h"
 #include "dds/DCPS/transport/tcp/TcpInst.h"
 #include "dds/DCPS/transport/tcp/TcpInst_rch.h"
 #include "UpdateManager.h"
@@ -2199,13 +2200,13 @@ int TAO_DDS_DCPSInfo_i::init_transport(int listen_address_given,
     std::string inst_name =
       OpenDDS::DCPS::TransportRegistry::DEFAULT_INST_PREFIX
       + std::string("InfoRepoBITTCPTransportInst");
-    OpenDDS::DCPS::TransportInst* inst =
+    OpenDDS::DCPS::TransportInst_rch inst =
       OpenDDS::DCPS::TransportRegistry::instance()->create_inst(inst_name,
                                                                "tcp");
     config->instances_.push_back(inst);
 
-    OpenDDS::DCPS::TcpInst* tcp_inst =
-      dynamic_cast<OpenDDS::DCPS::TcpInst*>(inst);
+    OpenDDS::DCPS::TcpInst_rch tcp_inst =
+      OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::DCPS::TcpInst>(inst);
     inst->datalink_release_delay_ = 0;
 
     tcp_inst->conn_retry_attempts_ = 0;

--- a/dds/InfoRepo/FederatorManagerImpl.cpp
+++ b/dds/InfoRepo/FederatorManagerImpl.cpp
@@ -182,7 +182,7 @@ ManagerImpl::initialize()
 
   std::string inst_name = OpenDDS::DCPS::TransportRegistry::DEFAULT_INST_PREFIX
     + std::string("FederationBITTCPTransportInst");
-  OpenDDS::DCPS::TransportInst* inst =
+  OpenDDS::DCPS::TransportInst_rch inst =
     OpenDDS::DCPS::TransportRegistry::instance()->create_inst(inst_name,
                                                               "tcp");
   config->instances_.push_back(inst);

--- a/dds/monitor/MonitorFactoryImpl.cpp
+++ b/dds/monitor/MonitorFactoryImpl.cpp
@@ -166,7 +166,7 @@ MonitorFactoryImpl::initialize()
 
     std::string inst_name = TransportRegistry::DEFAULT_INST_PREFIX
       + std::string("FederationBITTCPTransportInst");
-    TransportInst* inst =
+    TransportInst_rch inst =
       TransportRegistry::instance()->create_inst(inst_name, "tcp");
     config->instances_.push_back(inst);
   }

--- a/examples/DCPS/ishapes/main.cpp
+++ b/examples/DCPS/ishapes/main.cpp
@@ -39,10 +39,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
 
     TransportConfig_rch config =
       TransportRegistry::instance()->create_config("rtps_interop_demo");
-    TransportInst* inst =
+    TransportInst_rch inst =
       TransportRegistry::instance()->create_inst("the_rtps_transport",
                                                  "rtps_udp");
-    RtpsUdpInst* rui = static_cast<RtpsUdpInst*>(inst);
+    RtpsUdpInst_rch rui = static_rchandle_cast<RtpsUdpInst>(inst);
     rui->handshake_timeout_ = 1;
 
     config->instances_.push_back(inst);

--- a/performance-tests/Bench/src/Publication.cpp
+++ b/performance-tests/Bench/src/Publication.cpp
@@ -281,7 +281,7 @@ Publication::enable(
   if (this->verbose_) {
     OpenDDS::DCPS::MulticastInst* mcconfig
       = dynamic_cast<OpenDDS::DCPS::MulticastInst*>(
-          transport->instances_[0]
+          transport->instances_[0].in()
         );
     bool isMcast    = false;
     bool isReliable = false;

--- a/performance-tests/Bench/src/Subscription.cpp
+++ b/performance-tests/Bench/src/Subscription.cpp
@@ -148,7 +148,7 @@ Subscription::enable(
   if (this->verbose_) {
     OpenDDS::DCPS::MulticastInst* mcconfig
       = dynamic_cast<OpenDDS::DCPS::MulticastInst*>(
-          transport->instances_[0]
+          transport->instances_[0].in()
         );
     bool isMcast    = false;
     bool isReliable = false;

--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -56,10 +56,10 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(TheServiceParticipant->federation_backoff_multiplier() == 3);
     TEST_CHECK(TheServiceParticipant->federation_liveliness() == 70);
 
-    TransportInst* inst = TransportRegistry::instance()->get_inst("mytcp");
+    TransportInst_rch inst = TransportRegistry::instance()->get_inst("mytcp");
     TEST_CHECK(inst);
 
-    TcpInst* tcp_inst = dynamic_cast<TcpInst*>(inst);
+    TcpInst_rch tcp_inst = dynamic_rchandle_cast<TcpInst>(inst);
     TEST_CHECK(tcp_inst);
 
     // tcp_inst->dump(std::cout);
@@ -81,7 +81,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(tcp_inst->passive_reconnect_duration_ == 4000);
     TEST_CHECK(tcp_inst->max_output_pause_period_ == 1000);
 
-    TransportInst* inst2 = TransportRegistry::instance()->get_inst("anothertcp");
+    TransportInst_rch inst2 = TransportRegistry::instance()->get_inst("anothertcp");
     TEST_CHECK(inst2);
     TEST_CHECK(inst2->name() == "anothertcp");
 

--- a/tests/DCPS/DpShutdown/dpshutdown.cpp
+++ b/tests/DCPS/DpShutdown/dpshutdown.cpp
@@ -52,10 +52,10 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
             OpenDDS::DCPS::TransportRegistry::instance()->create_config("dds4ccm_rtps");
         }
 
-      OpenDDS::DCPS::TransportInst* inst =
+      OpenDDS::DCPS::TransportInst_rch inst =
         OpenDDS::DCPS::TransportRegistry::instance()->get_inst("the_rtps_transport");
 
-      if (!inst)
+      if (inst.is_nil())
         {
           inst =
             OpenDDS::DCPS::TransportRegistry::instance()->create_inst("the_rtps_transport",
@@ -77,10 +77,10 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
             OpenDDS::DCPS::TransportRegistry::instance()->create_config("dds4ccm_rtps_2");
         }
 
-      OpenDDS::DCPS::TransportInst* inst2 =
+      OpenDDS::DCPS::TransportInst_rch inst2 =
         OpenDDS::DCPS::TransportRegistry::instance()->get_inst("the_rtps_transport_2");
 
-      if (!inst2)
+      if (inst2.is_nil())
         {
           inst2 =
             OpenDDS::DCPS::TransportRegistry::instance()->create_inst("the_rtps_transport_2",

--- a/tests/DCPS/Footprint/Args.h
+++ b/tests/DCPS/Footprint/Args.h
@@ -87,7 +87,7 @@ parse_args(int argc, ACE_TCHAR *argv[])
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("too many instances on default config, using first\n"), argv[0]));
     }
-    OpenDDS::DCPS::TransportInst* inst = *(config->instances_.begin());
+    OpenDDS::DCPS::TransportInst_rch inst = *(config->instances_.begin());
     inst->thread_per_connection_ = true;
   }
 

--- a/tests/DCPS/LargeSample/subscriber.cpp
+++ b/tests/DCPS/LargeSample/subscriber.cpp
@@ -18,6 +18,7 @@
 #include <dds/DCPS/WaitSet.h>
 
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
+#include "dds/DCPS/transport/framework/TransportInst_rch.h"
 #if defined (sun)
 #include "dds/DCPS/transport/udp/UdpInst.h"
 #include "dds/DCPS/transport/udp/UdpInst_rch.h"

--- a/tests/DCPS/ManyToMany/subscriber.cpp
+++ b/tests/DCPS/ManyToMany/subscriber.cpp
@@ -17,6 +17,7 @@
 
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include <dds/DCPS/transport/framework/TransportExceptions.h>
+#include "dds/DCPS/transport/framework/TransportInst_rch.h"
 #if defined (sun)
 #include "dds/DCPS/transport/udp/UdpInst.h"
 #include "dds/DCPS/transport/udp/UdpInst_rch.h"

--- a/tests/DCPS/Messenger/Args.h
+++ b/tests/DCPS/Messenger/Args.h
@@ -87,7 +87,7 @@ parse_args(int argc, ACE_TCHAR *argv[])
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("too many instances on default config, using first\n"), argv[0]));
     }
-    OpenDDS::DCPS::TransportInst* inst = *(config->instances_.begin());
+    OpenDDS::DCPS::TransportInst_rch inst = *(config->instances_.begin());
     inst->thread_per_connection_ = true;
   }
 

--- a/tests/DCPS/RecorderReplayer/Args.h
+++ b/tests/DCPS/RecorderReplayer/Args.h
@@ -77,7 +77,7 @@ parse_args(int argc, ACE_TCHAR *argv[])
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("too many instances on default config, using first\n"), argv[0]));
     }
-    OpenDDS::DCPS::TransportInst* inst = *(config->instances_.begin());
+    OpenDDS::DCPS::TransportInst_rch inst = *(config->instances_.begin());
     inst->thread_per_connection_ = true;
   }
 

--- a/tests/DCPS/RtiSerialization/Args.h
+++ b/tests/DCPS/RtiSerialization/Args.h
@@ -83,7 +83,7 @@ parse_args(int argc, ACE_TCHAR *argv[])
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("too many instances on default config, using first\n"), argv[0]));
     }
-    OpenDDS::DCPS::TransportInst* inst = *(config->instances_.begin());
+    OpenDDS::DCPS::TransportInst_rch inst = *(config->instances_.begin());
     inst->thread_per_connection_ = true;
   }
 

--- a/tests/DCPS/TcpReconnect/Args.h
+++ b/tests/DCPS/TcpReconnect/Args.h
@@ -94,7 +94,7 @@ parse_args(int argc, ACE_TCHAR *argv[])
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("too many instances on default config, using first\n"), argv[0]));
     }
-    OpenDDS::DCPS::TransportInst* inst = *(config->instances_.begin());
+    OpenDDS::DCPS::TransportInst_rch inst = *(config->instances_.begin());
     inst->thread_per_connection_ = true;
   }
 

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -69,8 +69,9 @@ ParticipantTask::svc()
         config_name));
       OpenDDS::DCPS::TransportConfig_rch config =
         TheTransportRegistry->create_config(config_name);
-      config->instances_.push_back(
-        TheTransportRegistry->create_inst(inst_name, "rtps_udp"));
+      OpenDDS::DCPS::TransportInst_rch inst =
+        TheTransportRegistry->create_inst(inst_name, "rtps_udp");
+      config->instances_.push_back(inst);
       TheTransportRegistry->bind_config(config_name, participant);
 #endif
 

--- a/tests/DCPS/ZeroCopyDataReaderListener/Args.h
+++ b/tests/DCPS/ZeroCopyDataReaderListener/Args.h
@@ -77,7 +77,7 @@ parse_args(int argc, ACE_TCHAR *argv[])
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("too many instances on default config, using first\n"), argv[0]));
     }
-    OpenDDS::DCPS::TransportInst* inst = *(config->instances_.begin());
+    OpenDDS::DCPS::TransportInst_rch inst = *(config->instances_.begin());
     inst->thread_per_connection_ = true;
   }
 

--- a/tests/transport/error_handling/main.cpp
+++ b/tests/transport/error_handling/main.cpp
@@ -33,13 +33,13 @@ bool testConnectionErrorHandling()
   acceptor.get_local_addr(addr);
   portNum = addr.get_port_number();
 
-  OpenDDS::DCPS::TransportInst* inst =
+  OpenDDS::DCPS::TransportInst_rch inst =
     TheTransportRegistry->create_inst("tcp1", "tcp");
-  OpenDDS::DCPS::TcpInst* tcp_inst =
-    dynamic_cast<OpenDDS::DCPS::TcpInst*>(inst);
+  OpenDDS::DCPS::TcpInst_rch tcp_inst =
+    OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::DCPS::TcpInst>(inst);
 
   DDS_TEST test;
-  acceptor.get_local_addr(test.local_address(tcp_inst));
+  acceptor.get_local_addr(test.local_address(tcp_inst.in()));
 
   OpenDDS::DCPS::TransportConfig_rch cfg =
     TheTransportRegistry->create_config("cfg");

--- a/tests/transport/rtps/publisher.cpp
+++ b/tests/transport/rtps/publisher.cpp
@@ -215,10 +215,10 @@ int DDS_TEST::test(ACE_TString host, u_short port)
     remote_addr = ACE_INET_Addr(port, host.c_str(), AF_INET);
   }
 
-  TransportInst* inst = TheTransportRegistry->create_inst("my_rtps",
-                                                          "rtps_udp");
+  TransportInst_rch inst = TheTransportRegistry->create_inst("my_rtps",
+                                                             "rtps_udp");
 
-  RtpsUdpInst* rtps_inst = dynamic_cast<RtpsUdpInst*>(inst);
+  RtpsUdpInst* rtps_inst = dynamic_cast<RtpsUdpInst*>(inst.in());
   if (!rtps_inst) {
     std::cerr << "ERROR: Failed to cast to RtpsUdpInst\n";
     return 1;

--- a/tests/transport/rtps/subscriber.cpp
+++ b/tests/transport/rtps/subscriber.cpp
@@ -223,10 +223,10 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       return 1;
     }
 
-    TransportInst* inst = TheTransportRegistry->create_inst("my_rtps",
+    TransportInst_rch inst = TheTransportRegistry->create_inst("my_rtps",
                                                                "rtps_udp");
 
-    RtpsUdpInst* rtps_inst = dynamic_cast<RtpsUdpInst*>(inst);
+    RtpsUdpInst* rtps_inst = dynamic_cast<RtpsUdpInst*>(inst.in());
 #ifdef OPENDDS_SAFETY_PROFILE
     if (host == "localhost") {
       host = "127.0.0.1";

--- a/tests/transport/rtps_reliability/rtps_reliability.cpp
+++ b/tests/transport/rtps_reliability/rtps_reliability.cpp
@@ -675,9 +675,9 @@ struct ReactorTask : ACE_Task_Base {
 
 void transport_setup()
 {
-  TransportInst* inst =
+  TransportInst_rch inst =
     TheTransportRegistry->create_inst("my_rtps", "rtps_udp");
-  RtpsUdpInst* rtps_inst = dynamic_cast<RtpsUdpInst*>(inst);
+  RtpsUdpInst* rtps_inst = dynamic_cast<RtpsUdpInst*>(inst.in());
   if (!rtps_inst) {
     std::cerr << "ERROR: Could not cast to RtpsUdpInst\n";
     return;

--- a/tests/transport/simple/PubDriver.cpp
+++ b/tests/transport/simple/PubDriver.cpp
@@ -196,7 +196,7 @@ PubDriver::init()
 {
   DBG_ENTRY("PubDriver","init");
 
-  OpenDDS::DCPS::TransportInst* inst;
+  OpenDDS::DCPS::TransportInst_rch inst;
 
   if (shmem_) {
     VDBG((LM_DEBUG, "(%P|%t) DBG:   Create a new ShmemInst object.\n"));
@@ -208,8 +208,8 @@ PubDriver::init()
 
     inst = TheTransportRegistry->create_inst("tcp1", "tcp");
 
-    OpenDDS::DCPS::TcpInst* tcp_inst =
-      dynamic_cast<OpenDDS::DCPS::TcpInst*>(inst);
+    OpenDDS::DCPS::TcpInst_rch tcp_inst =
+      OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::DCPS::TcpInst>(inst);
 
     VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                "Set the inst->local_address_ to our (local) pub_addr_.\n"));

--- a/tests/transport/simple/SubDriver.cpp
+++ b/tests/transport/simple/SubDriver.cpp
@@ -175,7 +175,7 @@ SubDriver::init()
 {
   DBG_ENTRY("SubDriver","init");
 
-  OpenDDS::DCPS::TransportInst* inst;
+  OpenDDS::DCPS::TransportInst_rch inst;
 
   if (shmem_) {
     VDBG((LM_DEBUG, "(%P|%t) DBG:   Create a new ShmemInst object.\n"));
@@ -188,8 +188,8 @@ SubDriver::init()
 
     inst = TheTransportRegistry->create_inst("tcp1", "tcp");
 
-    OpenDDS::DCPS::TcpInst* tcp_inst =
-      dynamic_cast<OpenDDS::DCPS::TcpInst*>(inst);
+    OpenDDS::DCPS::TcpInst_rch tcp_inst =
+      OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::DCPS::TcpInst>(inst);
 
     VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                "Set the tcp_inst->local_address_ to our (local) sub_addr_.\n"));

--- a/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/traits_cpp.xsl
+++ b/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/traits_cpp.xsl
@@ -97,11 +97,11 @@
       <xsl:text>Inst</xsl:text>
     </xsl:variable>
     <xsl:value-of select="concat(
-        '  OpenDDS::DCPS::TransportInst*', $varname, ' = ', $newline,
+        '  OpenDDS::DCPS::TransportInst_rch ', $varname, ' = ', $newline,
         '      TheTransportRegistry->get_inst(&quot;', $transportinstname, '&quot;);',
         $newline)"/>
     <xsl:value-of select="concat(
-        '  if (!', $varname, ') {',
+        '  if (', $varname, '.is_nil()) {',
         $newline
     )"/>
     <xsl:value-of select="concat(
@@ -110,9 +110,9 @@
         '&quot;', $transport-type, '&quot;);', $newline
     )"/>
     <xsl:value-of select="concat(
-        '    ', $transport-class, '* child_inst =', $newline,
-        '        static_cast&lt;', $transport-class,
-        '*&gt;(', $varname, ');', $newline)"/>
+        '    ', $transport-class, '_rch child_inst =', $newline,
+        '        OpenDDS::DCPS::static_rchandle_cast&lt;', $transport-class,
+        '&gt;(', $varname, ');', $newline)"/>
     <xsl:apply-templates select="*"/>
     <xsl:text>  }
 


### PR DESCRIPTION
Restore the TransportRegistry API to what it was before using TransportInst_rch

This (partially) reverts commit 794f1e6972c7d9c3d874910fb658afd7486ebb4e.