### PR TITLE
Dissector: Various Improvements 

### DIFF
--- a/tools/dissector/README
+++ b/tools/dissector/README
@@ -2,7 +2,7 @@ The OpenDDS DCPS Wireshark dissector supports the TCP/IP, UDP/IP, and IP
 multicast transports. Dissection of transport headers and encapsulated sample
 headers are fully supported. Optional dissection of sample payloads is also
 supported from Wireshark 1.12 on. The dissector is compatible with Wireshark
-1.2 up to at least 2.4 and has been tested with Windows, macOS, and Linux.
+1.2 up to at least 2.6 and has been tested with Windows, macOS, and Linux.
 
 
 ======================================================================
@@ -44,7 +44,7 @@ libraries must be installed through a development package like:
 
        - Any version of Wireshark built with autoconf, which is try if you
          ran autogen.sh. This is the recommended way to build on Linux as
-         of Wireshark 2.4.
+         of Wireshark 2.6.
 
        - Wireshark 1.x built on Windows. Also %WIRETAP_VERSION% should also
          be set to the version of wiretap in the build.

--- a/tools/dissector/packet-opendds.cpp
+++ b/tools/dissector/packet-opendds.cpp
@@ -567,7 +567,7 @@ namespace OpenDDS
           payload_item, ett_sample_payload);
 
       // Try to Dissect Payload
-      Sample_Dissector_rch data_dissector =
+      Sample_Dissector* data_dissector =
         Sample_Manager::instance().find(data_name);
       if (!data_dissector) {
         ACE_DEBUG ((LM_DEBUG,
@@ -653,7 +653,7 @@ namespace OpenDDS
 #ifndef NO_EXPERT
           proto_tree_add_expert_format(
             contents_tree, pinfo_, &ei_sample_payload_error,
-            tvb_, offset, -1, e.what()
+            tvb_, offset, -1, "%s", e.what()
           );
 #endif
           ACE_DEBUG ((LM_DEBUG,

--- a/tools/dissector/packet-opendds.cpp
+++ b/tools/dissector/packet-opendds.cpp
@@ -567,9 +567,9 @@ namespace OpenDDS
           payload_item, ett_sample_payload);
 
       // Try to Dissect Payload
-      Sample_Dissector *data_dissector =
-        Sample_Manager::instance().find (data_name);
-      if (data_dissector == 0) {
+      Sample_Dissector_rch data_dissector =
+        Sample_Manager::instance().find(data_name);
+      if (!data_dissector) {
         ACE_DEBUG ((LM_DEBUG,
                     "DDS_Dissector::dissect_sample_payload: "
                     "couldn't dissect payload: "

--- a/tools/dissector/packet-opendds.cpp
+++ b/tools/dissector/packet-opendds.cpp
@@ -536,9 +536,8 @@ namespace OpenDDS
       if (data_name == 0) {
         ACE_DEBUG ((LM_DEBUG,
                     "DDS_Dissector::dissect_sample_payload: "
-                    "no topic for %C\n",
+                    "couldn't dissect payload: no topic for %C\n",
                     std::string(converter).c_str()));
-        offset += header.message_length_; // skip marshaled data
 
         // Mark Packet
 #ifndef NO_EXPERT
@@ -549,10 +548,12 @@ namespace OpenDDS
           tvb_,
           offset,
           (gint) header.message_length_,
-          "No Topic Found for %s \n",
+          "Couldn't Dissect Payload: No Topic Found for %s \n",
           std::string(converter).c_str()
         );
 #endif
+
+        offset += header.message_length_; // skip marshaled data
 
         return;
       }
@@ -571,6 +572,7 @@ namespace OpenDDS
       if (data_dissector == 0) {
         ACE_DEBUG ((LM_DEBUG,
                     "DDS_Dissector::dissect_sample_payload: "
+                    "couldn't dissect payload: "
                     "no dissector found for %C \n",
                     data_name));
 
@@ -583,6 +585,7 @@ namespace OpenDDS
           tvb_,
           offset,
           (gint) header.message_length_,
+          "Couldn't Dissect Payload: "
           "No Dissector Found for %s \n",
           data_name
         );
@@ -592,6 +595,7 @@ namespace OpenDDS
       } else {
         // Push DCPS Primary Data Type Namespace
         // Convert, for example, "1::2::3" to "1.2.3"
+        Sample_Base::clear_ns();
         std::string ns;
         char c = 'a';
         bool delimiter = false;
@@ -643,7 +647,20 @@ namespace OpenDDS
         ACE_Sig_Action sig_act(sample_dissect_handle_sigsegv);
         if (handle) sig_act.register_action(SIGSEGV); // Handle Segfaults
 
-        offset = data_dissector->dissect(params); // Dissect Sample Payload
+        try {
+          offset = data_dissector->dissect(params); // Dissect Sample Payload
+        } catch (Sample_Dissector_Error& e) {
+#ifndef NO_EXPERT
+          proto_tree_add_expert_format(
+            contents_tree, pinfo_, &ei_sample_payload_error,
+            tvb_, offset, -1, e.what()
+          );
+#endif
+          ACE_DEBUG ((LM_DEBUG,
+            "DDS_Dissector::dissect_sample_payload: %C\n", e.what()
+          ));
+          offset = params.offset + header.message_length_;
+        }
 
         // Clean Up
         if (handle) sig_act.handler(SIG_DFL); // Restore default segfault behavior
@@ -701,21 +718,7 @@ namespace OpenDDS
             this->dissect_sample_header (sample_tree, sample, offset);
 
             sample_tree = proto_item_add_subtree (item, ett_sample_header);
-            try {
-              this->dissect_sample_payload (sample_tree, sample, offset);
-            } catch (Sample_Dissector_Error & e) {
-#ifndef NO_EXPERT
-              proto_tree_add_expert_format(
-                trans_tree, pinfo_, &ei_sample_payload_error,
-                tvb_, offset, -1, e.what()
-              );
-#endif
-              Sample_Base::clear_ns();
-              ACE_DEBUG ((LM_DEBUG,
-                "DDS_Dissector::dissect_sample_payload: %C\n", e.what()
-              ));
-            }
-
+            this->dissect_sample_payload (sample_tree, sample, offset);
           }
       }
       return offset;
@@ -780,7 +783,10 @@ namespace OpenDDS
                        get_pdu_len,
                        dissect_common
                        WS_TCP_DISSECT_PDUS_EXTRA_ARG);
-      WS_DISSECTOR_RETURN_VALUE
+
+#ifdef WS_DISSECTOR_RETURN_INT
+      return tvb_captured_length(tvb);
+#endif
     }
 
     extern "C"

--- a/tools/dissector/packet-opendds.cpp
+++ b/tools/dissector/packet-opendds.cpp
@@ -649,7 +649,7 @@ namespace OpenDDS
 
         try {
           offset = data_dissector->dissect(params); // Dissect Sample Payload
-        } catch (Sample_Dissector_Error& e) {
+        } catch (const Sample_Dissector_Error& e) {
 #ifndef NO_EXPERT
           proto_tree_add_expert_format(
             contents_tree, pinfo_, &ei_sample_payload_error,

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -151,9 +151,10 @@ namespace OpenDDS
       return fc;
     }
 
+    // Sample_Base static members
     std::list<std::string> Sample_Base::ns_stack_;
     std::string Sample_Base::ns_;
-
+    
     int Sample_Base::get_hf() {
       if (!field_contexts_.count(ns_)) {
         return -1;
@@ -763,10 +764,12 @@ namespace OpenDDS
           add_protocol_field(FT_STRINGZ);
           break;
 
+        /*
         default:
           throw Sample_Dissector_Error(
             get_ns()  + " is not a valid Field Type."
           );
+        */
         }
       } else if (nested_ != NULL) {
         push_ns(label_);
@@ -1343,7 +1346,7 @@ namespace OpenDDS
         } else {
           throw Sample_Dissector_Error("Error Reading Fixed Type");
         }
-#else
+#else // ACE_HAS_CDR_FIXED
         // Place Dummy value and inform user
         const char * missing_fixed = "Fixed Type Support is missing from ACE";
         if (params.use_index) {

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -46,7 +46,7 @@ namespace OpenDDS
      * result to the reason it failed.
      */
     bool utf16_to_utf8(
-       std::string &result, const ACE_CDR::WChar* from, const size_t length = 1
+       std::string& result, const ACE_CDR::WChar* from, const size_t length = 1
     ) {
 
       const gchar* from_;
@@ -65,9 +65,9 @@ namespace OpenDDS
       from_ = reinterpret_cast<gchar*>(const_cast<ACE_CDR::WChar*>(from));
 #endif
 
-      GError * error = NULL;
-      char * utf8 = g_convert(
-        from_, length * sizeof(ACE_CDR::WChar),
+      GError* error = NULL;
+      char* utf8 = g_convert(
+        from_, length* sizeof(ACE_CDR::WChar),
         "UTF-8", "UTF-16LE", NULL, NULL, &error
       );
 
@@ -76,7 +76,7 @@ namespace OpenDDS
         g_free(utf8);
         return false;
       } else {
-        const char * error_msg = "UTF-16 to UTF-8 conversion failed: ";
+        const char* error_msg = "UTF-16 to UTF-8 conversion failed: ";
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%C%C\n"),
           error_msg,
           error->message
@@ -89,7 +89,7 @@ namespace OpenDDS
     }
 
     Wireshark_Bundle::Wireshark_Bundle(
-      char * data, size_t size, bool swap_bytes, Serializer::Alignment align
+      char* data, size_t size, bool swap_bytes, Serializer::Alignment align
     ) :
       block(data, size),
       serializer(&block, swap_bytes, align)
@@ -98,7 +98,7 @@ namespace OpenDDS
       get_size_only = false;
     }
 
-    Wireshark_Bundle::Wireshark_Bundle(const Wireshark_Bundle & other) :
+    Wireshark_Bundle::Wireshark_Bundle(const Wireshark_Bundle& other) :
       block(other.block.rd_ptr(), other.block.size()),
       serializer(
         &block,
@@ -123,11 +123,11 @@ namespace OpenDDS
       return reinterpret_cast<size_t>(block.rd_ptr());
     }
 
-    guint8 *
+    guint8*
     Wireshark_Bundle::get_remainder()
     {
       gint remainder = ws_tvb_length(tvb) - offset;
-      return reinterpret_cast<guint8 *>(ws_ep_tvb_memdup(tvb, offset, remainder));
+      return reinterpret_cast<guint8*>(ws_ep_tvb_memdup(tvb, offset, remainder));
     }
 
     Sample_Base::~Sample_Base() {
@@ -140,7 +140,7 @@ namespace OpenDDS
       }
     }
 
-    Field_Context * Sample_Base::get_context() {
+    Field_Context* Sample_Base::get_context() {
       if (field_contexts_.count(ns_)) {
         return field_contexts_[ns_];
       }
@@ -172,7 +172,7 @@ namespace OpenDDS
       return payload_namespace + ns_;
     }
 
-    void Sample_Base::push_ns(const std::string & name) {
+    void Sample_Base::push_ns(const std::string& name) {
       ns_stack_.push_back(name);
       rebuild_ns();
     }
@@ -245,8 +245,7 @@ namespace OpenDDS
       // call long_name_) is the string used for filtering.
       // In our case (and probably most cases for any WS dissector) "abbrev"
       // will be longer than the first member "name".
-      // This confused was confusing to me, so just wanted to make a note of
-      // this.
+      // This was confusing to me, so just wanted to make a note of this.
         fc->short_name_.c_str(), fc->long_name_.c_str(),
         ft, fd, NULL, 0, NULL, HFILL
       }};
@@ -255,30 +254,27 @@ namespace OpenDDS
       return fc;
     }
 
-    Sample_Field::Sample_Field (IDLTypeID id, const std::string &label)
-      : label_ (label),
-        type_id_ (id),
-        nested_ (0),
-        next_(0)
-    {
-    }
-
-    Sample_Field::Sample_Field (Sample_Dissector *n, const std::string &label)
+    Sample_Field::Sample_Field(IDLTypeID id, const std::string &label)
       : label_(label),
-        type_id_ (Undefined),
-        nested_ (n),
+        type_id_(id),
         next_(0)
     {
     }
 
-    Sample_Field::~Sample_Field ()
+    Sample_Field::Sample_Field(Sample_Dissector_wrch n, const std::string &label)
+      : label_(label),
+        type_id_(Undefined),
+        nested_(n),
+        next_(0)
     {
-      delete nested_;
+    }
+
+    Sample_Field::~Sample_Field()
+    {
       delete next_;
     }
 
-    Sample_Field *
-    Sample_Field::chain (Sample_Field *f)
+    Sample_Field* Sample_Field::chain(Sample_Field* f)
     {
       if (next_ != 0)
         next_->chain (f);
@@ -287,20 +283,17 @@ namespace OpenDDS
       return f;
     }
 
-    Sample_Field *
-    Sample_Field::chain (IDLTypeID ti, const std::string &l)
+    Sample_Field* Sample_Field::chain(IDLTypeID ti, const std::string& l)
     {
       return chain (new Sample_Field (ti, l));
     }
 
-    Sample_Field *
-    Sample_Field::chain (Sample_Dissector *n, const std::string &l)
+    Sample_Field* Sample_Field::chain(Sample_Dissector_wrch n, const std::string& l)
     {
       return chain (new Sample_Field (n, l));
     }
 
-    Sample_Field *
-    Sample_Field::get_link (size_t index)
+    Sample_Field* Sample_Field::get_link(size_t index)
     {
       if (index == 0)
         return this;
@@ -308,7 +301,7 @@ namespace OpenDDS
       return (next_ == 0) ? 0 : next_->get_link (index - 1);
     }
 
-    void Sample_Field::to_stream(std::stringstream &s, Wireshark_Bundle & p) {
+    void Sample_Field::to_stream(std::stringstream& s, Wireshark_Bundle& p) {
       size_t location = p.buffer_pos();
 
       TAO::String_Manager string_value;
@@ -422,12 +415,12 @@ namespace OpenDDS
     }
 
 #define ADD_FIELD_PARAMS params.tree, hf, params.tvb, params.offset, (gint) len
-    size_t
-    Sample_Field::dissect_i (Wireshark_Bundle &params, bool recur) {
+    size_t Sample_Field::dissect_i(Wireshark_Bundle& params, bool recur)
+    {
 
       size_t len = 0;
 
-      if (!this->nested_) {
+      if (!nested_) {
 
         int hf = -1;
         if (!params.get_size_only) {
@@ -742,7 +735,13 @@ namespace OpenDDS
         }
       } else {
         push_ns(this->label_);
-        len = this->nested_->dissect_i(params);
+        Sample_Dissector_rch sd = nested_.lock();
+        if (!sd) {
+            throw Sample_Dissector_Error(
+              get_ns()  + " nested dissector is missing!"
+            );
+        }
+        len = sd->dissect_i(params);
         pop_ns();
       }
 
@@ -827,9 +826,15 @@ namespace OpenDDS
             get_ns()  + " is not a valid Field Type."
           );
         }
-      } else if (nested_ != NULL) {
+      } else if (nested_) {
         push_ns(label_);
-        nested_->init_ws_fields(first_pass);
+        Sample_Dissector_rch sd = nested_.lock();
+        if (!sd) {
+            throw Sample_Dissector_Error(
+              get_ns()  + " nested dissector is missing!"
+            );
+        }
+        sd->init_ws_fields(first_pass);
         pop_ns();
       }
       if (next_ != NULL) {
@@ -846,15 +851,16 @@ namespace OpenDDS
 
     //------------------------------------------------------------------------
 
-    Sample_Dissector::Sample_Dissector (const std::string &subtree)
+    Sample_Dissector::Sample_Dissector(const std::string& subtree)
       : field_(0),
         ett_(-1),
         subtree_label_(),
         is_struct_(false),
         is_root_(false)
     {
-      if (!subtree.empty())
+      if (!subtree.empty()) {
         this->init (subtree);
+      }
     }
 
     Sample_Dissector::~Sample_Dissector ()
@@ -899,14 +905,14 @@ namespace OpenDDS
     }
 
     Sample_Field *
-    Sample_Dissector::add_field(Sample_Dissector *n,
+    Sample_Dissector::add_field(Sample_Dissector_wrch n,
                                 const std::string &label)
     {
       return add_field(new Sample_Field(n, label));
     }
 
     size_t
-    Sample_Dissector::dissect_i (Wireshark_Bundle &params)
+    Sample_Dissector::dissect_i(Wireshark_Bundle& params)
     {
       size_t len = 0;
       if (!params.get_size_only) {
@@ -952,15 +958,14 @@ namespace OpenDDS
       return len;
     }
 
-    size_t
-    Sample_Dissector::compute_length(const Wireshark_Bundle & p) {
+    size_t Sample_Dissector::compute_length(const Wireshark_Bundle& p)
+    {
       Wireshark_Bundle size_params(p);
       size_params.get_size_only = true;
       return dissect_i(size_params);
     }
 
-    gint
-    Sample_Dissector::dissect (Wireshark_Bundle &params)
+    gint Sample_Dissector::dissect (Wireshark_Bundle& params)
     {
       params.use_index = false;
       is_root_ = true;
@@ -975,7 +980,7 @@ namespace OpenDDS
       return field_->type_id_;
     }
 
-    std::string Sample_Dissector::stringify(Wireshark_Bundle & p) {
+    std::string Sample_Dissector::stringify(Wireshark_Bundle& p) {
       std::stringstream outstream;
       if (field_) {
         field_->to_stream(outstream, p);
@@ -1012,14 +1017,13 @@ namespace OpenDDS
     }
 
     //----------------------------------------------------------------------
-    Sample_Sequence::Sample_Sequence (Sample_Dissector *sub)
+    Sample_Sequence::Sample_Sequence (Sample_Dissector_wrch sub)
       : element_ (sub)
     {
       this->init ("sequence");
     }
 
-    Sample_Dissector *
-    Sample_Sequence::element ()
+    Sample_Dissector_wrch Sample_Sequence::element()
     {
       return element_;
     }
@@ -1063,12 +1067,19 @@ namespace OpenDDS
       push_ns(element_namespace);
 
       // Dissect Elements
+
       bool prev_use_index = params.use_index;
       size_t all_elements_size = 0;
+      Sample_Dissector_rch sd = element_.lock();
+      if (!sd) {
+          throw Sample_Dissector_Error(
+            get_ns()  + " element dissector is missing!"
+          );
+      }
       for (guint32 ndx = 0; ndx < count; ndx++) {
         params.index = ndx;
         params.use_index = true;
-        size_t element_size = element_->dissect_i(params);
+        size_t element_size = sd->dissect_i(params);
         all_elements_size += element_size;
       }
       if (params.get_size_only) {
@@ -1114,14 +1125,19 @@ namespace OpenDDS
         add_protocol_field();
       }
       push_ns(element_namespace);
-      element_->init_ws_fields(first_pass);
+      Sample_Dissector_rch sd = element_.lock();
+      if (!sd) {
+          throw Sample_Dissector_Error(
+            get_ns()  + " element dissector is missing!"
+          );
+      }
+      sd->init_ws_fields(first_pass);
       pop_ns();
     }
 
     //----------------------------------------------------------------------
 
-    Sample_Array::Sample_Array (size_t count,
-                                Sample_Dissector *sub)
+    Sample_Array::Sample_Array(size_t count, Sample_Dissector_wrch sub)
       : Sample_Sequence (sub),
         count_ (count)
     {
@@ -1257,8 +1273,7 @@ namespace OpenDDS
     //----------------------------------------------------------------------
 
     Sample_Union::Sample_Union ()
-      :discriminator_ (0),
-       default_ (0)
+      : default_ (0)
     {
       this->init ("union");
     }
@@ -1268,8 +1283,7 @@ namespace OpenDDS
       delete default_;
     }
 
-    void
-    Sample_Union::discriminator (Sample_Dissector *d)
+    void Sample_Union::discriminator(Sample_Dissector_wrch d)
     {
       this->discriminator_ = d;
     }
@@ -1288,9 +1302,15 @@ namespace OpenDDS
 
     size_t Sample_Union::dissect_i (Wireshark_Bundle &params) {
       // Get Type
-      size_t len = discriminator_->compute_length(params);
+      Sample_Dissector_rch sd = discriminator_.lock();
+      if (!sd) {
+          throw Sample_Dissector_Error(
+            get_ns()  + " discriminator dissector is missing!"
+          );
+      }
+      size_t len = sd->compute_length(params);
       Sample_Field* value = this->default_;
-      std::string _d = discriminator_->stringify(params);
+      std::string _d = sd->stringify(params);
       MapType::const_iterator pos = map_.find(_d);
       if (pos != map_.end()) {
         value = pos->second;
@@ -1348,7 +1368,7 @@ namespace OpenDDS
 
     //-----------------------------------------------------------------------
 
-    Sample_Alias::Sample_Alias (Sample_Dissector *base)
+    Sample_Alias::Sample_Alias(Sample_Dissector_wrch base)
       :base_(base)
     {
       this->init ("alias");
@@ -1357,11 +1377,23 @@ namespace OpenDDS
     size_t
     Sample_Alias::dissect_i (Wireshark_Bundle &p)
     {
-      return base_->dissect_i (p);
+      Sample_Dissector_rch sd = base_.lock();
+      if (!sd) {
+          throw Sample_Dissector_Error(
+            get_ns()  + " alias dissector is missing!"
+          );
+      }
+      return sd->dissect_i (p);
     }
 
     void Sample_Alias::init_ws_fields(bool first_pass) {
-      base_->init_ws_fields(first_pass);
+      Sample_Dissector_rch sd = base_.lock();
+      if (!sd) {
+          throw Sample_Dissector_Error(
+            get_ns()  + " alias dissector is missing!"
+          );
+      }
+      sd->init_ws_fields(first_pass);
     }
 
     //-----------------------------------------------------------------------

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -136,9 +136,7 @@ namespace OpenDDS
         i != field_contexts_.end();
         ++i
       ) {
-        if (i->second) {
-          delete i->second;
-        }
+        delete i->second;
       }
     }
 
@@ -146,7 +144,7 @@ namespace OpenDDS
       if (field_contexts_.count(ns_)) {
         return field_contexts_[ns_];
       }
-      return (Field_Context*) 0;
+      return 0;
     }
 
     // Sample_Base static members
@@ -226,7 +224,6 @@ namespace OpenDDS
     void Sample_Base::add_protocol_field() {
       Field_Context* fc = get_context();
       if (fc) {
-        printf("Field: %s\n", get_ns().c_str());
         Sample_Manager::instance().add_protocol_field(fc->hf_info_);
       }
     }
@@ -276,12 +273,8 @@ namespace OpenDDS
 
     Sample_Field::~Sample_Field ()
     {
-      if (nested_) {
-        delete nested_;
-      }
-      if (next_) {
-        delete next_;
-      }
+      delete nested_;
+      delete next_;
     }
 
     Sample_Field *
@@ -862,9 +855,7 @@ namespace OpenDDS
 
     Sample_Dissector::~Sample_Dissector ()
     {
-      if (field_) {
-        delete field_;
-      }
+      delete field_;
     }
 
     void

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -154,7 +154,7 @@ namespace OpenDDS
     // Sample_Base static members
     std::list<std::string> Sample_Base::ns_stack_;
     std::string Sample_Base::ns_;
-    
+
     int Sample_Base::get_hf() {
       if (!field_contexts_.count(ns_)) {
         return -1;

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -488,7 +488,9 @@ namespace OpenDDS
             if (!params.get_size_only) {
               std::string s;
               bool utf_fail = utf16_to_utf8(s, &wchar_value);
-#ifndef NO_EXPERT
+#ifdef NO_EXPERT
+              ACE_UNUSED_ARG(utf_fail);
+#else
               if (utf_fail) {
                 proto_tree_add_expert_format(
                     params.tree, params.info, params.warning_ef, params.tvb,
@@ -704,7 +706,9 @@ namespace OpenDDS
               // Get UTF8 Version of the String
               std::string s;
               bool utf_fail = utf16_to_utf8(s, wstring_value, wstring_length);
-#ifndef NO_EXPERT
+#ifdef NO_EXPERT
+              ACE_UNUSED_ARG(utf_fail);
+#else
               if (utf_fail) {
                 proto_tree_add_expert_format(
                     params.tree, params.info, params.warning_ef, params.tvb,

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -116,10 +116,19 @@ namespace OpenDDS
 
     /// Holds Wireshark field information in relationship to a namespace
     struct Field_Context {
+    public:
+      Field_Context(
+        const std::string& short_name, const std::string& long_name,
+        ftenum ft, field_display_e fd
+      );
+
+      /// Default Wireshark Field Registration Values
+      static const hf_register_info default_hf_register_info;
+
       /// Field's Display/Short Name
-      std::string short_name_;
+      const std::string short_name_;
       /// Field's Namespace/Long Name
-      std::string long_name_;
+      const std::string long_name_;
       /// Wireshark API Field Index
       int hf_;
       /// Wireshark API Field Structure
@@ -130,8 +139,12 @@ namespace OpenDDS
     /**
      * Base Class for Sample_Dissector, Sample_Field, and all the other
      * elements that make up the dissector tree. Contains global namespace
-     * tracking and any infomation to be passed to Wireshark about the
+     * tracking and any information to be passed to Wireshark about the
      * field.
+     *
+     * The dissector tree represents all the possible valid formats the
+     * sample payload dissector can dissect. Its structure and contents are
+     * defined by the ITL files read when the plugin is loaded.
      *
      * Simplified Example of the Dissector Tree Structure:
      *
@@ -202,7 +215,7 @@ namespace OpenDDS
        * This occurs in two passes:
        *   - The first pass creates the field information and evaluates
        *     if the information is valid. If not a Sample_Dissector_Error
-       *     will be thrown. The whole Sample_Dissector will be removed.
+       *     will be thrown.
        *   - The second pass will collect the hf_register_info structs
        *     from the Dissectors and Fields.
        */

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -114,7 +114,7 @@ namespace OpenDDS
       guint8* get_remainder();
     };
 
-    /// Holds Wireshark field infomation in relationship to a namespace
+    /// Holds Wireshark field information in relationship to a namespace
     struct Field_Context {
       /// Field's Display/Short Name
       std::string short_name_;
@@ -127,14 +127,14 @@ namespace OpenDDS
     };
     typedef std::map<std::string, Field_Context*> Field_Contexts;
 
-    /// Base for Sample_Dissector and Sample_Field. Helps build the wireshark
+    /// Base for Sample_Dissector and Sample_Field. Helps build the Wireshark
     /// protocol tree.
     class Sample_Base {
     private:
       /// Associated Wireshark Header Field Contexts
       Field_Contexts field_contexts_;
 
-      /// Keep track of the wireshark namespace to use
+      /// Keep track of the Wireshark namespace to use
       static std::list<std::string> ns_stack_;
       static std::string ns_;
 
@@ -154,7 +154,7 @@ namespace OpenDDS
        */
       Field_Context* get_context();
 
-      /// Get hf for wireshark, returns -1 if there is no such context
+      /// Get hf for Wireshark, returns -1 if there is no such context
       int get_hf();
 
       /// Have the current context's field info registered later
@@ -164,11 +164,11 @@ namespace OpenDDS
       virtual ~Sample_Base();
 
       /**
-       * Traverse the Dissector Tree nodes to create the protocol infomation
+       * Traverse the Dissector Tree nodes to create the protocol information
        * to be passed to Wireshark.
        * This occurs in two passes:
        *   - The first pass creates the field information and evaluates
-       *     if the infomation is valid. If not a Sample_Dissector_Error
+       *     if the information is valid. If not a Sample_Dissector_Error
        *     will be thrown. The whole Sample_Dissector will be removed.
        *   - The second pass will collect the hf_register_info structs
        *     from the Dissectors and Fields.
@@ -197,7 +197,7 @@ namespace OpenDDS
 
     class dissector_Export Sample_Dissector;
 
-    /// Sample_Field decribes a single element of the sample. This can be
+    /// Sample_Field describes a single element of the sample. This can be
     /// a fixed length field, such as a short, long, etc. or variable length
     /// such as a string, enum, union, sequence, or another struct.
     ///
@@ -302,7 +302,7 @@ namespace OpenDDS
       virtual void init (const std::string &subtree_label = "");
 
       /// Dissect is the hook function called from an owning dissector.
-      /// The signature matches that required by wireshark. The offset
+      /// The signature matches that required by Wireshark. The offset
       /// is incremented as a side-effect of calling dissect. The real
       /// work of dissecting a sample is delegated to dissect_i.
       gint dissect (Wireshark_Bundle &params);
@@ -317,7 +317,7 @@ namespace OpenDDS
       Sample_Field *add_field (Sample_Field::IDLTypeID, const std::string &l);
       Sample_Field *add_field (Sample_Dissector *n, const std::string &l);
 
-      /// Run init_ws_fields on the childern of the Sample_Dissector
+      /// Run init_ws_fields on the children of the Sample_Dissector
       void init_ws_proto_tree(bool first_pass);
 
       virtual void init_ws_fields(bool first_pass);
@@ -343,7 +343,7 @@ namespace OpenDDS
       /// The list of fields defining the sample.
       Sample_Field *field_;
 
-      /// Values used by the wireshark framework for rendering a sub-tree.
+      /// Values used by the Wireshark framework for rendering a sub-tree.
       /// These get set in init(), a subtree is defined only if label_ is not
       /// empty.
       gint ett_;

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -72,7 +72,13 @@ namespace OpenDDS
      */
     class Wireshark_Bundle {
     public:
+      /// Used by the serializer
       ACE_Message_Block block;
+
+      /**
+       * OpenDDS Serializer, used to convert packet buffer into ACE/OpenDDS
+       * datatypes.
+       */
       Serializer serializer;
 
       /**
@@ -83,6 +89,9 @@ namespace OpenDDS
        */
       bool get_size_only;
 
+      /*
+       * Information used by us to communicate with Wireshark
+       */
       tvbuff_t* tvb;
       packet_info* info;
       proto_tree* tree;
@@ -105,12 +114,16 @@ namespace OpenDDS
       guint8* get_remainder();
     };
 
-    /// Holds Wireshark field index in relationship to a namespace
+    /// Holds Wireshark field infomation in relationship to a namespace
     struct Field_Context {
-      /// Actual Label to give to wireshark
-      std::string label_;
-      /// Wireshark Field Index
+      /// Field's Display/Short Name
+      std::string short_name_;
+      /// Field's Namespace/Long Name
+      std::string long_name_;
+      /// Wireshark API Field Index
       int hf_;
+      /// Wireshark API Field Structure
+      hf_register_info hf_info_;
     };
     typedef std::map<std::string, Field_Context*> Field_Contexts;
 
@@ -129,33 +142,56 @@ namespace OpenDDS
       static void rebuild_ns();
 
     protected:
-      /// Get or Create Context for the current namespace
+      /**
+       * Create Field_Context for the current dissection element and
+       * namespace.
+       */
+      Field_Context* create_context(ftenum ft, field_display_e fd = BASE_NONE);
+
+      /**
+       * Returns context for the current namespace, else null if no such
+       * context exists.
+       */
       Field_Context* get_context();
 
       /// Get hf for wireshark, returns -1 if there is no such context
       int get_hf();
 
-      /// Add sample field to register later
-      void add_protocol_field(ftenum ft, field_display_e fd = BASE_NONE);
+      /// Have the current context's field info registered later
+      void add_protocol_field();
 
     public:
       virtual ~Sample_Base();
 
-      /// Traverse the Dissector Tree nodes to build the Sample Payload Tree.
-      /// This is to be done after the ITL files have been parsed and before
-      /// dissection of any packets.
-      virtual void init_ws_fields() = 0;
+      /**
+       * Traverse the Dissector Tree nodes to create the protocol infomation
+       * to be passed to Wireshark.
+       * This occurs in two passes:
+       *   - The first pass creates the field information and evaluates
+       *     if the infomation is valid. If not a Sample_Dissector_Error
+       *     will be thrown. The whole Sample_Dissector will be removed.
+       *   - The second pass will collect the hf_register_info structs
+       *     from the Dissectors and Fields.
+       */
+      virtual void init_ws_fields(bool first_pass) = 0;
 
       /// Get the full namespace including the "opendds.sample.payload..."
       static std::string get_ns();
+
       /// Append a name to the end of the namespace
       static void push_ns(const std::string & name);
+
       /// Remove the last name from the namepspace
       static std::string pop_ns();
+
       /// Reset the namespace
       static void clear_ns();
+
       /// Get the last name in the namespace
       static std::string get_label();
+
+      /// Push IDL name "IDL:a/b/c" on to the namespace stack as "a.b.c"
+      static void push_idl_name(std::string name);
 
     };
 
@@ -221,10 +257,7 @@ namespace OpenDDS
 
       void to_stream(std::stringstream &s, Wireshark_Bundle & p);
 
-      /// Traverse the Dissector Tree nodes to build the Sample Payload Tree.
-      /// This is to be done after the ITL files have been parsed and before
-      /// Dissection.
-      void init_ws_fields();
+      void init_ws_fields(bool first_pass);
 
       /// Fixed length fields supply a label for identifying the field along
       /// with a type identifier. Fields that are members of an array or
@@ -254,7 +287,6 @@ namespace OpenDDS
      * registered with more than one name to allow for aliases, but that
      * would require reference counting, which currently isn't done.
      */
-
     class dissector_Export Sample_Dissector : public Sample_Base
     {
     public:
@@ -286,9 +318,9 @@ namespace OpenDDS
       Sample_Field *add_field (Sample_Dissector *n, const std::string &l);
 
       /// Run init_ws_fields on the childern of the Sample_Dissector
-      void init_ws_proto_tree();
+      void init_ws_proto_tree(bool first_pass);
 
-      virtual void init_ws_fields();
+      virtual void init_ws_fields(bool first_pass);
 
       /// The actual dissector method. Since a sample can be composed of
       /// complex fields which need to do their own dissection, this method
@@ -321,7 +353,7 @@ namespace OpenDDS
       bool is_root_;
     };
 
-    /*
+    /**
      * A specialized sample dissector for rendering sequences. Sequences
      * may contain any other type of field, which are rendered separately.
      */
@@ -334,7 +366,7 @@ namespace OpenDDS
 
       Sample_Dissector *element();
 
-      virtual void init_ws_fields();
+      virtual void init_ws_fields(bool first_pass);
 
     protected:
       /// Common Dissection Code for Arrays and Sequences
@@ -347,7 +379,7 @@ namespace OpenDDS
       Sample_Dissector *element_;
     };
 
-    /*
+    /**
      * A specialized sample dissector for rendering Arrays. Arrays may
      * contain any other type of field, which are rendered separately.
      *
@@ -364,7 +396,7 @@ namespace OpenDDS
       size_t count_;
     };
 
-    /*
+    /**
      * A specialized sample dissector for rendering Enumerations. An enum
      * is marshaled as a 4-byte value, but is rendered using a name. A chain
      * of sample fields is used hold the enumeration labels.
@@ -382,7 +414,7 @@ namespace OpenDDS
       Sample_Field *add_value (const std::string &val);
       bool index_of (const std::string &value, size_t &result);
       virtual std::string stringify(Wireshark_Bundle & p);
-      virtual void init_ws_fields();
+      virtual void init_ws_fields(bool first_pass);
 
     protected:
       virtual size_t dissect_i (Wireshark_Bundle &p);
@@ -390,11 +422,10 @@ namespace OpenDDS
       Sample_Field *value_;
     };
 
-    /*
+    /**
      * A specialized sample dissector for rendering Unions. A union is
      * marshaled as discriminator of some type, and a value of some type
      * determined by the discriminator.
-     *
      */
     class dissector_Export Sample_Union : public Sample_Dissector
     {
@@ -405,7 +436,7 @@ namespace OpenDDS
       void discriminator (Sample_Dissector *d);
       void add_label (const std::string& label, Sample_Field* field);
       void add_default (Sample_Field *value);
-      virtual void init_ws_fields();
+      virtual void init_ws_fields(bool first_pass);
 
     protected:
       virtual size_t dissect_i (Wireshark_Bundle &p);
@@ -416,16 +447,15 @@ namespace OpenDDS
       Sample_Field *default_;
     };
 
-    /*
+    /**
      * A sample dissector for types that are aliases of other types
      */
-
     class dissector_Export Sample_Alias : public Sample_Dissector
     {
     public:
       Sample_Alias (Sample_Dissector *base);
 
-      virtual void init_ws_fields();
+      virtual void init_ws_fields(bool first_pass);
 
     protected:
       virtual size_t dissect_i (Wireshark_Bundle &p);
@@ -433,7 +463,7 @@ namespace OpenDDS
       Sample_Dissector *base_;
     };
 
-    /*
+    /**
      * A Dissector for Fixed Point Types (FACE/Fixed.h)
      */
     class dissector_Export Sample_Fixed : public Sample_Dissector
@@ -445,7 +475,7 @@ namespace OpenDDS
       unsigned scale() { return scale_; }
 
     protected:
-      virtual void init_ws_fields();
+      virtual void init_ws_fields(bool first_pass);
       virtual size_t dissect_i(Wireshark_Bundle &params);
 
     private:

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -63,11 +63,22 @@ namespace OpenDDS
 
     };
 
-    /// Bundle of Parameters passed between the recursive dissection calls.
+    /**
+     * Bundle of Parameters passed between the recursive dissection calls
+     * that represents the state of the dissector at any point in the sample
+     * dissection.
+     */
     class Wireshark_Bundle {
     public:
       ACE_Message_Block block;
       Serializer serializer;
+
+      /**
+       * In order to use the DCPS Serializer, we must pass over the packet
+       * twice, once to just get the size from Serializer and ignore the data
+       * and again so we can pass the field size to Wireshark for trees before
+       * we fully dissect them.
+       */
       bool get_size_only;
 
       tvbuff_t* tvb;
@@ -75,14 +86,16 @@ namespace OpenDDS
       proto_tree* tree;
       size_t offset;
 #ifndef NO_EXPERT
-      expert_field * warning_ef;
+      expert_field* warning_ef;
 #endif
 
+      /// Defines if we are in a indexed structure (Array or Sequence)
       bool use_index;
+      /// Defines the index if use_index is true.
       guint32 index;
 
       Wireshark_Bundle(
-        char * data, size_t size, bool swap_bytes, Serializer::Alignment align
+        char* data, size_t size, bool swap_bytes, Serializer::Alignment align
       );
       Wireshark_Bundle(const Wireshark_Bundle & other);
 
@@ -128,15 +141,20 @@ namespace OpenDDS
 
       /// Traverse the Dissector Tree nodes to build the Sample Payload Tree.
       /// This is to be done after the ITL files have been parsed and before
-      /// Dissection.
+      /// dissection of any packets.
       virtual void init_ws_fields() = 0;
 
+      /// Get the full namespace including the "opendds.sample.payload..."
       static std::string get_ns();
+      /// Append a name to the end of the namespace
       static void push_ns(const std::string & name);
+      /// Remove the last name from the namepspace
       static std::string pop_ns();
+      /// Reset the nameps
       static void clear_ns();
+      /// Get the last name in the namespace
       static std::string get_label();
-
+      
     };
 
     class dissector_Export Sample_Dissector;

--- a/tools/dissector/sample_dissector.h
+++ b/tools/dissector/sample_dissector.h
@@ -43,8 +43,11 @@ namespace OpenDDS
   namespace DCPS
   {
 
-    /// Thrown when there is a inconsistency in the sample dissection.
-    /// Packet should be marked by wireshark.
+    /**
+     * Thrown when there is a inconsistency in the sample dissection or
+     * initialization of the fields.
+     * Packet will be marked by Wireshark, if thrown during dissection.
+     */
     class Sample_Dissector_Error : public std::exception {
     public:
       explicit Sample_Dissector_Error(const std::string & message)
@@ -65,8 +68,7 @@ namespace OpenDDS
 
     /**
      * Bundle of Parameters passed between the recursive dissection calls
-     * that represents the state of the dissector at any point in the sample
-     * dissection.
+     * that represents most of the state of the dissector.
      */
     class Wireshark_Bundle {
     public:
@@ -77,7 +79,7 @@ namespace OpenDDS
        * In order to use the DCPS Serializer, we must pass over the packet
        * twice, once to just get the size from Serializer and ignore the data
        * and again so we can pass the field size to Wireshark for trees before
-       * we fully dissect them.
+       * we pass the rest of the field data to Wireshark.
        */
       bool get_size_only;
 
@@ -150,11 +152,11 @@ namespace OpenDDS
       static void push_ns(const std::string & name);
       /// Remove the last name from the namepspace
       static std::string pop_ns();
-      /// Reset the nameps
+      /// Reset the namespace
       static void clear_ns();
       /// Get the last name in the namespace
       static std::string get_label();
-      
+
     };
 
     class dissector_Export Sample_Dissector;
@@ -242,7 +244,7 @@ namespace OpenDDS
       Sample_Field *next_;
     };
 
-    /*
+    /**
      * A Sample_Dissector is the base type dissector for samples. A sample base
      * instance is initialized with a list of fields that is used to walk
      * through a data buffer to compose a tree of named values.
@@ -283,10 +285,9 @@ namespace OpenDDS
       Sample_Field *add_field (Sample_Field::IDLTypeID, const std::string &l);
       Sample_Field *add_field (Sample_Dissector *n, const std::string &l);
 
-      /// Traverse the Dissector Tree nodes to build the Sample Payload Tree.
-      /// This is to be done after the ITL files have been parsed and before
-      /// Dissection.
+      /// Run init_ws_fields on the childern of the Sample_Dissector
       void init_ws_proto_tree();
+
       virtual void init_ws_fields();
 
       /// The actual dissector method. Since a sample can be composed of
@@ -395,7 +396,6 @@ namespace OpenDDS
      * determined by the discriminator.
      *
      */
-
     class dissector_Export Sample_Union : public Sample_Dissector
     {
     public:

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -290,7 +290,17 @@ namespace OpenDDS
       std::ifstream str(filename);
       itl::Dictionary d;
       bool no_dcps_data_types = true;
+
+      /*
+       * To reduce the number of fields we create in Wireshark, we just
+       * want to initialize fields off based on the primary data types as
+       * the bases. The TAO IDL compiler will mark them in ITL files after
+       * OpenDDS 3.12. ITL files created at and before 3.12 will work but
+       * will populate Wireshark with more fields in the auto complete than
+       * necessary.
+       */
       DissectorsType primary_dissectors;
+
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("Found Dissector ITL File: %C\n"),
         filename));

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -373,7 +373,7 @@ namespace OpenDDS
 
       } catch (const Sample_Dissector_Error & e) {
         ACE_DEBUG((LM_ERROR,
-          ACE_TEXT("Error during dissector initization of %s: %s\n"),
+          ACE_TEXT("Error during dissector initization of %C: %C\n"),
           filename, e.what()
         ));
       }

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -281,7 +281,9 @@ namespace OpenDDS
     void
     Sample_Manager::init_from_file (const ACE_TCHAR *filename)
     {
-#ifndef NO_ITL
+#ifdef NO_ITL
+      ACE_UNUSED_ARG(filename);
+#else
       std::ifstream str(filename);
       itl::Dictionary d;
       bool no_dcps_data_types = true;

--- a/tools/dissector/sample_manager.cpp
+++ b/tools/dissector/sample_manager.cpp
@@ -370,9 +370,9 @@ namespace OpenDDS
         // Push namespace when we find a '/'
         name.push_back('/'); // For last namespace
         l = 0;
-        for (size_t i = 0; i != name.size(); i++) {
-            if (name[i] == '/') {
-                Sample_Base::push_ns(name.substr(i - l, l));
+        for (size_t index = 0; index != name.size(); index++) {
+            if (name[index] == '/') {
+                Sample_Base::push_ns(name.substr(index - l, l));
                 l = 0;
             } else {
                 l++;

--- a/tools/dissector/sample_manager.h
+++ b/tools/dissector/sample_manager.h
@@ -64,7 +64,7 @@ namespace OpenDDS
       static Sample_Manager& instance();
 
       void init();
-      Sample_Dissector_rch find(const char* repo_id);
+      Sample_Dissector* find(const char* repo_id);
 
       /// Add a hf_register_info struct to register later
       void add_protocol_field(const hf_register_info& field);
@@ -78,8 +78,7 @@ namespace OpenDDS
     private:
       static Sample_Manager instance_;
 
-      typedef std::map<std::string, Sample_Dissector_rch> DissectorsType;
-      DissectorsType dissectors_;
+      Dissector_Map dissectors_;
 
       std::vector<hf_register_info> hf_vector_;
       hf_register_info* hf_array_;

--- a/tools/dissector/sample_manager.h
+++ b/tools/dissector/sample_manager.h
@@ -66,18 +66,13 @@ namespace OpenDDS
       void init ();
       Sample_Dissector *find (const char *repo_id);
 
-      /// Add sample field to register later.
-      void add_protocol_field(
-        int* hf_index,
-        const std::string& full_name, const std::string& short_name,
-        enum ftenum ft, field_display_e fd = BASE_NONE
-      );
-
-      /// Add a premade hf_register_info struct to register later
-      void add_protocol_field(hf_register_info field);
+      /// Add a hf_register_info struct to register later
+      void add_protocol_field(const hf_register_info& field);
 
       /// Field information to be passed to wireshark
       hf_register_info* fields_array();
+
+      /// Number of fields in the fields_array_
       size_t number_of_fields();
 
     private:
@@ -88,9 +83,6 @@ namespace OpenDDS
 
       std::vector<hf_register_info> hf_vector_;
       hf_register_info* hf_array_;
-
-      /// Dynamic Field Names (Long and Short) to be deleted later
-      std::list<char*> field_names_;
 
       void init_from_file (const ACE_TCHAR *filename);
     };

--- a/tools/dissector/sample_manager.h
+++ b/tools/dissector/sample_manager.h
@@ -61,10 +61,10 @@ namespace OpenDDS
       /// Clean up Header Fields
       ~Sample_Manager();
 
-      static Sample_Manager &instance();
+      static Sample_Manager& instance();
 
-      void init ();
-      Sample_Dissector *find (const char *repo_id);
+      void init();
+      Sample_Dissector_rch find(const char* repo_id);
 
       /// Add a hf_register_info struct to register later
       void add_protocol_field(const hf_register_info& field);
@@ -78,13 +78,13 @@ namespace OpenDDS
     private:
       static Sample_Manager instance_;
 
-      typedef std::map<std::string, Sample_Dissector*> DissectorsType;
+      typedef std::map<std::string, Sample_Dissector_rch> DissectorsType;
       DissectorsType dissectors_;
 
       std::vector<hf_register_info> hf_vector_;
       hf_register_info* hf_array_;
 
-      void init_from_file (const ACE_TCHAR *filename);
+      void init_from_file(const ACE_TCHAR* filename);
     };
   }
 }

--- a/tools/dissector/sample_manager.h
+++ b/tools/dissector/sample_manager.h
@@ -49,7 +49,7 @@ namespace OpenDDS
     /// Namespace for arrays and sequence elements
     const std::string element_namespace = "_e";
 
-    /*
+    /**
      * The Sample_Manager is a singleton which contains a map
      * of Sample_Dissectors keyed to type identifiers. This singleton is
      * used by the greater packet-opendds dissector to find type-specific
@@ -68,16 +68,16 @@ namespace OpenDDS
 
       /// Add sample field to register later.
       void add_protocol_field(
-        int * hf_index,
-        const std::string & full_name, const std::string & short_name,
+        int* hf_index,
+        const std::string& full_name, const std::string& short_name,
         enum ftenum ft, field_display_e fd = BASE_NONE
       );
 
       /// Add a premade hf_register_info struct to register later
       void add_protocol_field(hf_register_info field);
 
-      /// What is passed to wireshark
-      hf_register_info * fields_array();
+      /// Field information to be passed to wireshark
+      hf_register_info* fields_array();
       size_t number_of_fields();
 
     private:
@@ -87,10 +87,10 @@ namespace OpenDDS
       DissectorsType dissectors_;
 
       std::vector<hf_register_info> hf_vector_;
-      hf_register_info * hf_array_;
+      hf_register_info* hf_array_;
 
       /// Dynamic Field Names (Long and Short) to be deleted later
-      std::list<char *> field_names_;
+      std::list<char*> field_names_;
 
       void init_from_file (const ACE_TCHAR *filename);
     };

--- a/tools/dissector/ws_common.h
+++ b/tools/dissector/ws_common.h
@@ -12,28 +12,19 @@
 MAJOR * 1000000 + MINOR * 1000 + MICRO
 #define WIRESHARK_VERSION WIRESHARK_VERSION_NUMBER(VERSION_MAJOR,VERSION_MINOR,VERSION_MICRO)
 
+/*
+ * Version 1.4
+ */
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1, 4, 0)
 
-#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 5, 0)
-// find_conversation after 2.5/2.6 takes endpoint_type instead of port_type
-// but also provides a shortcut function which we will use instead.
-inline conversation_t *ws_find_conversation(packet_info *pinfo) {
-  return find_conversation_pinfo(pinfo, 0);
-}
-#else // if 2.4.x or before
-inline conversation_t *ws_find_conversation(packet_info *pinfo) {
-  return find_conversation(
-    pinfo->fd->num, &pinfo->src, &pinfo->dst,
-    pinfo->ptype, pinfo->srcport, pinfo->destport, 0
-  );
-}
-#endif
-
-#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1,4,0)
 // 1.4 introduced find_or_create_conversation
 inline conversation_t *ws_find_or_create_conversation(packet_info *pinfo) {
   return find_or_create_conversation(pinfo);
 }
+
 #else // if 1.3.x or before
+
+// else emulate it
 inline conversation_t *ws_find_or_create_conversation(packet_info *pinfo) {
   conversation_t *conv = NULL;
   if (!(conv = ws_find_conversation(pinfo))) {
@@ -44,83 +35,142 @@ inline conversation_t *ws_find_or_create_conversation(packet_info *pinfo) {
   }
   return conv;
 }
+
 #endif
 
-#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 2, 0)
-inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
-                                 gint offset, gint length)
-{
-  return tvb_get_string_enc(alloc, tvb, offset, length, ENC_ASCII);
-}
-#else // Before 2.2
-#define ws_tvb_get_string ::tvb_get_string
+/*
+ * Version 1.8
+ */
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1, 8, 0)
+
+#define WS_CONST const
+#define WS_HEUR_DISSECTOR_T_EXTRA_PARAM ,void*
+
+#else // Before 1.8
+
+#define WS_CONST
+#define WS_HEUR_DISSECTOR_T_EXTRA_PARAM
+
 #endif
 
-#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 2, 0)
-#define WS_DISSECTOR_RETURN_TYPE int
-#define WS_DISSECTOR_RETURN_INT
-#define ws_dissector_add_handle dissector_add_for_decode_as
-#define WS_CONV_IDX conv_index
-// create_dissector_handle wants the new dissector_t here
-#define WS_DISSECTOR_EXTRA_PARAM ,void*
-#else // Before 2.2
-#define WS_DISSECTOR_RETURN_TYPE void
-#define ws_dissector_add_handle dissector_add_handle
-#define WS_CONV_IDX index
-#define WS_DISSECTOR_EXTRA_PARAM
-#endif
+/*
+ * Version 1.12
+ *
+ * This is the earliest version to support conventional sample dissection and
+ * expert info, and probably was the biggest change to the Wireshark EPAN API
+ * so far.
+ */
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1, 12, 0)
 
-#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 0, 0)
-#define WS_DISSECTOR_EXTRA_ARG ,0
-#define ws_tvb_length tvb_reported_length
-#define WS_GET_PDU_LEN_EXTRA_PARAM ,void*
-#define WS_HEUR_DISSECTOR_EXTRA_ARGS1(ucase, lcase) \
-  "OpenDDS over " #ucase, "opendds_" #lcase,
-#define WS_HEUR_DISSECTOR_EXTRA_ARGS2 , HEURISTIC_ENABLE
-#else // Before 2.0
-#define WS_1
-#define WS_DISSECTOR_EXTRA_ARG
-#define ws_tvb_length tvb_length
-#define WS_GET_PDU_LEN_EXTRA_PARAM
-#define WS_HEUR_DISSECTOR_EXTRA_ARGS1(A, B)
-#define WS_HEUR_DISSECTOR_EXTRA_ARGS2
-#endif
-
-#if (WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1,12,0) )
 inline guint8 *ws_tvb_get_ephemeral_string(tvbuff_t *tvb, const gint offset, const gint length) {
   return ws_tvb_get_string(wmem_packet_scope(), tvb, offset, length);
 }
 inline void *ws_ep_tvb_memdup(tvbuff_t *tvb, const gint offset, size_t remainder) {
   return ::tvb_memdup(wmem_packet_scope(), tvb, offset, remainder);
 }
+
 #define WS_TCP_DISSECT_PDUS_EXTRA_ARG ,0
 #define WS_DISSECTOR_T_RETURN_TYPE int
 #define WS_DISSECTOR_T_RETURN_TYPE_INT
 #define WS_DISSECTOR_T_EXTRA_PARAM ,void*
+
 #else // Before 1.12
+
 inline guint8 *ws_tvb_get_ephemeral_string(tvbuff_t *tvb, const gint offset, const gint length) {
   return ::tvb_get_ephemeral_string(tvb, offset, length);
 }
 inline void *ws_ep_tvb_memdup(tvbuff_t *tvb, const gint offset, size_t remainder) {
   return ::ep_tvb_memdup(tvb, offset, remainder);
 }
+
 #define WS_TCP_DISSECT_PDUS_EXTRA_ARG
 #define WS_DISSECTOR_T_RETURN_TYPE void
 #define WS_DISSECTOR_T_EXTRA_PARAM
+
 // Field Display Enum was created for 1.12 and is used many places in the
 // sample dissector, so we're disabling sample dissection.
 #define NO_ITL
 typedef int field_display_e; // Dummy type for code outside NO_ITL blocks
+
 // Older expert info was completely different system before 1.12
 #define NO_EXPERT
-#endif
-
-#if (WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1,8,0) )
-#define WS_CONST const
-#define WS_HEUR_DISSECTOR_T_EXTRA_PARAM ,void*
-#else // Before 1.8
-#define WS_CONST
-#define WS_HEUR_DISSECTOR_T_EXTRA_PARAM
-#endif
 
 #endif
+
+/*
+ * Version 2.0
+ */
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 0, 0)
+
+#define WS_DISSECTOR_EXTRA_ARG ,0
+#define ws_tvb_length tvb_reported_length
+#define WS_GET_PDU_LEN_EXTRA_PARAM ,void*
+#define WS_HEUR_DISSECTOR_EXTRA_ARGS1(ucase, lcase) \
+  "OpenDDS over " #ucase, "opendds_" #lcase,
+#define WS_HEUR_DISSECTOR_EXTRA_ARGS2 , HEURISTIC_ENABLE
+
+#else // Before 2.0
+
+#define WS_1
+
+#define WS_DISSECTOR_EXTRA_ARG
+#define ws_tvb_length tvb_length
+#define WS_GET_PDU_LEN_EXTRA_PARAM
+#define WS_HEUR_DISSECTOR_EXTRA_ARGS1(A, B)
+#define WS_HEUR_DISSECTOR_EXTRA_ARGS2
+
+#endif
+
+
+/*
+ * Version 2.2
+ */
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 2, 0)
+
+inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
+                                 gint offset, gint length)
+{
+  return tvb_get_string_enc(alloc, tvb, offset, length, ENC_ASCII);
+}
+
+#define WS_DISSECTOR_RETURN_TYPE int
+#define WS_DISSECTOR_RETURN_INT
+#define ws_dissector_add_handle dissector_add_for_decode_as
+#define WS_CONV_IDX conv_index
+// create_dissector_handle wants the new dissector_t here
+#define WS_DISSECTOR_EXTRA_PARAM ,void*
+
+#else // Before 2.2
+
+#define WS_DISSECTOR_RETURN_TYPE void
+#define ws_dissector_add_handle dissector_add_handle
+#define WS_CONV_IDX index
+#define WS_DISSECTOR_EXTRA_PARAM
+#define ws_tvb_get_string ::tvb_get_string
+
+#endif
+
+/*
+ * Version 2.5 (Released as 2.6)
+ */
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 5, 0)
+
+// find_conversation after 2.5/2.6 takes endpoint_type instead of port_type
+// but also provides a shortcut function which we will use instead.
+inline conversation_t *ws_find_conversation(packet_info *pinfo) {
+  return find_conversation_pinfo(pinfo, 0);
+}
+
+#else // if 2.4.x or before
+
+// else emulate it
+inline conversation_t *ws_find_conversation(packet_info *pinfo) {
+  return find_conversation(
+    pinfo->fd->num, &pinfo->src, &pinfo->dst,
+    pinfo->ptype, pinfo->srcport, pinfo->destport, 0
+  );
+}
+
+#endif
+
+#endif // WS_COMMON_H

--- a/tools/dissector/ws_common.h
+++ b/tools/dissector/ws_common.h
@@ -52,20 +52,19 @@ inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
 {
   return tvb_get_string_enc(alloc, tvb, offset, length, ENC_ASCII);
 }
-#else
+#else // Before 2.2
 #define ws_tvb_get_string ::tvb_get_string
 #endif
 
 #if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 2, 0)
 #define WS_DISSECTOR_RETURN_TYPE int
-#define WS_DISSECTOR_RETURN_VALUE return 0; //TODO
+#define WS_DISSECTOR_RETURN_INT
 #define ws_dissector_add_handle dissector_add_for_decode_as
 #define WS_CONV_IDX conv_index
 // create_dissector_handle wants the new dissector_t here
 #define WS_DISSECTOR_EXTRA_PARAM ,void*
-#else
+#else // Before 2.2
 #define WS_DISSECTOR_RETURN_TYPE void
-#define WS_DISSECTOR_RETURN_VALUE
 #define ws_dissector_add_handle dissector_add_handle
 #define WS_CONV_IDX index
 #define WS_DISSECTOR_EXTRA_PARAM
@@ -78,7 +77,7 @@ inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
 #define WS_HEUR_DISSECTOR_EXTRA_ARGS1(ucase, lcase) \
   "OpenDDS over " #ucase, "opendds_" #lcase,
 #define WS_HEUR_DISSECTOR_EXTRA_ARGS2 , HEURISTIC_ENABLE
-#else
+#else // Before 2.0
 #define WS_1
 #define WS_DISSECTOR_EXTRA_ARG
 #define ws_tvb_length tvb_length
@@ -119,7 +118,7 @@ typedef int field_display_e; // Dummy type for code outside NO_ITL blocks
 #if (WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1,8,0) )
 #define WS_CONST const
 #define WS_HEUR_DISSECTOR_T_EXTRA_PARAM ,void*
-#else
+#else // Before 1.8
 #define WS_CONST
 #define WS_HEUR_DISSECTOR_T_EXTRA_PARAM
 #endif

--- a/tools/dissector/ws_common.h
+++ b/tools/dissector/ws_common.h
@@ -62,6 +62,17 @@ inline conversation_t *ws_find_or_create_conversation(packet_info *pinfo) {
  */
 #if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(1, 12, 0)
 
+// Emulate tvb_get_string for ws_tvb_get_ephemeral_string below
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 2, 0)
+inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
+                                 gint offset, gint length)
+{
+  return tvb_get_string_enc(alloc, tvb, offset, length, ENC_ASCII);
+}
+#else
+#define ws_tvb_get_string ::tvb_get_string
+#endif
+
 inline guint8 *ws_tvb_get_ephemeral_string(tvbuff_t *tvb, const gint offset, const gint length) {
   return ws_tvb_get_string(wmem_packet_scope(), tvb, offset, length);
 }
@@ -121,17 +132,10 @@ typedef int field_display_e; // Dummy type for code outside NO_ITL blocks
 
 #endif
 
-
 /*
  * Version 2.2
  */
 #if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 2, 0)
-
-inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
-                                 gint offset, gint length)
-{
-  return tvb_get_string_enc(alloc, tvb, offset, length, ENC_ASCII);
-}
 
 #define WS_DISSECTOR_RETURN_TYPE int
 #define WS_DISSECTOR_RETURN_INT
@@ -146,7 +150,6 @@ inline guint8* ws_tvb_get_string(wmem_allocator_t* alloc, tvbuff_t *tvb,
 #define ws_dissector_add_handle dissector_add_handle
 #define WS_CONV_IDX index
 #define WS_DISSECTOR_EXTRA_PARAM
-#define ws_tvb_get_string ::tvb_get_string
 
 #endif
 


### PR DESCRIPTION
- Gave dissector proper return value for WS 2.2 and later.
- Some formatting fixes and more comments
- Fixed a malformed packet error where multiple samples caused a bounds check error inside Wireshark's ethernet dissector.
- Updated README to mention 2.6 where applicable
- Renamed for loop variable that clashed with it's parent for loop's variable (using `i` is very enticing).
- Updated Field Registration to allow for "canceling" of fields to be registered with Wireshark. 