### PR TITLE
configure: Added alt unzip method: Archive::Zip

### DIFF
--- a/configure
+++ b/configure
@@ -613,8 +613,7 @@ if (!$ace_src || !$tao_src) {
       else {
         $err = system(($^O eq 'solaris' ? 'g' : '') . "tar xzf $ddsroot/$file");
       }
-    }
-    if ($err) {
+    } elsif ($err) {
       # Try Archive::Zip
       print "Archive::Extract isn't installed, trying Archive::Zip\n" if $opts{'verbose'};
       eval {require Archive::Zip};

--- a/configure
+++ b/configure
@@ -613,7 +613,7 @@ if (!$ace_src || !$tao_src) {
       else {
         $err = system(($^O eq 'solaris' ? 'g' : '') . "tar xzf $ddsroot/$file");
       }
-    } elsif ($err) {
+    } else {
       # Try Archive::Zip
       print "Archive::Extract isn't installed, trying Archive::Zip\n" if $opts{'verbose'};
       eval {require Archive::Zip};
@@ -623,13 +623,10 @@ if (!$ace_src || !$tao_src) {
         if ($opts{'dry-run'}) {
           print "Dry-run: would Archive::Zip $file\n";
         } else {
-          use Archive::Zip qw( :ERROR_CODES );
           my $zip = Archive::Zip->new();
-          if ($zip->read( $file ) == AZ_OK &&
-            $zip->extractTree() == AZ_OK) {
+          if ($zip->read( $file ) == Archive::Zip::AZ_OK() &&
+            $zip->extractTree() == Archive::Zip::AZ_OK()) {
             $err = 0;
-          } else {
-            $err = 1;
           }
         }
       }

--- a/configure
+++ b/configure
@@ -615,6 +615,28 @@ if (!$ace_src || !$tao_src) {
       }
     }
     if ($err) {
+      # Try Archive::Zip
+      print "Archive::Extract isn't installed, trying Archive::Zip\n" if $opts{'verbose'};
+      eval {require Archive::Zip};
+      if ($@) {
+        print "Neither Archive::Extract or Archive::Zip are installed\n" if $opts{'verbose'};
+      } else {
+        if ($opts{'dry-run'}) {
+          print "Dry-run: would Archive::Zip $file\n";
+        } else {
+          use Archive::Zip qw( :ERROR_CODES );
+          my $zip = Archive::Zip->new();
+          if ($zip->read( $file ) == AZ_OK &&
+            $zip->extractTree() == AZ_OK) {
+            $err = 0;
+          } else {
+            $err = 1;
+          }
+        }
+      }
+    }
+
+    if ($err) {
       die "ERROR: Can't extract $file, extract it to " . Cwd::abs_path('.') .
         "\nand run this script again.\nStopped";
     }


### PR DESCRIPTION
In response to #849 and #783 I looked up if ActiveState Perl came with any zip modules on Windows, and it does, `Archive::Zip`, at least with 5.24.2.203. I added it as an alternative if `Archive:Extract` isn't installed, and `configure` will fall back to the manual extraction error message if `Archive::Zip` isn't installed or if it fails.