### PR TITLE
Use RcEventHandler in TransportReceiveStrategy subclasses

### DIFF
--- a/dds/DCPS/transport/framework/TransportStrategy.h
+++ b/dds/DCPS/transport/framework/TransportStrategy.h
@@ -22,7 +22,7 @@ namespace DCPS {
  * TransportReceiveStrategy.
  */
 class OpenDDS_Dcps_Export TransportStrategy
-  : public RcObject {
+  : public virtual RcObject {
 public:
 
   virtual ~TransportStrategy();

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
@@ -18,9 +18,6 @@ namespace DCPS {
 MulticastReceiveStrategy::MulticastReceiveStrategy(MulticastDataLink* link)
   : link_(link)
 {
-#if WIN32
-	this->reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
-#endif
 }
 
 ACE_HANDLE

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
@@ -18,6 +18,9 @@ namespace DCPS {
 MulticastReceiveStrategy::MulticastReceiveStrategy(MulticastDataLink* link)
   : link_(link)
 {
+#if WIN32
+	this->reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
+#endif
 }
 
 ACE_HANDLE

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
@@ -45,6 +45,17 @@ protected:
   virtual int start_i();
   virtual void stop_i();
 
+
+	virtual inline ACE_Event_Handler::Reference_Count add_reference() {
+		RcObject::_add_ref();
+		return 1;
+	}
+
+	virtual inline ACE_Event_Handler::Reference_Count remove_reference() {
+		RcObject::_remove_ref();
+		return 1;
+	}
+
   virtual bool reassemble(ReceivedDataSample& data);
 
 private:

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
@@ -10,8 +10,7 @@
 
 #include "Multicast_Export.h"
 
-#include "ace/Event_Handler.h"
-
+#include "dds/DCPS/RcEventHandler.h"
 #include "dds/DCPS/transport/framework/TransportReceiveStrategy_T.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -23,7 +22,8 @@ class MulticastDataLink;
 
 class OpenDDS_Multicast_Export MulticastReceiveStrategy
   : public TransportReceiveStrategy<>,
-    public ACE_Event_Handler {
+    public RcEventHandler
+{
 public:
   explicit MulticastReceiveStrategy(MulticastDataLink* link);
 

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
@@ -45,17 +45,6 @@ protected:
   virtual int start_i();
   virtual void stop_i();
 
-
-	virtual inline ACE_Event_Handler::Reference_Count add_reference() {
-		RcObject::_add_ref();
-		return 1;
-	}
-
-	virtual inline ACE_Event_Handler::Reference_Count remove_reference() {
-		RcObject::_remove_ref();
-		return 1;
-	}
-
   virtual bool reassemble(ReceivedDataSample& data);
 
 private:

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -15,8 +15,8 @@
 #include "dds/DCPS/transport/framework/TransportReceiveStrategy_T.h"
 
 #include "dds/DCPS/RTPS/RtpsCoreC.h"
+#include "dds/DCPS/RcEventHandler.h"
 
-#include "ace/Event_Handler.h"
 #include "ace/INET_Addr.h"
 
 #include <cstring>
@@ -31,7 +31,8 @@ class ReceivedDataSample;
 
 class OpenDDS_Rtps_Udp_Export RtpsUdpReceiveStrategy
   : public TransportReceiveStrategy<RtpsTransportHeader, RtpsSampleHeader>,
-    public ACE_Event_Handler {
+    public RcEventHandler
+{
 public:
   explicit RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix);
 

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
@@ -10,7 +10,6 @@
 
 #include "Shmem_Export.h"
 
-#include "ace/Event_Handler.h"
 #include "ace/INET_Addr.h"
 
 #include "dds/DCPS/transport/framework/TransportReceiveStrategy_T.h"

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
@@ -12,6 +12,7 @@
 #include "TcpDataLink_rch.h"
 #include "dds/DCPS/transport/framework/TransportReceiveStrategy_T.h"
 #include "dds/DCPS/transport/framework/TransportReactorTask_rch.h"
+#include "dds/DCPS/RcEventHandler.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -20,7 +21,10 @@ namespace DCPS {
 
 class TcpConnection;
 
-class TcpReceiveStrategy : public TransportReceiveStrategy<> {
+class TcpReceiveStrategy
+  : public TransportReceiveStrategy<>,
+    public RcEventHandler
+{
 public:
 
   TcpReceiveStrategy(TcpDataLink& link,

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.h
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.h
@@ -10,11 +10,10 @@
 
 #include "Udp_Export.h"
 
-#include "ace/Event_Handler.h"
 #include "ace/INET_Addr.h"
 
 #include "dds/DCPS/transport/framework/TransportReceiveStrategy_T.h"
-#include "dds/DCPS/PoolAllocator.h"
+#include "dds/DCPS/RcEventHandler.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -25,7 +24,8 @@ class UdpDataLink;
 
 class OpenDDS_Udp_Export UdpReceiveStrategy
   : public TransportReceiveStrategy<>,
-    public ACE_Event_Handler {
+    public RcEventHandler
+{
 public:
   explicit UdpReceiveStrategy(UdpDataLink* link);
 


### PR DESCRIPTION
This is an attempt to correct a Access Violation on Windows when the ACE Reactor Implementation `WFMO_Reactor` for the Multicast Transport tries tries to access the Transport's `MulticastReceivedStrategy` as part of it's cleanup. The problem is that it has already been deleted earlier in the destruction of the transport. This enables `ACE_Event_Handler`'s reference counting policy on Windows and connects it to `MulticastReceiverStrategy`'s `RcObject` count, keeping the `MulticastReceivedStrategy` alive until `WFMO_Reactor` is done with it and calls `remove_reference()` in `make_changes_in_current_info()`.

This is based off `RcEventHandler`, which might be preferred to this.