### PR TITLE
Detect when we are using the new std atomic usage introduced with TAO…

### DIFF
--- a/dds/CORBA/tao/Object.cpp
+++ b/dds/CORBA/tao/Object.cpp
@@ -59,7 +59,11 @@ CORBA::Object::_remove_ref()
 CORBA::ULong
 CORBA::Object::_refcount_value() const
 {
-  return static_cast<CORBA::ULong>(this->refcount_.value());
+#if defined (ACE_HAS_CPP11) && defined (TAO_OBJECT_USES_STD_ATOMIC_REFCOUNT)
+  return this->refcount_;
+#else
+  return this->refcount_.value ();
+#endif /* ACE_HAS_CPP11 */
 }
 
 void


### PR DESCRIPTION
… > 2.5.0

    * dds/CORBA/tao/Object.cpp: