### PR TITLE
Adding durability / history depth to fix occasional StaticDiscoveryTest failures under load.

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -681,7 +681,7 @@ DataReaderImpl::remove_all_associations()
 
   } catch (const CORBA::Exception&) {
       ACE_DEBUG((LM_WARNING,
-                 ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::remove_all_associations() - ")
+                 ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::remove_all_associations() - ")
                  ACE_TEXT("caught exception from remove_associations.\n")));
   }
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1140,10 +1140,10 @@ RtpsUdpDataLink::received(const RTPS::HeartBeatSubmessage& heartbeat,
       RtpsReaderMap::const_iterator riter = readers_.find(readerid);
       if (riter == readers_.end()) {
         // Reader has no associations.
-        interesting_ack_nacks_.insert (InterestingAckNack(writerid, readerid, pos->second.address));
+        interesting_ack_nacks_.insert(InterestingAckNack(writerid, readerid, pos->second.address));
       } else if (riter->second.remote_writers_.find(writerid) == riter->second.remote_writers_.end()) {
         // Reader is not associated with this writer.
-        interesting_ack_nacks_.insert (InterestingAckNack(writerid, readerid, pos->second.address));
+        interesting_ack_nacks_.insert(InterestingAckNack(writerid, readerid, pos->second.address));
       }
       pos->second.last_activity = now;
       if (pos->second.status == InterestingRemote::DOES_NOT_EXIST) {
@@ -1475,7 +1475,7 @@ RtpsUdpDataLink::send_heartbeat_replies() // from DR to DW
 
   for (RtpsReaderMap::iterator rr = readers_.begin(); rr != readers_.end();
        ++rr) {
-    send_ack_nacks (rr);
+    send_ack_nacks(rr);
   }
 }
 
@@ -2565,7 +2565,7 @@ RtpsUdpDataLink::send_heartbeats_manual(const TransportSendControlElement* tsce)
 
   // Populate the recipients.
   OPENDDS_SET(ACE_INET_Addr) recipients;
-  get_locators (pub_id, recipients);
+  get_locators(pub_id, recipients);
   if (recipients.empty()) {
     return;
   }
@@ -2574,8 +2574,8 @@ RtpsUdpDataLink::send_heartbeats_manual(const TransportSendControlElement* tsce)
 
   SequenceNumber firstSN, lastSN;
   CORBA::Long counter;
-  RtpsWriterMap::iterator pos = writers_.find (pub_id);
-  if (pos != writers_.end ()) {
+  RtpsWriterMap::iterator pos = writers_.find(pub_id);
+  if (pos != writers_.end()) {
     // Reliable.
     const bool has_data = !pos->second.send_buff_.is_nil() && !pos->second.send_buff_->empty();
     SequenceNumber durable_max;
@@ -2797,12 +2797,12 @@ RtpsUdpDataLink::HeartBeat::disable()
 }
 
 void
-RtpsUdpDataLink::send_final_acks (const RepoId& readerid)
+RtpsUdpDataLink::send_final_acks(const RepoId& readerid)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-  RtpsReaderMap::iterator rr = readers_.find (readerid);
-  if (rr != readers_.end ()) {
-    send_ack_nacks (rr, true);
+  RtpsReaderMap::iterator rr = readers_.find(readerid);
+  if (rr != readers_.end()) {
+    send_ack_nacks(rr, true);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -130,7 +130,7 @@ public:
 
   virtual void pre_stop_i();
 
-  virtual void send_final_acks (const RepoId& readerid);
+  virtual void send_final_acks(const RepoId& readerid);
 
 #ifdef OPENDDS_SECURITY
   Security::SecurityConfig_rch security_config() const

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -79,7 +79,7 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
         ACE_DEBUG((LM_DEBUG, "(%P|%t) datareader deleted\n"));
         done_callback_(builtin_read_error_);
       } else {
-        ACE_DEBUG((LM_INFO, "(%P|%t) Got message %d\n", received_samples_));
+        ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from writer %C)\n", id_.data(), received_samples_, message.value, writers_[message.src].data()));
       }
     }
   } else {

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -79,7 +79,11 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
         ACE_DEBUG((LM_DEBUG, "(%P|%t) datareader deleted\n"));
         done_callback_(builtin_read_error_);
       } else {
-        ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from writer %C)\n", id_.data(), received_samples_, message.value, writers_[message.src].data()));
+        if (static_cast<int>(writers_.size()) == total_writers_) {
+          ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from known writer %C)\n", id_.data(), received_samples_, message.value, writers_[message.src].data()));
+        } else {
+          ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from (ambiguous) writer #%d)\n", id_.data(), received_samples_, message.value, message.src));
+        }
       }
     }
   } else {

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -13,8 +13,6 @@
 #include "dds/DdsDcpsCoreTypeSupportC.h"
 #endif // !defined (DDS_HAS_MINIMUM_BIT)
 
-#include <iostream>
-
 DataReaderListenerImpl::~DataReaderListenerImpl()
 {
   ACE_DEBUG((LM_DEBUG, "(%P|%t) DataReader %C is done\n", id_.c_str()));

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -20,9 +20,10 @@ typedef void (*callback_t)(bool);
 class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
 public:
-  DataReaderListenerImpl(const std::string& id, const std::vector<std::string>& writers, const int expected_samples, callback_t done_callback, DDS::Subscriber_ptr subscriber, bool check_bits)
+  DataReaderListenerImpl(const std::string& id, const std::vector<std::string>& writers, const int total_writers, const int expected_samples, callback_t done_callback, DDS::Subscriber_ptr subscriber, bool check_bits)
     : id_(id)
     , writers_(writers)
+    , total_writers_(total_writers)
     , expected_samples_(expected_samples)
     , received_samples_(0)
     , done_callback_(done_callback)
@@ -73,6 +74,7 @@ public:
 private:
   std::string id_;
   const std::vector<std::string>& writers_;
+  const int total_writers_;
   const int expected_samples_;
   int received_samples_;
   callback_t done_callback_;

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -13,14 +13,16 @@
 #include <dds/DCPS/Definitions.h>
 
 #include <string>
+#include <vector>
 
 typedef void (*callback_t)(bool);
 
 class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
 public:
-  DataReaderListenerImpl(const std::string& id, int expected_samples, callback_t done_callback, DDS::Subscriber_ptr subscriber, bool check_bits)
+  DataReaderListenerImpl(const std::string& id, const std::vector<std::string>& writers, const int expected_samples, callback_t done_callback, DDS::Subscriber_ptr subscriber, bool check_bits)
     : id_(id)
+    , writers_(writers)
     , expected_samples_(expected_samples)
     , received_samples_(0)
     , done_callback_(done_callback)
@@ -70,6 +72,7 @@ public:
 
 private:
   std::string id_;
+  const std::vector<std::string>& writers_;
   const int expected_samples_;
   int received_samples_;
   callback_t done_callback_;

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -109,7 +109,7 @@ public:
       qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
     }
     qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-    qos.history.depth = 10;
+    qos.history.depth = MSGS_PER_WRITER;
 
     // Create DataWriter
     DDS::DataWriter_var writer =
@@ -381,7 +381,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       qos.user_data.value[2] = fromhex(*pos, 2);
       qos.reliability.kind = reliable ? DDS::RELIABLE_RELIABILITY_QOS : DDS::BEST_EFFORT_RELIABILITY_QOS;
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-      qos.history.depth = 10;
+      qos.history.depth = MSGS_PER_WRITER;
 
 
       DDS::DataReader_var reader =

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -22,7 +22,6 @@
 #include "ace/OS_NS_stdlib.h"
 #include "ace/OS_NS_unistd.h"
 
-#include <sstream>
 /*
   NOTE:  The messages may not be processed by the reader in this test.
   This behavior is not an error.
@@ -88,10 +87,12 @@ public:
 
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Starting DataWriter %C\n", writers_[thread_id].c_str()));
 
-    size_t v = static_cast<size_t>(fromhex(writers_[thread_id], 2)) + (256 * static_cast<size_t>(fromhex(writers_[thread_id], 1))) + (256 * 256 * static_cast<size_t>(fromhex(writers_[thread_id], 0)));
-    std::stringstream ss;
-    ss << "Config" << v;
-    OpenDDS::DCPS::TransportRegistry::instance()->bind_config(ss.str().data(), publisher);
+    unsigned long binary_id = static_cast<unsigned long>(fromhex(writers_[thread_id], 2))
+                            + (256 * static_cast<unsigned long>(fromhex(writers_[thread_id], 1)))
+                            + (256 * 256 * static_cast<unsigned long>(fromhex(writers_[thread_id], 0)));
+    char config_name_buffer[16];
+    sprintf(config_name_buffer, "Config%lu", binary_id);
+    OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config_name_buffer, publisher);
 
     DDS::DataWriterQos qos;
     publisher->get_default_datawriter_qos(qos);
@@ -365,10 +366,12 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       listener_servant->set_builtin_datareader(bitdr.in());
 #endif /* DDS_HAS_MINIMUM_BIT */
 
-      size_t v = static_cast<size_t>(fromhex(*pos, 2)) + (256 * static_cast<size_t>(fromhex(*pos, 1))) + (256 * 256 * static_cast<size_t>(fromhex(*pos, 0)));
-      std::stringstream ss;
-      ss << "Config" << v;
-      OpenDDS::DCPS::TransportRegistry::instance()->bind_config(ss.str().data(), subscriber);
+      unsigned long binary_id = static_cast<unsigned long>(fromhex(*pos, 2))
+                              + (256 * static_cast<unsigned long>(fromhex(*pos, 1)))
+                              + (256 * 256 * static_cast<unsigned long>(fromhex(*pos, 0)));
+      char config_name_buffer[16];
+      sprintf(config_name_buffer, "Config%lu", binary_id);
+      OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config_name_buffer, subscriber);
 
       DDS::DataReaderQos qos;
       subscriber->get_default_datareader_qos(qos);

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -347,7 +347,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
          pos != limit;
          ++pos) {
       pos->resize(6);
-      DDS::DataReaderListener_var listener(new DataReaderListenerImpl(*pos, writers, n_msgs, reader_done_callback, subscriber.in(), check_bits));
+      DDS::DataReaderListener_var listener(new DataReaderListenerImpl(*pos, writers, total_writers, n_msgs, reader_done_callback, subscriber.in(), check_bits));
 
 #ifndef DDS_HAS_MINIMUM_BIT
       DataReaderListenerImpl* listener_servant =

--- a/tests/DCPS/StaticDiscovery/TestMsg.idl
+++ b/tests/DCPS/StaticDiscovery/TestMsg.idl
@@ -2,5 +2,6 @@
 #pragma DCPS_DATA_TYPE "TestMsg"
 
 struct TestMsg {
-  long value;
+  short src;
+  short value;
 };

--- a/tests/DCPS/StaticDiscovery/run_test.pl
+++ b/tests/DCPS/StaticDiscovery/run_test.pl
@@ -183,6 +183,18 @@ if ($test->flag('mp')) {
   # mw
   # 1 process with 1 reader and 5 writers
   runTest(1, 1, 5, 0, 0, 0, 0, 45000000);
+} elsif ($test->flag('mrmw9')) {
+  # mw
+  # 1 process with 5 readers and 5 writers
+  runTest(1, 9, 9, 0, 0, 0, 0, 128000000);
+} elsif ($test->flag('mrmw16')) {
+  # mw
+  # 1 process with 5 readers and 5 writers
+  runTest(1, 16, 16, 0, 0, 0, 0, 256000000);
+} elsif ($test->flag('mrmw25')) {
+  # mw
+  # 1 process with 25 readers and 25 writers
+  runTest(1, 25, 25, 0, 0, 0, 0, 512000000);
 } elsif ($test->flag('mpmrmw')) {
   # mpmrmw
   # 5 processes with 5 readers and 5 writers


### PR DESCRIPTION
Also adding per-writer message tracking, support for binding generated transport config sections even when using rtps discovery to help with debugging, and fixing a few typos and code guideline violations.