### PR TITLE
adding mpc idl gen support for safety profile without builtin topics

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,8 @@ jobs:
         ConfigOpts: --no-debug --optimize
       Safety:
         ConfigOpts: --safety-profile
+      SafetyBaseNoBuiltinTopics:
+        ConfigOpts: --safety-profile=base --no-built-in-topics
       SecurityWithoutFeatures:
         ConfigOpts: --no-inline --no-debug --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --security
         PackageDeps: libxerces-c-dev libssl-dev cmake

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -142,18 +142,18 @@ project(OpenDDS_Dcps): core, coverage_optional, \
 // For IDL files containing message types, there are three scenarios (see
 // dcps_optional_safety.mpb):
 
-//  1. Standard profile with builtin topics
+//  1. Standard profile (with builtin topics)
 
-//    The main driver here in the InfoRepo.  Most files will be processed
+//    The main driver here is the InfoRepo.  Most files will be processed
 //    with tao_idl, type support will be generated with opendds_idl, and
 //    then fileTypeSupport.idl will be processed with tao_idl.
 
-// 2. Standard profile with no builtin topics
+// 2. Standard profile (with no builtin topics)
 
 //    Similar to the previous case except fileTypeSupport.idl and its
 //    products can be avoided for most files.
 
-// 3. Safety profile (with builtinin topics)
+// 3. Safety profile (with builtin topics)
 
 //    The main driver here is control of the language mapping.  In this
 //    configuration, opendds_idl is used with -I (prevent

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -162,6 +162,11 @@ project(OpenDDS_Dcps): core, coverage_optional, \
 //    DdsDcpsCore.idl which means that opendds_idl generates
 //    DdsDcpsCoreTypeSupport.idl which is then processed with tao_idl.
 
+// 4. Safety profile (with no builtin topics)
+
+//    Similar to the previous case except fileTypeSupport.idl and its
+//    products can almost be avoided entirely.
+
 // Various interfaces use sequences of interfaces.  This is a problem in
 // safety profile builds because the included TAO headers have calls to
 // global operator new.  Sequences of interfaces are handled by pulling

--- a/dds/dcps_optional_safety.mpb
+++ b/dds/dcps_optional_safety.mpb
@@ -145,3 +145,23 @@ feature(!no_opendds_safety_profile, built_in_topics) : dds_suppress_any_support,
     DdsDcpsCoreTypeSupportS.h
   }
 }
+
+feature(!no_opendds_safety_profile, !built_in_topics) : dds_suppress_any_support, dcps_ts_defaults, dds_versioning_idl_defaults {
+  TypeSupport_Files {
+    dcps_ts_flags += -SI -Lspcpp
+    DdsDcpsGuid.idl
+    DdsDcpsInfoUtils.idl
+    DdsSecurityParams.idl
+    DdsDcpsCore.idl
+  }
+
+  TypeSupport_Files {
+    dcps_ts_flags += -SI -Lspcpp -ZC DdsDcpsInfrastructureC.h
+    DdsDcpsConditionSeq.idl
+  }
+
+  TypeSupport_Files {
+    dcps_ts_flags += -SI -Lspcpp -ZC DdsDcpsSubscriptionC.h
+    DdsDcpsDataReaderSeq.idl
+  }
+}


### PR DESCRIPTION
Fixing another odd configuration flag combination which caused a build error.