### PR TITLE
The deletion of a DataReader is not allowed if there are any existing ReadCondition or QueryCondition objects that are attached to the DataReader

### DIFF
--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -269,6 +269,10 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
     if (dr_servant->has_zero_copies()) {
       return DDS::RETCODE_PRECONDITION_NOT_MET;
     }
+
+    if (!dr_servant->read_conditions_.empty()) {
+      return DDS::RETCODE_PRECONDITION_NOT_MET;
+    }
   }
   if (dr_servant) {
     // marks entity as deleted and stops future associating
@@ -389,7 +393,10 @@ SubscriberImpl::delete_contained_entities()
   }
 
   for (size_t i = 0; i < drs.size(); ++i) {
-    const DDS::ReturnCode_t ret = delete_datareader(drs[i]);
+    DDS::ReturnCode_t ret = drs[i]->delete_contained_entities();
+    if (ret == DDS::RETCODE_OK) {
+      ret = delete_datareader(drs[i]);
+    }
     if (ret != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: ")
@@ -415,8 +422,10 @@ SubscriberImpl::delete_contained_entities()
   }
 
   for (size_t i = 0; i < drs.size(); ++i) {
-    DDS::ReturnCode_t ret = delete_datareader(drs[i]);
-
+    DDS::ReturnCode_t ret = drs[i]->delete_contained_entities();
+    if (ret == DDS::RETCODE_OK) {
+      ret = delete_datareader(drs[i]);
+    }
     if (ret != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: ")

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -559,6 +559,7 @@ namespace {
     if (OpenDDS::DCPS::DCPS_debug_level > 3) {
       ACE_DEBUG((LM_DEBUG, "(%P|%t) cleanup_opendds_subscriber - subscriber no longer in use, delete sub\n"));
     }
+    sub->delete_contained_entities();
     dp->delete_subscriber(sub);
     return true;
   }

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -312,6 +312,7 @@ void Destroy_Connection(CONNECTION_ID_TYPE connection_id,
       const DDS::Subscriber_var sub = datareader->get_subscriber();
       delete readers[connection_id];
       readers.erase(connection_id);
+      datareader->delete_contained_entities();
       sub->delete_datareader(datareader);
       dp = sub->get_participant();
       try_cleanup_participant = cleanup_opendds_subscriber(sub);

--- a/tests/DCPS/QueryCondition/QueryConditionTest.cpp
+++ b/tests/DCPS/QueryCondition/QueryConditionTest.cpp
@@ -221,7 +221,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   if (!dr_qc) {
     cerr << "ERROR: failed to create QueryCondition" << endl;
     return false;
-  }  
+  }
   WaitSet_var ws = new WaitSet;
   ws->attach_condition(dr_qc);
   ConditionSeq active;
@@ -295,7 +295,7 @@ bool run_complex_filtering_test(const DomainParticipant_var& dp,
   if (!dr_qc1) {
     cerr << "ERROR: failed to create QueryCondition 1" << endl;
     return false;
-  }  
+  }
   QueryCondition_var dr_qc2 = dr2->create_querycondition(NOT_READ_SAMPLE_STATE,
     NEW_VIEW_STATE | NOT_NEW_VIEW_STATE, ANY_INSTANCE_STATE, "( (iteration < %0) OR (iteration > %1) )", params);
   if (!dr_qc2) {
@@ -412,7 +412,7 @@ bool run_sorting_test(const DomainParticipant_var& dp,
   if (!dr_qc) {
     cerr << "ERROR: failed to create QueryCondition" << endl;
     return false;
-  }  
+  }
   WaitSet_var ws = new WaitSet;
   ws->attach_condition(dr_qc);
   MessageDataReader_var mdr = MessageDataReader::_narrow(dr);

--- a/tests/DCPS/QueryCondition/QueryConditionTest.cpp
+++ b/tests/DCPS/QueryCondition/QueryConditionTest.cpp
@@ -221,7 +221,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   if (!dr_qc) {
     cerr << "ERROR: failed to create QueryCondition" << endl;
     return false;
-  }
+  }  
   WaitSet_var ws = new WaitSet;
   ws->attach_condition(dr_qc);
   ConditionSeq active;
@@ -295,7 +295,7 @@ bool run_complex_filtering_test(const DomainParticipant_var& dp,
   if (!dr_qc1) {
     cerr << "ERROR: failed to create QueryCondition 1" << endl;
     return false;
-  }
+  }  
   QueryCondition_var dr_qc2 = dr2->create_querycondition(NOT_READ_SAMPLE_STATE,
     NEW_VIEW_STATE | NOT_NEW_VIEW_STATE, ANY_INSTANCE_STATE, "( (iteration < %0) OR (iteration > %1) )", params);
   if (!dr_qc2) {
@@ -412,12 +412,17 @@ bool run_sorting_test(const DomainParticipant_var& dp,
   if (!dr_qc) {
     cerr << "ERROR: failed to create QueryCondition" << endl;
     return false;
-  }
+  }  
   WaitSet_var ws = new WaitSet;
   ws->attach_condition(dr_qc);
   MessageDataReader_var mdr = MessageDataReader::_narrow(dr);
   Duration_t five_seconds = {5, 0};
   bool passed = true, done = false;
+  if (sub->delete_datareader(dr) != DDS::RETCODE_PRECONDITION_NOT_MET) {
+    cerr << "ERROR: the deletion of a DataReader is not allowed if there are any existing QueryCondition objects that are attached to the DataReader." << endl;
+    passed = false;
+    done = true;
+  }
   while (!done) {
     ConditionSeq active;
     ret = ws->wait(active, five_seconds);

--- a/tests/DCPS/ReadCondition/ReadConditionTest.cpp
+++ b/tests/DCPS/ReadCondition/ReadConditionTest.cpp
@@ -63,13 +63,13 @@ int run_test_instance(DDS::DomainParticipant_ptr dp)
   }
 
   ReadCondition_var dr_rc = dr->create_readcondition(NOT_READ_SAMPLE_STATE,
-    NEW_VIEW_STATE, ALIVE_INSTANCE_STATE);
+    NEW_VIEW_STATE, ALIVE_INSTANCE_STATE);  
   ReadCondition_var dr_rc2 = dr->create_readcondition(ANY_SAMPLE_STATE,
     ANY_VIEW_STATE, NOT_ALIVE_DISPOSED_INSTANCE_STATE);
   ws->attach_condition(dr_rc);
   ws->attach_condition(dr_rc2);
   MessageDataReader_var mdr = MessageDataReader::_narrow(dr);
-  bool passed = true, done = false;
+  bool passed = true, done = false;  
   while (!done) {
     ret = ws->wait(active, infinite);
     if (ret != RETCODE_OK) {
@@ -177,6 +177,11 @@ int run_test_next_instance(DDS::DomainParticipant_ptr dp)
   ws->attach_condition(dr_rc2);
   MessageDataReader_var mdr = MessageDataReader::_narrow(dr);
   bool passed = true, done = false;
+  if (sub->delete_datareader(dr) != DDS::RETCODE_PRECONDITION_NOT_MET) {
+    cout << "ERROR: the deletion of a DataReader is not allowed if there are any existing ReadCondition objects that are attached to the DataReader." << endl;
+    passed = false;
+    done = true;
+  }
   while (!done) {
     ret = ws->wait(active, infinite);
     if (ret != RETCODE_OK) {
@@ -223,7 +228,7 @@ int run_test_next_instance(DDS::DomainParticipant_ptr dp)
   }
   ws->detach_condition(dr_rc);
   ws->detach_condition(dr_rc2);
-
+  
   dp->delete_contained_entities();
   return passed ? 0 : 1;
 }

--- a/tests/DCPS/ReadCondition/ReadConditionTest.cpp
+++ b/tests/DCPS/ReadCondition/ReadConditionTest.cpp
@@ -63,13 +63,13 @@ int run_test_instance(DDS::DomainParticipant_ptr dp)
   }
 
   ReadCondition_var dr_rc = dr->create_readcondition(NOT_READ_SAMPLE_STATE,
-    NEW_VIEW_STATE, ALIVE_INSTANCE_STATE);  
+    NEW_VIEW_STATE, ALIVE_INSTANCE_STATE);
   ReadCondition_var dr_rc2 = dr->create_readcondition(ANY_SAMPLE_STATE,
     ANY_VIEW_STATE, NOT_ALIVE_DISPOSED_INSTANCE_STATE);
   ws->attach_condition(dr_rc);
   ws->attach_condition(dr_rc2);
   MessageDataReader_var mdr = MessageDataReader::_narrow(dr);
-  bool passed = true, done = false;  
+  bool passed = true, done = false;
   while (!done) {
     ret = ws->wait(active, infinite);
     if (ret != RETCODE_OK) {
@@ -228,7 +228,7 @@ int run_test_next_instance(DDS::DomainParticipant_ptr dp)
   }
   ws->detach_condition(dr_rc);
   ws->detach_condition(dr_rc2);
-  
+
   dp->delete_contained_entities();
   return passed ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #957