### PR TITLE
The total_count_change value should be the incremental changes in tot…

### DIFF
--- a/dds/DCPS/OfferedDeadlineWatchdog.cpp
+++ b/dds/DCPS/OfferedDeadlineWatchdog.cpp
@@ -114,6 +114,10 @@ OpenDDS::DCPS::OfferedDeadlineWatchdog::execute(
           //       catch all exceptions, and act accordingly.
           listener->on_offered_deadline_missed(&writer,
                                               status);
+
+          // We need to update the last total count value to our current total
+          // so that the next time we will calculate the correct total_count_change;
+          this->last_total_count_ = this->status_.total_count;
         }
 
         writer.notify_status_condition();

--- a/dds/DCPS/RequestedDeadlineWatchdog.cpp
+++ b/dds/DCPS/RequestedDeadlineWatchdog.cpp
@@ -139,6 +139,10 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::execute(SubscriptionInstance_rch insta
           //       catch all exceptions, and act accordingly.
           listener->on_requested_deadline_missed(reader.in(),
                                                 status);
+
+          // We need to update the last total count value to our current total
+          // so that the next time we will calculate the correct total_count_change;
+          this->last_total_count_ = this->status_.total_count;
         }
 
         reader->notify_status_condition();

--- a/tests/DCPS/Deadline/DataReaderListenerImpl.h
+++ b/tests/DCPS/Deadline/DataReaderListenerImpl.h
@@ -63,6 +63,8 @@ public:
 
   int wait_matched(long count, const ACE_Time_Value *abstime) const;
 
+  CORBA::Long requested_deadline_total_count (void) const;
+
 protected:
 
   virtual ~DataReaderListenerImpl (void);
@@ -73,6 +75,7 @@ private:
   mutable ACE_Condition<ACE_Thread_Mutex> matched_condition_;
   long matched_;
   long num_arrived_;
+  CORBA::Long requested_deadline_total_count_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/Deadline/DataWriterListenerImpl.cpp
+++ b/tests/DCPS/Deadline/DataWriterListenerImpl.cpp
@@ -11,6 +11,7 @@ DataWriterListenerImpl::DataWriterListenerImpl()
   : mutex_()
   , matched_condition_(mutex_)
   , matched_(0)
+  , offered_deadline_total_count_ (0)
 {
 }
 
@@ -23,13 +24,23 @@ DataWriterListenerImpl::on_offered_deadline_missed(
     ::DDS::DataWriter_ptr /* writer */,
     const ::DDS::OfferedDeadlineMissedStatus& status)
 {
-  ACE_DEBUG((LM_DEBUG,
-    ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_offered_deadline_missed:")
-    ACE_TEXT("total_count=%d total_count_change=%d last_instance_handle=%d \n"),
-    status.total_count, status.total_count_change, status.last_instance_handle));
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_offered_deadline_missed\n")
-    ACE_TEXT("  total_count        = %d\n")
-    ACE_TEXT("  total_count_change = %d\n"), status.total_count, status.total_count_change));
+  if ((offered_deadline_total_count_ + status.total_count_change) != status.total_count)
+    {
+      ACE_ERROR((LM_ERROR,
+        ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_offered_deadline_missed:")
+        ACE_TEXT("Received incorrect total_count_change, previous total count %d ")
+        ACE_TEXT("new total_count=%d total_count_change=%d last_instance_handle=%d\n"),
+        offered_deadline_total_count_, status.total_count, status.total_count_change,
+        status.last_instance_handle));
+    }
+  else
+    {
+      ACE_DEBUG((LM_DEBUG,
+        ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_offered_deadline_missed:")
+        ACE_TEXT("total_count=%d total_count_change=%d last_instance_handle=%d\n"),
+        status.total_count, status.total_count_change, status.last_instance_handle));
+    }
+  offered_deadline_total_count_ += status.total_count_change;
 }
 
 void
@@ -94,3 +105,7 @@ int DataWriterListenerImpl::wait_matched(long count, const ACE_Time_Value *absti
   return count == matched_ ? 0 : result;
 }
 
+CORBA::Long DataWriterListenerImpl::offered_deadline_total_count (void) const
+{
+  return offered_deadline_total_count_;
+}

--- a/tests/DCPS/Deadline/DataWriterListenerImpl.h
+++ b/tests/DCPS/Deadline/DataWriterListenerImpl.h
@@ -20,50 +20,44 @@ public:
 
   virtual void on_offered_deadline_missed (
       ::DDS::DataWriter_ptr writer,
-      const ::DDS::OfferedDeadlineMissedStatus& status
-    );
+      const ::DDS::OfferedDeadlineMissedStatus& status);
 
   virtual void on_offered_incompatible_qos (
       ::DDS::DataWriter_ptr writer,
-      const ::DDS::OfferedIncompatibleQosStatus& status
-    );
+      const ::DDS::OfferedIncompatibleQosStatus& status);
 
   virtual void on_liveliness_lost (
       ::DDS::DataWriter_ptr writer,
-      const ::DDS::LivelinessLostStatus& status
-    );
+      const ::DDS::LivelinessLostStatus& status);
 
   virtual void on_publication_matched (
       ::DDS::DataWriter_ptr writer,
-      const ::DDS::PublicationMatchedStatus& status
-    );
+      const ::DDS::PublicationMatchedStatus& status);
 
   virtual void on_publication_disconnected (
       ::DDS::DataWriter_ptr reader,
-      const ::OpenDDS::DCPS::PublicationDisconnectedStatus& status
-    );
+      const ::OpenDDS::DCPS::PublicationDisconnectedStatus& status);
 
   virtual void on_publication_reconnected (
       ::DDS::DataWriter_ptr reader,
-      const ::OpenDDS::DCPS::PublicationReconnectedStatus& status
-    );
+      const ::OpenDDS::DCPS::PublicationReconnectedStatus& status);
 
   virtual void on_publication_lost (
       ::DDS::DataWriter_ptr writer,
-      const ::OpenDDS::DCPS::PublicationLostStatus& status
-    );
+      const ::OpenDDS::DCPS::PublicationLostStatus& status);
 
   int wait_matched(long count, const ACE_Time_Value *abstime) const;
 
-protected:
+  CORBA::Long offered_deadline_total_count (void) const;
 
+protected:
   virtual ~DataWriterListenerImpl (void);
 
 private:
-
   mutable ACE_Thread_Mutex mutex_;
   mutable ACE_Condition<ACE_Thread_Mutex> matched_condition_;
   long matched_;
+  CORBA::Long offered_deadline_total_count_;
 };
 
 #endif /* DATAWRITER_LISTENER_IMPL  */


### PR DESCRIPTION
…al_count since the last time the listener was called or the status was read. Tested and fixed this for on_offered_deadline_missed and on_requested_deadline_missed, see issue #619

    * dds/DCPS/OfferedDeadlineWatchdog.cpp:
    * dds/DCPS/RequestedDeadlineWatchdog.cpp:
    * tests/DCPS/Deadline/DataReaderListenerImpl.cpp:
    * tests/DCPS/Deadline/DataReaderListenerImpl.h:
    * tests/DCPS/Deadline/DataWriterListenerImpl.cpp:
    * tests/DCPS/Deadline/DataWriterListenerImpl.h:
    * tests/DCPS/Deadline/publisher.cpp:
    * tests/DCPS/Deadline/subscriber.cpp: