### PR TITLE
Remove manual release of a guard, we only log a message after it, no …

### DIFF
--- a/dds/DCPS/security/framework/SecurityRegistry.cpp
+++ b/dds/DCPS/security/framework/SecurityRegistry.cpp
@@ -115,7 +115,6 @@ SecurityRegistry::register_plugin(const OPENDDS_STRING& plugin_name,
   GuardType guard(lock_);
 
   if (registered_plugins_.find(plugin_name) != registered_plugins_.end()) {
-    guard.release();
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) SecurityRegistry::register_plugin: ")
                ACE_TEXT("plugin=%C already exists.\n"),


### PR DESCRIPTION
…need to release it manually here

    * dds/DCPS/security/framework/SecurityRegistry.cpp: