### PR TITLE
replace std::string with OPENDDS_STRING in some case

### DIFF
--- a/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.cpp
@@ -40,8 +40,8 @@ DataReaderRemoteImpl::add_association(const RepoId& yourId,
     GuidConverter reader_converter(writer.writerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderRemoteImpl::add_association - ")
                ACE_TEXT("local %C remote %C\n"),
-               std::string(writer_converter).c_str(),
-               std::string(reader_converter).c_str()));
+               OPENDDS_STRING(writer_converter).c_str(),
+               OPENDDS_STRING(reader_converter).c_str()));
   }
 
   // the local copy of parent_ is necessary to prevent race condition

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
@@ -40,8 +40,8 @@ DataWriterRemoteImpl::add_association(const RepoId& yourId,
     GuidConverter reader_converter(reader.readerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataWriterRemoteImpl::add_association - ")
                ACE_TEXT("local %C remote %C\n"),
-               std::string(writer_converter).c_str(),
-               std::string(reader_converter).c_str()));
+               OPENDDS_STRING(writer_converter).c_str(),
+               OPENDDS_STRING(reader_converter).c_str()));
   }
 
   // the local copy of parent_ is necessary to prevent race condition

--- a/dds/InfoRepo/DCPS_IR_Publication.cpp
+++ b/dds/InfoRepo/DCPS_IR_Publication.cpp
@@ -413,9 +413,9 @@ void DCPS_IR_Publication::disassociate_subscription(OpenDDS::DCPS::RepoId id,
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DCPS_IR_Publication::disassociate_subscription: ")
                    ACE_TEXT("publication %C testing if subscription %C == %C.\n"),
-                   std::string(pub_converter).c_str(),
-                   std::string(sub_converter).c_str(),
-                   std::string(pub_sub_converter).c_str()));
+                   OPENDDS_STRING(pub_converter).c_str(),
+                   OPENDDS_STRING(sub_converter).c_str(),
+                   OPENDDS_STRING(pub_sub_converter).c_str()));
       }
 
       if (id == sub->get_id()) {

--- a/dds/InfoRepo/DCPS_IR_Subscription.cpp
+++ b/dds/InfoRepo/DCPS_IR_Subscription.cpp
@@ -418,9 +418,9 @@ void DCPS_IR_Subscription::disassociate_publication(OpenDDS::DCPS::RepoId id,
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DCPS_IR_Subscription::disassociate_publication: ")
                    ACE_TEXT("subscription %C testing if publication %C == %C.\n"),
-                   std::string(sub_converter).c_str(),
-                   std::string(pub_converter).c_str(),
-                   std::string(sub_pub_converter).c_str()));
+                   OPENDDS_STRING(sub_converter).c_str(),
+                   OPENDDS_STRING(pub_converter).c_str(),
+                   OPENDDS_STRING(sub_pub_converter).c_str()));
       }
 
       if (id == pub->get_id()) {


### PR DESCRIPTION
By learning from historical log revisions, we find several log revisions all **update std::string to OPENDDS_STRING**. With this knowledge, we find some missed log revision in the OPENDDS-3.13 version. Following is our patches.

If more information of the historical log revisions we have found is needed, please leave a comment ^^ 