### PR TITLE
Update output format of log variables

### DIFF
--- a/dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h
+++ b/dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h
@@ -105,8 +105,8 @@ public:
         if (DCPS_debug_level >= 6)
           if (allocs_from_heap_.value() % 500 == 0)
             ACE_DEBUG((LM_DEBUG,
-                       "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::malloc %x"
-                       " %d heap allocs with %d outstanding\n",
+                       "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::malloc %@"
+                       " %Lu heap allocs with %Lu outstanding\n",
                        this, this->allocs_from_heap_.value(),
                        this->allocs_from_heap_.value() - this->frees_to_heap_.value()));
       }
@@ -166,8 +166,8 @@ public:
       if (DCPS_debug_level >= 6) {
         if (frees_to_heap_.value() % 500 == 0) {
           ACE_DEBUG((LM_DEBUG,
-                     "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::free %x"
-                     " %d heap allocs with %d oustanding\n",
+                     "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::free %@"
+                     " %Lu heap allocs with %Lu oustanding\n",
                      this, this->allocs_from_heap_.value(),
                      this->allocs_from_heap_.value() - this->frees_to_heap_.value()));
         }

--- a/tests/DCPS/ConfigTransports/publisher.cpp
+++ b/tests/DCPS/ConfigTransports/publisher.cpp
@@ -191,7 +191,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
   catch (const std::runtime_error& rte)
   {
     ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) main() exception: %s\n"), rte.what()), -1);
+                      ACE_TEXT("(%P|%t) main() exception: %C\n"), rte.what()), -1);
   }
   catch (const OpenDDS::DCPS::Transport::MiscProblem& )
   {


### PR DESCRIPTION
By learning from historical log revisions, we find some consistent updates of output format of log variables. Under the guidance of these consistent updates, we find several missed spot in the latest version. 

More information please see the following commits or leave a comment ^^