### PR TITLE
update verbosity of log statement whose static text contains "notice" to LM_NOTICE

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1559,7 +1559,7 @@ Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
     }
 
     if (got_publisher_content_filter) {
-      ACE_DEBUG((LM_DEBUG,
+      ACE_DEBUG((LM_NOTICE,
                  ACE_TEXT("(%P|%t) NOTICE: using DCPSPublisherContentFilter ")
                  ACE_TEXT("value from command option (overrides value if it's ")
                  ACE_TEXT("in config file).\n")));


### PR DESCRIPTION
We find two patches between  OpenDDS-2.2 and OpenDDS-2.3. These two patches both **update the verbosity of log statements whose static text contains "notice" to LM_NOTICE**.  And find one missed spot in the latest version.

More information please see the commit or leave a comment^^