### PR TITLE
use ACE_TEXT to combine multi-line of static text

### DIFF
--- a/tests/DCPS/LatencyBudget/publisher.cpp
+++ b/tests/DCPS/LatencyBudget/publisher.cpp
@@ -59,9 +59,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         case '?':
         default:
           ACE_ERROR_RETURN ((LM_ERROR,
-            "usage:  %s "
-            "-o offset (in seconds) "
-            "\n",
+            ACE_TEXT("usage:  %s -o offset (in seconds) \n"),
             argv [0]),
             -1);
         }

--- a/tests/DCPS/LatencyBudget/subscriber.cpp
+++ b/tests/DCPS/LatencyBudget/subscriber.cpp
@@ -55,9 +55,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         case '?':
         default:
           ACE_ERROR_RETURN ((LM_ERROR,
-            "usage:  %s "
-            "-l expected late samples "
-            "\n",
+            ACE_TEXT("usage:  %s -l expected late samples \n"),
             argv [0]),
             -1);
         }

--- a/tests/DCPS/ManualAssertLiveliness/subscriber.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/subscriber.cpp
@@ -56,8 +56,7 @@ parse_args (int argc, ACE_TCHAR *argv[])
     case '?':
     default:
       ACE_ERROR_RETURN ((LM_ERROR,
-        "usage:  %s "
-        "\n",
+        ACE_TEXT("usage:  %s \n"),
         argv [0]),
         -1);
     }

--- a/tests/DCPS/Monitor/publisher.cpp
+++ b/tests/DCPS/Monitor/publisher.cpp
@@ -40,9 +40,7 @@ parse_args (int argc, ACE_TCHAR *argv[])
     case '?':
     default:
       ACE_ERROR_RETURN ((LM_ERROR,
-        "usage:  %s "
-        "-i <send_interval_sec> "
-        "\n",
+        ACE_TEXT("usage:  %s -i <send_interval_sec> \n"),
         argv [0]),
         -1);
     }

--- a/tests/DCPS/PersistentDurability/publisher.cpp
+++ b/tests/DCPS/PersistentDurability/publisher.cpp
@@ -51,9 +51,7 @@ parse_args (int argc, ACE_TCHAR *argv[])
       case '?':
       default:
         ACE_ERROR_RETURN ((LM_ERROR,
-                           "usage:  %s "
-                           "[-w] [-d directory]"
-                           "\n",
+                           ACE_TEXT("usage:  %s [-w] [-d directory]\n"),
                            argv [0]),
                           -1);
       }

--- a/tests/DCPS/SimpleFooTest/main.cpp
+++ b/tests/DCPS/SimpleFooTest/main.cpp
@@ -43,9 +43,7 @@ int parse_args (int argc, ACE_TCHAR *argv[])
       case '?':
       default:
         ACE_ERROR_RETURN ((LM_ERROR,
-                           "usage:  %s "
-                           "-k <Info Repo ior> "
-                           "\n",
+                           ACE_TEXT("usage:  %s -k <Info Repo ior> \n"),
                            argv [0]),
                           -1);
       }


### PR DESCRIPTION
We find three pieces of patches that all use ACE_TEXT to deal with multiple lines of static text. These patches taken place between OpenDDS-1.1 and OpenDDS-1.2 in files examples/DCPS/Messenger_Imr/
subscriber.cpp and examples/DCPS/Messenger_IOGR_Imr/publisher.cpp.

Based on this knowledge, we find several missed spots in OpenDDS-3.13.
One of these patches look like this:

```
while ((c = get_opts ()) != -1)
{
   switch (c)
   ...
   default:
      ACE_ERROR_RETURN ((LM_ERROR,
-       "usage: %s "
-       "-t <tcp/udp/default> "
-       "\n",
+       ACE_TEXT("usage: %s -t <tcp/udp/default> n"),
         argv [0]),
         -1);
```