### PR TITLE
Shared Memory Transport Platform Macros

### DIFF
--- a/dds/DCPS/transport/shmem/ShmemDataLink.cpp
+++ b/dds/DCPS/transport/shmem/ShmemDataLink.cpp
@@ -43,7 +43,7 @@ ShmemDataLink::open(const std::string& peer_address)
   const ACE_TString name = ACE_TEXT_CHAR_TO_TCHAR(peer_address.c_str());
   ShmemAllocator::MEMORY_POOL_OPTIONS alloc_opts;
 
-#ifdef ACE_WIN32
+#ifdef OPENDDS_SHMEM_WINDOWS
   const bool use_opts = true;
   const ACE_TString name_under = name + ACE_TEXT('_');
   // Find max size of peer's pool so enough local address space is reserved.

--- a/dds/DCPS/transport/shmem/ShmemDataLink.h
+++ b/dds/DCPS/transport/shmem/ShmemDataLink.h
@@ -47,9 +47,9 @@ typedef HANDLE ShmemSharedSemaphore;
 #  define OPENDDS_SHMEM_UNIX
 typedef ACE_Shared_Memory_Pool ShmemPool;
 typedef sem_t ShmemSharedSemaphore;
-#  if !defined (ACE_HAS_POSIX_SEM_TIMEOUT) && \
-      !defined (ACE_DISABLE_POSIX_SEM_TIMEOUT_EMULATION)
-#    define OPENDDS_SHMEM_UNIX_NO_SEM_TIMEOUT
+#  if !defined ACE_HAS_POSIX_SEM_TIMEOUT && \
+      !defined ACE_DISABLE_POSIX_SEM_TIMEOUT_EMULATION
+#    define OPENDDS_SHMEM_UNIX_EMULATE_SEM_TIMEOUT
 #  endif
 
 // No Support for this Platform, Trying to Use Shared Memory Transport Will

--- a/dds/DCPS/transport/shmem/ShmemDataLink.h
+++ b/dds/DCPS/transport/shmem/ShmemDataLink.h
@@ -36,20 +36,29 @@ class ShmemTransport;
 class ReceivedDataSample;
 typedef RcHandle<ShmemTransport> ShmemTransport_rch;
 
-#ifdef ACE_WIN32
-  typedef ACE_Pagefile_Memory_Pool ShmemPool;
-#elif !defined ACE_LACKS_SYSV_SHMEM
-  typedef ACE_Shared_Memory_Pool ShmemPool;
-#else // no shared memory support (will yield a runtime error if used)
-  typedef ACE_Local_Memory_Pool ShmemPool;
-#endif
+#if defined ACE_WIN32 && !defined ACE_HAS_WINCE
+#  define OPENDDS_SHMEM_WINDOWS
+typedef ACE_Pagefile_Memory_Pool ShmemPool;
+typedef HANDLE ShmemSharedSemaphore;
 
-#ifdef ACE_WIN32
-  typedef HANDLE ShmemSharedSemaphore;
-#elif defined ACE_HAS_POSIX_SEM
-  typedef sem_t ShmemSharedSemaphore;
+#elif !defined ACE_LACKS_SYSV_SHMEM \
+      && defined ACE_HAS_POSIX_SEM \
+      && !defined ACE_LACKS_UNNAMED_SEMAPHORE
+#  define OPENDDS_SHMEM_UNIX
+typedef ACE_Shared_Memory_Pool ShmemPool;
+typedef sem_t ShmemSharedSemaphore;
+#  if !defined (ACE_HAS_POSIX_SEM_TIMEOUT) && \
+      !defined (ACE_DISABLE_POSIX_SEM_TIMEOUT_EMULATION)
+#    define OPENDDS_SHMEM_UNIX_NO_SEM_TIMEOUT
+#  endif
+
+// No Support for this Platform, Trying to Use Shared Memory Transport Will
+// Yield a Runtime Error
 #else
-  typedef int ShmemSharedSemaphore;
+#  define OPENDDS_SHMEM_UNSUPPORTED
+// These are just place holders
+typedef ACE_Local_Memory_Pool ShmemPool;
+typedef int ShmemSharedSemaphore;
 #endif
 
 typedef ACE_Malloc_T<ShmemPool, ACE_Process_Mutex, ACE_PI_Control_Block>
@@ -61,7 +70,10 @@ struct ShmemData {
   ACE_Based_Pointer_Basic<char> payload_;
 };
 
-enum { // values for ShmemData::status_
+/**
+ * values for ShmemData::status_
+ */
+enum {
   SHMEM_DATA_FREE = 0,
   SHMEM_DATA_IN_USE = 1,
   SHMEM_DATA_RECV_DONE = 2,

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
@@ -136,7 +136,7 @@ ShmemReceiveStrategy::receive_bytes(iovec iov[],
     const size_t space = (i == 0) ? iov[i].iov_len - total : iov[i].iov_len,
       chunk = std::min(space, remaining);
 
-#ifdef ACE_WIN32
+#ifdef OPENDDS_SHMEM_WINDOWS
     if (alloc->memory_pool().remap((void*)(src_iter + chunk - 1)) == -1) {
       VDBG_LVL((LM_ERROR, "(%P|%t) ERROR: ShmemReceiveStrategy::receive_bytes "
                 "shared memory pool couldn't be extended\n"), 0);

--- a/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
@@ -27,7 +27,7 @@ ShmemSendStrategy::ShmemSendStrategy(ShmemDataLink* link)
   , current_data_(0)
   , datalink_control_size_(link->impl().config().datalink_control_size_)
 {
-#ifdef ACE_HAS_POSIX_SEM
+#ifdef OPENDDS_SHMEM_UNIX
   memset(&peer_semaphore_, 0, sizeof(peer_semaphore_));
 #endif
 }
@@ -56,7 +56,7 @@ ShmemSendStrategy::start_i()
   ShmemAllocator* peer = link_->peer_allocator();
   peer->find("Semaphore", mem);
   ShmemSharedSemaphore* sem = reinterpret_cast<ShmemSharedSemaphore*>(mem);
-#if defined ACE_WIN32 && !defined ACE_HAS_WINCE
+#if defined OPENDDS_SHMEM_WINDOWS
   HANDLE srcProc = ::OpenProcess(PROCESS_DUP_HANDLE, false /*bInheritHandle*/,
                                  link_->peer_pid());
   ::DuplicateHandle(srcProc, *sem, GetCurrentProcess(), &peer_semaphore_,
@@ -64,7 +64,7 @@ ShmemSendStrategy::start_i()
                     false /*bInheritHandle*/,
                     DUPLICATE_SAME_ACCESS /*dwOptions*/);
   ::CloseHandle(srcProc);
-#elif defined ACE_HAS_POSIX_SEM
+#elif defined OPENDDS_SHMEM_UNIX
   peer_semaphore_.sema_ = sem;
   peer_semaphore_.name_ = 0;
 #else
@@ -174,7 +174,7 @@ ShmemSendStrategy::send_bytes_i(const iovec iov[], int n)
 void
 ShmemSendStrategy::stop_i()
 {
-#if defined ACE_WIN32 && !defined ACE_HAS_WINCE
+#ifdef OPENDDS_SHMEM_WINDOWS
   ::CloseHandle(peer_semaphore_);
 #endif
 }

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -147,7 +147,7 @@ ShmemTransport::configure_i(ShmemInst& config)
   ACE_sema_t ace_sema;
   std::memset(&ace_sema, 0, sizeof ace_sema);
   ace_sema.sema_ = pSem;
-#    ifdef OPENDDS_SHMEM_UNIX_NO_SEM_TIMEOUT
+#    ifdef OPENDDS_SHMEM_UNIX_EMULATE_SEM_TIMEOUT
   ace_sema.lock_ = PTHREAD_MUTEX_INITIALIZER;
   ace_sema.count_nonzero_ = PTHREAD_COND_INITIALIZER;
 #    endif

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -48,10 +48,9 @@ ShmemTransport::make_datalink(const std::string& remote_address)
   if (link->open(remote_address))
     return link;
 
-  ACE_ERROR((LM_ERROR,
-                    ACE_TEXT("(%P|%t) ERROR: ")
-                    ACE_TEXT("ShmemTransport::make_datalink: ")
-                    ACE_TEXT("failed to open DataLink!\n")));
+  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+             ACE_TEXT("ShmemTransport::make_datalink: ")
+             ACE_TEXT("failed to open DataLink!\n")));
   return ShmemDataLink_rch();
 }
 
@@ -102,24 +101,23 @@ ShmemTransport::stop_accepting_or_connecting(const TransportClient_wrch&, const 
 bool
 ShmemTransport::configure_i(ShmemInst& config)
 {
-#if (!defined ACE_WIN32 && defined ACE_LACKS_SYSV_SHMEM) || defined ACE_HAS_WINCE
+#ifdef OPENDDS_SHMEM_UNSUPPORTED
   ACE_UNUSED_ARG(config);
-  ACE_ERROR_RETURN((LM_ERROR,
-                    ACE_TEXT("(%P|%t) ERROR: ")
+  ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
                     ACE_TEXT("ShmemTransport::configure_i: ")
                     ACE_TEXT("no platform support for shared memory!\n")),
                    false);
-#else
+#else // ifdef OPENDDS_SHMEM_UNSUPPORTED
 
   ShmemAllocator::MEMORY_POOL_OPTIONS alloc_opts;
-# ifdef ACE_WIN32
+#  if defined OPENDDS_SHMEM_WINDOWS
   alloc_opts.max_size_ = config.pool_size_;
-# elif !defined ACE_LACKS_SYSV_SHMEM
+#  elif defined OPENDDS_SHMEM_UNIX
   alloc_opts.base_addr_ = 0;
   alloc_opts.segment_size_ = config.pool_size_;
   alloc_opts.minimum_bytes_ = alloc_opts.segment_size_;
   alloc_opts.max_segments_ = 1;
-# endif
+#  endif // if defined OPENDDS_SHMEM_WINDOWS
 
   alloc_.reset(
     new ShmemAllocator(ACE_TEXT_CHAR_TO_TCHAR(config.poolname().c_str()),
@@ -137,29 +135,25 @@ ShmemTransport::configure_i(ShmemInst& config)
   alloc_->bind("Semaphore", pSem);
 
   bool ok;
-# ifdef ACE_WIN32
+#  if defined OPENDDS_SHMEM_WINDOWS
   *pSem = ::CreateSemaphoreW(0 /*default security*/,
                              0 /*initial count*/,
                              0x7fffffff /*max count (ACE's default)*/,
                              0 /*no name*/);
   ACE_sema_t ace_sema = *pSem;
   ok = (*pSem != 0);
-# elif !defined ACE_LACKS_UNNAMED_SEMAPHORE
+#  elif defined OPENDDS_SHMEM_UNIX
   ok = (0 == ::sem_init(pSem, 1 /*process shared*/, 0 /*initial count*/));
   ACE_sema_t ace_sema;
   std::memset(&ace_sema, 0, sizeof ace_sema);
   ace_sema.sema_ = pSem;
-#  if !defined (ACE_HAS_POSIX_SEM_TIMEOUT) && !defined (ACE_DISABLE_POSIX_SEM_TIMEOUT_EMULATION)
+#    ifdef OPENDDS_SHMEM_UNIX_NO_SEM_TIMEOUT
   ace_sema.lock_ = PTHREAD_MUTEX_INITIALIZER;
   ace_sema.count_nonzero_ = PTHREAD_COND_INITIALIZER;
-#  endif
-# else
-  ok = false;
-  ACE_sema_t ace_sema;
-# endif
+#    endif
+#  endif // if defined OPENDDS_SHMEM_WINDOWS
   if (!ok) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: ")
+    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("ShmemTransport::configure_i: ")
                       ACE_TEXT("could not create semaphore\n")),
                      false);
@@ -171,7 +165,7 @@ ShmemTransport::configure_i(ShmemInst& config)
             this, config.poolname().c_str()), 1);
 
   return true;
-#endif
+#endif // ifdef OPENDDS_SHMEM_UNSUPPORTED
 }
 
 void
@@ -190,16 +184,16 @@ ShmemTransport::shutdown_i()
   read_task_.reset();
 
   if (alloc_) {
+#ifndef OPENDDS_SHMEM_UNSUPPORTED
     void* mem = 0;
     alloc_->find("Semaphore", mem);
     ShmemSharedSemaphore* pSem = reinterpret_cast<ShmemSharedSemaphore*>(mem);
-#ifdef ACE_WIN32
+#  if defined OPENDDS_SHMEM_WINDOWS
     ::CloseHandle(*pSem);
-#elif defined ACE_HAS_POSIX_SEM && !defined ACE_LACKS_UNNAMED_SEMAPHORE
+#  elif defined OPENDDS_SHMEM_UNIX
     ::sem_destroy(pSem);
-#else
-    ACE_UNUSED_ARG(pSem);
-#endif
+#  endif // if defined OPENDDS_SHMEM_WINDOWS
+#endif // ifndef OPENDDS_SHMEM_UNSUPPORTED
 
     alloc_->release(1 /*close*/);
     alloc_.reset();


### PR DESCRIPTION
Created common shared memory platform macros to reduce redundancy.

Incorporated @jwillemsen's fix for older Android NDKs with newer APIs: #976