### PR TITLE
Fix Jenkins PR build by adding "apt-get update" to jenkins_packages.sh

### DIFF
--- a/tools/scripts/jenkins_packages.sh
+++ b/tools/scripts/jenkins_packages.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+set -e
 # Install dependency packages for use by Jenkins (debian stable)
+apt-get -y update
 apt-get -y --fix-missing install \
     qtbase5-dev \
     wireshark-dev \


### PR DESCRIPTION
Try to fix PR jenkins when running `jenkins_packages.sh` by adding a `apt-get update`.

```
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/g/ghostscript/libgs9-common_9.25~dfsg-0+deb9u1_all.deb 404 Not Found [IP: 151.101.44.204 80]
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/g/ghostscript/libgs9_9.25~dfsg-0+deb9u1_amd64.deb 404 Not Found [IP: 151.101.44.204 80]
E: Aborting install.
```

Also fail script automatically by adding `set -e`.