### PR TITLE
configure does not download ACE with curl and --doc_group

### DIFF
--- a/configure
+++ b/configure
@@ -593,7 +593,7 @@ if (!$ace_src || !$tao_src) {
     if ($opts{'doc_group'}) {
       my $github_url_tao_version = $doc_tao_version;
       $github_url_tao_version =~ s/\./_/g;
-      $urlbase = 'http://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-' . $github_url_tao_version . '/';
+      $urlbase = 'https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-' . $github_url_tao_version . '/';
       $file = 'ACE+TAO-src-' . $doc_tao_version . '.'
         . ($is_windows ? 'zip' : 'tar.gz');
       $download_message = "Downloading $file";
@@ -637,9 +637,9 @@ if (!$ace_src || !$tao_src) {
         elsif (which('curl')) {
           print $download_message . " (using curl)\n";
           if ($opts{'dry-run'}) {
-            print "Dry-run: would run curl $urlbase$file -o $file\n";
+            print "Dry-run: would run curl -L $urlbase$file -o $file\n";
           }
-          elsif (system("curl $urlbase$file -o $file")) {
+          elsif (system("curl -L $urlbase$file -o $file")) {
             die "ERROR: from curl, stopped";
           }
         }


### PR DESCRIPTION
Problem: configure does not download ACE with curl and --doc_group

The url for the tarball returns a redirect.

Solution: Add -L to curl to make it follow redirects.