### PR TITLE
RTPS Relay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 ADD . /opt/OpenDDS
 
 RUN cd /opt/OpenDDS && \
-    ./configure --prefix=/usr/local --security --doc_group --no-tests && \
+    ./configure --prefix=/usr/local --security --doc_group --no-tests --std=c++11 && \
     make && \
     make install && \
     cp -a /opt/OpenDDS/ACE_wrappers/MPC /usr/local/share/ace/MPC && \

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -100,6 +100,8 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
       OPENDDS_STRING default_multicast_group = "239.255.0.1" /*RTPS v2.1 9.6.1.4.1*/;
       OPENDDS_STRING mi, sla, gi;
       OPENDDS_STRING spdpaddr;
+      ACE_INET_Addr spdp_rtps_relay_address;
+      ACE_INET_Addr sedp_rtps_relay_address;
       bool has_resend = false, has_pb = false, has_dg = false, has_pg = false,
         has_d0 = false, has_d1 = false, has_dx = false, has_sm = false,
         has_ttl = false, sm = false;
@@ -228,6 +230,10 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
             spdp_send_addrs.push_back(value.substr(i, (n == OPENDDS_STRING::npos) ? n : n - i));
             i = value.find(',', i);
           } while (i++ != OPENDDS_STRING::npos); // skip past comma if there is one
+        } else if (name == "SpdpRtpsRelayAddress") {
+          spdp_rtps_relay_address = ACE_INET_Addr(it->second.c_str());
+        } else if (name == "SedpRtpsRelayAddress") {
+          sedp_rtps_relay_address = ACE_INET_Addr(it->second.c_str());
         } else {
           ACE_ERROR_RETURN((LM_ERROR,
                             ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
@@ -250,6 +256,8 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
       discovery->multicast_interface(mi);
       discovery->default_multicast_group(default_multicast_group);
       discovery->spdp_send_addrs().swap(spdp_send_addrs);
+      discovery->spdp_rtps_relay_address(spdp_rtps_relay_address);
+      discovery->sedp_rtps_relay_address(sedp_rtps_relay_address);
       discovery->sedp_local_address(sla);
       discovery->guid_interface(gi);
       discovery->spdp_local_address(spdpaddr);

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -140,6 +140,17 @@ public:
   void guid_interface(const OPENDDS_STRING& gi) {
     guid_interface_ = gi;
   }
+
+  const ACE_INET_Addr& spdp_rtps_relay_address() const { return spdp_rtps_relay_address_; }
+  void spdp_rtps_relay_address(const ACE_INET_Addr& address) {
+    spdp_rtps_relay_address_ = address;
+  }
+
+  const ACE_INET_Addr& sedp_rtps_relay_address() const { return sedp_rtps_relay_address_; }
+  void sedp_rtps_relay_address(const ACE_INET_Addr& address) {
+    sedp_rtps_relay_address_ = address;
+  }
+
 private:
   ACE_Time_Value resend_period_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
@@ -149,6 +160,8 @@ private:
   OPENDDS_STRING default_multicast_group_;  /// FUTURE: handle > 1 group.
   OPENDDS_STRING guid_interface_;
   AddrVec spdp_send_addrs_;
+  ACE_INET_Addr spdp_rtps_relay_address_;
+  ACE_INET_Addr sedp_rtps_relay_address_;
 
   /// Guids will be unique within this RTPS configuration
   GuidGenerator guid_gen_;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -377,6 +377,13 @@ Sedp::init(const RepoId& guid,
   return DDS::RETCODE_OK;
 }
 
+void
+Sedp::rtps_relay_address(const ACE_INET_Addr& address) {
+  DCPS::RtpsUdpInst_rch rtps_inst =
+    DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
+  rtps_inst->rtps_relay_address(address);
+}
+
 #ifdef OPENDDS_SECURITY
 DDS::ReturnCode_t Sedp::init_security(DDS::Security::IdentityHandle /* id_handle */,
                                       DDS::Security::PermissionsHandle perm_handle,

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -72,6 +72,8 @@ public:
                          const RtpsDiscovery& disco,
                          DDS::DomainId_t domainId);
 
+  void rtps_relay_address(const ACE_INET_Addr& address);
+
 #ifdef OPENDDS_SECURITY
   DDS::ReturnCode_t init_security(DDS::Security::IdentityHandle id_handle,
                                   DDS::Security::PermissionsHandle perm_handle,

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -130,6 +130,8 @@ void Spdp::init(DDS::DomainId_t /*domain*/,
     sedp_multicast_.length(1);
     sedp_multicast_[0] = mc_locator;
   }
+
+  sedp_.rtps_relay_address(disco->sedp_rtps_relay_address());
 }
 
 
@@ -505,6 +507,12 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::data_received - ")
       ACE_TEXT("failed to convert from ParameterList to ")
       ACE_TEXT("SPDPdiscoveredParticipantData\n")));
+    return;
+  }
+
+  const DCPS::RepoId guid = make_guid(pdata.participantProxy.guidPrefix, DCPS::ENTITYID_PARTICIPANT);
+  if (guid == guid_) {
+    // About us, stop.
     return;
   }
 
@@ -1380,6 +1388,10 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer, bool securityGuids)
   for (iter it = outer_->disco_->spdp_send_addrs().begin(),
        end = outer_->disco_->spdp_send_addrs().end(); it != end; ++it) {
     send_addrs_.insert(ACE_INET_Addr(it->c_str()));
+  }
+
+  if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
+    send_addrs_.insert(outer_->disco_->spdp_rtps_relay_address());
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -375,6 +375,7 @@ private:
   void check_heartbeats();
   void send_heartbeats_manual(const TransportSendControlElement* tsce);
   void send_heartbeat_replies();
+  void send_relay_beacon();
 
   CORBA::Long best_effort_heartbeat_count_;
 
@@ -451,7 +452,7 @@ private:
 
   };
 
-  RcHandle<HeartBeat> heartbeat_, heartbeatchecker_;
+  RcHandle<HeartBeat> heartbeat_, heartbeatchecker_, relay_beacon_;
 
   /// Data structure representing an "interesting" remote entity for static discovery.
   struct InterestingRemote {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -96,6 +96,15 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
                         heartbeat_response_delay_);
   GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("handshake_timeout"),
                         handshake_timeout_);
+
+  ACE_TString rtps_relay_address_s;
+  GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DataRtpsRelayAddress"),
+                           rtps_relay_address_s);
+  if (!rtps_relay_address_s.is_empty()) {
+    ACE_INET_Addr addr(rtps_relay_address_s.c_str());
+    rtps_relay_address(addr);
+  }
+
   return 0;
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -69,6 +69,9 @@ public:
     set_port_in_addr_string(local_address_config_str_, port_number);
   }
 
+  void rtps_relay_address(const ACE_INET_Addr& address) { rtps_relay_address_ = address; }
+  ACE_INET_Addr rtps_relay_address() const { return rtps_relay_address_; }
+
 private:
   friend class RtpsUdpType;
   template <typename T, typename U>
@@ -84,6 +87,7 @@ private:
 
   ACE_INET_Addr local_address_;
   OPENDDS_STRING local_address_config_str_;
+  ACE_INET_Addr rtps_relay_address_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -84,6 +84,9 @@ ssize_t
 RtpsUdpSendStrategy::send_bytes_i_helper(const iovec iov[], int n)
 {
   if (override_single_dest_) {
+    if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
+      send_single_i(iov, n, link_->config().rtps_relay_address());
+    }
     return send_single_i(iov, n, *override_single_dest_);
   }
 
@@ -162,6 +165,9 @@ RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
 
   iovec iov[MAX_SEND_BLOCKS];
   const int num_blocks = mb_to_iov(use_mb, iov);
+  if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
+    send_single_i(iov, num_blocks, link_->config().rtps_relay_address());
+  }
   const ssize_t result = send_single_i(iov, num_blocks, addr);
   if (result < 0) {
     const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
@@ -200,6 +206,9 @@ ssize_t
 RtpsUdpSendStrategy::send_multi_i(const iovec iov[], int n,
                                   const OPENDDS_SET(ACE_INET_Addr)& addrs)
 {
+  if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
+    send_single_i(iov, n, link_->config().rtps_relay_address());
+  }
   ssize_t result = -1;
   typedef OPENDDS_SET(ACE_INET_Addr)::const_iterator iter_t;
   for (iter_t iter = addrs.begin(); iter != addrs.end(); ++iter) {

--- a/tests/DCPS/Messenger/publisher.cpp
+++ b/tests/DCPS/Messenger/publisher.cpp
@@ -54,9 +54,9 @@ bool dw_reliable() {
   return !(gc->instances_[0]->transport_type_ == "udp");
 }
 
-void append(DDS::PropertySeq& props, const char* name, const char* value)
+void append(DDS::PropertySeq& props, const char* name, const char* value, bool propagate = false)
 {
-  const DDS::Property_t prop = {name, value, false /*propagate*/};
+  const DDS::Property_t prop = {name, value, propagate};
   const unsigned int len = props.length();
   props.length(len + 1);
   props[len] = prop;
@@ -92,6 +92,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         append(props, DDSSEC_PROP_PERM_CA, perm_ca_file);
         append(props, DDSSEC_PROP_PERM_GOV_DOC, governance_file);
         append(props, DDSSEC_PROP_PERM_DOC, permissions_file);
+        append(props, "OpenDDS.RtpsRelay.Groups", "Messenger", true);
       }
 #endif
 

--- a/tests/DCPS/Messenger/subscriber.cpp
+++ b/tests/DCPS/Messenger/subscriber.cpp
@@ -53,9 +53,9 @@ const char DDSSEC_PROP_PERM_DOC[] = "dds.sec.access.permissions";
 bool reliable = false;
 bool wait_for_acks = false;
 
-void append(DDS::PropertySeq& props, const char* name, const char* value)
+void append(DDS::PropertySeq& props, const char* name, const char* value, bool propagate = false)
 {
-  const DDS::Property_t prop = {name, value, false /*propagate*/};
+  const DDS::Property_t prop = {name, value, propagate};
   const unsigned int len = props.length();
   props.length(len + 1);
   props[len] = prop;
@@ -87,6 +87,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       append(props, DDSSEC_PROP_PERM_CA, perm_ca_file);
       append(props, DDSSEC_PROP_PERM_GOV_DOC, governance_file);
       append(props, DDSSEC_PROP_PERM_DOC, permissions_file);
+      append(props, "OpenDDS.RtpsRelay.Groups", "Messenger", true);
     }
 #endif
 

--- a/tools/rtpsrelay/.gitignore
+++ b/tools/rtpsrelay/.gitignore
@@ -1,0 +1,10 @@
+/RtpsRelay
+.obj
+.depend.*
+GNUMakefile*
+*~
+README.html
+RelayC.*
+RelayS.*
+RelayTypeSupport*
+RtpsRelay.dSYM

--- a/tools/rtpsrelay/GroupTable.cpp
+++ b/tools/rtpsrelay/GroupTable.cpp
@@ -1,0 +1,276 @@
+#include "GroupTable.h"
+
+#include <dds/DCPS/Marked_Default_Qos.h>
+
+int GroupTable::initialize(DDS::DomainParticipant_var a_participant,
+                           std::string const & a_topic_name) {
+  RtpsRelay::GroupEntryTypeSupportImpl::_var_type routing_table_ts = new RtpsRelay::GroupEntryTypeSupportImpl();
+  if (routing_table_ts->register_type(a_participant.in(), "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to register type\n"));
+    return -1;
+  }
+
+  DDS::Topic_var topic = a_participant->create_topic(
+                                                   a_topic_name.c_str(),
+                                                   routing_table_ts->get_type_name(),
+                                                   TOPIC_QOS_DEFAULT,
+                                                   nullptr,
+                                                   OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (CORBA::is_nil(topic.in())) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create topic\n"));
+    return -1;
+  }
+
+  DDS::Publisher_var publisher = a_participant->create_publisher(
+                                                               PUBLISHER_QOS_DEFAULT,
+                                                               nullptr,
+                                                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (CORBA::is_nil(publisher.in())) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create publisher\n"));
+    return -1;
+  }
+
+  DDS::Subscriber_var subscriber = a_participant->create_subscriber(
+                                                                  SUBSCRIBER_QOS_DEFAULT,
+                                                                  nullptr,
+                                                                  OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (CORBA::is_nil(subscriber.in())) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create subscriber\n"));
+    return -1;
+  }
+
+  {
+    DDS::DataWriterQos qos;
+    publisher->get_default_datawriter_qos(qos);
+
+    qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    qos.lifespan.duration.sec = m_lifespan.sec();
+    qos.lifespan.duration.nanosec = 0;
+
+    DDS::DataWriter_var writer = publisher->create_datawriter(
+                                                              topic.in(),
+                                                              qos,
+                                                              nullptr,
+                                                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(writer.in())) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create data writer\n"));
+      return -1;
+    }
+
+    m_writer = RtpsRelay::GroupEntryDataWriter::_narrow(writer.in());
+
+    if (! m_writer) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to narrow data writer\n"));
+      return -1;
+    }
+  }
+
+  {
+    DDS::DataReaderQos qos;
+    subscriber->get_default_datareader_qos(qos);
+
+    qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
+    DDS::DataReader_var reader = subscriber->create_datareader(
+                                                               topic.in(),
+                                                               qos,
+                                                               nullptr,
+                                                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(reader.in())) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create data reader\n"));
+      return -1;
+    }
+
+    m_reader =  RtpsRelay::GroupEntryDataReader::_narrow(reader);
+
+    if (!m_reader) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to narrow data reader\n"));
+      return -1;
+    }
+
+    DDS::StringSeq group_query_parameters;
+    group_query_parameters.length(1);
+    m_group_query_condition = m_reader->create_querycondition(
+                                                            DDS::ANY_SAMPLE_STATE,
+                                                            DDS::ANY_VIEW_STATE,
+                                                            DDS::ALIVE_INSTANCE_STATE,
+                                                            "group = %0",
+                                                            group_query_parameters);
+
+    if (!m_group_query_condition) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create group query condition\n"));
+      return -1;
+    }
+
+    DDS::StringSeq guid_query_parameters;
+    guid_query_parameters.length(1);
+    m_guid_query_condition = m_reader->create_querycondition(
+                                                           DDS::ANY_SAMPLE_STATE,
+                                                           DDS::ANY_VIEW_STATE,
+                                                           DDS::ALIVE_INSTANCE_STATE,
+                                                           "guid = %0",
+                                                           guid_query_parameters);
+
+    if (!m_guid_query_condition) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::initialize failed to create guid query condition\n"));
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+void GroupTable::update(std::string const & a_guid, GroupSet const & a_groups, ACE_Time_Value const & a_now) {
+  const GroupSet prev = this->groups(a_guid);
+
+  GroupSet::const_iterator pos1 = a_groups.begin(), limit1 = a_groups.end();
+  GroupSet::const_iterator pos2 = prev.begin(), limit2 = prev.end();
+
+  while (pos1 != limit1 && pos2 != limit2) {
+    if (*pos1 < *pos2) {
+      insert(a_guid, *pos1, a_now);
+      ++pos1;
+    } else if(*pos1 > *pos2) {
+      remove(a_guid, *pos2);
+      ++pos2;
+    } else {
+      // No change.
+      ++pos1;
+      ++pos2;
+    }
+  }
+
+  while (pos1 != limit1) {
+    insert(a_guid, *pos1, a_now);
+    ++pos1;
+  }
+
+  while (pos2 != limit2) {
+    remove(a_guid, *pos2);
+    ++pos2;
+  }
+}
+
+GroupTable::GuidSet GroupTable::guids(std::string const & a_group) const {
+  GuidSet retval;
+  ::RtpsRelay::GroupEntrySeq received_data;
+  ::DDS::SampleInfoSeq info_seq;
+
+  DDS::StringSeq group_query_parameters;
+  group_query_parameters.length(1);
+  group_query_parameters[0] = a_group.c_str();
+  DDS::ReturnCode_t rc = m_group_query_condition->set_query_parameters(group_query_parameters);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::guids failed to set query parameters\n"));
+    return retval;
+  }
+  rc = m_reader->read_w_condition(received_data, info_seq, DDS::LENGTH_UNLIMITED, m_group_query_condition);
+  if (rc == DDS::RETCODE_NO_DATA) {
+    ACE_ERROR((LM_WARNING, "(%P|%t) %N:%l WARNING: GroupTable::guids no guids for group %s\n", a_group.c_str()));
+  }
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::guids failed to read with condition\n"));
+    return retval;
+  }
+
+  for (size_t idx = 0; idx != received_data.length(); ++idx) {
+    retval.insert(received_data[idx].guid());
+  }
+
+  return retval;
+}
+
+GroupTable::GroupSet GroupTable::groups(std::string const & a_guid) const {
+  GroupSet retval;
+  ::RtpsRelay::GroupEntrySeq received_data;
+  ::DDS::SampleInfoSeq info_seq;
+
+  DDS::StringSeq guid_query_parameters;
+  guid_query_parameters.length(1);
+  guid_query_parameters[0] = a_guid.c_str();
+  DDS::ReturnCode_t rc = m_guid_query_condition->set_query_parameters(guid_query_parameters);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::groups failed to set query parameters\n"));
+    return retval;
+  }
+  rc = m_reader->read_w_condition(received_data, info_seq, DDS::LENGTH_UNLIMITED, m_guid_query_condition);
+  if (rc == DDS::RETCODE_NO_DATA) {
+    ACE_ERROR((LM_WARNING, "(%P|%t) %N:%l WARNING: GroupTable::groups no groups for guid %s\n", a_guid.c_str()));
+    return retval;
+  }
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::groups failed to read with condition\n"));
+    return retval;
+  }
+
+  for (size_t idx = 0; idx != received_data.length(); ++idx) {
+    retval.insert(received_data[idx].group());
+  }
+
+  return retval;
+}
+
+void GroupTable::insert(std::string const & a_guid, std::string const & a_group, ACE_Time_Value const & a_now) {
+  RtpsRelay::GroupEntry entry;
+  entry.guid(a_guid);
+  entry.group(a_group);
+  entry.expiration_timestamp((a_now + m_lifespan).sec());
+
+  // Read the existing.
+  auto reader_handle = m_reader->lookup_instance(entry);
+  if (reader_handle) {
+    ::RtpsRelay::GroupEntrySeq received_data(1);
+    ::DDS::SampleInfoSeq info_seq(1);
+
+    DDS::ReturnCode_t rc = m_reader->read_instance(received_data,
+                                                   info_seq,
+                                                   1,
+                                                   reader_handle,
+                                                   DDS::ANY_SAMPLE_STATE,
+                                                   DDS::ANY_VIEW_STATE,
+                                                   DDS::ALIVE_INSTANCE_STATE);
+
+    if (rc == DDS::RETCODE_OK &&
+        received_data[0].group() == a_group &&
+        ACE_Time_Value(received_data[0].expiration_timestamp()) - a_now < m_lifespan - m_renew_after) {
+      // Not different or not ready to renew.
+      return;
+    }
+  }
+
+  auto writer_handle = m_writer->register_instance(entry);
+  if (!writer_handle) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::insert failed to register instance\n"));
+    return;
+  }
+
+  DDS::ReturnCode_t rc = m_writer->write(entry, writer_handle);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::insert failed to write\n"));
+    return;
+  }
+}
+
+void GroupTable::remove(std::string const & a_guid, std::string const & a_group) {
+  RtpsRelay::GroupEntry entry;
+  entry.guid(a_guid);
+  entry.group(a_group);
+
+  auto handle = m_writer->lookup_instance(entry);
+  if (!handle) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::remove failed to lookup instance\n"));
+    return;
+  }
+
+  DDS::ReturnCode_t rc = m_writer->dispose(entry, handle);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: GroupTable::remove failed to dispose\n"));
+  }
+}

--- a/tools/rtpsrelay/GroupTable.h
+++ b/tools/rtpsrelay/GroupTable.h
@@ -1,0 +1,33 @@
+#ifndef RTPSRELAY_GROUP_TABLE_H_
+#define RTPSRELAY_GROUP_TABLE_H_
+
+#include <dds/DCPS/Service_Participant.h>
+
+#include "RelayTypeSupportImpl.h"
+
+class GroupTable
+{
+public:
+  using GuidSet = std::set<std::string>;
+  using GroupSet = std::set<std::string>;
+
+  GroupTable(ACE_Time_Value const & a_renew_after, ACE_Time_Value const & a_lifespan)
+    : m_renew_after(a_renew_after), m_lifespan(a_lifespan) {}
+  int initialize(DDS::DomainParticipant_var a_dp, std::string const & a_topic_name);
+  void update(std::string const & a_guid, GroupSet const & a_groups, ACE_Time_Value const & a_now);
+  GuidSet guids(std::string const & a_group) const;
+  GroupSet groups(std::string const & a_guid) const;
+
+private:
+  ACE_Time_Value const m_renew_after;
+  ACE_Time_Value const m_lifespan;
+  RtpsRelay::GroupEntryDataWriter_ptr m_writer;
+  RtpsRelay::GroupEntryDataReader_ptr m_reader;
+  DDS::QueryCondition_var m_group_query_condition;
+  DDS::QueryCondition_var m_guid_query_condition;
+
+  void insert(std::string const & a_guid, std::string const & a_group, ACE_Time_Value const & a_now);
+  void remove(std::string const & a_guid, std::string const & a_group);
+};
+
+#endif /* RTPSRELAY_GROUP_TABLE_H_ */

--- a/tools/rtpsrelay/README.rst
+++ b/tools/rtpsrelay/README.rst
@@ -1,0 +1,184 @@
+==========
+RTPS Relay
+==========
+
+Motivation
+==========
+
+The designers of DDS and related technologies like RTPS made
+assumptions about networks that are not generally valid.  The two
+assumptions motivating this work are multicast and that participants
+are not subject to network address translation.  Most cloud providers
+do not support multicast.  Consequently, deployments of OpenDDS in the
+cloud cannot use RTPS discovery and instead must either use the InfoRepo,
+which has its own issues, or solve discovery in some other way.
+Network Address Translation (NAT) is a common technique for
+establishing private networks that have Internet connectivity.  For
+example, many homes and small business have networks deployed behind a
+firewall that performs NAT.  An OpenDDS deployment that spans NATs
+will face communication problems since the network addresses know by
+the participants are only valid behind the NAT and not suitable for
+communication across the NAT.
+
+Scope
+=====
+
+There are three types of communication paths between DDS Participants.
+Participants on the same network (LAN) can communicate directly.  In
+situations were one participant is behind a NAT firewall, there exists
+the possibility that the participants can communicate by using an
+address on the public side of the NAT.  A protocol like ICE may be
+used to determine these addresses and establish connectivity.
+Finally, participants with access to a common peer can use the peer to
+relay messages.  The scope of this work is to develop such a relay for
+RTPS messages.
+
+Objectives
+==========
+
+In addition to the basic functionality of relaying RTPS messages, we
+have the following objectives:
+
+* Scalability - the RTPS relay should be able to scale horizontally.
+* Efficiency - The relay should not forward messages to participants
+  that are not interested in those messages.  The final answer to this
+  problem is to make the relay partcipate in discovery and learn the
+  associations between readers and writers.  In the interim, we will
+  allow each participant to declare a list of groups in which it will
+  participate.  Any RTPS message sent by a group member will be
+  forwarded to all of the members in the group.
+
+Architecture
+============
+
+The following diagram shows the major components of an RtpsRelay::
+
+    +-------------------------+   +-------------------------+
+    | RtpsRelay               |   | RtpsRelay               |
+    |                         |   |                         |
+    |  +-------------------+  |   |  +-------------------+  |
+    |  | Relay Participant |<-+---+->| Relay Participant |  |
+    |  +-------------------+  |   |  +-------------------+  |
+    |                         |   |                         |
+    |   +-----------------+   |   |   +-----------------+   |
+    |   | Horizontal Port |<--+---+-->| Horizontal Port |   |
+    |   +-----------------+   |   |   +-----------------+   |
+    |                         |   |                         |
+    |    +---------------+    |   |    +---------------+    |
+    |    | Vertical Port |    |   |    | Vertical Port |    |
+    |    +---------------+    |   |    +---------------+    |
+    |            ^            |   |            ^            |
+    |            |            |   |            |            |
+    +------------+------------+   +------------+------------+
+                 |                             |
+          +------+------+               +------+------+
+          | Participant |               | Participant |
+          +-------------+               +-------------+
+
+* Relay Participant - A DDS Participant that the relays use to
+  exchange information about participant groups and addresses.
+* Horizontal Port - A UDP port that the relays use to send and receive
+  RTPS messages with other relays.
+* Vertical Port - A UDP port that the relays use to send and receive
+  RTPS messages with participants.
+
+A participant should be associated with a single relay.  When a
+participant sends a message to a relay, a couple of things happen.
+First, if the participant is behind a NAT, then the NAT bindings are
+updated to allow traffic from the relay back to the participant.
+Second, the relay records the public address of the participant and
+its group information (if an SPDP message).  It shares the group and
+address information with the other relays via a DDS topic.  Third, the
+relay makes a forwarding decision that might involve sending the
+message to other participants that are using the relay in question or
+forwarding the message to other relays because they have participants
+that should receive the message.
+
+If a relay receives a message from another relay, it forwards the
+message to any participants that it serves that should be recipients
+of the message.
+
+The horizontal port and vertical ports are replicated three times for
+SPDP, SEDP, and the data transports.
+
+Every transport (in OpenDDS terminology) must send at least one
+message to its associated relay so the relay can learn its public
+address.  Realistically, each transport should send messages
+periodically to refresh the NAT bindings.  For SPDP, this is generally
+not a problem since SPDP broadcasts are periodic.  This is a potential
+problem for SEDP even though it has not be observed in practice
+because SEDP traffic is linked to the periodic SPDP traffic.  This is
+a confirmed problem for data readers since the RTPS protocol does not
+require a reader to send any messages.  To address this problem,
+OpenDDS periodically sends empty RTPS messages to the relay for
+readers.
+
+Arguments
+=========
+
+* :code:`-HorizontalAddress` - An IP:port pair indicating the address
+  to use for the horizontal SPDP port.  The SEDP port will listen at
+  port + 1 and the data port will listen at port + 2.  The default
+  port is 11444.
+* :code:`-VerticalAddress` - An IP:port pair indicating the address to
+  use for the vertical SPDP port.  The SEDP port will listen at port +
+  1 and the data port will listen at port + 2.  The default port
+  is 444.
+* :code:`-Domain` - The DDS domain to use for the Relay Participant.
+  The default is 0.
+* :code:`-RenewAfter` - Time in seconds after which the relay will
+  renew group and routing information for an active participant.  The
+  default is 60 seconds.
+* :code:`-Lifespan` - Time in seconds after which the relay will purge
+  group and routing information for an inactive participant.  The
+  default is 300 seconds.
+
+Participant Configuration
+=========================
+
+To use a relay, a participant must use the following configuration options:
+
+* :code:`SpdpRtpsRelayAddress` - Vertical SPDP IP:port of an RtpsRelay.
+* :code:`SedpRtpsRelayAddress` - Vertical SEDP IP:port of an RtpsRelay.
+* :code:`DataRtpsRelayAddress` - Vertical data IP:port of an RtpsRelay.
+
+A participant must declare its groups via a comma separated list of
+strings stored in a DDS Security property with the key
+"OpenDDS.RtpsRelay.Groups".
+
+A participant may change the period for sending empty RTPS messages
+for readers by adjusting the :code:`heartbeat_period` configuration
+option.
+
+Deployment Notes
+================
+
+Many UDP load balancers won't work with the RtpsRelay in scenarios
+where the participants are subject to network address translation.
+Conceptually, there is no problem creating a UDP load balancer that is
+serviced by a pool of RtpsRelays.  The load balancers in question
+would forward the datagram from a participant to a relay without
+difficulty.  However, the relays could not send datagrams back to the
+participants because the NAT bindings set up by the outgoing messages
+are expecting return traffic from the UDP load balancer IP.  For
+return traffic to flow, the relays would need to spoof the load
+balancer's IP as the source address.  This would require hacking on a
+variety of levels to the point that it is not a feasible option.
+
+From the previous result, we conclude that a pool of relays must all
+have a public IP address so they can exchange messages with
+participants.  Load balancing can be accomplished by having the
+participants choose a relay according to some load balancing
+algorithm.  To this end, one can run a simple web server on each relay
+machine that serves the vertical addresses and ports for the relay on
+the same machine.  These webservers can be placed behind a load
+balancer.  A participant, then, contacts the load balancer for the
+webservers to find the relay to use.
+
+Limitations and Future Work
+===========================
+
+* Secure SPDP messages.  The routing decisions made by the relays are
+  driven by the groups declared in SPDP messages.  These messages are
+  unencrypted and unauthenticated.
+* Make the relay participate in discovery to optimize network traffic.

--- a/tools/rtpsrelay/Relay.idl
+++ b/tools/rtpsrelay/Relay.idl
@@ -1,0 +1,30 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+module RtpsRelay {
+
+#pragma DCPS_DATA_TYPE "RtpsRelay::GroupEntry"
+#pragma DCPS_DATA_KEY  "RtpsRelay::GroupEntry guid"
+#pragma DCPS_DATA_KEY  "RtpsRelay::GroupEntry group"
+
+  struct GroupEntry {
+    string guid;
+    string group;
+    unsigned long expiration_timestamp;
+  };
+
+#pragma DCPS_DATA_TYPE "RtpsRelay::RoutingEntry"
+#pragma DCPS_DATA_KEY  "RtpsRelay::RoutingEntry guid"
+
+  struct RoutingEntry {
+    string guid;
+    string address;
+    string horizontal_relay_address;
+    unsigned long expiration_timestamp;
+  };
+
+};

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -1,0 +1,367 @@
+#include "RelayHandler.h"
+
+#include <array>
+#include <sstream>
+
+#include <ace/Reactor.h>
+#include <dds/DCPS/RTPS/MessageTypes.h>
+#include <dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h>
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
+
+namespace {
+  const CORBA::UShort encap_LE = 0x0300; // {PL_CDR_LE} in LE
+  const CORBA::UShort encap_BE = 0x0200; // {PL_CDR_BE} in LE
+
+  std::string guid_to_string(OpenDDS::DCPS::GUID_t const & a_guid) {
+    std::stringstream ss;
+    ss << a_guid;
+    return ss.str();
+  }
+
+  void parse_property(GroupTable::GroupSet & a_groups, DDS::Property_t const & a_property) {
+    if (strncmp(a_property.name.in(), "OpenDDS.RtpsRelay.Groups", strlen(a_property.name.in())) == 0) {
+      std::string value(a_property.value.in());
+      for (size_t idx = 0, limit = value.length(); idx != limit;) {
+        size_t const n = value.find(',', idx);
+        a_groups.insert(value.substr(idx, (n == std::string::npos) ? n : n - idx));
+        idx = (n == std::string::npos) ? limit : n + 1;
+      }
+    }
+  }
+
+  void parse_property_seq(GroupTable::GroupSet & a_groups, DDS::PropertySeq const & a_property_seq) {
+    for (size_t idx = 0, count = a_property_seq.length(); idx != count; ++idx) {
+      parse_property(a_groups, a_property_seq[idx]);
+    }
+  }
+
+  void parse_rtps_parameter(GroupTable::GroupSet & a_groups, OpenDDS::RTPS::Parameter const & a_parameter) {
+    if (a_parameter._d() == OpenDDS::RTPS::PID_PROPERTY_LIST) {
+      parse_property_seq(a_groups, a_parameter.property().value);
+    }
+  }
+
+  std::string addr_to_string(ACE_INET_Addr const & a_addr) {
+    std::array<char, 256> as_string{};
+    if (a_addr.addr_to_string(as_string.data(), as_string.size()) != 0) {
+      ACE_ERROR((LM_ERROR, "(%P:%t) %N:%l ERROR: addr_to_string failed to convert address to string"));
+      return "";
+    }
+    return as_string.data();
+  }
+}
+
+RelayHandler::RelayHandler(ACE_Reactor * a_reactor,
+                           GroupTable const & a_group_table)
+  : ACE_Event_Handler(a_reactor),
+    m_group_table(a_group_table),
+    m_bytes_received(0),
+    m_bytes_sent(0)
+{ }
+
+int RelayHandler::open(ACE_INET_Addr const & a_local) {
+  m_relay_address = addr_to_string(a_local);
+
+  if (m_socket.open(a_local) != 0) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::open failed to open socket on '%s'\n", m_relay_address.c_str()));
+    return -1;
+  }
+  if (m_socket.enable(ACE_NONBLOCK) != 0) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::open failed to enable ACE_NONBLOCK\n"));
+    return -1;
+  }
+  if (reactor()->register_handler(this, READ_MASK) != 0) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::open failed to register READ_MASK handler\n"));
+    return -1;
+  }
+
+  return 0;
+}
+
+int RelayHandler::handle_input(ACE_HANDLE /*a_handle*/) {
+
+  ACE_Message_Block* buffer = nullptr;
+  ACE_INET_Addr remote;
+
+  iovec iov;
+  ssize_t bytes = m_socket.recv(&iov, remote);
+
+  if (bytes <= 0) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::handle_input failed to recv\n"));
+    return 0;
+  }
+
+  m_bytes_received += bytes;
+
+  ACE_Data_Block* data_block = new ACE_Data_Block(bytes, ACE_Message_Block::MB_DATA, static_cast<const char*>(iov.iov_base), 0, 0, 0, 0);
+  buffer = new ACE_Message_Block(data_block);
+  buffer->length(bytes);
+
+  char* rd_ptr = buffer->rd_ptr();
+
+  OpenDDS::DCPS::Serializer serializer(buffer, false, OpenDDS::DCPS::Serializer::ALIGN_CDR);
+  OpenDDS::RTPS::Header header;
+  if (!(serializer >> header)) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::handle_input failed to deserialize RTPS header\n"));
+    buffer->release();
+    return 0;
+  }
+  bool empty_message = buffer->length() == 0;
+
+  OpenDDS::DCPS::RepoId src_guid;
+  std::memcpy(src_guid.guidPrefix, header.guidPrefix, sizeof(OpenDDS::DCPS::GuidPrefix_t));
+  src_guid.entityId = OpenDDS::DCPS::ENTITYID_PARTICIPANT;
+  const std::string guid = guid_to_string(src_guid);
+
+  buffer->rd_ptr(rd_ptr);
+  process_message(remote, ACE_Time_Value().now(), guid, buffer, empty_message);
+  buffer->release();
+  return 0;
+}
+
+int RelayHandler::handle_output(ACE_HANDLE /*a_handle*/) {
+  if (!m_outgoing.empty()) {
+    const OutgoingType::value_type& out = m_outgoing.front();
+
+    ACE_INET_Addr addr(out.first.c_str());
+    ssize_t bytes = m_socket.send(out.second->rd_ptr(), out.second->length(), addr, 0, 0);
+
+    if (bytes < 0) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::handle_output failed to send to %s\n", out.first.c_str()));
+    } else {
+      m_bytes_sent += bytes;
+    }
+
+    out.second->release();
+    m_outgoing.pop();
+  }
+
+  if (m_outgoing.empty()) {
+    this->reactor()->remove_handler(this, WRITE_MASK);
+  }
+
+  return 0;
+}
+
+void RelayHandler::enqueue_message(std::string const & a_addr, ACE_Message_Block * a_msg) {
+  bool empty = m_outgoing.empty();
+
+  m_outgoing.push(std::make_pair(a_addr, a_msg->duplicate()));
+
+  if (empty) {
+    reactor()->register_handler(this, WRITE_MASK);
+  }
+}
+
+VerticalHandler::VerticalHandler(ACE_Reactor * a_reactor,
+                                     GroupTable const & a_group_table,
+                                     RoutingTable & a_routing_table)
+  : RelayHandler(a_reactor, a_group_table),
+    m_routing_table(a_routing_table),
+    m_horizontal_handler(nullptr)
+{}
+
+void VerticalHandler::process_message(ACE_INET_Addr const & a_remote,
+                                      ACE_Time_Value const & a_now,
+                                      std::string const & a_src_guid,
+                                      ACE_Message_Block * a_msg,
+                                      bool a_empty_message) {
+  // Readers send empty messages so we know where they are.
+  m_routing_table.update(a_src_guid, m_horizontal_handler->relay_address(), addr_to_string(a_remote), a_now);
+
+  if (a_empty_message) {
+    return;
+  }
+
+  std::set<std::string> addrs;
+  std::set<std::string> horizontal_relay_addrs;
+
+  for (auto g : m_group_table.groups(a_src_guid)) {
+    for (auto p : m_group_table.guids(g)) {
+      // Don't reflect.
+      if (p == a_src_guid) {
+        continue;
+      }
+
+      std::string addr = m_routing_table.horizontal_relay_address(p);
+      if (addr.empty()) {
+        ACE_ERROR((LM_WARNING, "(%P|%t) %N:%l WARNING: VerticalHandler::process_message failed to get horizontal relay address for %s\n", p.c_str()));
+        continue;
+      }
+
+      if (addr == m_horizontal_handler->relay_address()) {
+        // Replace with local.
+        addr = m_routing_table.address(p);
+        if (addr.empty()) {
+          ACE_ERROR((LM_WARNING, "(%P|%t) %N:%l WARNING: VerticalHandler::process_message failed to get address for %s\n", addr.c_str()));
+          continue;
+        }
+        addrs.insert(addr);
+      } else {
+        horizontal_relay_addrs.insert(addr);
+      }
+    }
+  }
+
+  for (auto p : addrs) {
+    enqueue_message(p, a_msg);
+  }
+
+  for (auto p : horizontal_relay_addrs) {
+    m_horizontal_handler->enqueue_message(p, a_msg);
+  }
+}
+
+HorizontalHandler::HorizontalHandler(ACE_Reactor * a_reactor,
+                                     GroupTable const & a_group_table,
+                                     RoutingTable const & a_routing_table)
+  : RelayHandler(a_reactor, a_group_table),
+    m_routing_table(a_routing_table),
+    m_vertical_handler(nullptr)
+{}
+
+void HorizontalHandler::process_message(ACE_INET_Addr const &,
+                                        ACE_Time_Value const & /*a_now*/,
+                                        std::string const & a_src_guid,
+                                        ACE_Message_Block * a_msg,
+                                        bool a_empty_message) {
+  if (a_empty_message) {
+    return;
+  }
+
+  std::set<std::string> addrs;
+
+  for (auto g : m_group_table.groups(a_src_guid)) {
+    for (auto p : m_group_table.guids(g)) {
+      // Don't reflect.
+      if (p == a_src_guid) {
+        continue;
+      }
+
+      std::string addr = m_routing_table.horizontal_relay_address(p);
+      if (addr != relay_address()) {
+        continue;
+      }
+
+      // Replace with local.
+      addr = m_routing_table.address(p);
+      if (addr.empty()) {
+        ACE_ERROR((LM_WARNING, "(%P|%t) %N:%l WARNING: HorizontalHandler::process_message failed to get address for %s\n", p.c_str()));
+        continue;
+      }
+
+      addrs.insert(addr);
+    }
+  }
+
+  for (auto p : addrs) {
+    m_vertical_handler->enqueue_message(p, a_msg);
+  }
+}
+
+SpdpHandler::SpdpHandler(ACE_Reactor * a_reactor,
+                         GroupTable & a_group_table,
+                         RoutingTable & a_routing_table)
+  : VerticalHandler(a_reactor, a_group_table, a_routing_table),
+    m_mutable_group_table(a_group_table)
+{}
+
+void SpdpHandler::process_message(ACE_INET_Addr const & a_remote,
+                                  ACE_Time_Value const & a_now,
+                                  std::string const & a_src_guid,
+                                  ACE_Message_Block * a_buffer,
+                                  bool a_empty_message) {
+  if (a_empty_message) {
+    return;
+  }
+
+  char* rd_ptr = a_buffer->rd_ptr();
+
+  OpenDDS::DCPS::Serializer serializer(a_buffer, false, OpenDDS::DCPS::Serializer::ALIGN_CDR);
+  OpenDDS::RTPS::Header header;
+  if (!(serializer >> header)) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: SpdpHandler::handle_input failed to deserialize RTPS header\n"));
+    a_buffer->release();
+    return;
+  }
+
+  while (a_buffer->length() > 3) {
+    const char subm = a_buffer->rd_ptr()[0], flags = a_buffer->rd_ptr()[1];
+    serializer.swap_bytes((flags & OpenDDS::RTPS::FLAG_E) != ACE_CDR_BYTE_ORDER);
+    const size_t start = a_buffer->length();
+    CORBA::UShort submessageLength = 0;
+    switch (subm) {
+    case OpenDDS::RTPS::DATA: {
+      OpenDDS::RTPS::DataSubmessage data;
+      if (!(serializer >> data)) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: SpdpHandler::handle_input failed to deserialize RTPS data header\n"));
+        return;
+      }
+      submessageLength = data.smHeader.submessageLength;
+
+      if (data.writerId != OpenDDS::DCPS::ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER) {
+        // Not our message: this could be the same multicast group used
+        // for SEDP and other traffic.
+        break;
+      }
+
+      OpenDDS::RTPS::ParameterList plist;
+      if (data.smHeader.flags & (OpenDDS::RTPS::FLAG_D | OpenDDS::RTPS::FLAG_K_IN_DATA)) {
+        serializer.swap_bytes(!ACE_CDR_BYTE_ORDER); // read "encap" itself in LE
+        CORBA::UShort encap, options;
+        if (!(serializer >> encap) || (encap != encap_LE && encap != encap_BE)) {
+          ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: SpdpHandler::handle_input failed to deserialize RTPS encapsulation header\n"));
+          return;
+        }
+        serializer >> options;
+        // bit 8 in encap is on if it's PL_CDR_LE
+        serializer.swap_bytes(((encap & 0x100) >> 8) != ACE_CDR_BYTE_ORDER);
+        if (!(serializer >> plist)) {
+          ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: SpdpHandler::handle_input failed to deserialize RTPS data payload\n"));
+          return;
+        }
+      } else {
+        plist.length(1);
+        OpenDDS::DCPS::RepoId guid;
+        std::memcpy(guid.guidPrefix, header.guidPrefix, sizeof(OpenDDS::DCPS::GuidPrefix_t));
+        guid.entityId = OpenDDS::DCPS::ENTITYID_PARTICIPANT;
+        plist[0].guid(guid);
+        plist[0]._d(OpenDDS::RTPS::PID_PARTICIPANT_GUID);
+      }
+
+      GroupTable::GroupSet groups;
+
+      for (size_t idx = 0, count = plist.length(); idx != count; ++idx) {
+        parse_rtps_parameter(groups, plist[idx]);
+      }
+
+      m_mutable_group_table.update(a_src_guid, groups, a_now);
+
+      break;
+    }
+    default:
+      OpenDDS::RTPS::SubmessageHeader smHeader;
+      if (!(serializer >> smHeader)) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: SpdpHandler::handle_input failed to deserialize RTPS submessage header\n"));
+        return;
+      }
+      submessageLength = smHeader.submessageLength;
+      break;
+    }
+    if (submessageLength && a_buffer->length()) {
+      const size_t read = start - a_buffer->length();
+      if (read < static_cast<size_t>(submessageLength + OpenDDS::RTPS::SMHDR_SZ)) {
+        if (!serializer.skip(static_cast<CORBA::UShort>(submessageLength + OpenDDS::RTPS::SMHDR_SZ
+                                                        - read))) {
+          ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: SpdpHandler::handle_input failed to skip submessage length\n"));
+          return;
+        }
+      }
+    } else if (!submessageLength) {
+      break; // submessageLength of 0 indicates the last submessage
+    }
+  }
+
+  a_buffer->rd_ptr(rd_ptr);
+  VerticalHandler::process_message(a_remote, a_now, a_src_guid, a_buffer, a_empty_message);
+}

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -1,0 +1,94 @@
+#ifndef RTPSRELAY_RELAY_HANDLER_H_
+#define RTPSRELAY_RELAY_HANDLER_H_
+
+#include <ace/SOCK_Dgram.h>
+
+#include "GroupTable.h"
+#include "RoutingTable.h"
+
+class RelayHandler : public ACE_Event_Handler {
+public:
+  RelayHandler(ACE_Reactor * a_reactor,
+               GroupTable const & a_group_table);
+  int open(ACE_INET_Addr const & a_local);
+  int handle_input(ACE_HANDLE /*a_handle*/) override;
+  int handle_output(ACE_HANDLE /*a_handle*/) override;
+  ACE_HANDLE get_handle() const override { return m_socket.get_handle(); }
+  std::string const & relay_address() const { return m_relay_address; }
+  size_t bytes_received() const { return m_bytes_received; }
+  size_t bytes_sent() const { return m_bytes_sent; }
+  void reset_byte_counts() { m_bytes_received = 0; m_bytes_sent = 0; }
+  void enqueue_message(std::string const & a_addr, ACE_Message_Block * a_msg);
+
+protected:
+  GroupTable const & m_group_table;
+
+  virtual void process_message(ACE_INET_Addr const & a_remote,
+                               ACE_Time_Value const & a_now,
+                               std::string const & a_src_guid,
+                               ACE_Message_Block * a_msg,
+                               bool a_empty_message) = 0;
+
+private:
+  std::string m_relay_address;
+  ACE_SOCK_Dgram m_socket;
+  typedef std::queue<std::pair<std::string, ACE_Message_Block *> > OutgoingType;
+  OutgoingType m_outgoing;
+  size_t m_bytes_received;
+  size_t m_bytes_sent;
+};
+
+class HorizontalHandler;
+
+// Sends to and receives from peers.
+class VerticalHandler : public RelayHandler {
+public:
+  VerticalHandler(ACE_Reactor * a_reactor,
+                  GroupTable const & a_group_table,
+                  RoutingTable & a_routing_table);
+  void horizontal_handler(HorizontalHandler * a_horizontal_handler) { m_horizontal_handler = a_horizontal_handler; }
+
+protected:
+  RoutingTable & m_routing_table;
+  HorizontalHandler * m_horizontal_handler;
+  void process_message(ACE_INET_Addr const & a_remote,
+                       ACE_Time_Value const & a_now,
+                       std::string const & a_src_guid,
+                       ACE_Message_Block * a_msg,
+                       bool a_empty_message) override;
+};
+
+// Sends to and receives from other relays.
+class HorizontalHandler : public RelayHandler {
+public:
+  HorizontalHandler(ACE_Reactor * a_reactor,
+                    GroupTable const & a_group_table,
+                    RoutingTable const & a_routing_table);
+  void vertical_handler(VerticalHandler * a_vertical_handler) { m_vertical_handler = a_vertical_handler; }
+
+private:
+  RoutingTable const & m_routing_table; // NS rw, EW readonly
+  VerticalHandler * m_vertical_handler;
+  void process_message(ACE_INET_Addr const & a_remote,
+                       ACE_Time_Value const & a_now,
+                       std::string const & a_src_guid,
+                       ACE_Message_Block * a_msg,
+                       bool a_empty_message) override;
+};
+
+class SpdpHandler : public VerticalHandler {
+public:
+  SpdpHandler(ACE_Reactor * a_reactor,
+              GroupTable & a_group_table,
+              RoutingTable & a_routing_table);
+
+private:
+  GroupTable& m_mutable_group_table;
+  void process_message(ACE_INET_Addr const & a_remote,
+                       ACE_Time_Value const & a_now,
+                       std::string const & a_src_guid,
+                       ACE_Message_Block * a_msg,
+                       bool a_empty_message) override;
+};
+
+#endif /* RTPSRELAY_RELAY_HANDLER_H_ */

--- a/tools/rtpsrelay/RoutingTable.cpp
+++ b/tools/rtpsrelay/RoutingTable.cpp
@@ -1,0 +1,192 @@
+#include "RoutingTable.h"
+
+#include <array>
+
+#include <dds/DCPS/Marked_Default_Qos.h>
+
+int RoutingTable::initialize(DDS::DomainParticipant_var a_participant,
+                             std::string const & a_topic_name) {
+  RtpsRelay::RoutingEntryTypeSupportImpl::_var_type routing_table_ts =
+    new RtpsRelay::RoutingEntryTypeSupportImpl();
+  if (routing_table_ts->register_type(a_participant.in(), "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to register type\n"));
+    return -1;
+  }
+
+  DDS::Topic_var topic = a_participant->create_topic(
+                                                   a_topic_name.c_str(),
+                                                   routing_table_ts->get_type_name(),
+                                                   TOPIC_QOS_DEFAULT,
+                                                   nullptr,
+                                                   OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (CORBA::is_nil(topic.in())) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to create topic\n"));
+    return -1;
+  }
+
+  DDS::Publisher_var publisher = a_participant->create_publisher(
+                                                               PUBLISHER_QOS_DEFAULT,
+                                                               nullptr,
+                                                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (CORBA::is_nil(publisher.in())) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to create publisher\n"));
+    return -1;
+  }
+
+  DDS::Subscriber_var subscriber = a_participant->create_subscriber(
+                                                                  SUBSCRIBER_QOS_DEFAULT,
+                                                                  nullptr,
+                                                                  OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (CORBA::is_nil(subscriber.in())) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to create subscriber\n"));
+    return -1;
+  }
+
+  {
+    DDS::DataWriterQos qos;
+    publisher->get_default_datawriter_qos(qos);
+
+    qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    qos.lifespan.duration.sec = m_lifespan.sec();
+    qos.lifespan.duration.nanosec = 0;
+
+    DDS::DataWriter_var writer = publisher->create_datawriter(
+                                                              topic.in(),
+                                                              qos,
+                                                              nullptr,
+                                                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(writer.in())) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to create data writer\n"));
+      return -1;
+    }
+
+    m_writer = RtpsRelay::RoutingEntryDataWriter::_narrow(writer.in());
+
+    if (!writer) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to narrow data writer\n"));
+      return -1;
+    }
+  }
+
+  {
+    DDS::DataReaderQos qos;
+    subscriber->get_default_datareader_qos(qos);
+
+    qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
+    DDS::DataReader_var reader = subscriber->create_datareader(
+                                                               topic.in(),
+                                                               qos,
+                                                               nullptr,
+                                                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(reader.in())) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to create data reader\n"));
+      return -1;
+    }
+
+    m_reader =  RtpsRelay::RoutingEntryDataReader::_narrow(reader.in());
+
+    if (!reader) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::initialize failed to narrow data reader\n"));
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+bool RoutingTable::fetch(RtpsRelay::RoutingEntry & a_entry) const {
+  auto handle = m_reader->lookup_instance(a_entry);
+  if (!handle) {
+    return false;
+  }
+
+  ::RtpsRelay::RoutingEntrySeq received_data(1);
+  ::DDS::SampleInfoSeq info_seq(1);
+
+  DDS::ReturnCode_t rc = m_reader->read_instance(received_data,
+                                                info_seq,
+                                                1,
+                                                handle,
+                                                DDS::ANY_SAMPLE_STATE,
+                                                DDS::ANY_VIEW_STATE,
+                                                DDS::ALIVE_INSTANCE_STATE);
+
+  if (rc != DDS::RETCODE_OK) {
+    return false;
+  }
+
+  a_entry = received_data[0];
+  return true;
+}
+
+std::string RoutingTable::horizontal_relay_address(std::string const & a_guid) const {
+  RtpsRelay::RoutingEntry entry;
+  entry.guid(a_guid);
+  if (fetch(entry)) {
+    return entry.horizontal_relay_address();;
+  }
+  return std::string();
+}
+
+std::string RoutingTable::address(std::string const & a_guid) const {
+  RtpsRelay::RoutingEntry entry;
+  entry.guid(a_guid);
+  if (fetch(entry)) {
+    return entry.address();
+  }
+  return std::string();
+}
+
+void RoutingTable::update(std::string const & a_guid,
+                          std::string const & a_horizontal_relay_address,
+                          std::string const & a_address,
+                          ACE_Time_Value const & a_now) {
+  RtpsRelay::RoutingEntry entry;
+  entry.guid(a_guid);
+  entry.horizontal_relay_address(a_horizontal_relay_address);
+  entry.address(a_address);
+  entry.expiration_timestamp((a_now + m_lifespan).sec());
+
+  auto reader_handle = m_reader->lookup_instance(entry);
+  if (reader_handle) {
+    ::RtpsRelay::RoutingEntrySeq received_data(1);
+    ::DDS::SampleInfoSeq info_seq(1);
+
+    DDS::ReturnCode_t rc = m_reader->read_instance(received_data,
+                                                   info_seq,
+                                                   1,
+                                                   reader_handle,
+                                                   DDS::ANY_SAMPLE_STATE,
+                                                   DDS::ANY_VIEW_STATE,
+                                                   DDS::ALIVE_INSTANCE_STATE);
+
+    if (rc == DDS::RETCODE_OK &&
+        received_data[0].horizontal_relay_address() == a_horizontal_relay_address &&
+        received_data[0].address() == a_address &&
+        ACE_Time_Value(received_data[0].expiration_timestamp()) - a_now < m_lifespan - m_renew_after) {
+      // Not different or not ready to renew.
+      return;
+    }
+  }
+
+
+  auto handle = m_writer->register_instance(entry);
+  if (!handle) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::update failed to register instance\n"));
+    return;
+  }
+
+  DDS::ReturnCode_t rc = m_writer->write(entry, handle);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RoutingTable::update failed to write\n"));
+    return;
+  }
+}

--- a/tools/rtpsrelay/RoutingTable.h
+++ b/tools/rtpsrelay/RoutingTable.h
@@ -1,0 +1,33 @@
+#ifndef RTPSRELAY_ROUTING_TABLE_H_
+#define RTPSRELAY_ROUTING_TABLE_H_
+
+#include <ace/INET_Addr.h>
+#include <dds/DCPS/Service_Participant.h>
+
+#include "RelayTypeSupportImpl.h"
+
+class RoutingTable
+{
+ public:
+  RoutingTable(ACE_Time_Value const & a_renew_after,
+               ACE_Time_Value const & a_lifespan)
+    : m_renew_after(a_renew_after), m_lifespan(a_lifespan) {}
+  int initialize(DDS::DomainParticipant_var a_dp,
+                 std::string const & a_topic_name);
+  void update(std::string const & a_guid,
+              std::string const & a_horizontal_relay_address,
+              std::string const & a_address,
+              ACE_Time_Value const & a_now);
+  std::string horizontal_relay_address(std::string const & a_guid) const;
+  std::string address(std::string const & a_guid) const;
+
+ private:
+  ACE_Time_Value const m_renew_after;
+  ACE_Time_Value const m_lifespan;
+  RtpsRelay::RoutingEntryDataWriter_ptr m_writer;
+  RtpsRelay::RoutingEntryDataReader_ptr m_reader;
+
+  bool fetch(RtpsRelay::RoutingEntry & a_entry) const;
+};
+
+#endif // RTPSRELAY_ROUTING_TABLE_H_

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -1,0 +1,184 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <iostream>
+
+#include <ace/Arg_Shifter.h>
+#include <ace/Reactor.h>
+#include <dds/DCPS/transport/framework/NetworkAddress.h>
+
+#include "GroupTable.h"
+#include "RelayHandler.h"
+#include "RoutingTable.h"
+#include "StatisticsHandler.h"
+
+namespace {
+  ACE_INET_Addr get_bind_addr(unsigned short port) {
+    OPENDDS_VECTOR(ACE_INET_Addr) NICs;
+    OpenDDS::DCPS::get_interface_addrs(NICs);
+
+    for (auto NIC : NICs) {
+      if (NIC.is_loopback()) {
+        continue;
+      }
+
+      NIC.set_port_number(port);
+      return NIC;
+    }
+    return ACE_INET_Addr();
+  }
+}
+
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
+  DDS::DomainId_t domain = 0;
+  ACE_INET_Addr NIC_horizontal, NIC_vertical;
+  ACE_Time_Value renew_after(60); // 1 minute
+  ACE_Time_Value lifespan(300);   // 5 minutes
+
+  ACE_Arg_Shifter args(argc, argv);
+  while (args.is_anything_left()) {
+    const char* arg = nullptr;
+
+    if ((arg = args.get_the_parameter("-HorizontalAddress"))) {
+      NIC_horizontal = ACE_INET_Addr(arg);
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-VerticalAddress"))) {
+      NIC_vertical = ACE_INET_Addr(arg);
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-Domain"))) {
+      domain = ACE_OS::atoi(arg);
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-RenewAfter"))) {
+      renew_after = ACE_Time_Value(ACE_OS::atoi(arg));
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-Lifespan"))) {
+      lifespan = ACE_Time_Value(ACE_OS::atoi(arg));
+      args.consume_arg();
+    } else {
+      args.ignore_arg();
+    }
+  }
+
+  if (NIC_horizontal == ACE_INET_Addr()) {
+    NIC_horizontal = ACE_INET_Addr(get_bind_addr(11444));
+  }
+
+  if (NIC_vertical == ACE_INET_Addr()) {
+    NIC_vertical = ACE_INET_Addr(get_bind_addr(4444));
+  }
+
+  DDS::DomainParticipantQos qos;
+
+  DDS::DomainParticipantFactory_var factory = TheParticipantFactoryWithArgs(argc, argv);
+  factory->get_default_participant_qos(qos);
+
+  if (! factory) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to initialize participant factory\n"));
+    return -1;
+  }
+
+  DDS::DomainParticipant_var participant = factory->create_participant(
+                                                                       domain,
+                                                                       qos,
+                                                                       nullptr,
+                                                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (! participant) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to create participant\n"));
+    return -1;
+  }
+
+  GroupTable group_table(renew_after, lifespan);
+  RoutingTable spdp_table(renew_after, lifespan);
+  RoutingTable sedp_table(renew_after, lifespan);
+  RoutingTable data_table(renew_after, lifespan);
+
+  int err;
+
+  err = group_table.initialize(participant, "Group Info");
+
+  if (err) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to initialize group table\n"));
+    return err;
+  }
+
+  err = spdp_table.initialize(participant, "Spdp Routing Info");
+
+  if (err) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to initialize SPDP routing table\n"));
+    return err;
+  }
+
+  err = sedp_table.initialize(participant, "Sedp Routing Info");
+
+  if (err) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to initialize SEDP routing table\n"));
+    return err;
+  }
+
+  err = data_table.initialize(participant, "Data Routing Info");
+
+  if (err) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to initialize data routing table\n"));
+    return err;
+  }
+
+  auto addr_horizontal = NIC_horizontal.get_ip_address();
+  auto port_horizontal = NIC_horizontal.get_port_number();
+  ACE_INET_Addr spdp_horizontal_addr(port_horizontal++, addr_horizontal);
+  ACE_INET_Addr sedp_horizontal_addr(port_horizontal++, addr_horizontal);
+  ACE_INET_Addr data_horizontal_addr(port_horizontal++, addr_horizontal);
+
+  auto addr_vertical = NIC_vertical.get_ip_address();
+  auto port_vertical = NIC_vertical.get_port_number();
+  ACE_INET_Addr spdp_vertical_addr(port_vertical++, addr_vertical);
+  ACE_INET_Addr sedp_vertical_addr(port_vertical++, addr_vertical);
+  ACE_INET_Addr data_vertical_addr(port_vertical++, addr_vertical);
+
+  ACE_Reactor* reactor = ACE_Reactor::instance();
+
+  HorizontalHandler spdp_horizontal_handler(reactor, group_table, spdp_table);
+  HorizontalHandler sedp_horizontal_handler(reactor, group_table, sedp_table);
+  HorizontalHandler data_horizontal_handler(reactor, group_table, data_table);
+
+  SpdpHandler spdp_vertical_handler(reactor, group_table, spdp_table);
+  VerticalHandler sedp_vertical_handler(reactor, group_table, sedp_table);
+  VerticalHandler data_vertical_handler(reactor, group_table, data_table);
+
+  spdp_horizontal_handler.vertical_handler(&spdp_vertical_handler);
+  sedp_horizontal_handler.vertical_handler(&sedp_vertical_handler);
+  data_horizontal_handler.vertical_handler(&data_vertical_handler);
+
+  spdp_vertical_handler.horizontal_handler(&spdp_horizontal_handler);
+  sedp_vertical_handler.horizontal_handler(&sedp_horizontal_handler);
+  data_vertical_handler.horizontal_handler(&data_horizontal_handler);
+
+  spdp_horizontal_handler.open(spdp_horizontal_addr);
+  sedp_horizontal_handler.open(sedp_horizontal_addr);
+  data_horizontal_handler.open(data_horizontal_addr);
+
+  spdp_vertical_handler.open(spdp_vertical_addr);
+  sedp_vertical_handler.open(sedp_vertical_addr);
+  data_vertical_handler.open(data_vertical_addr);
+
+  std::cout << "SPDP Horizontal listening on " << spdp_horizontal_handler.relay_address() << '\n';
+  std::cout << "SEDP Horizontal listening on " << sedp_horizontal_handler.relay_address() << '\n';
+  std::cout << "Data Horizontal listening on " << data_horizontal_handler.relay_address() << '\n';
+  std::cout << "SPDP Vertical listening on " << spdp_vertical_handler.relay_address() << '\n';
+  std::cout << "SEDP Vertical listening on " << sedp_vertical_handler.relay_address() << '\n';
+  std::cout << "Data Vertical listening on " << data_vertical_handler.relay_address() << std::endl;
+
+  StatisticsHandler statistics_h(reactor,
+                                 &spdp_vertical_handler, &spdp_horizontal_handler,
+                                 &sedp_vertical_handler, &sedp_horizontal_handler,
+                                 &data_vertical_handler, &data_horizontal_handler);
+  statistics_h.open();
+
+  reactor->run_reactor_event_loop();
+
+  return 0;
+}

--- a/tools/rtpsrelay/RtpsRelay.mpc
+++ b/tools/rtpsrelay/RtpsRelay.mpc
@@ -1,0 +1,51 @@
+//
+//
+
+project(RtpsRelay_Idl): dcps, opendds_cxx11 {
+  dcps_ts_flags += -Wb,export_include=RtpsRelay_export.h \
+                   -Wb,export_macro=RtpsRelay_Export
+  idlflags      += -Wb,export_macro=RtpsRelay_Export
+  dynamicflags  += RTPSRELAY_BUILD_DLL
+  libout = .
+
+  TypeSupport_Files {
+    Relay.idl
+  }
+
+  IDL_Files {
+    RelayTypeSupport.idl
+  }
+
+  // Prevent blanket include of all C++ sources
+  Source_Files {
+  }
+}
+
+project(RtpsRelay_RtpsRelay): dcps_rtps {
+  requires += no_opendds_safety_profile
+  avoids += no_cxx11
+  exename = RtpsRelay
+  after += RtpsRelay_Idl
+  libs += RtpsRelay_Idl
+
+  Source_Files {
+    GroupTable.cpp
+    RelayHandler.cpp
+    RoutingTable.cpp
+    RtpsRelay.cpp
+    StatisticsHandler.cpp
+  }
+
+  Header_Files {
+    GroupTable.h
+    RelayHandler.h
+    RoutingTable.h
+    StatisticsHandler.h
+  }
+
+  // Prevent blanket include of all IDL files
+  IDL_Files {
+  }
+}
+
+

--- a/tools/rtpsrelay/RtpsRelay_export.h
+++ b/tools/rtpsrelay/RtpsRelay_export.h
@@ -1,0 +1,57 @@
+
+// -*- C++ -*-
+// Definition for Win32 Export directives.
+// This file is generated automatically by generate_export_file.pl RtpsRelay
+// ------------------------------
+#ifndef RTPSRELAY_EXPORT_H
+#define RTPSRELAY_EXPORT_H
+
+#include "ace/config-all.h"
+
+#if defined (ACE_AS_STATIC_LIBS) && !defined (RTPSRELAY_HAS_DLL)
+#  define RTPSRELAY_HAS_DLL 0
+#endif /* ACE_AS_STATIC_LIBS && RTPSRELAY_HAS_DLL */
+
+#if !defined (RTPSRELAY_HAS_DLL)
+#  define RTPSRELAY_HAS_DLL 1
+#endif /* ! RTPSRELAY_HAS_DLL */
+
+#if defined (RTPSRELAY_HAS_DLL) && (RTPSRELAY_HAS_DLL == 1)
+#  if defined (RTPSRELAY_BUILD_DLL)
+#    define RtpsRelay_Export ACE_Proper_Export_Flag
+#    define RTPSRELAY_SINGLETON_DECLARATION(T) ACE_EXPORT_SINGLETON_DECLARATION (T)
+#    define RTPSRELAY_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK) ACE_EXPORT_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
+#  else /* RTPSRELAY_BUILD_DLL */
+#    define RtpsRelay_Export ACE_Proper_Import_Flag
+#    define RTPSRELAY_SINGLETON_DECLARATION(T) ACE_IMPORT_SINGLETON_DECLARATION (T)
+#    define RTPSRELAY_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK) ACE_IMPORT_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
+#  endif /* RTPSRELAY_BUILD_DLL */
+#else /* RTPSRELAY_HAS_DLL == 1 */
+#  define RtpsRelay_Export
+#  define RTPSRELAY_SINGLETON_DECLARATION(T)
+#  define RTPSRELAY_SINGLETON_DECLARE(SINGLETON_TYPE, CLASS, LOCK)
+#endif /* RTPSRELAY_HAS_DLL == 1 */
+
+// Set RTPSRELAY_NTRACE = 0 to turn on library specific tracing even if
+// tracing is turned off for ACE.
+#if !defined (RTPSRELAY_NTRACE)
+#  if (ACE_NTRACE == 1)
+#    define RTPSRELAY_NTRACE 1
+#  else /* (ACE_NTRACE == 1) */
+#    define RTPSRELAY_NTRACE 0
+#  endif /* (ACE_NTRACE == 1) */
+#endif /* !RTPSRELAY_NTRACE */
+
+#if (RTPSRELAY_NTRACE == 1)
+#  define RTPSRELAY_TRACE(X)
+#else /* (RTPSRELAY_NTRACE == 1) */
+#  if !defined (ACE_HAS_TRACE)
+#    define ACE_HAS_TRACE
+#  endif /* ACE_HAS_TRACE */
+#  define RTPSRELAY_TRACE(X) ACE_TRACE_IMPL(X)
+#  include "ace/Trace.h"
+#endif /* (RTPSRELAY_NTRACE == 1) */
+
+#endif /* RTPSRELAY_EXPORT_H */
+
+// End of auto generated file.

--- a/tools/rtpsrelay/StatisticsHandler.cpp
+++ b/tools/rtpsrelay/StatisticsHandler.cpp
@@ -1,0 +1,70 @@
+#include "StatisticsHandler.h"
+
+#include <iostream>
+
+#include <ace/Reactor.h>
+
+namespace {
+  const ACE_Time_Value STATISTICS_INTERVAL(60);
+}
+
+StatisticsHandler::StatisticsHandler(ACE_Reactor * a_reactor,
+                                     RelayHandler * a_spdp_vertical, RelayHandler * a_spdp_horizontal,
+                                     RelayHandler * a_sedp_vertical, RelayHandler * a_sedp_horizontal,
+                                     RelayHandler * a_data_vertical, RelayHandler * a_data_horizontal)
+  : ACE_Event_Handler(a_reactor)
+  , m_spdp_vertical(a_spdp_vertical)
+  , m_spdp_horizontal(a_spdp_horizontal)
+  , m_sedp_vertical(a_sedp_vertical)
+  , m_sedp_horizontal(a_sedp_horizontal)
+  , m_data_vertical(a_data_vertical)
+  , m_data_horizontal(a_data_horizontal)
+  , m_last_collection(ACE_Time_Value().now()) {}
+
+void StatisticsHandler::open() {
+  this->reactor()->schedule_timer(this, 0, STATISTICS_INTERVAL, STATISTICS_INTERVAL);
+}
+
+int StatisticsHandler::handle_timeout(ACE_Time_Value const & a_now, void const *) {
+  ACE_Time_Value duration = a_now - m_last_collection;
+  m_last_collection = a_now;
+
+  std::cout << "SPDP VERTICAL "
+            << m_spdp_vertical->bytes_received() << " bytes in "
+            << m_spdp_vertical->bytes_sent() << " bytes out "
+            << duration.sec() << '.' << duration.usec() << " seconds" << std::endl;
+
+  std::cout << "SPDP HORIZONTAL "
+            << m_spdp_horizontal->bytes_received() << " bytes in "
+            << m_spdp_horizontal->bytes_sent() << " bytes out "
+            << duration.sec() << '.' << duration.usec() << " seconds" << std::endl;
+
+  std::cout << "SEDP VERTICAL "
+            << m_sedp_vertical->bytes_received() << " bytes in "
+            << m_sedp_vertical->bytes_sent() << " bytes out "
+            << duration.sec() << '.' << duration.usec() << " seconds" << std::endl;
+
+  std::cout << "SEDP HORIZONTAL "
+            << m_sedp_horizontal->bytes_received() << " bytes in "
+            << m_sedp_horizontal->bytes_sent() << " bytes out "
+            << duration.sec() << '.' << duration.usec() << " seconds" << std::endl;
+
+  std::cout << "DATA VERTICAL "
+            << m_data_vertical->bytes_received() << " bytes in "
+            << m_data_vertical->bytes_sent() << " bytes out "
+            << duration.sec() << '.' << duration.usec() << " seconds" << std::endl;
+
+  std::cout << "DATA HORIZONTAL "
+            << m_data_horizontal->bytes_received() << " bytes in "
+            << m_data_horizontal->bytes_sent() << " bytes out "
+            << duration.sec() << '.' << duration.usec() << " seconds" << std::endl;
+
+  m_spdp_vertical->reset_byte_counts();
+  m_spdp_horizontal->reset_byte_counts();
+  m_sedp_vertical->reset_byte_counts();
+  m_sedp_horizontal->reset_byte_counts();
+  m_data_vertical->reset_byte_counts();
+  m_data_horizontal->reset_byte_counts();
+
+  return 0;
+}

--- a/tools/rtpsrelay/StatisticsHandler.h
+++ b/tools/rtpsrelay/StatisticsHandler.h
@@ -1,0 +1,27 @@
+#ifndef RTPSRELAY_STATISTICS_HANDLER_H_
+#define RTPSRELAY_STATISTICS_HANDLER_H_
+
+#include <ace/Event_Handler.h>
+
+#include "RelayHandler.h"
+
+class StatisticsHandler : public ACE_Event_Handler {
+public:
+  StatisticsHandler(ACE_Reactor * a_reactor,
+                    RelayHandler * a_spdp_vertical, RelayHandler * a_spdp_horizontal,
+                    RelayHandler * a_sedp_vertical, RelayHandler * a_sedp_horizontal,
+                    RelayHandler * a_data_vertical, RelayHandler * a_data_horizontal);
+  void open();
+  int handle_timeout(ACE_Time_Value const & a_now, void const *) override;
+
+private:
+  RelayHandler * const m_spdp_vertical;
+  RelayHandler * const m_spdp_horizontal;
+  RelayHandler * const m_sedp_vertical;
+  RelayHandler * const m_sedp_horizontal;
+  RelayHandler * const m_data_vertical;
+  RelayHandler * const m_data_horizontal;
+  ACE_Time_Value m_last_collection;
+};
+
+#endif /* RTPSRELAY_STATISTICS_HANDLER_H_ */

--- a/tools/rtpsrelay/rtps.ini
+++ b/tools/rtpsrelay/rtps.ini
@@ -1,0 +1,12 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[domain/0]
+DiscoveryConfig=rtps
+
+[rtps_discovery/rtps]
+SedpMulticast=0
+
+[transport/the_rtps_transport]
+transport_type=rtps_udp
+use_multicast=0


### PR DESCRIPTION
Problem: RTPS does not work behind NATing firewalls

Network address translation (NAT) breaks RTPS in at least two ways.
Assume that two participants want to communicate via RTPS over the
public Internet and both of them are behind a firewall/router that
performs NAT.  First, multicast cannot be used for discovery because
the firewall will most likely not forward multicast traffic and even
if it did, multicast is not supported on the public Internet.  Second,
the locators advertised by SPDP and SEDP are only valid on the local
LAN due to NAT.

Solution: Relay RTPS messages through a well-known server.  The server
uses PropertyQosPolicy at the participant level to create virtual
multicast groups.  Whenever a participant in one of the groups sends a
message, all of the other participants in the group will receive the
message.  See the README.rst for more details.