### PR TITLE
update idl v8 generation to use decimal strings for signed and unsign…

### DIFF
--- a/dds/idl/v8_generator.cpp
+++ b/dds/idl/v8_generator.cpp
@@ -121,13 +121,14 @@ namespace {
           "  }\n";
         return;
 
-      } else if (v8Type == "Number") {
-        prefix = "static_cast<double>(";
-        suffix = ")";
-      } else if (v8Type == "String" && (pt == AST_PredefinedType::PT_longlong || pt == AST_PredefinedType::PT_ulonglong)) {
+      } else if (pt == AST_PredefinedType::PT_longlong || pt == AST_PredefinedType::PT_ulonglong) {
         prefix = "std::to_string(";
         suffix = ").c_str()";
         postNew = ".ToLocalChecked()";
+
+      } else if (v8Type == "Number") {
+        prefix = "static_cast<double>(";
+        suffix = ")";
       }
 
       strm <<

--- a/dds/idl/v8_generator.cpp
+++ b/dds/idl/v8_generator.cpp
@@ -40,6 +40,8 @@ namespace {
       switch (p->pt()) {
       case AST_PredefinedType::PT_char:
       case AST_PredefinedType::PT_wchar:
+      case AST_PredefinedType::PT_longlong:  // Can't fully fit in a JS "number"
+      case AST_PredefinedType::PT_ulonglong: // Can't fully fit in a JS "number"
         return "String";
       case AST_PredefinedType::PT_boolean:
         return "Boolean";
@@ -122,6 +124,10 @@ namespace {
       } else if (v8Type == "Number") {
         prefix = "static_cast<double>(";
         suffix = ")";
+      } else if (v8Type == "String" && (pt == AST_PredefinedType::PT_longlong || pt == AST_PredefinedType::PT_ulonglong)) {
+        prefix = "std::to_string(";
+        suffix = ").c_str()";
+        postNew = ".ToLocalChecked()";
       }
 
       strm <<


### PR DESCRIPTION
…ed 64-bit integers to avoid javascript 'number' truncation for numbers above 2^53