### PR TITLE
Send participant properties when not using security

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -250,7 +250,6 @@ namespace {
     return qos != def_qos;
   }
 
-#ifdef OPENDDS_SECURITY
   bool not_default(const DDS::PropertyQosPolicy& qos) {
     for (unsigned int i = 0; i < qos.value.length(); ++i) {
       if (qos.value[i].propagate) {
@@ -260,7 +259,6 @@ namespace {
     // binary_value is not sent in the parameter list (DDSSEC12-37)
     return false;
   }
-#endif
 
   bool not_default(const DDS::TimeBasedFilterQosPolicy& qos)
   {
@@ -543,6 +541,13 @@ int to_param_list(const ParticipantProxy_t& proxy,
   ml_param.count(proxy.manualLivelinessCount);
   add_param(param_list, ml_param);
 
+  if (not_default(proxy.property))
+  {
+    Parameter param_p;
+    param_p.property(proxy.property);
+    add_param(param_list, param_p);
+  }
+
   return 0;
 }
 
@@ -645,6 +650,9 @@ int from_param_list(const ParameterList& param_list,
         set_port(proxy.metatrafficMulticastLocatorList,
                  mm_last_state,
                  param.udpv4_port());
+        break;
+      case PID_PROPERTY_LIST:
+        proxy.property = param.property();
         break;
       case PID_SENTINEL:
       case PID_PAD:

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -523,6 +523,7 @@ module OpenDDS {
       DCPS::LocatorSeq defaultMulticastLocatorList;
       DCPS::LocatorSeq defaultUnicastLocatorList;
       Count_t manualLivelinessCount;
+      DDS::PropertyQosPolicy property;
     };
 
     // top-level data type for SPDP

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1271,7 +1271,8 @@ Spdp::build_local_pdata(
       sedp_multicast_,
       nonEmptyList /*defaultMulticastLocatorList*/,
       nonEmptyList /*defaultUnicastLocatorList*/,
-      {0 /*manualLivelinessCount*/}   //FUTURE: implement manual liveliness
+      {0 /*manualLivelinessCount*/},   //FUTURE: implement manual liveliness
+      qos_.property
     },
     { // Duration_t (leaseDuration)
       static_cast<CORBA::Long>((disco_->resend_period() * LEASE_MULT).sec()),


### PR DESCRIPTION
Problem: Participant properties do not get sent without security

Solution: Add properties to relevant data structures and the parameter
list converter.