### PR TITLE
ICE for RTPS

### DIFF
--- a/dds/DCPS/DataDurabilityCache.cpp
+++ b/dds/DCPS/DataDurabilityCache.cpp
@@ -84,8 +84,8 @@ public:
   {
   }
 
-  virtual int handle_timeout(ACE_Time_Value const & /* current_time */,
-                             void const * /* act */) {
+  virtual int handle_timeout(const ACE_Time_Value& /* current_time */,
+                             const void* /* act */) {
     if (OpenDDS::DCPS::DCPS_debug_level >= 4) {
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) OpenDDS - Cleaning up ")

--- a/dds/DCPS/DataReaderCallbacks.h
+++ b/dds/DCPS/DataReaderCallbacks.h
@@ -19,6 +19,11 @@
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
+
+namespace ICE {
+  class Endpoint;
+}
+
 namespace DCPS {
 
 /**
@@ -59,6 +64,8 @@ public:
   virtual void unregister_for_writer(const RepoId& /*participant*/,
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/) { }
+
+  virtual ICE::Endpoint* get_ice_endpoint() = 0;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3282,6 +3282,12 @@ DataReaderImpl::unregister_for_writer(const RepoId& participant,
   TransportClient::unregister_for_writer(participant, readerid, writerid);
 }
 
+ICE::Endpoint*
+DataReaderImpl::get_ice_endpoint()
+{
+  return TransportClient::get_ice_endpoint();
+}
+
 void DataReaderImpl::accept_sample_processing(const SubscriptionInstance_rch& instance, const DataSampleHeader& header, bool is_new_instance)
 {
   bool accepted = true;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -382,8 +382,8 @@ public:
 
   virtual void dds_demarshal(const ReceivedDataSample& sample,
                              SubscriptionInstance_rch& instance,
-                             bool & is_new_instance,
-                             bool & filtered,
+                             bool& is_new_instance,
+                             bool& filtered,
                              MarshalingType marshaling_type)= 0;
 
   virtual void dispose_unregister(const ReceivedDataSample& sample,
@@ -556,6 +556,8 @@ public:
   virtual void unregister_for_writer(const RepoId& /*participant*/,
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/);
+
+  virtual ICE::Endpoint* get_ice_endpoint();
 
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1015,8 +1015,8 @@ protected:
 
   virtual void dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample& sample,
                              OpenDDS::DCPS::SubscriptionInstance_rch& instance,
-                             bool & just_registered,
-                             bool & filtered,
+                             bool& just_registered,
+                             bool& filtered,
                              OpenDDS::DCPS::MarshalingType marshaling_type)
   {
     unique_ptr<MessageTypeWithAllocator> data(new (*data_allocator()) MessageTypeWithAllocator);
@@ -1611,8 +1611,8 @@ void store_instance_data(
                          unique_ptr<MessageTypeWithAllocator> instance_data,
                          const OpenDDS::DCPS::DataSampleHeader& header,
                          OpenDDS::DCPS::SubscriptionInstance_rch& instance_ptr,
-                         bool & just_registered,
-                         bool & filtered)
+                         bool& just_registered,
+                         bool& filtered)
 {
   const bool is_dispose_msg =
     header.message_id_ == OpenDDS::DCPS::DISPOSE_INSTANCE ||

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -18,6 +18,11 @@
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
+
+namespace ICE {
+  class Endpoint;
+}
+
 namespace DCPS {
 
 /**
@@ -60,6 +65,7 @@ public:
                                      const RepoId& /*writerid*/,
                                      const RepoId& /*readerid*/) { }
 
+  virtual ICE::Endpoint* get_ice_endpoint() = 0;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -2692,6 +2692,12 @@ DataWriterImpl::send_control(const DataSampleHeader& header,
   return status;
 }
 
+ICE::Endpoint*
+DataWriterImpl::get_ice_endpoint()
+{
+  return TransportClient::get_ice_endpoint();
+}
+
 int
 LivenessTimer::handle_timeout(const ACE_Time_Value &tv,
                              const void *arg)

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -463,6 +463,7 @@ public:
  PublicationInstance_rch get_handle_instance(
    DDS::InstanceHandle_t handle);
 
+ virtual ICE::Endpoint* get_ice_endpoint();
 
 protected:
 

--- a/dds/DCPS/ICE/Ice.cpp
+++ b/dds/DCPS/ICE/Ice.cpp
@@ -1,0 +1,90 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+#include "Ice.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+#if OPENDDS_SECURITY
+
+bool
+candidates_sorted(const Candidate& x, const Candidate& y)
+{
+  if (x.address != y.address) {
+    return x.address < y.address;
+  }
+
+  if (x.base != y.base) {
+    return x.base < y.base;
+  }
+
+  return x.priority > y.priority;
+}
+
+bool candidates_equal(const Candidate& x, const Candidate& y)
+{
+  return x.address == y.address && x.base == y.base;
+}
+
+Candidate make_host_candidate(const ACE_INET_Addr& address)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation = std::string("H") + std::string(address.get_host_addr()) + "U";
+  // See https://tools.ietf.org/html/rfc8445#section-5.1.2.1 for an explanation of the formula below.
+  candidate.priority = (126 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+  candidate.type = HOST;
+  candidate.base = address;
+  return candidate;
+}
+
+Candidate
+make_server_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation = std::string("S") + std::string(base.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+  // See https://tools.ietf.org/html/rfc8445#section-5.1.2.1 for an explanation of the formula below.
+  candidate.priority = (100 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+  candidate.type = SERVER_REFLEXIVE;
+  candidate.base = base;
+  return candidate;
+}
+
+Candidate
+make_peer_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address, uint32_t priority)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation = std::string("P") + std::string(base.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+  candidate.priority = priority;
+  candidate.type = PEER_REFLEXIVE;
+  candidate.base = base;
+  return candidate;
+}
+
+Candidate
+make_peer_reflexive_candidate(const ACE_INET_Addr& address, uint32_t priority, size_t q)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation = std::string("Q") + stringify(q) + "U";
+  candidate.priority = priority;
+  candidate.type = PEER_REFLEXIVE;
+  return candidate;
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ICE/Ice.h
+++ b/dds/DCPS/ICE/Ice.h
@@ -1,0 +1,116 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_ICE_H
+#define OPENDDS_ICE_H
+
+#include "dds/DCPS/dcps_export.h"
+#include "ace/INET_Addr.h"
+#include "dds/DCPS/Serializer.h"
+#include "dds/DdsDcpsInfoUtilsC.h"
+#include "dds/DCPS/GuidUtils.h"
+
+#include <sstream>
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+template <typename T>
+std::string stringify(T x)
+{
+  std::stringstream str;
+  str << x;
+  return str.str();
+}
+
+enum AgentType {
+  FULL = 0x0,
+  LITE = 0x1,
+};
+
+enum CandidateType {
+  HOST = 0x0,
+  SERVER_REFLEXIVE = 0x1,
+  PEER_REFLEXIVE = 0x2,
+  RELAYED = 0x3,
+};
+
+struct OpenDDS_Dcps_Export Candidate {
+  ACE_INET_Addr address;
+  // Transport - UDP or TCP
+  std::string foundation;
+  // Component ID
+  uint32_t priority;
+  CandidateType type;
+  // Related Address and Port
+  // Extensibility Parameters
+
+  ACE_INET_Addr base;  // Not sent.
+
+  bool operator==(const Candidate& other) const
+  {
+    return
+      this->address == other.address &&
+      this->foundation == other.foundation &&
+      this->priority == other.priority &&
+      this->type == other.type;
+  }
+};
+
+bool candidates_sorted(const Candidate& x, const Candidate& y);
+bool candidates_equal(const Candidate& x, const Candidate& y);
+
+Candidate make_host_candidate(const ACE_INET_Addr& address);
+Candidate make_server_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address);
+Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address, uint32_t priority);
+Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, uint32_t priority, size_t q);
+
+struct OpenDDS_Dcps_Export AgentInfo {
+  typedef std::vector<Candidate> CandidatesType;
+  typedef CandidatesType::const_iterator const_iterator;
+
+  CandidatesType candidates;
+  AgentType type;
+  // Connectivity-Check Pacing Value
+  std::string username;
+  std::string password;
+  // Extensions
+
+  const_iterator begin() const
+  {
+    return candidates.begin();
+  }
+  const_iterator end() const
+  {
+    return candidates.end();
+  }
+  bool operator==(const AgentInfo& other) const
+  {
+    return
+      this->username == other.username &&
+      this->password == other.password &&
+      this->type == other.type &&
+      this->candidates == other.candidates;
+  }
+  bool operator!=(const AgentInfo& other) const
+  {
+    return !(*this == other);
+  }
+};
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_ICE_H */

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -1,0 +1,220 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "AgentImpl.h"
+
+#include "dds/DCPS/Service_Participant.h"
+#include "Task.h"
+#include "EndpointManager.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+#if OPENDDS_SECURITY
+
+bool AgentImpl::TaskCompare::operator()(const Task* x, const Task* y) const
+{
+  return x->release_time_ > y->release_time_;
+}
+
+struct ScheduleTimerCommand : public DCPS::ReactorInterceptor::Command {
+  ACE_Reactor* reactor;
+  ACE_Event_Handler* event_handler;
+  ACE_Time_Value delay;
+
+  ScheduleTimerCommand(ACE_Reactor* a_reactor, ACE_Event_Handler* a_event_handler, const ACE_Time_Value& a_delay) :
+    reactor(a_reactor), event_handler(a_event_handler), delay(a_delay) {}
+
+  void execute()
+  {
+    reactor->cancel_timer(event_handler, 0);
+    reactor->schedule_timer(event_handler, 0, delay);
+  }
+};
+
+void AgentImpl::enqueue(Task* a_task)
+{
+  if (!a_task->in_queue_) {
+    tasks_.push(a_task);
+    a_task->in_queue_ = true;
+
+    if (a_task == tasks_.top()) {
+      ACE_Time_Value const delay = std::max(get_configuration().T_a(), a_task->release_time_ - ACE_Time_Value().now());
+      ScheduleTimerCommand c(reactor(), this, delay);
+      execute_or_enqueue(c);
+    }
+  }
+}
+
+bool AgentImpl::reactor_is_shut_down() const
+{
+  return TheServiceParticipant->is_shut_down();
+}
+
+int AgentImpl::handle_timeout(const ACE_Time_Value& a_now, const void* /*act*/)
+{
+  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, mutex, 0);
+  check_invariants();
+
+  if (tasks_.empty()) {
+    return 0;
+  }
+
+  Task* task = tasks_.top();
+  tasks_.pop();
+  task->in_queue_ = false;
+
+  task->execute(a_now);
+
+  if (!tasks_.empty()) {
+    ACE_Time_Value const delay = std::max(get_configuration().T_a(), tasks_.top()->release_time_ - a_now);
+    ScheduleTimerCommand c(reactor(), this, delay);
+    execute_or_enqueue(c);
+  }
+
+  check_invariants();
+  return 0;
+}
+
+AgentImpl::AgentImpl() :
+  ReactorInterceptor(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner()),
+  remote_peer_reflexive_counter_(0) {}
+
+void AgentImpl::add_endpoint(Endpoint* a_endpoint)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  check_invariants();
+
+  if (endpoint_managers_.find(a_endpoint) == endpoint_managers_.end()) {
+    EndpointManager* em = new EndpointManager(this, a_endpoint);
+    endpoint_managers_[a_endpoint] = em;
+  }
+
+  check_invariants();
+}
+
+void AgentImpl::remove_endpoint(Endpoint* a_endpoint)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  check_invariants();
+
+  EndpointManagerMapType::iterator pos = endpoint_managers_.find(a_endpoint);
+
+  if (pos != endpoint_managers_.end()) {
+    EndpointManager* em = pos->second;
+    endpoint_managers_.erase(pos);
+    em->schedule_for_destruction();
+  }
+
+  check_invariants();
+}
+
+AgentInfo AgentImpl::get_local_agent_info(Endpoint* a_endpoint) const
+{
+  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, const_cast<ACE_Recursive_Thread_Mutex&>(mutex), AgentInfo());
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  return pos->second->agent_info();
+}
+
+void AgentImpl::add_local_agent_info_listener(Endpoint* a_endpoint,
+                                              const DCPS::RepoId& a_local_guid,
+                                              AgentInfoListener* a_agent_info_listener)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  pos->second->add_agent_info_listener(a_local_guid, a_agent_info_listener);
+}
+
+void AgentImpl::remove_local_agent_info_listener(Endpoint* a_endpoint,
+                                                 const DCPS::RepoId& a_local_guid)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  pos->second->remove_agent_info_listener(a_local_guid);
+}
+
+void  AgentImpl::start_ice(Endpoint* a_endpoint,
+                           const DCPS::RepoId& a_local_guid,
+                           const DCPS::RepoId& a_remote_guid,
+                           const AgentInfo& a_remote_agent_info)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  check_invariants();
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  pos->second->start_ice(a_local_guid, a_remote_guid, a_remote_agent_info);
+  check_invariants();
+}
+
+void AgentImpl::stop_ice(Endpoint* a_endpoint,
+                         const DCPS::RepoId& a_local_guid,
+                         const DCPS::RepoId& a_remote_guid)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  check_invariants();
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  pos->second->stop_ice(a_local_guid, a_remote_guid);
+  check_invariants();
+}
+
+ACE_INET_Addr  AgentImpl::get_address(Endpoint* a_endpoint,
+                                      const DCPS::RepoId& a_local_guid,
+                                      const DCPS::RepoId& a_remote_guid) const
+{
+  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, const_cast<ACE_Recursive_Thread_Mutex&>(mutex), ACE_INET_Addr());
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  return pos->second->get_address(a_local_guid, a_remote_guid);
+}
+
+// Receive a STUN message.
+void  AgentImpl::receive(Endpoint* a_endpoint,
+                         const ACE_INET_Addr& a_local_address,
+                         const ACE_INET_Addr& a_remote_address,
+                         const STUN::Message& a_message)
+{
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
+  check_invariants();
+  EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
+  assert(pos != endpoint_managers_.end());
+  pos->second->receive(a_local_address, a_remote_address, a_message);
+  check_invariants();
+}
+
+void AgentImpl::unfreeze(const FoundationType& a_foundation)
+{
+  for (EndpointManagerMapType::const_iterator pos = endpoint_managers_.begin(),
+       limit = endpoint_managers_.end(); pos != limit; ++pos) {
+    pos->second->unfreeze(a_foundation);
+  }
+}
+
+void AgentImpl::check_invariants() const
+{
+  ActiveFoundationSet expected;
+
+  for (EndpointManagerMapType::const_iterator pos = endpoint_managers_.begin(),
+       limit = endpoint_managers_.end(); pos != limit; ++pos) {
+    pos->second->compute_active_foundations(expected);
+    pos->second->check_invariants();
+  }
+
+  assert(expected == active_foundations);
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/ICE/AgentImpl.h
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.h
@@ -1,0 +1,138 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_AGENT_IMPL_H
+#define OPENDDS_RTPS_ICE_AGENT_IMPL_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include <ace/Time_Value.h>
+#include "dds/Versioned_Namespace.h"
+#include "dds/DCPS/ReactorInterceptor.h"
+#include "Ice.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+struct Task;
+struct EndpointManager;
+
+typedef std::pair<std::string, std::string> FoundationType;
+
+class ActiveFoundationSet {
+public:
+  void add(const FoundationType& a_foundation)
+  {
+    std::pair<FoundationsType::iterator, bool> x = foundations_.insert(std::make_pair(a_foundation, 0));
+    x.first->second += 1;
+  }
+
+  void remove(const FoundationType& a_foundation)
+  {
+    FoundationsType::iterator pos = foundations_.find(a_foundation);
+    assert(pos != foundations_.end());
+    pos->second -= 1;
+
+    if (pos->second == 0) {
+      foundations_.erase(pos);
+    }
+  }
+
+  bool contains(const FoundationType& a_foundation) const
+  {
+    return foundations_.find(a_foundation) != foundations_.end();
+  }
+
+  bool operator==(const ActiveFoundationSet& a_other) const
+  {
+    return foundations_ == a_other.foundations_;
+  }
+
+private:
+  typedef std::map<FoundationType, size_t> FoundationsType;
+  FoundationsType foundations_;
+};
+
+class AgentImpl : public Agent, public DCPS::ReactorInterceptor {
+public:
+  ActiveFoundationSet active_foundations;
+
+  AgentImpl();
+
+  Configuration& get_configuration()
+  {
+    return configuration_;
+  }
+
+  void add_endpoint(Endpoint* a_endpoint);
+
+  void remove_endpoint(Endpoint* a_endpoint);
+
+  AgentInfo get_local_agent_info(Endpoint* a_endpoint) const;
+
+  void add_local_agent_info_listener(Endpoint* a_endpoint,
+                                     const DCPS::RepoId& a_local_guid,
+                                     AgentInfoListener* a_agent_info_listener);
+
+  void remove_local_agent_info_listener(Endpoint* a_endpoint,
+                                        const DCPS::RepoId& a_local_guid);
+
+  void start_ice(Endpoint* a_endpoint,
+                 const DCPS::RepoId& a_local_guid,
+                 const DCPS::RepoId& a_remote_guid,
+                 const AgentInfo& a_remote_agent_info);
+
+  void stop_ice(Endpoint* a_endpoint,
+                const DCPS::RepoId& a_local_guid,
+                const DCPS::RepoId& a_remote_guid);
+
+  ACE_INET_Addr get_address(Endpoint* a_endpoint,
+                            const DCPS::RepoId& a_local_guid,
+                            const DCPS::RepoId& a_remote_guid) const;
+
+  void receive(Endpoint* a_endpoint,
+               const ACE_INET_Addr& a_local_address,
+               const ACE_INET_Addr& a_remote_address,
+               const STUN::Message& a_message);
+
+  void enqueue(Task* a_task);
+
+  size_t remote_peer_reflexive_counter()
+  {
+    return remote_peer_reflexive_counter_++;
+  }
+
+  void unfreeze(const FoundationType& a_foundation);
+
+  ACE_Recursive_Thread_Mutex mutex;
+
+private:
+  Configuration configuration_;
+  size_t remote_peer_reflexive_counter_;
+  typedef std::map<Endpoint*, EndpointManager*> EndpointManagerMapType;
+  EndpointManagerMapType endpoint_managers_;
+  struct TaskCompare {
+    bool operator()(const Task* x, const Task* y) const;
+  };
+  std::priority_queue<Task*, std::vector<Task*>, TaskCompare> tasks_;
+
+  bool reactor_is_shut_down() const;
+  int handle_timeout(const ACE_Time_Value& a_now, const void* /*act*/);
+
+  void check_invariants() const;
+};
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_AGENT_IMPL_H */

--- a/dds/DCPS/RTPS/ICE/Checklist.cpp
+++ b/dds/DCPS/RTPS/ICE/Checklist.cpp
@@ -1,0 +1,789 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Checklist.h"
+
+#include "EndpointManager.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+#if OPENDDS_SECURITY
+
+const uint32_t PEER_REFLEXIVE_PRIORITY = (110 << 24) + (65535 << 8) + ((256 - 1) << 0);  // No local preference, component 1.
+
+CandidatePair::CandidatePair(const Candidate& a_local,
+                             const Candidate& a_remote,
+                             bool a_local_is_controlling,
+                             bool a_use_candidate)
+  : local(a_local),
+    remote(a_remote),
+    foundation(std::make_pair(a_local.foundation, a_remote.foundation)),
+    local_is_controlling(a_local_is_controlling),
+    priority(compute_priority()),
+    use_candidate(a_use_candidate)
+{
+  assert(!a_local.foundation.empty());
+  assert(!a_remote.foundation.empty());
+}
+
+bool CandidatePair::operator==(const CandidatePair& other) const
+{
+  return
+    this->local == other.local &&
+    this->remote == other.remote &&
+    this->use_candidate == other.use_candidate;
+}
+
+uint64_t CandidatePair::compute_priority()
+{
+  uint64_t const g = local_is_controlling ? local.priority : remote.priority;
+  uint64_t const d = local_is_controlling ? remote.priority : local.priority;
+  return (std::min(g,d) << 32) + 2 * std::max(g,d) + (g > d ? 1 : 0);
+}
+
+ConnectivityCheck::ConnectivityCheck(const CandidatePair& a_candidate_pair,
+                                     const AgentInfo& a_local_agent_info, const AgentInfo& a_remote_agent_info,
+                                     uint64_t a_ice_tie_breaker, const ACE_Time_Value& a_expiration_date)
+  : candiate_pair_(a_candidate_pair), cancelled_(false), expiration_date_(a_expiration_date)
+{
+  request_.class_ = STUN::REQUEST;
+  request_.method = STUN::BINDING;
+  request_.generate_transaction_id();
+  request_.append_attribute(STUN::make_priority(PEER_REFLEXIVE_PRIORITY));
+
+  if (a_candidate_pair.local_is_controlling) {
+    request_.append_attribute(STUN::make_ice_controlling(a_ice_tie_breaker));
+  }
+
+  else {
+    request_.append_attribute(STUN::make_ice_controlled(a_ice_tie_breaker));
+  }
+
+  if (a_candidate_pair.local_is_controlling && a_candidate_pair.use_candidate) {
+    request_.append_attribute(STUN::make_use_candidate());
+  }
+
+  request_.append_attribute(STUN::make_username(a_remote_agent_info.username + ":" + a_local_agent_info.username));
+  request_.password = a_remote_agent_info.password;
+  request_.append_attribute(STUN::make_message_integrity());
+  request_.append_attribute(STUN::make_fingerprint());
+}
+
+Checklist::Checklist(EndpointManager* a_endpoint_manager,
+                     const AgentInfo& local, const AgentInfo& remote, ACE_UINT64 a_ice_tie_breaker)
+  : Task(a_endpoint_manager->agent_impl)
+  , scheduled_for_destruction_(false)
+  , endpoint_manager_(a_endpoint_manager)
+  , local_agent_info_(local)
+  , remote_agent_info_(remote)
+  , original_remote_agent_info_(remote)
+  , local_is_controlling_(local.username < remote.username)
+  , ice_tie_breaker_(a_ice_tie_breaker)
+  , nominating_(valid_list_.end())
+  , nominated_(valid_list_.end())
+  , nominated_is_live_(false)
+{
+  endpoint_manager_->set_responsible_checklist(remote_agent_info_.username, this);
+
+  generate_candidate_pairs();
+}
+
+void Checklist::reset()
+{
+  fix_foundations();
+
+  for (ConnectivityChecksType::const_iterator pos = connectivity_checks_.begin(),
+       limit = connectivity_checks_.end(); pos != limit; ++pos) {
+    endpoint_manager_->unset_responsible_checklist(pos->request().transaction_id, this);
+  }
+
+  frozen_.clear();
+  waiting_.clear();
+  in_progress_.clear();
+  succeeded_.clear();
+  failed_.clear();
+  triggered_check_queue_.clear();
+  valid_list_.clear();
+  nominating_ = valid_list_.end();
+  nominated_ = valid_list_.end();
+  nominated_is_live_ = false;
+  check_interval_ = ACE_Time_Value();
+  max_check_interval_ = ACE_Time_Value();
+  connectivity_checks_.clear();
+}
+
+void Checklist::generate_candidate_pairs()
+{
+  // Add the candidate pairs.
+  for (AgentInfo::CandidatesType::const_iterator local_pos = local_agent_info_.candidates.begin(), local_limit = local_agent_info_.candidates.end(); local_pos != local_limit; ++local_pos) {
+    for (AgentInfo::CandidatesType::const_iterator remote_pos = remote_agent_info_.candidates.begin(), remote_limit = remote_agent_info_.candidates.end(); remote_pos != remote_limit; ++remote_pos) {
+      frozen_.push_back(CandidatePair(*local_pos, *remote_pos, local_is_controlling_));
+    }
+  }
+
+  // Sort by priority.
+  frozen_.sort(CandidatePair::priority_sorted);
+
+  // Eliminate duplicates.
+  for (CandidatePairsType::iterator pos = frozen_.begin(), limit = frozen_.end(); pos != limit; ++pos) {
+    CandidatePairsType::iterator test_pos = pos;
+    ++test_pos;
+
+    while (test_pos != limit) {
+      if (pos->local.base == test_pos->local.base && pos->remote == test_pos->remote) {
+        frozen_.erase(test_pos++);
+      }
+
+      else {
+        ++test_pos;
+      }
+    }
+  }
+
+  if (frozen_.size() != 0) {
+    check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
+    double s = frozen_.size();
+    max_check_interval_ = endpoint_manager_->agent_impl->get_configuration().checklist_period() * (1.0 / s);
+    enqueue(ACE_Time_Value().now());
+  }
+}
+
+void Checklist::compute_active_foundations(ActiveFoundationSet& active_foundations) const
+{
+  for (CandidatePairsType::const_iterator pos = waiting_.begin(), limit = waiting_.end(); pos != limit; ++pos) {
+    active_foundations.add(pos->foundation);
+  }
+
+  for (CandidatePairsType::const_iterator pos = in_progress_.begin(), limit = in_progress_.end(); pos != limit; ++pos) {
+    active_foundations.add(pos->foundation);
+  }
+}
+
+void Checklist::check_invariants() const
+{
+  for (CandidatePairsType::const_iterator pos = valid_list_.begin(), limit = valid_list_.end(); pos != limit; ++pos) {
+    assert(pos->use_candidate);
+  }
+}
+
+void Checklist::unfreeze()
+{
+  for (CandidatePairsType::iterator pos = frozen_.begin(), limit = frozen_.end(); pos != limit;) {
+    const CandidatePair& cp = *pos;
+
+    if (!endpoint_manager_->agent_impl->active_foundations.contains(cp.foundation)) {
+      endpoint_manager_->agent_impl->active_foundations.add(cp.foundation);
+      waiting_.push_back(cp);
+      waiting_.sort(CandidatePair::priority_sorted);
+      frozen_.erase(pos++);
+    }
+
+    else {
+      ++pos;
+    }
+  }
+}
+
+void Checklist::unfreeze(const FoundationType& a_foundation)
+{
+  for (CandidatePairsType::iterator pos = frozen_.begin(), limit = frozen_.end(); pos != limit;) {
+    const CandidatePair& cp = *pos;
+
+    if (cp.foundation == a_foundation) {
+      endpoint_manager_->agent_impl->active_foundations.add(cp.foundation);
+      waiting_.push_back(cp);
+      waiting_.sort(CandidatePair::priority_sorted);
+      frozen_.erase(pos++);
+    }
+
+    else {
+      ++pos;
+    }
+  }
+}
+
+void Checklist::add_valid_pair(const CandidatePair& valid_pair)
+{
+  assert(valid_pair.use_candidate);
+  valid_list_.push_back(valid_pair);
+  valid_list_.sort(CandidatePair::priority_sorted);
+}
+
+void Checklist::fix_foundations()
+{
+  for (CandidatePairsType::const_iterator pos = waiting_.begin(), limit = waiting_.end(); pos != limit; ++pos) {
+    endpoint_manager_->agent_impl->active_foundations.remove(pos->foundation);
+  }
+
+  for (CandidatePairsType::const_iterator pos = in_progress_.begin(), limit = in_progress_.end(); pos != limit; ++pos) {
+    endpoint_manager_->agent_impl->active_foundations.remove(pos->foundation);
+  }
+}
+
+bool Checklist::get_local_candidate(const ACE_INET_Addr& address, Candidate& candidate)
+{
+  for (AgentInfo::const_iterator pos = local_agent_info_.begin(), limit = local_agent_info_.end(); pos != limit; ++pos) {
+    if (pos->address == address) {
+      candidate = *pos;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Checklist::get_remote_candidate(const ACE_INET_Addr& address, Candidate& candidate)
+{
+  for (AgentInfo::const_iterator pos = remote_agent_info_.begin(), limit = remote_agent_info_.end(); pos != limit; ++pos) {
+    if (pos->address == address) {
+      candidate = *pos;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void Checklist::add_triggered_check(const CandidatePair& a_candidate_pair)
+{
+  if (nominated_ != valid_list_.end()) {
+    // Don't generate a check when we are done.
+    return;
+  }
+
+  CandidatePairsType::iterator pos;
+
+  pos = std::find(frozen_.begin(), frozen_.end(), a_candidate_pair);
+
+  if (pos != frozen_.end()) {
+    frozen_.erase(pos);
+    endpoint_manager_->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+    waiting_.push_back(a_candidate_pair);
+    waiting_.sort(CandidatePair::priority_sorted);
+    triggered_check_queue_.push_back(a_candidate_pair);
+    return;
+  }
+
+  pos = std::find(waiting_.begin(), waiting_.end(), a_candidate_pair);
+
+  if (pos != waiting_.end()) {
+    // Done.
+    return;
+  }
+
+  pos = std::find(in_progress_.begin(), in_progress_.end(), a_candidate_pair);
+
+  if (pos != in_progress_.end()) {
+    // Duplicating to waiting.
+    endpoint_manager_->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+    waiting_.push_back(a_candidate_pair);
+    waiting_.sort(CandidatePair::priority_sorted);
+    triggered_check_queue_.push_back(a_candidate_pair);
+    return;
+  }
+
+  pos = std::find(succeeded_.begin(), succeeded_.end(), a_candidate_pair);
+
+  if (pos != succeeded_.end()) {
+    // Done.
+    return;
+  }
+
+  pos = std::find(failed_.begin(), failed_.end(), a_candidate_pair);
+
+  if (pos != failed_.end()) {
+    failed_.erase(pos);
+    endpoint_manager_->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+    waiting_.push_back(a_candidate_pair);
+    waiting_.sort(CandidatePair::priority_sorted);
+    triggered_check_queue_.push_back(a_candidate_pair);
+    return;
+  }
+
+  // Not in checklist.
+  endpoint_manager_->agent_impl->active_foundations.add(a_candidate_pair.foundation);
+  waiting_.push_back(a_candidate_pair);
+  waiting_.sort(CandidatePair::priority_sorted);
+  triggered_check_queue_.push_back(a_candidate_pair);
+}
+
+void Checklist::remove_from_in_progress(const CandidatePair& a_candidate_pair)
+{
+  endpoint_manager_->agent_impl->active_foundations.remove(a_candidate_pair.foundation);
+  // Candidates can be in progress multiple times.
+  CandidatePairsType::iterator pos = std::find(in_progress_.begin(), in_progress_.end(), a_candidate_pair);
+  in_progress_.erase(pos);
+}
+
+void Checklist::generate_triggered_check(const ACE_INET_Addr& local_address, const ACE_INET_Addr& remote_address,
+                                         uint32_t priority,
+                                         bool use_candidate)
+{
+  Candidate remote;
+
+  if (!get_remote_candidate(remote_address, remote)) {
+    // 7.3.1.3
+    remote = make_peer_reflexive_candidate(remote_address, priority, endpoint_manager_->agent_impl->remote_peer_reflexive_counter());
+    remote_agent_info_.candidates.push_back(remote);
+    std::sort(remote_agent_info_.candidates.begin(), remote_agent_info_.candidates.end(), candidates_sorted);
+  }
+
+  // 7.3.1.4
+  Candidate local;
+  bool flag = get_local_candidate(local_address, local);
+  assert(flag);
+
+  CandidatePair cp(local, remote, local_is_controlling_, use_candidate);
+
+  if (is_succeeded(cp)) {
+    return;
+  }
+
+  if (is_in_progress(cp)) {
+    ConnectivityChecksType::iterator pos = std::find(connectivity_checks_.begin(), connectivity_checks_.end(), cp);
+    pos->cancel();
+  }
+
+  add_triggered_check(cp);
+  // This can move something from failed to in progress.
+  // In that case, we need to schedule.
+  check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
+  enqueue(ACE_Time_Value().now());
+}
+
+void Checklist::succeeded(const ConnectivityCheck& cc)
+{
+  const CandidatePair& cp = cc.candidate_pair();
+
+  // 7.2.5.3.3
+  // 7.2.5.4
+
+  remove_from_in_progress(cp);
+  succeeded_.push_back(cp);
+  succeeded_.sort(CandidatePair::priority_sorted);
+
+  if (cp.use_candidate) {
+    if (local_is_controlling_) {
+      nominated_ = nominating_;
+      nominating_ = valid_list_.end();
+      assert(frozen_.empty());
+      assert(waiting_.empty());
+    }
+
+    else {
+      nominated_ = std::find(valid_list_.begin(), valid_list_.end(), cp);
+
+      // This is the case where the use_candidate check succeeded before the normal check.
+      if (nominated_ == valid_list_.end()) {
+        valid_list_.push_front(cp);
+        nominated_ = valid_list_.begin();
+      }
+
+      while (!frozen_.empty()) {
+        CandidatePair cp = frozen_.front();
+        frozen_.pop_front();
+        failed_.push_back(cp);
+      }
+
+      while (!waiting_.empty()) {
+        CandidatePair cp = waiting_.front();
+        waiting_.pop_front();
+        endpoint_manager_->agent_impl->active_foundations.remove(cp.foundation);
+        failed_.push_back(cp);
+      }
+
+      triggered_check_queue_.clear();
+    }
+
+    nominated_is_live_ = true;
+    last_indication_ = ACE_Time_Value().now();
+
+    while (!connectivity_checks_.empty()) {
+      ConnectivityCheck cc = connectivity_checks_.front();
+      connectivity_checks_.pop_front();
+
+      if (!cc.cancelled()) {
+        failed(cc);
+      }
+
+      else {
+        remove_from_in_progress(cc.candidate_pair());
+      }
+    }
+
+    assert(frozen_.empty());
+    assert(waiting_.empty());
+    assert(triggered_check_queue_.empty());
+    assert(in_progress_.empty());
+    assert(connectivity_checks_.empty());
+  }
+
+  endpoint_manager_->agent_impl->unfreeze(cp.foundation);
+}
+
+void Checklist::failed(const ConnectivityCheck& cc)
+{
+  const CandidatePair& cp = cc.candidate_pair();
+  // 7.2.5.4
+  remove_from_in_progress(cp);
+  failed_.push_back(cp);
+  failed_.sort(CandidatePair::priority_sorted);
+
+  if (cp.use_candidate && local_is_controlling_) {
+    valid_list_.pop_front();
+    nominating_ = valid_list_.end();
+  }
+}
+
+void Checklist::success_response(const ACE_INET_Addr& local_address,
+                                 const ACE_INET_Addr& remote_address,
+                                 const STUN::Message& a_message)
+{
+  ConnectivityChecksType::iterator pos = std::find(connectivity_checks_.begin(), connectivity_checks_.end(), a_message.transaction_id);
+  assert(pos != connectivity_checks_.end());
+
+  ConnectivityCheck const cc = *pos;
+
+  std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+
+  if (!unknown_attributes.empty()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING Unknown comprehension required attributes\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  if (!a_message.has_fingerprint()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No FINGERPRINT attribute\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  ACE_INET_Addr mapped_address;
+
+  if (!a_message.get_mapped_address(mapped_address)) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No (XOR_)MAPPED_ADDRESS attribute\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  if (!a_message.has_message_integrity()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No MESSAGE_INTEGRITY attribute\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  // Require integrity for checks.
+  if (!a_message.verify_message_integrity(cc.request().password)) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING MESSAGE_INTEGRITY check failed\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  // At this point the check will either succeed or fail so remove from the list.
+  connectivity_checks_.erase(pos);
+  endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+
+  const CandidatePair& cp = cc.candidate_pair();
+
+  if (remote_address != cp.remote.address || local_address != cp.local.base) {
+    // 7.2.5.2.1 Non-Symmetric Transport Addresses
+    failed(cc);
+    return;
+  }
+
+  succeeded(cc);
+
+  if (cp.use_candidate) {
+    return;
+  }
+
+  // 7.2.5.3.2 Constructing a Valid Pair
+  Candidate local;
+
+  if (!get_local_candidate(mapped_address, local)) {
+    // 7.2.5.3.1 Discovering Peer-Reflexive Candidates
+    uint32_t priority;
+    // Our message, no need to check.
+    cc.request().get_priority(priority);
+    local = make_peer_reflexive_candidate(mapped_address, cp.local.base, cp.remote.address, priority);
+    local_agent_info_.candidates.push_back(local);
+    std::sort(local_agent_info_.candidates.begin(), local_agent_info_.candidates.end(), candidates_sorted);
+  }
+
+  // The valid pair
+  CandidatePair vp(local, cp.remote, local_is_controlling_, true);
+
+  add_valid_pair(vp);
+}
+
+void Checklist::error_response(const ACE_INET_Addr& /*local_address*/,
+                               const ACE_INET_Addr& /*remote_address*/,
+                               const STUN::Message& a_message)
+{
+  ConnectivityChecksType::iterator pos = std::find(connectivity_checks_.begin(), connectivity_checks_.end(), a_message.transaction_id);
+  assert(pos != connectivity_checks_.end());
+
+  ConnectivityCheck const cc = *pos;
+
+  if (!a_message.has_message_integrity()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING No MESSAGE_INTEGRITY attribute\n")));
+    // Retry.
+    return;
+  }
+
+  if (!a_message.verify_message_integrity(cc.request().password)) {
+    // Retry.
+    return;
+  }
+
+  // We have a verified error response.
+  std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+
+  if (!unknown_attributes.empty()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING Unknown comprehension required attributes\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  if (!a_message.has_fingerprint()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING No FINGERPRINT attribute\n")));
+    failed(cc);
+    connectivity_checks_.erase(pos);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    return;
+  }
+
+  if (a_message.has_error_code()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING STUN error response code=%d reason=%s\n"), a_message.get_error_code(), a_message.get_error_reason().c_str()));
+
+    if (a_message.get_error_code() == 420 && a_message.has_unknown_attributes()) {
+      std::vector<STUN::AttributeType> unknown_attributes = a_message.get_unknown_attributes();
+
+      for (std::vector<STUN::AttributeType>::const_iterator pos = unknown_attributes.begin(),
+           limit = unknown_attributes.end(); pos != limit; ++pos) {
+        ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING Unknown STUN attribute %d\n"), *pos));
+      }
+    }
+
+    if (a_message.get_error_code() == 400 && a_message.get_error_code() == 420) {
+      // Waiting and/or resending won't fix these errors.
+      failed(cc);
+      connectivity_checks_.erase(pos);
+      endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    }
+  }
+
+  else {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING STUN error response (no code)\n")));
+  }
+}
+
+void Checklist::do_next_check(const ACE_Time_Value& a_now)
+{
+  // Triggered checks.
+  if (!triggered_check_queue_.empty()) {
+    CandidatePair cp = triggered_check_queue_.front();
+    triggered_check_queue_.pop_front();
+
+    ConnectivityCheck cc(cp, local_agent_info_, remote_agent_info_, ice_tie_breaker_, a_now + endpoint_manager_->agent_impl->get_configuration().connectivity_check_ttl());
+
+    waiting_.remove(cp);
+    in_progress_.push_back(cp);
+    in_progress_.sort(CandidatePair::priority_sorted);
+
+    endpoint_manager_->endpoint->send(cc.candidate_pair().remote.address, cc.request());
+    connectivity_checks_.push_back(cc);
+    endpoint_manager_->set_responsible_checklist(cc.request().transaction_id, this);
+    check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
+    return;
+  }
+
+  unfreeze();
+
+  // Ordinary check.
+  if (!waiting_.empty()) {
+    CandidatePair cp = waiting_.front();
+    waiting_.pop_front();
+
+    ConnectivityCheck cc(cp, local_agent_info_, remote_agent_info_, ice_tie_breaker_, a_now + endpoint_manager_->agent_impl->get_configuration().connectivity_check_ttl());
+
+    in_progress_.push_back(cp);
+    in_progress_.sort(CandidatePair::priority_sorted);
+
+    endpoint_manager_->endpoint->send(cc.candidate_pair().remote.address, cc.request());
+    connectivity_checks_.push_back(cc);
+    endpoint_manager_->set_responsible_checklist(cc.request().transaction_id, this);
+    check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
+    return;
+  }
+
+  // Retry.
+  while (!connectivity_checks_.empty()) {
+    ConnectivityCheck cc = connectivity_checks_.front();
+    connectivity_checks_.pop_front();
+
+    if (cc.expiration_date() < a_now) {
+      if (!cc.cancelled()) {
+        // Failing can allow nomination to proceed.
+        failed(cc);
+      }
+
+      else {
+        remove_from_in_progress(cc.candidate_pair());
+      }
+
+      continue;
+    }
+
+    // We leave the cancelled checks in case we get a response.
+    if (!cc.cancelled()) {
+      // Reset the password in the event that it changed.
+      cc.password(remote_agent_info_.password);
+      endpoint_manager_->endpoint->send(cc.candidate_pair().remote.address, cc.request());
+    }
+
+    connectivity_checks_.push_back(cc);
+
+    // Backoff.
+    check_interval_ = std::min(check_interval_ * 2, max_check_interval_);
+    break;
+  }
+
+  // Waiting for the remote.
+  check_interval_ = endpoint_manager_->agent_impl->get_configuration().checklist_period();
+}
+
+void Checklist::execute(const ACE_Time_Value& a_now)
+{
+  if (scheduled_for_destruction_) {
+    delete this;
+    return;
+  }
+
+  // Nominating check.
+  if (frozen_.empty() &&
+      waiting_.empty() &&
+      // in_progress_.empty() &&
+      local_is_controlling_ &&
+      !valid_list_.empty() &&
+      nominating_ == valid_list_.end() &&
+      nominated_ == valid_list_.end()) {
+    add_triggered_check(valid_list_.front());
+    nominating_ = valid_list_.begin();
+  }
+
+  bool flag = false;
+  ACE_Time_Value interval = std::max(check_interval_, endpoint_manager_->agent_impl->get_configuration().indication_period());
+
+  if (!triggered_check_queue_.empty() ||
+      !frozen_.empty() ||
+      !waiting_.empty() ||
+      !connectivity_checks_.empty()) {
+    do_next_check(a_now);
+    flag = true;
+    interval = std::min(interval, check_interval_);
+  }
+
+  if (nominated_ != valid_list_.end()) {
+    // Send an indication.
+    STUN::Message message;
+    message.class_ = STUN::INDICATION;
+    message.method = STUN::BINDING;
+    message.generate_transaction_id();
+    message.append_attribute(STUN::make_username(remote_agent_info_.username + ":" + local_agent_info_.username));
+    message.password = remote_agent_info_.password;
+    message.append_attribute(STUN::make_message_integrity());
+    message.append_attribute(STUN::make_fingerprint());
+    endpoint_manager_->endpoint->send(selected_address(), message);
+    flag = true;
+    interval = std::min(interval, endpoint_manager_->agent_impl->get_configuration().indication_period());
+
+    // Check that we are receiving indications.
+    nominated_is_live_ = (a_now - last_indication_) < endpoint_manager_->agent_impl->get_configuration().nominated_ttl();
+  }
+
+  if (flag) {
+    enqueue(ACE_Time_Value().now() + interval);
+  }
+
+  // The checklist has failed.  Don't schedule.
+}
+
+void Checklist::add_guid(const GuidPair& a_guid_pair)
+{
+  guids_.insert(a_guid_pair);
+  endpoint_manager_->set_responsible_checklist(a_guid_pair, this);
+}
+
+void Checklist::remove_guid(const GuidPair& a_guid_pair)
+{
+  guids_.erase(a_guid_pair);
+  endpoint_manager_->unset_responsible_checklist(a_guid_pair, this);
+
+  if (guids_.empty()) {
+    // Cleanup this checklist.
+    endpoint_manager_->unset_responsible_checklist(remote_agent_info_.username, this);
+    reset();
+    scheduled_for_destruction_ = true;
+
+    // Flush ourselves out of the task queue.
+    // Schedule for now but it may be later.
+    enqueue(ACE_Time_Value().now());
+  }
+}
+
+void Checklist::add_guids(const GuidSetType& a_guids)
+{
+  for (GuidSetType::const_iterator pos = a_guids.begin(), limit = a_guids.end(); pos != limit; ++pos) {
+    add_guid(*pos);
+  }
+}
+
+void Checklist::remove_guids()
+{
+  GuidSetType guids = guids_;
+
+  for (GuidSetType::const_iterator pos = guids.begin(), limit = guids.end(); pos != limit; ++pos) {
+    remove_guid(*pos);
+  }
+}
+
+ACE_INET_Addr Checklist::selected_address() const
+{
+  if (nominated_is_live_ && nominated_ != valid_list_.end()) {
+    return nominated_->remote.address;
+  }
+
+  return ACE_INET_Addr();
+}
+
+void Checklist::indication()
+{
+  last_indication_ = ACE_Time_Value().now();
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/ICE/Checklist.h
+++ b/dds/DCPS/RTPS/ICE/Checklist.h
@@ -1,0 +1,256 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_CHECKLIST_H
+#define OPENDDS_RTPS_ICE_CHECKLIST_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "Task.h"
+#include "AgentImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+struct CandidatePair {
+  Candidate const local;
+  Candidate const remote;
+  FoundationType const foundation;
+  bool const local_is_controlling;
+  uint64_t const priority;
+  // 1) set the use_candidate when local is controlling and
+  // 2) nominate when the response is successful (controlling and controlled)
+  bool const use_candidate;
+
+  CandidatePair(const Candidate& a_local,
+                const Candidate& a_remote,
+                bool a_local_is_controlling,
+                bool a_use_candidate = false);
+
+  bool operator==(const CandidatePair& a_other) const;
+
+  static bool priority_sorted(const CandidatePair& x, const CandidatePair& y)
+  {
+    return x.priority > y.priority;
+  }
+
+private:
+  uint64_t compute_priority();
+};
+
+struct ConnectivityCheck {
+  ConnectivityCheck(const CandidatePair& a_candidate_pair,
+                    const AgentInfo& a_local_agent_info, const AgentInfo& a_remote_agent_info,
+                    uint64_t a_ice_tie_breaker, const ACE_Time_Value& a_expiration_date);
+
+  const CandidatePair& candidate_pair() const
+  {
+    return candiate_pair_;
+  }
+  const STUN::Message& request() const
+  {
+    return request_;
+  }
+  void cancel()
+  {
+    cancelled_ = true;
+  }
+  bool cancelled() const
+  {
+    return cancelled_;
+  }
+  ACE_Time_Value expiration_date() const
+  {
+    return expiration_date_;
+  }
+  void password(const std::string& a_password)
+  {
+    request_.password = a_password;
+  }
+private:
+  CandidatePair candiate_pair_;
+  STUN::Message request_;
+  bool cancelled_;
+  ACE_Time_Value expiration_date_;
+};
+
+inline bool operator==(const ConnectivityCheck& a_cc, const STUN::TransactionId& a_tid)
+{
+  return a_cc.request().transaction_id == a_tid;
+}
+
+inline bool operator==(const ConnectivityCheck& a_cc, const CandidatePair& a_cp)
+{
+  return a_cc.candidate_pair() == a_cp;
+}
+
+struct GuidPair {
+  DCPS::RepoId local;
+  DCPS::RepoId remote;
+
+  GuidPair(const DCPS::RepoId& a_local, const DCPS::RepoId& a_remote) : local(a_local), remote(a_remote) {}
+
+  bool operator<(const GuidPair& a_other) const
+  {
+    if (DCPS::GUID_tKeyLessThan()(this->local, a_other.local)) return true;
+
+    if (DCPS::GUID_tKeyLessThan()(a_other.local, this->local)) return false;
+
+    if (DCPS::GUID_tKeyLessThan()(this->remote, a_other.remote)) return true;
+
+    if (DCPS::GUID_tKeyLessThan()(a_other.remote, this->remote)) return false;
+
+    return false;
+  }
+};
+
+#if !OPENDDS_SAFETY_PROFILE
+inline std::ostream& operator<<(std::ostream& stream, const GuidPair& guidp)
+{
+  stream << guidp.local << ':' << guidp.remote;
+  return stream;
+}
+#endif
+
+typedef std::set<GuidPair> GuidSetType;
+
+struct Checklist : public Task {
+  Checklist(EndpointManager* a_endpoint,
+            const AgentInfo& a_local, const AgentInfo& a_remote,
+            ACE_UINT64 a_ice_tie_breaker);
+
+  void compute_active_foundations(ActiveFoundationSet& a_active_foundations) const;
+
+  void check_invariants() const;
+
+  void unfreeze();
+
+  void unfreeze(const FoundationType& a_foundation);
+
+  void generate_triggered_check(const ACE_INET_Addr& a_local_address, const ACE_INET_Addr& a_remote_address,
+                                uint32_t a_priority,
+                                bool a_use_candidate);
+
+  void success_response(const ACE_INET_Addr& a_local_address,
+                        const ACE_INET_Addr& a_remote_address,
+                        const STUN::Message& a_message);
+
+  void error_response(const ACE_INET_Addr& a_local_address,
+                      const ACE_INET_Addr& a_remote_address,
+                      const STUN::Message& a_message);
+
+  void add_guid(const GuidPair& a_guid_pair);
+
+  void remove_guid(const GuidPair& a_guid_pair);
+
+  void add_guids(const GuidSetType& a_guids);
+
+  void remove_guids();
+
+  GuidSetType guids() const
+  {
+    return guids_;
+  }
+
+  ACE_INET_Addr selected_address() const;
+
+  const AgentInfo& original_remote_agent_info() const
+  {
+    return original_remote_agent_info_;
+  }
+
+  void set_remote_password(const std::string& a_password)
+  {
+    remote_agent_info_.password = a_password;
+    original_remote_agent_info_.password = a_password;
+  }
+
+  void indication();
+
+private:
+  bool scheduled_for_destruction_;
+  EndpointManager* const endpoint_manager_;
+  GuidSetType guids_;
+  AgentInfo local_agent_info_;
+  AgentInfo remote_agent_info_;
+  AgentInfo original_remote_agent_info_;
+  bool const local_is_controlling_;
+  ACE_UINT64 const ice_tie_breaker_;
+
+  typedef std::list<CandidatePair> CandidatePairsType;
+  CandidatePairsType frozen_;
+  CandidatePairsType waiting_;
+  CandidatePairsType in_progress_;
+  CandidatePairsType succeeded_;
+  CandidatePairsType failed_;
+  // The triggered check queue is a subset of waiting.
+  CandidatePairsType triggered_check_queue_;
+  // The valid list is a subset of succeeded.
+  CandidatePairsType valid_list_;
+  // These are iterators into valid_list_.
+  CandidatePairsType::const_iterator nominating_;
+  CandidatePairsType::const_iterator nominated_;
+  ACE_Time_Value nominated_is_live_;
+  ACE_Time_Value last_indication_;
+  ACE_Time_Value check_interval_;
+  ACE_Time_Value max_check_interval_;
+  typedef std::list<ConnectivityCheck> ConnectivityChecksType;
+  ConnectivityChecksType connectivity_checks_;
+
+  ~Checklist() {}
+
+  void reset();
+
+  void generate_candidate_pairs();
+
+  void fix_foundations();
+
+  void add_valid_pair(const CandidatePair& a_valid_pair);
+
+  bool get_local_candidate(const ACE_INET_Addr& a_address, Candidate& a_candidate);
+
+  bool get_remote_candidate(const ACE_INET_Addr& a_address, Candidate& a_candidate);
+
+  bool is_succeeded(const CandidatePair& a_candidate_pair) const
+  {
+    return std::find(succeeded_.begin(), succeeded_.end(), a_candidate_pair) != succeeded_.end();
+  }
+
+  bool is_in_progress(const CandidatePair& a_candidate_pair) const
+  {
+    return std::find(in_progress_.begin(), in_progress_.end(), a_candidate_pair) != in_progress_.end();
+  }
+
+  void add_triggered_check(const CandidatePair& a_candidate_pair);
+
+  void remove_from_in_progress(const CandidatePair& a_candidate_pair);
+
+  void succeeded(const ConnectivityCheck& a_connectivity_check);
+
+  void failed(const ConnectivityCheck& a_connectivity_check);
+
+  // Measure of now many checks are left.
+  size_t size() const
+  {
+    return frozen_.size() + waiting_.size() + in_progress_.size();
+  }
+
+  void do_next_check(const ACE_Time_Value& a_now);
+
+  void execute(const ACE_Time_Value& a_now);
+};
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_CHECKLIST_H */

--- a/dds/DCPS/RTPS/ICE/EndpointManager.cpp
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.cpp
@@ -1,0 +1,765 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "EndpointManager.h"
+
+#include <ace/Reverse_Lock_T.h>
+#include "dds/DCPS/security/framework/SecurityRegistry.h"
+#include "dds/DCPS/security/framework/SecurityConfig.h"
+
+#include "Checklist.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+#if OPENDDS_SECURITY
+
+std::string stringify(unsigned char x[16])
+{
+  char retval[32];
+
+  for (size_t idx = 0; idx != 16; ++idx) {
+    retval[2 * idx] = (x[idx] & 0x0F) + 97;
+    retval[2 * idx + 1] = ((x[idx] & 0xF0) >> 4) + 97;
+  }
+
+  return std::string(retval, 32);
+}
+
+EndpointManager::EndpointManager(AgentImpl* a_agent_impl, Endpoint* a_endpoint) :
+  agent_impl(a_agent_impl),
+  endpoint(a_endpoint),
+  scheduled_for_destruction_(false),
+  requesting_(true),
+  send_count_(0),
+  server_reflexive_task_(this),
+  change_password_task_(this)
+{
+
+  // Set the type.
+  agent_info_.type = FULL;
+
+  TheSecurityRegistry->default_config()->get_utility()->generate_random_bytes(&ice_tie_breaker_, sizeof(ice_tie_breaker_));
+
+  change_username();
+  set_host_addresses(endpoint->host_addresses());
+}
+
+void EndpointManager::start_ice(const DCPS::RepoId& a_local_guid,
+                                const DCPS::RepoId& a_remote_guid,
+                                const AgentInfo& a_remote_agent_info)
+{
+  // Check for username collision.
+  if (a_remote_agent_info.username == agent_info_.username) {
+    change_username();
+  }
+
+  GuidPair guidp(a_local_guid, a_remote_guid);
+
+  // Try to find by guid.
+  Checklist* guid_checklist = 0;
+  {
+    GuidPairToChecklistType::const_iterator pos = guid_pair_to_checklist_.find(guidp);
+
+    if (pos != guid_pair_to_checklist_.end()) {
+      guid_checklist = pos->second;
+    }
+  }
+
+  // Try to find by username.
+  Checklist* username_checklist = 0;
+  {
+    UsernameToChecklistType::const_iterator pos = username_to_checklist_.find(a_remote_agent_info.username);
+
+    if (pos != username_to_checklist_.end()) {
+      username_checklist = pos->second;
+    }
+
+    else {
+      username_checklist = create_checklist(a_remote_agent_info);
+    }
+  }
+
+  if (guid_checklist != username_checklist) {
+    if (guid_checklist != 0) {
+      guid_checklist->remove_guid(guidp);
+    }
+
+    username_checklist->add_guid(guidp);
+  }
+
+  AgentInfo old_remote_agent_info = username_checklist->original_remote_agent_info();
+
+  if (old_remote_agent_info == a_remote_agent_info) {
+    // No change.
+    return;
+  }
+
+  old_remote_agent_info.password = a_remote_agent_info.password;
+
+  if (old_remote_agent_info == a_remote_agent_info) {
+    // Password change.
+    username_checklist->set_remote_password(a_remote_agent_info.password);
+    return;
+  }
+
+  // The remote agent changed its info without changing its username.
+  GuidSetType const guids = username_checklist->guids();
+  username_checklist->remove_guids();
+  username_checklist = create_checklist(a_remote_agent_info);
+  username_checklist->add_guids(guids);
+}
+
+void EndpointManager::stop_ice(const DCPS::RepoId& a_local_guid,
+                               const DCPS::RepoId& a_remote_guid)
+{
+  GuidPair guidp(a_local_guid, a_remote_guid);
+
+  GuidPairToChecklistType::const_iterator pos = guid_pair_to_checklist_.find(guidp);
+
+  if (pos != guid_pair_to_checklist_.end()) {
+    Checklist* guid_checklist = pos->second;
+    guid_checklist->remove_guid(guidp);
+  }
+}
+
+ACE_INET_Addr EndpointManager::get_address(const DCPS::RepoId& a_local_guid,
+                                           const DCPS::RepoId& a_remote_guid) const
+{
+  GuidPair guidp(a_local_guid, a_remote_guid);
+  GuidPairToChecklistType::const_iterator pos = guid_pair_to_checklist_.find(guidp);
+
+  if (pos != guid_pair_to_checklist_.end()) {
+    return pos->second->selected_address();
+  }
+
+  return ACE_INET_Addr();
+}
+
+void EndpointManager::receive(const ACE_INET_Addr& a_local_address,
+                              const ACE_INET_Addr& a_remote_address,
+                              const STUN::Message& a_message)
+{
+  switch (a_message.class_) {
+  case STUN::REQUEST:
+    request(a_local_address, a_remote_address, a_message);
+    return;
+
+  case STUN::INDICATION:
+    indication(a_message);
+    return;
+
+  case STUN::SUCCESS_RESPONSE:
+    success_response(a_local_address, a_remote_address, a_message);
+    return;
+
+  case STUN::ERROR_RESPONSE:
+    error_response(a_local_address, a_remote_address, a_message);
+    return;
+  }
+
+  ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::receive: WARNING Unknown ICE message class %d\n"), a_message.class_));
+}
+
+void EndpointManager::change_username()
+{
+  // Generate the username.
+  unsigned char username[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+  TheSecurityRegistry->default_config()->get_utility()->generate_random_bytes(username, sizeof(username));
+  agent_info_.username = stringify(username);
+  change_password(false);
+}
+
+void EndpointManager::change_password(bool password_only)
+{
+  unsigned char password[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+  TheSecurityRegistry->default_config()->get_utility()->generate_random_bytes(password, sizeof(password));
+  agent_info_.password = stringify(password);
+  regenerate_agent_info(password_only);
+}
+
+void EndpointManager::set_host_addresses(const AddressListType& a_host_addresses)
+{
+  // Section IETF RFC 8445 5.1.1.1
+  // TODO(jrw972):  Handle IPv6.
+  AddressListType host_addresses;
+
+  for (AddressListType::const_iterator pos = a_host_addresses.begin(), limit = a_host_addresses.end();
+       pos != limit; ++pos) {
+    if (pos->is_loopback()) {
+      continue;
+    }
+
+    host_addresses.push_back(*pos);
+  }
+
+  if (host_addresses_ != host_addresses) {
+    host_addresses_ = host_addresses;
+    regenerate_agent_info(false);
+  }
+}
+
+void EndpointManager::set_server_reflexive_address(const ACE_INET_Addr& a_server_reflexive_address,
+                                                   const ACE_INET_Addr& a_stun_server_address)
+{
+  if (server_reflexive_address_ != a_server_reflexive_address ||
+      stun_server_address_ != a_stun_server_address) {
+    server_reflexive_address_ = a_server_reflexive_address;
+    stun_server_address_ = a_stun_server_address;
+    regenerate_agent_info(false);
+  }
+}
+
+void EndpointManager::regenerate_agent_info(bool password_only)
+{
+  if (!password_only) {
+    // Populate candidates.
+    agent_info_.candidates.clear();
+
+    for (AddressListType::const_iterator pos = host_addresses_.begin(), limit = host_addresses_.end(); pos != limit; ++pos) {
+      agent_info_.candidates.push_back(make_host_candidate(*pos));
+
+      if (server_reflexive_address_ != ACE_INET_Addr() &&
+          stun_server_address_ != ACE_INET_Addr()) {
+        agent_info_.candidates.push_back(make_server_reflexive_candidate(server_reflexive_address_, *pos, stun_server_address_));
+      }
+    }
+
+    // Eliminate duplicates.
+    std::sort(agent_info_.candidates.begin(), agent_info_.candidates.end(), candidates_sorted);
+    AgentInfo::CandidatesType::iterator last = std::unique(agent_info_.candidates.begin(), agent_info_.candidates.end(), candidates_equal);
+    agent_info_.candidates.erase(last, agent_info_.candidates.end());
+
+    // Start over.
+    UsernameToChecklistType old_checklists = username_to_checklist_;
+
+    for (UsernameToChecklistType::const_iterator pos = old_checklists.begin(),
+         limit = old_checklists.end();
+         pos != limit; ++pos) {
+      Checklist* old_checklist = pos->second;
+      AgentInfo const remote_agent_info = old_checklist->original_remote_agent_info();
+      GuidSetType const guids = old_checklist->guids();
+      old_checklist->remove_guids();
+      Checklist* new_checklist = create_checklist(remote_agent_info);
+      new_checklist->add_guids(guids);
+    }
+  }
+
+  {
+    // Propagate changed agent info.
+
+    // Make a copy.
+    AgentInfoListenersType agent_info_listeners = agent_info_listeners_;
+    AgentInfo agent_info = agent_info_;
+
+    // Release the lock.
+    ACE_Reverse_Lock<ACE_Recursive_Thread_Mutex> rev_lock(agent_impl->mutex);
+    ACE_GUARD(ACE_Reverse_Lock<ACE_Recursive_Thread_Mutex>, rev_guard, rev_lock);
+
+    for (AgentInfoListenersType::const_iterator pos = agent_info_listeners.begin(),
+         limit =  agent_info_listeners.end(); pos != limit; ++pos) {
+      pos->second->update_agent_info(pos->first, agent_info);
+    }
+  }
+}
+
+void EndpointManager::server_reflexive_task(const ACE_Time_Value& a_now)
+{
+  // Request and maintain a server-reflexive address.
+  next_stun_server_address_ = endpoint->stun_server_address();
+
+  if (next_stun_server_address_ != ACE_INET_Addr()) {
+    binding_request_ = STUN::Message();
+    binding_request_.class_ = requesting_ ? STUN::REQUEST : STUN::INDICATION;
+    binding_request_.method = STUN::BINDING;
+    binding_request_.generate_transaction_id();
+    binding_request_.append_attribute(STUN::make_fingerprint());
+
+    endpoint->send(next_stun_server_address_, binding_request_);
+
+    if (!requesting_ && send_count_ == agent_impl->get_configuration().server_reflexive_indication_count() - 1) {
+      requesting_ = true;
+    }
+
+    send_count_ = (send_count_ + 1) % agent_impl->get_configuration().server_reflexive_indication_count();
+  }
+
+  else {
+    requesting_ = true;
+    send_count_ = 0;
+  }
+
+  // Remove expired deferred checks.
+  for (DeferredTriggeredChecksType::iterator pos = deferred_triggered_checks_.begin(),
+       limit = deferred_triggered_checks_.end(); pos != limit;) {
+    DeferredTriggeredCheckListType& list = pos->second;
+
+    while (!list.empty() && list.front().expiration_date < a_now) {
+      list.pop_front();
+    }
+
+    if (list.empty()) {
+      deferred_triggered_checks_.erase(pos++);
+    }
+
+    else {
+      ++pos;
+    }
+  }
+
+  // Repopulate the host addresses.
+  set_host_addresses(endpoint->host_addresses());
+}
+
+bool EndpointManager::success_response(const STUN::Message& a_message)
+{
+  if (a_message.transaction_id != binding_request_.transaction_id) {
+    return false;
+  }
+
+  std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+
+  if (!unknown_attributes.empty()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::success_response: WARNING Unknown comprehension required attributes\n")));
+    return true;
+  }
+
+  ACE_INET_Addr server_reflexive_address;
+
+  if (a_message.get_mapped_address(server_reflexive_address)) {
+    set_server_reflexive_address(server_reflexive_address, next_stun_server_address_);
+    requesting_ = false;
+    send_count_ = 0;
+  }
+
+  else {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::success_response: WARNING No (XOR)_MAPPED_ADDRESS attribute\n")));
+    set_server_reflexive_address(ACE_INET_Addr(), ACE_INET_Addr());
+    requesting_ = true;
+    send_count_ = 0;
+  }
+
+  return true;
+}
+
+bool EndpointManager::error_response(const STUN::Message& a_message)
+{
+  if (a_message.transaction_id != binding_request_.transaction_id) {
+    return false;
+  }
+
+  if (a_message.has_error_code()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING STUN error response code=%d reason=%s\n"), a_message.get_error_code(), a_message.get_error_reason().c_str()));
+
+    if (a_message.get_error_code() == 420 && a_message.has_unknown_attributes()) {
+      std::vector<STUN::AttributeType> unknown_attributes = a_message.get_unknown_attributes();
+
+      for (std::vector<STUN::AttributeType>::const_iterator pos = unknown_attributes.begin(),
+           limit = unknown_attributes.end(); pos != limit; ++pos) {
+        ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING Unknown STUN attribute %d\n"), *pos));
+      }
+    }
+  }
+
+  else {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING STUN error response (no code)\n")));
+  }
+
+  return true;
+}
+
+Checklist* EndpointManager::create_checklist(const AgentInfo& remote_agent_info)
+{
+  Checklist* checklist = new Checklist(this, agent_info_, remote_agent_info, ice_tie_breaker_);
+  // Add the deferred triggered first in case there was a nominating check.
+  DeferredTriggeredChecksType::iterator pos = deferred_triggered_checks_.find(remote_agent_info.username);
+
+  if (pos != deferred_triggered_checks_.end()) {
+    const DeferredTriggeredCheckListType& list = pos->second;
+
+    for (DeferredTriggeredCheckListType::const_iterator pos = list.begin(), limit = list.end(); pos != limit; ++pos) {
+      checklist->generate_triggered_check(pos->local_address, pos->remote_address, pos->priority, pos->use_candidate);
+    }
+
+    deferred_triggered_checks_.erase(pos);
+  }
+
+  checklist->unfreeze();
+
+  return checklist;
+}
+
+STUN::Message EndpointManager::make_unknown_attributes_error_response(const STUN::Message& a_message,
+                                                                      const std::vector<STUN::AttributeType>& a_unknown_attributes)
+{
+  STUN::Message response;
+  response.class_ = STUN::ERROR_RESPONSE;
+  response.method = a_message.method;
+  memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+  response.append_attribute(STUN::make_error_code(420, "Unknown Attributes"));
+  response.append_attribute(STUN::make_unknown_attributes(a_unknown_attributes));
+  response.append_attribute(STUN::make_message_integrity());
+  response.password = agent_info_.password;
+  response.append_attribute(STUN::make_fingerprint());
+  return response;
+}
+
+STUN::Message EndpointManager::make_bad_request_error_response(const STUN::Message& a_message,
+                                                               const std::string& a_reason)
+{
+  STUN::Message response;
+  response.class_ = STUN::ERROR_RESPONSE;
+  response.method = a_message.method;
+  memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+  response.append_attribute(STUN::make_error_code(400, a_reason));
+  response.append_attribute(STUN::make_message_integrity());
+  response.password = agent_info_.password;
+  response.append_attribute(STUN::make_fingerprint());
+  return response;
+}
+
+STUN::Message EndpointManager::make_unauthorized_error_response(const STUN::Message& a_message)
+{
+  STUN::Message response;
+  response.class_ = STUN::ERROR_RESPONSE;
+  response.method = a_message.method;
+  memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+  response.append_attribute(STUN::make_error_code(401, "Unauthorized"));
+  response.append_attribute(STUN::make_message_integrity());
+  response.password = agent_info_.password;
+  response.append_attribute(STUN::make_fingerprint());
+  return response;
+}
+
+// STUN Message processing.
+void EndpointManager::request(const ACE_INET_Addr& a_local_address,
+                              const ACE_INET_Addr& a_remote_address,
+                              const STUN::Message& a_message)
+{
+  std::string username;
+
+  if (!a_message.get_username(username)) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No USERNAME attribute\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: USERNAME must be present"));
+    return;
+  }
+
+  if (!a_message.has_message_integrity()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No MESSAGE_INTEGRITY attribute\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: MESSAGE_INTEGRITY must be present"));
+    return;
+  }
+
+  size_t idx = username.find(':');
+
+  if (idx == std::string::npos) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING USERNAME does not contain a colon\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: USERNAME must be colon-separated"));
+    return;
+  }
+
+  if (username.substr(0, idx) != agent_info_.username) {
+    // We expect this to happen.
+    endpoint->send(a_remote_address,
+                   make_unauthorized_error_response(a_message));
+    return;
+  }
+
+  const std::string remote_username = username.substr(++idx);
+
+  // Check the message_integrity.
+  if (!a_message.verify_message_integrity(agent_info_.password)) {
+    // We expect this to happen.
+    endpoint->send(a_remote_address,
+                   make_unauthorized_error_response(a_message));
+    return;
+  }
+
+  std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+
+  if (!unknown_attributes.empty()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING Unknown comprehension required attributes\n")));
+    endpoint->send(a_remote_address,
+                   make_unknown_attributes_error_response(a_message, unknown_attributes));
+    return;
+  }
+
+  if (!a_message.has_fingerprint()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No FINGERPRINT attribute\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: FINGERPRINT must be present"));
+    return;
+  }
+
+  if (!a_message.has_ice_controlled() && !a_message.has_ice_controlling()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No ICE_CONTROLLED/ICE_CONTROLLING attribute\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: Either ICE_CONTROLLED or ICE_CONTROLLING must be present"));
+    return;
+  }
+
+  bool use_candidate = a_message.has_use_candidate();
+
+  if (use_candidate && a_message.has_ice_controlled()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING USE_CANDIDATE without ICE_CONTROLLED\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: USE_CANDIDATE can only be present when ICE_CONTROLLED is present"));
+    return;
+  }
+
+  uint32_t priority;
+
+  if (!a_message.get_priority(priority)) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING No PRIORITY attribute\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: PRIORITY must be present"));
+    return;
+  }
+
+  switch (a_message.method) {
+  case STUN::BINDING: {
+    // 7.3
+    STUN::Message response;
+    response.class_ = STUN::SUCCESS_RESPONSE;
+    response.method = STUN::BINDING;
+    memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+    response.append_attribute(STUN::make_mapped_address(a_remote_address));
+    response.append_attribute(STUN::make_xor_mapped_address(a_remote_address));
+    response.append_attribute(STUN::make_message_integrity());
+    response.password = agent_info_.password;
+    response.append_attribute(STUN::make_fingerprint());
+    endpoint->send(a_remote_address, response);
+
+    // 7.3.1.3
+    UsernameToChecklistType::const_iterator pos = username_to_checklist_.find(remote_username);
+
+    if (pos != username_to_checklist_.end()) {
+      // We have a checklist.
+      Checklist* checklist = pos->second;
+      checklist->generate_triggered_check(a_local_address, a_remote_address, priority, use_candidate);
+    }
+
+    else {
+      std::pair<DeferredTriggeredChecksType::iterator, bool> x = deferred_triggered_checks_.insert(std::make_pair(remote_username, DeferredTriggeredCheckListType()));
+      x.first->second.push_back(DeferredTriggeredCheck(a_local_address, a_remote_address, priority, use_candidate, ACE_Time_Value().now() + agent_impl->get_configuration().deferred_triggered_check_ttl()));
+    }
+  }
+  break;
+
+  default:
+    // Unknown method.  Stop processing.
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::request: WARNING Unknown ICE method\n")));
+    endpoint->send(a_remote_address,
+                   make_bad_request_error_response(a_message, "Bad Request: Unknown method"));
+    break;
+  }
+}
+
+void EndpointManager::indication(const STUN::Message& a_message)
+{
+  std::string username;
+
+  if (!a_message.get_username(username)) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING No USERNAME attribute\n")));
+    return;
+  }
+
+  if (!a_message.has_message_integrity()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING No MESSAGE_INTEGRITY attribute\n")));
+    return;
+  }
+
+  size_t idx = username.find(':');
+
+  if (idx == std::string::npos) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING USERNAME does not contain a colon\n")));
+    return;
+  }
+
+  if (username.substr(0, idx) != agent_info_.username) {
+    // We expect this to happen.
+    return;
+  }
+
+  const std::string remote_username = username.substr(++idx);
+
+  // Check the message_integrity.
+  if (!a_message.verify_message_integrity(agent_info_.password)) {
+    // We expect this to happen.
+    return;
+  }
+
+  std::vector<STUN::AttributeType> unknown_attributes = a_message.unknown_comprehension_required_attributes();
+
+  if (!unknown_attributes.empty()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING Unknown comprehension required attributes\n")));
+    return;
+  }
+
+  if (!a_message.has_fingerprint()) {
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING No FINGERPRINT attribute\n")));
+    return;
+  }
+
+  switch (a_message.method) {
+  case STUN::BINDING: {
+    // Section 11
+    UsernameToChecklistType::const_iterator pos = username_to_checklist_.find(remote_username);
+
+    if (pos != username_to_checklist_.end()) {
+      // We have a checklist.
+      pos->second->indication();
+    }
+  }
+  break;
+
+  default:
+    // Unknown method.  Stop processing.
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::indication: WARNING Unknown ICE method\n")));
+    break;
+  }
+}
+
+void EndpointManager::success_response(const ACE_INET_Addr& a_local_address,
+                                       const ACE_INET_Addr& a_remote_address,
+                                       const STUN::Message& a_message)
+{
+  switch (a_message.method) {
+  case STUN::BINDING: {
+    if (success_response(a_message)) {
+      return;
+    }
+
+    TransactionIdToChecklistType::const_iterator pos = transaction_id_to_checklist_.find(a_message.transaction_id);
+
+    if (pos == transaction_id_to_checklist_.end()) {
+      // Probably a check that got cancelled.
+      return;
+    }
+
+    // Checklist is responsible for updating the map.
+    // Checklist also checks for required parameters.
+    pos->second->success_response(a_local_address, a_remote_address, a_message);
+  }
+  break;
+
+  default:
+    // Unknown method.  Stop processing.
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::success_response: WARNING Unknown ICE method\n")));
+    break;
+  }
+}
+
+void EndpointManager::error_response(const ACE_INET_Addr& a_local_address,
+                                     const ACE_INET_Addr& a_remote_address,
+                                     const STUN::Message& a_message)
+{
+  switch (a_message.method) {
+  case STUN::BINDING: {
+    if (error_response(a_message)) {
+      return;
+    }
+
+    TransactionIdToChecklistType::const_iterator pos = transaction_id_to_checklist_.find(a_message.transaction_id);
+
+    if (pos == transaction_id_to_checklist_.end()) {
+      // Probably a check that got cancelled.
+      return;
+    }
+
+    // Checklist is responsible for updating the map.
+    // Checklist also checks for required parameters.
+    pos->second->error_response(a_local_address, a_remote_address, a_message);
+  }
+  break;
+
+  default:
+    // Unknown method.  Stop processing.
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::error_response: WARNING Unknown ICE method\n")));
+    break;
+  }
+}
+
+void EndpointManager::compute_active_foundations(ActiveFoundationSet& a_active_foundations) const
+{
+  for (UsernameToChecklistType::const_iterator pos = username_to_checklist_.begin(),
+       limit = username_to_checklist_.end(); pos != limit; ++pos) {
+    const Checklist* checklist = pos->second;
+    checklist->compute_active_foundations(a_active_foundations);
+  }
+}
+
+void EndpointManager::check_invariants() const
+{
+  for (UsernameToChecklistType::const_iterator pos = username_to_checklist_.begin(),
+       limit = username_to_checklist_.end(); pos != limit; ++pos) {
+    const Checklist* checklist = pos->second;
+    checklist->check_invariants();
+  }
+}
+
+void EndpointManager::schedule_for_destruction()
+{
+  scheduled_for_destruction_ = true;
+  UsernameToChecklistType old_checklists = username_to_checklist_;
+
+  for (UsernameToChecklistType::const_iterator pos = old_checklists.begin(),
+       limit = old_checklists.end(); pos != limit; ++pos) {
+    pos->second->remove_guids();
+  }
+}
+
+void EndpointManager::unfreeze(const FoundationType& a_foundation)
+{
+  for (UsernameToChecklistType::const_iterator pos = username_to_checklist_.begin(),
+       limit = username_to_checklist_.end(); pos != limit; ++pos) {
+    pos->second->unfreeze(a_foundation);
+  }
+}
+
+EndpointManager::ServerReflexiveTask::ServerReflexiveTask(EndpointManager* a_endpoint_manager)
+  : Task(a_endpoint_manager->agent_impl),
+    endpoint_manager(a_endpoint_manager)
+{
+  enqueue(ACE_Time_Value().now());
+}
+
+void EndpointManager::ServerReflexiveTask::execute(const ACE_Time_Value& a_now)
+{
+  if (endpoint_manager->scheduled_for_destruction_) {
+    delete endpoint_manager;
+    return;
+  }
+
+  endpoint_manager->server_reflexive_task(a_now);
+  enqueue(a_now + endpoint_manager->agent_impl->get_configuration().server_reflexive_address_period());
+}
+
+EndpointManager::ChangePasswordTask::ChangePasswordTask(EndpointManager* a_endpoint_manager)
+  : Task(a_endpoint_manager->agent_impl),
+    endpoint_manager(a_endpoint_manager)
+{
+  enqueue(ACE_Time_Value().now() + endpoint_manager->agent_impl->get_configuration().change_password_period());
+}
+
+void EndpointManager::ChangePasswordTask::execute(const ACE_Time_Value& a_now)
+{
+  endpoint_manager->change_password(true);
+  enqueue(a_now + endpoint_manager->agent_impl->get_configuration().change_password_period());
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/ICE/EndpointManager.h
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.h
@@ -1,0 +1,232 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_ENDPOINT_MANAGER_H
+#define OPENDDS_RTPS_ICE_ENDPOINT_MANAGER_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "dds/Versioned_Namespace.h"
+#include <ace/INET_Addr.h>
+
+#include "Ice.h"
+#include "Task.h"
+#include "Checklist.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+class AgentImpl;
+struct Checklist;
+
+struct DeferredTriggeredCheck {
+  ACE_INET_Addr local_address;
+  ACE_INET_Addr remote_address;
+  uint32_t priority;
+  bool use_candidate;
+  ACE_Time_Value expiration_date;
+
+  DeferredTriggeredCheck(const ACE_INET_Addr& a_local_address,
+                         const ACE_INET_Addr& a_remote_address,
+                         uint32_t a_priority,
+                         bool a_use_candidate,
+                         const ACE_Time_Value& a_expiration_date)
+  : local_address(a_local_address)
+  , remote_address(a_remote_address)
+  , priority(a_priority)
+  , use_candidate(a_use_candidate)
+  , expiration_date(a_expiration_date)
+  {}
+};
+
+struct EndpointManager {
+  AgentImpl* const agent_impl;
+  Endpoint* const endpoint;
+
+  EndpointManager(AgentImpl* a_agent_impl, Endpoint* a_endpoint);
+
+  const AgentInfo& agent_info() const
+  {
+    return agent_info_;
+  }
+
+  void add_agent_info_listener(const DCPS::RepoId& a_local_guid,
+                               AgentInfoListener* a_agent_info_listener)
+  {
+    agent_info_listeners_[a_local_guid] = a_agent_info_listener;
+  }
+
+  void remove_agent_info_listener(const DCPS::RepoId& a_local_guid)
+  {
+    agent_info_listeners_.erase(a_local_guid);
+  }
+
+  void start_ice(const DCPS::RepoId& a_local_guid,
+                 const DCPS::RepoId& a_remote_guid,
+                 const AgentInfo& a_remote_agent_info);
+
+  void stop_ice(const DCPS::RepoId& local_guid,
+                const DCPS::RepoId& remote_guid);
+
+  ACE_INET_Addr get_address(const DCPS::RepoId& a_local_guid,
+                            const DCPS::RepoId& a_remote_guid) const;
+
+  void receive(const ACE_INET_Addr& a_local_address,
+               const ACE_INET_Addr& a_remote_address,
+               const STUN::Message& a_message);
+
+  void set_responsible_checklist(const STUN::TransactionId& a_transaction_id, Checklist* a_checklist)
+  {
+    TransactionIdToChecklistType::const_iterator pos = transaction_id_to_checklist_.find(a_transaction_id);
+    assert(pos == transaction_id_to_checklist_.end());
+    transaction_id_to_checklist_[a_transaction_id] = a_checklist;
+  }
+
+  void unset_responsible_checklist(const STUN::TransactionId& a_transaction_id, Checklist* a_checklist)
+  {
+    TransactionIdToChecklistType::iterator pos = transaction_id_to_checklist_.find(a_transaction_id);
+    assert(pos != transaction_id_to_checklist_.end());
+    assert(pos->second == a_checklist);
+    transaction_id_to_checklist_.erase(pos);
+  }
+
+  void set_responsible_checklist(const GuidPair& a_guid_pair, Checklist* a_checklist)
+  {
+    GuidPairToChecklistType::const_iterator pos = guid_pair_to_checklist_.find(a_guid_pair);
+    assert(pos == guid_pair_to_checklist_.end());
+    guid_pair_to_checklist_[a_guid_pair] = a_checklist;
+  }
+
+  void unset_responsible_checklist(const GuidPair& a_guid_pair, Checklist* a_checklist)
+  {
+    GuidPairToChecklistType::iterator pos = guid_pair_to_checklist_.find(a_guid_pair);
+    assert(pos != guid_pair_to_checklist_.end());
+    assert(pos->second == a_checklist);
+    guid_pair_to_checklist_.erase(pos);
+  }
+
+  void set_responsible_checklist(const std::string& a_username, Checklist* a_checklist)
+  {
+    UsernameToChecklistType::const_iterator pos = username_to_checklist_.find(a_username);
+    assert(pos == username_to_checklist_.end());
+    username_to_checklist_[a_username] = a_checklist;
+  }
+
+  void unset_responsible_checklist(const std::string& a_username, Checklist* a_checklist)
+  {
+    UsernameToChecklistType::iterator pos = username_to_checklist_.find(a_username);
+    assert(pos != username_to_checklist_.end());
+    assert(pos->second == a_checklist);
+    username_to_checklist_.erase(pos);
+  }
+
+  void unfreeze(const FoundationType& a_foundation);
+
+  void compute_active_foundations(ActiveFoundationSet& a_active_foundations) const;
+
+  void check_invariants() const;
+
+  void schedule_for_destruction();
+
+private:
+  bool scheduled_for_destruction_;
+  AddressListType host_addresses_;          // Cached list of host addresses.
+  ACE_INET_Addr server_reflexive_address_;  // Server-reflexive address (from STUN server).
+  ACE_INET_Addr stun_server_address_;       // Address of the STUN server.
+  ACE_UINT64 ice_tie_breaker_;
+  AgentInfo agent_info_;
+
+  // State variables for getting and maintaining the server reflexive address.
+  bool requesting_;
+  size_t send_count_;
+  ACE_INET_Addr next_stun_server_address_;
+  STUN::Message binding_request_;       // Binding request sent to STUN server.
+
+  typedef std::deque<DeferredTriggeredCheck> DeferredTriggeredCheckListType;
+  typedef std::map<std::string, DeferredTriggeredCheckListType> DeferredTriggeredChecksType;
+  DeferredTriggeredChecksType deferred_triggered_checks_;
+
+  // Managed by checklists.
+  typedef std::map<std::string, Checklist*> UsernameToChecklistType;
+  UsernameToChecklistType username_to_checklist_;
+
+  // Managed by checklists.
+  typedef std::map<STUN::TransactionId, Checklist*> TransactionIdToChecklistType;
+  TransactionIdToChecklistType transaction_id_to_checklist_;
+
+  // Managed by checklists.
+  typedef std::map<GuidPair, Checklist*> GuidPairToChecklistType;
+  GuidPairToChecklistType guid_pair_to_checklist_;
+
+  typedef std::map<DCPS::RepoId, AgentInfoListener*, DCPS::GUID_tKeyLessThan> AgentInfoListenersType;
+  AgentInfoListenersType agent_info_listeners_;
+
+  void change_username();
+
+  void change_password(bool password_only);
+
+  void set_host_addresses(const AddressListType& a_host_addresses);
+
+  void set_server_reflexive_address(const ACE_INET_Addr& a_server_reflexive_address,
+                                    const ACE_INET_Addr& a_stun_server_address);
+
+  void regenerate_agent_info(bool password_only);
+
+  void server_reflexive_task(const ACE_Time_Value& a_now);
+
+  bool success_response(const STUN::Message& a_message);
+
+  bool error_response(const STUN::Message& a_message);
+
+  Checklist* create_checklist(const AgentInfo& a_remote_agent_info);
+
+  // STUN Message processing.
+  STUN::Message make_unknown_attributes_error_response(const STUN::Message& a_message,
+                                                       const std::vector<STUN::AttributeType>& a_unknown_attributes);
+
+  STUN::Message make_bad_request_error_response(const STUN::Message& a_message,
+                                                const std::string& a_reason);
+
+  STUN::Message make_unauthorized_error_response(const STUN::Message& a_message);
+
+  void request(const ACE_INET_Addr& a_local_address,
+               const ACE_INET_Addr& a_remote_address,
+               const STUN::Message& a_message);
+
+  void indication(const STUN::Message& a_message);
+
+  void success_response(const ACE_INET_Addr& a_local_address,
+                        const ACE_INET_Addr& a_remote_address,
+                        const STUN::Message& a_message);
+
+  void error_response(const ACE_INET_Addr& a_local_address,
+                      const ACE_INET_Addr& a_remote_address,
+                      const STUN::Message& a_message);
+
+  struct ServerReflexiveTask : public Task {
+    EndpointManager* endpoint_manager;
+    ServerReflexiveTask(EndpointManager* a_endpoint_manager);
+    void execute(const ACE_Time_Value& a_now);
+  } server_reflexive_task_;
+
+  struct ChangePasswordTask : public Task {
+    EndpointManager* endpoint_manager;
+    ChangePasswordTask(EndpointManager* a_endpoint_manager);
+    void execute(const ACE_Time_Value& a_now);
+  } change_password_task_;
+};
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_ENDPOINT_MANAGER_H */

--- a/dds/DCPS/RTPS/ICE/Ice.cpp
+++ b/dds/DCPS/RTPS/ICE/Ice.cpp
@@ -1,0 +1,138 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Ice.h"
+
+#include "AgentImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+#if OPENDDS_SECURITY
+
+bool candidates_sorted(const Candidate& x, const Candidate& y)
+{
+  if (x.address != y.address) {
+    return x.address < y.address;
+  }
+
+  if (x.base != y.base) {
+    return x.base < y.base;
+  }
+
+  return x.priority > y.priority;
+}
+
+bool candidates_equal(const Candidate& x, const Candidate& y)
+{
+  return x.address == y.address && x.base == y.base;
+}
+
+Candidate make_host_candidate(const ACE_INET_Addr& address)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation += "H" + std::string(address.get_host_addr()) + "U";
+  candidate.priority = (126 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+  candidate.type = HOST;
+  candidate.base = address;
+  return candidate;
+}
+
+Candidate make_server_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation += "S" + std::string(base.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+  candidate.priority = (100 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+  candidate.type = SERVER_REFLEXIVE;
+  candidate.base = base;
+  return candidate;
+}
+
+Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& base, const ACE_INET_Addr& server_address, uint32_t priority)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation += "P" + std::string(base.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+  candidate.priority = priority;
+  candidate.type = PEER_REFLEXIVE;
+  candidate.base = base;
+  return candidate;
+}
+
+Candidate make_peer_reflexive_candidate(const ACE_INET_Addr& address, uint32_t priority, size_t q)
+{
+  Candidate candidate;
+  candidate.address = address;
+  candidate.foundation += "Q" + stringify(q) + "U";
+  candidate.priority = priority;
+  candidate.type = PEER_REFLEXIVE;
+  return candidate;
+}
+
+// Candidate make_relayed_candidate(const ACE_INET_Addr& address, const ACE_INET_Addr& server_address) {
+//   Candidate candidate;
+//   candidate.address = address;
+//   candidate.foundation = "R" + std::string(address.get_host_addr()) + "_" + std::string(server_address.get_host_addr()) + "U";
+//   candidate.priority = (0 << 24) + (65535 << 8) + ((256 - 1) << 0); // No local preference, component 1.
+//   candidate.type = RELAYED;
+//   candidate.base = address;
+//   return candidate;
+// }
+
+Agent* Agent::instance()
+{
+  return ACE_Singleton<AgentImpl, ACE_SYNCH_MUTEX>::instance();
+}
+
+std::ostream& operator<<(std::ostream& stream, const ACE_INET_Addr& address)
+{
+  stream << address.get_host_addr() << ':' << address.get_port_number();
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, const STUN::TransactionId& tid)
+{
+  for (size_t idx = 0; idx != 12; ++idx) {
+    stream << int(tid.data[idx]);
+  }
+
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, const ICE::Candidate& candidate)
+{
+  stream << "address:    " << candidate.address << '\n'
+         << "foundation: " << candidate.foundation << '\n'
+         << "priority:   " << candidate.priority << '\n'
+         << "type:       " << candidate.type << '\n'
+         << "base:       " << candidate.base << '\n';
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, const ICE::AgentInfo& agent_info)
+{
+  stream << "type:     " << agent_info.type     << '\n'
+         << "username: " << agent_info.username << '\n'
+         << "password: " << agent_info.password << '\n';
+
+  for (AgentInfo::const_iterator pos = agent_info.begin(), limit = agent_info.end(); pos != limit; ++pos) {
+    stream << *pos;
+  }
+
+  return stream;
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/ICE/Ice.h
+++ b/dds/DCPS/RTPS/ICE/Ice.h
@@ -1,0 +1,199 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_H
+#define OPENDDS_RTPS_ICE_H
+
+#include "dds/DCPS/ICE/Ice.h"
+#include "dds/DCPS/RTPS/ICE/Stun.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+typedef OPENDDS_VECTOR(ACE_INET_Addr) AddressListType;
+
+class OpenDDS_Rtps_Export Endpoint {
+public:
+  virtual ~Endpoint() {}
+  virtual AddressListType host_addresses() const = 0;
+  virtual void send(const ACE_INET_Addr& address, const STUN::Message& message) = 0;
+  virtual ACE_INET_Addr stun_server_address() const = 0;
+};
+
+class OpenDDS_Rtps_Export AgentInfoListener {
+public:
+  virtual ~AgentInfoListener() {}
+  virtual void update_agent_info(const DCPS::RepoId& a_local_guid,
+                                 const AgentInfo& a_agent_info) = 0;
+};
+
+class OpenDDS_Rtps_Export Configuration {
+public:
+  Configuration() :
+    T_a_(0, 50000),
+    connectivity_check_ttl_(5 * 60),
+    checklist_period_(10),
+    indication_period_(15),
+    nominated_ttl_(5 * 60),
+    server_reflexive_address_period_(30),
+    server_reflexive_indication_count_(10),
+    deferred_triggered_check_ttl_(5 * 60),
+    change_password_period_(5 * 60)
+  {}
+
+  void T_a(const ACE_Time_Value& x)
+  {
+    T_a_ = x;
+  }
+  ACE_Time_Value T_a() const
+  {
+    return T_a_;
+  }
+
+  void connectivity_check_ttl(const ACE_Time_Value& x)
+  {
+    connectivity_check_ttl_ = x;
+  }
+  ACE_Time_Value connectivity_check_ttl() const
+  {
+    return connectivity_check_ttl_;
+  }
+
+  void checklist_period(const ACE_Time_Value& x)
+  {
+    checklist_period_ = x;
+  }
+  ACE_Time_Value checklist_period() const
+  {
+    return checklist_period_;
+  }
+
+  void indication_period(const ACE_Time_Value& x)
+  {
+    indication_period_ = x;
+  }
+  ACE_Time_Value indication_period() const
+  {
+    return indication_period_;
+  }
+
+  void nominated_ttl(const ACE_Time_Value& x)
+  {
+    nominated_ttl_ = x;
+  }
+  ACE_Time_Value nominated_ttl() const
+  {
+    return nominated_ttl_;
+  }
+
+  void server_reflexive_address_period(const ACE_Time_Value& x)
+  {
+    server_reflexive_address_period_ = x;
+  }
+  ACE_Time_Value server_reflexive_address_period() const
+  {
+    return server_reflexive_address_period_;
+  }
+
+  void server_reflexive_indication_count(size_t x)
+  {
+    server_reflexive_indication_count_ = x;
+  }
+  size_t server_reflexive_indication_count() const
+  {
+    return server_reflexive_indication_count_;
+  }
+
+  void deferred_triggered_check_ttl(const ACE_Time_Value& x)
+  {
+    deferred_triggered_check_ttl_ = x;
+  }
+  ACE_Time_Value deferred_triggered_check_ttl() const
+  {
+    return deferred_triggered_check_ttl_;
+  }
+
+  void change_password_period(const ACE_Time_Value& x)
+  {
+    change_password_period_ = x;
+  }
+  ACE_Time_Value change_password_period() const
+  {
+    return change_password_period_;
+  }
+
+private:
+  // Mininum time between consecutive sends.
+  // RFC 8445 Section 14.2
+  ACE_Time_Value T_a_;
+  // Repeat a check for this long before failing it.
+  ACE_Time_Value connectivity_check_ttl_;
+  // Run all of the ordinary checks in a checklist in this amount of time.
+  ACE_Time_Value checklist_period_;
+  // Send an indication at this interval once an address is selected.
+  ACE_Time_Value indication_period_;
+  // The nominated pair will still be valid if an indication has been received within this amount of time.
+  ACE_Time_Value nominated_ttl_;
+  // Perform server-reflexive candidate gathering this often.
+  ACE_Time_Value server_reflexive_address_period_;
+  // Send this many binding indications to the STUN server before sending a binding request.
+  size_t server_reflexive_indication_count_;
+  // Lifetime of a deferred triggered check.
+  ACE_Time_Value deferred_triggered_check_ttl_;
+  // Change the password this often.
+  ACE_Time_Value change_password_period_;
+};
+
+class OpenDDS_Rtps_Export Agent {
+public:
+  virtual ~Agent() {}
+  virtual Configuration& get_configuration() = 0;
+  virtual void add_endpoint(Endpoint* a_endpoint) = 0;
+  virtual void remove_endpoint(Endpoint* a_endpoint) = 0;
+  virtual AgentInfo get_local_agent_info(Endpoint* a_endpoint) const = 0;
+  virtual void add_local_agent_info_listener(Endpoint* a_endpoint,
+                                             const DCPS::RepoId& a_local_guid,
+                                             AgentInfoListener* a_agent_info_listener) = 0;
+  virtual void remove_local_agent_info_listener(Endpoint* a_endpoint,
+                                                const DCPS::RepoId& a_local_guid) = 0;
+  virtual void start_ice(Endpoint* a_endpoint,
+                         const DCPS::RepoId& a_local_guid,
+                         const DCPS::RepoId& a_remote_guid,
+                         const AgentInfo& a_remote_agent_info) = 0;
+  virtual void stop_ice(Endpoint* a_endpoint,
+                        const DCPS::RepoId& a_local_guid,
+                        const DCPS::RepoId& a_remote_guid) = 0;
+  virtual ACE_INET_Addr get_address(Endpoint* a_endpoint,
+                                    const DCPS::RepoId& a_local_guid,
+                                    const DCPS::RepoId& a_remote_guid) const = 0;
+
+  // Receive a STUN message.
+  virtual void receive(Endpoint* a_endpoint,
+                       const ACE_INET_Addr& a_local_address,
+                       const ACE_INET_Addr& a_remote_address,
+                       const STUN::Message& a_message) = 0;
+
+  static Agent* instance();
+};
+
+std::ostream& operator<<(std::ostream& stream, const ACE_INET_Addr& address);
+std::ostream& operator<<(std::ostream& stream, const STUN::TransactionId& tid);
+std::ostream& operator<<(std::ostream& stream, const ICE::Candidate& candidate);
+std::ostream& operator<<(std::ostream& stream, const ICE::AgentInfo& agent_info);
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_H */

--- a/dds/DCPS/RTPS/ICE/Stun.cpp
+++ b/dds/DCPS/RTPS/ICE/Stun.cpp
@@ -1,0 +1,852 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Stun.h"
+
+#include "dds/DCPS/security/framework/SecurityRegistry.h"
+#include "dds/DCPS/security/framework/SecurityConfig.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace STUN {
+
+#if OPENDDS_SECURITY
+
+uint16_t Attribute::length() const
+{
+  switch (type) {
+  case MAPPED_ADDRESS:
+    // TODO(jrw972):  Handle IPv6.
+    return 8;
+
+  case USERNAME:
+    return username.size();
+
+  case MESSAGE_INTEGRITY:
+    return 20;
+
+  case ERROR_CODE:
+    return 4 + error.reason.size();
+
+  case UNKNOWN_ATTRIBUTES:
+    return 2 * unknown_attributes.size();
+
+  case XOR_MAPPED_ADDRESS:
+    // TODO(jrw972):  Handle IPv6.
+    return 8;
+
+  case PRIORITY:
+    return 4;
+
+  case USE_CANDIDATE:
+    return 0;
+
+  case FINGERPRINT:
+    return 4;
+
+  case ICE_CONTROLLED:
+  case ICE_CONTROLLING:
+    return 8;
+  }
+
+  return unknown_length;
+}
+
+Attribute make_mapped_address(const ACE_INET_Addr& addr)
+{
+  Attribute attribute;
+  attribute.type = MAPPED_ADDRESS;
+  // TODO(jrw972):  Handle IPv6.
+  attribute.mapped_address = addr;
+  return attribute;
+}
+
+Attribute make_username(const std::string& username)
+{
+  Attribute attribute;
+  attribute.type = USERNAME;
+  attribute.username = username;
+  return attribute;
+}
+
+Attribute make_message_integrity()
+{
+  Attribute attribute;
+  attribute.type = MESSAGE_INTEGRITY;
+  return attribute;
+}
+
+Attribute make_error_code(uint16_t code, const std::string& reason)
+{
+  Attribute attribute;
+  attribute.type = ERROR_CODE;
+  attribute.error.code = code;
+  attribute.error.reason = reason;
+  return attribute;
+}
+
+Attribute make_unknown_attributes(const std::vector<AttributeType>& unknown_attributes)
+{
+  Attribute attribute;
+  attribute.type = UNKNOWN_ATTRIBUTES;
+  attribute.unknown_attributes = unknown_attributes;
+  return attribute;
+}
+
+Attribute make_xor_mapped_address(const ACE_INET_Addr& addr)
+{
+  Attribute attribute;
+  attribute.type = XOR_MAPPED_ADDRESS;
+  // TODO(jrw972):  Handle IPv6.
+  attribute.mapped_address = addr;
+  return attribute;
+}
+
+Attribute make_priority(uint32_t priority)
+{
+  Attribute attribute;
+  attribute.type = PRIORITY;
+  attribute.priority = priority;
+  return attribute;
+}
+
+Attribute make_use_candidate()
+{
+  Attribute attribute;
+  attribute.type = USE_CANDIDATE;
+  return attribute;
+}
+
+Attribute make_fingerprint()
+{
+  Attribute attribute;
+  attribute.type = FINGERPRINT;
+  return attribute;
+}
+
+Attribute make_ice_controlling(ACE_UINT64 ice_tie_breaker)
+{
+  Attribute attribute;
+  attribute.type = ICE_CONTROLLING;
+  attribute.ice_tie_breaker = ice_tie_breaker;
+  return attribute;
+}
+
+Attribute make_ice_controlled(ACE_UINT64 ice_tie_breaker)
+{
+  Attribute attribute;
+  attribute.type = ICE_CONTROLLED;
+  attribute.ice_tie_breaker = ice_tie_breaker;
+  return attribute;
+}
+
+Attribute make_unknown_attribute(uint16_t type, uint16_t length)
+{
+  Attribute attribute;
+  attribute.type = static_cast<AttributeType>(type);
+  attribute.unknown_length = length;
+  return attribute;
+}
+
+bool operator>>(DCPS::Serializer& serializer, Attribute& attribute)
+{
+  uint16_t attribute_type;
+  uint16_t attribute_length;
+
+  if (!(serializer >> attribute_type)) {
+    return false;
+  }
+
+  if (!(serializer >> attribute_length)) {
+    return false;
+  }
+
+  switch (attribute_type) {
+  case MAPPED_ADDRESS: {
+    ACE_CDR::Char family;
+    uint16_t port;
+
+    if (!serializer.skip(1)) {
+      return false;
+    }
+
+    if (!(serializer >> family)) {
+      return false;
+    }
+
+    if (!(serializer >> port)) {
+      return false;
+    }
+
+    if (family == IPv4) {
+      if (attribute_length != 8) {
+        return false;
+      }
+
+      uint32_t address;
+
+      if (!(serializer >> address)) {
+        return false;
+      }
+
+      attribute = make_mapped_address(ACE_INET_Addr(port, address));
+    }
+
+    else if (family == IPv6) {
+      // TODO(jrw972):  Handle IPv6.
+    }
+  }
+  break;
+
+  case USERNAME: {
+    if (attribute_length > 512) {
+      return false;
+    }
+
+    unsigned char buffer[512];
+
+    if (!serializer.read_octet_array(buffer, attribute_length)) {
+      return false;
+    }
+
+    attribute = make_username(std::string(reinterpret_cast<char*>(buffer), attribute_length));
+  }
+  break;
+
+  case MESSAGE_INTEGRITY: {
+    attribute = make_message_integrity();
+
+    if (!serializer.read_octet_array(attribute.message_integrity, sizeof(attribute.message_integrity))) {
+      return false;
+    }
+  }
+  break;
+
+  case ERROR_CODE: {
+    uint32_t x;
+
+    if (!(serializer >> x)) {
+      return false;
+    }
+
+    uint32_t class_ = (x & (0x7 << 8)) >> 8;
+
+    if (class_ < 3 || class_ >= 7) {
+      return false;
+    }
+
+    uint32_t num = x & 0xFF;
+
+    if (num > 100) {
+      return false;
+    }
+
+    uint16_t code = class_ * 100 + num;
+
+    size_t reason_length = attribute_length - 4;
+
+    if (reason_length > 763) {
+      return false;
+    }
+
+    unsigned char buffer[763];
+
+    if (!serializer.read_octet_array(buffer, reason_length)) {
+      return false;
+    }
+
+    attribute = make_error_code(code, std::string(reinterpret_cast<char*>(buffer), reason_length));
+  }
+  break;
+
+  case UNKNOWN_ATTRIBUTES: {
+    std::vector<AttributeType> unknown_attributes;
+
+    for (size_t count = attribute_length / 2; count != 0; --count) {
+      uint16_t code;
+
+      if (!(serializer >> code)) {
+        return false;
+      }
+
+      unknown_attributes.push_back(static_cast<AttributeType>(code));
+    }
+
+    attribute = make_unknown_attributes(unknown_attributes);
+  }
+  break;
+
+  case XOR_MAPPED_ADDRESS: {
+    ACE_CDR::Char family;
+    uint16_t port;
+
+    if (!serializer.skip(1)) {
+      return false;
+    }
+
+    if (!(serializer >> family)) {
+      return false;
+    }
+
+    if (!(serializer >> port)) {
+      return false;
+    }
+
+    port ^= MAGIC_COOKIE >> 16;
+
+    if (family == IPv4) {
+      if (attribute_length != 8) {
+        return false;
+      }
+
+      uint32_t address;
+
+      if (!(serializer >> address)) {
+        return false;
+      }
+
+      address ^= MAGIC_COOKIE;
+      attribute = make_xor_mapped_address(ACE_INET_Addr(port, address));
+    }
+
+    else if (family == IPv6) {
+      // TODO(jrw972):  Handle IPv6.
+    }
+  }
+  break;
+
+  case PRIORITY: {
+    uint32_t priority;
+
+    if (!(serializer >> priority)) {
+      return false;
+    }
+
+    attribute = make_priority(priority);
+  }
+  break;
+
+  case USE_CANDIDATE:
+    attribute = make_use_candidate();
+    break;
+
+  case FINGERPRINT: {
+    attribute = make_fingerprint();
+
+    if (!(serializer >> attribute.fingerprint)) {
+      return false;
+    }
+  }
+  break;
+
+  case ICE_CONTROLLED: {
+    ACE_UINT64 ice_tie_breaker;
+
+    if (!(serializer >> ice_tie_breaker)) {
+      return false;
+    }
+
+    attribute = make_ice_controlled(ice_tie_breaker);
+  }
+  break;
+
+  case ICE_CONTROLLING: {
+    ACE_UINT64 ice_tie_breaker;
+
+    if (!(serializer >> ice_tie_breaker)) {
+      return false;
+    }
+
+    attribute = make_ice_controlling(ice_tie_breaker);
+  }
+  break;
+
+  default: {
+    if (!serializer.skip(attribute_length)) {
+      return false;
+    }
+
+    attribute = make_unknown_attribute(attribute_type, attribute_length);
+  }
+  break;
+  }
+
+  // All attributes are aligned on 32-bit boundaries.
+  if (!serializer.skip((4 - (attribute_length & 0x3)) % 4)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool operator<<(DCPS::Serializer& serializer, const Attribute& attribute)
+{
+  uint16_t attribute_type = attribute.type;
+  uint16_t attribute_length = attribute.length();
+  serializer << attribute_type;
+  serializer << attribute_length;
+
+  switch (attribute_type) {
+  case MAPPED_ADDRESS: {
+    serializer << static_cast<ACE_CDR::Char>(0);
+    serializer << static_cast<ACE_CDR::Char>(IPv4);
+    serializer << static_cast<uint16_t>(attribute.mapped_address.get_port_number());
+    serializer << attribute.mapped_address.get_ip_address();
+    // TODO(jrw972):  Handle IPv6.
+  }
+  break;
+
+  case USERNAME: {
+    serializer.write_octet_array(reinterpret_cast<const ACE_CDR::Octet*>(attribute.username.c_str()), attribute.username.size());
+  }
+  break;
+
+  case MESSAGE_INTEGRITY: {
+    serializer.write_octet_array(attribute.message_integrity, sizeof(attribute.message_integrity));
+  }
+  break;
+
+  case ERROR_CODE: {
+    uint8_t class_ = attribute.error.code / 100;
+    uint8_t num = attribute.error.code % 100;
+    serializer << static_cast<ACE_CDR::Char>(0);
+    serializer << static_cast<ACE_CDR::Char>(0);
+    serializer << static_cast<ACE_CDR::Char>(class_);
+    serializer << static_cast<ACE_CDR::Char>(num);
+    serializer.write_octet_array(reinterpret_cast<const ACE_CDR::Octet*>(attribute.error.reason.c_str()), attribute.error.reason.size());
+  }
+  break;
+
+  case UNKNOWN_ATTRIBUTES: {
+    for (std::vector<AttributeType>::const_iterator pos = attribute.unknown_attributes.begin(),
+         limit = attribute.unknown_attributes.end(); pos != limit; ++pos) {
+      serializer << static_cast<uint16_t>(*pos);
+    }
+  }
+  break;
+
+  case XOR_MAPPED_ADDRESS: {
+    serializer << static_cast<ACE_CDR::Char>(0);
+    serializer << static_cast<ACE_CDR::Char>(IPv4);
+    serializer << static_cast<uint16_t>(attribute.mapped_address.get_port_number() ^ (MAGIC_COOKIE >> 16));
+    serializer << (attribute.mapped_address.get_ip_address() ^ MAGIC_COOKIE);
+    // TODO(jrw972):  Handle IPv6.
+  }
+  break;
+
+  case PRIORITY: {
+    serializer << attribute.priority;
+  }
+  break;
+
+  case USE_CANDIDATE:
+    break;
+
+  case FINGERPRINT: {
+    serializer << attribute.fingerprint;
+  }
+  break;
+
+  case ICE_CONTROLLED:
+  case ICE_CONTROLLING: {
+    serializer << attribute.ice_tie_breaker;
+  }
+  break;
+
+  default:
+    // Don't serialize attributes that are not understood.
+    return false;
+    break;
+  }
+
+  // Align to 32 bits.
+  while (attribute_length % 4 != 0) {
+    serializer << static_cast<ACE_CDR::Char>(0);
+    attribute_length += 1;
+  }
+
+  return true;
+}
+
+bool TransactionId::operator<(const TransactionId& other) const
+{
+  return (memcmp(this->data, other.data, sizeof(data)) < 0);
+}
+
+bool TransactionId::operator==(const TransactionId& other) const
+{
+  return (memcmp(this->data, other.data, sizeof(data)) == 0);
+}
+
+bool TransactionId::operator!=(const TransactionId& other) const
+{
+  return (memcmp(this->data, other.data, sizeof(data)) != 0);
+}
+
+void Message::generate_transaction_id()
+{
+  TheSecurityRegistry->default_config()->get_utility()->generate_random_bytes(transaction_id.data, sizeof(transaction_id.data));
+}
+
+std::vector<AttributeType> Message::unknown_comprehension_required_attributes() const
+{
+  std::vector<AttributeType> retval;
+
+  for (const AttributesType::value_type& attribute : attributes_) {
+    switch (attribute.type) {
+    case MAPPED_ADDRESS:
+    case USERNAME:
+    case MESSAGE_INTEGRITY:
+    case ERROR_CODE:
+    case UNKNOWN_ATTRIBUTES:
+    case XOR_MAPPED_ADDRESS:
+    case PRIORITY:
+    case USE_CANDIDATE:
+      break;
+
+    default:
+      if (attribute.type < 0x8000) {
+        retval.push_back(attribute.type);
+      }
+    }
+  }
+
+  return retval;
+}
+
+bool Message::get_mapped_address(ACE_INET_Addr& address) const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::XOR_MAPPED_ADDRESS) {
+      address = pos->mapped_address;
+      return true;
+    }
+  }
+
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::MAPPED_ADDRESS) {
+      address = pos->mapped_address;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Message::get_priority(uint32_t& priority) const
+{
+  bool flag = false;
+
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::PRIORITY) {
+      flag = true;
+      priority = pos->priority;
+      // Use the last.
+    }
+  }
+
+  return flag;
+}
+
+bool Message::get_username(std::string& username) const
+{
+  bool flag = false;
+
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::USERNAME) {
+      flag = true;
+      username = pos->username;
+      // Use the last.
+    }
+  }
+
+  return flag;
+}
+
+bool Message::has_message_integrity() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::MESSAGE_INTEGRITY) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Message::verify_message_integrity(const std::string& password) const
+{
+  bool verified = false;
+
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::MESSAGE_INTEGRITY) {
+      unsigned char computed_message_integrity[20];
+      compute_message_integrity(password, computed_message_integrity);
+      verified = memcmp(computed_message_integrity, pos->message_integrity, 20) == 0;
+      // Use the last.
+    }
+  }
+
+  return verified;
+}
+
+void Message::compute_message_integrity(const std::string& password, unsigned char message_integrity[20]) const
+{
+  ACE_Message_Block* block = this->block->duplicate();
+  block->rd_ptr(block->base());
+  DCPS::Serializer serializer(block, true);
+
+  // Write the length and resize for hashing.
+  block->wr_ptr(block->base() + 2);
+  uint16_t message_length = length_for_message_integrity();
+  serializer << message_length;
+  block->wr_ptr(block->base() + 20 + length_for_message_integrity() - 24);
+
+  // Compute the SHA1.
+  TheSecurityRegistry->default_config()->get_utility()->hmac(message_integrity, block->rd_ptr(), block->length(), password);
+
+  // Write the correct length.
+  block->wr_ptr(block->base() + 2);
+  message_length = length();
+  serializer << message_length;
+
+  block->release();
+}
+
+bool Message::has_error_code() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::ERROR_CODE) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+uint16_t Message::get_error_code() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::ERROR_CODE) {
+      return pos->error.code;
+    }
+  }
+
+  return 0;
+}
+
+std::string Message::get_error_reason() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::ERROR_CODE) {
+      return pos->error.reason;
+    }
+  }
+
+  return std::string();
+}
+
+bool Message::has_unknown_attributes() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::UNKNOWN_ATTRIBUTES) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::vector<AttributeType> Message::get_unknown_attributes() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::UNKNOWN_ATTRIBUTES) {
+      return pos->unknown_attributes;
+    }
+  }
+
+  return std::vector<AttributeType>();
+}
+
+bool Message::has_fingerprint() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::FINGERPRINT) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+uint32_t Message::compute_fingerprint() const
+{
+  ACE_Message_Block* block = this->block->duplicate();
+  block->rd_ptr(block->base());
+  DCPS::Serializer serializer(block, true);
+
+  // Resize for hashing.
+  block->wr_ptr(block->base() + 20 + length() - 8);
+
+  // Compute the CRC-32
+  uint32_t crc = ACE::crc32(block->rd_ptr(), block->length());
+
+  block->release();
+
+  return crc ^ 0x5354554E;
+}
+
+bool Message::has_ice_controlled() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::ICE_CONTROLLED) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Message::has_ice_controlling() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::ICE_CONTROLLING) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Message::has_use_candidate() const
+{
+  for (STUN::Message::const_iterator pos = begin(), limit = end(); pos != limit; ++pos) {
+    if (pos->type == STUN::USE_CANDIDATE) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool operator>>(DCPS::Serializer& serializer, Message& message)
+{
+  uint16_t message_type;
+  uint16_t message_length;
+  uint32_t magic_cookie;
+
+  if (!(serializer >> message_type)) {
+    return false;
+  }
+
+  if (!(serializer >> message_length)) {
+    return false;
+  }
+
+  if ((message_type & 0xC000) != 0) {
+    return false;
+  }
+
+  if (message_length % 4 != 0) {
+    return false;
+  }
+
+  message.class_ = static_cast<Class>(((message_type & (1 << 8)) >> 7) | ((message_type & (1 << 4)) >> 4));
+  message.method = static_cast<Method>(((message_type & 0x3E00) >> 2) | ((message_type & 0xE0) >> 1) | (message_type & 0xF));
+
+  if (!(serializer >> magic_cookie)) {
+    return false;
+  }
+
+  if (magic_cookie != MAGIC_COOKIE) {
+    return false;
+  }
+
+  if (!serializer.read_octet_array(message.transaction_id.data, 12)) {
+    return false;
+  }
+
+  // At this point there should be message.length bytes remaining.
+  if (serializer.length() != message_length) {
+    return false;
+  }
+
+  while (serializer.length() != 0) {
+    bool have_integrity = false;
+    bool have_fingerprint = false;
+
+    Attribute attribute;
+
+    if (!(serializer >> attribute)) {
+      return false;
+    }
+
+    message.append_attribute(attribute);
+
+    if ((have_integrity && attribute.type != FINGERPRINT) || have_fingerprint) {
+      return false;
+    }
+
+    if (attribute.type == FINGERPRINT && attribute.fingerprint != message.compute_fingerprint()) {
+      return false;
+    }
+
+    if (message.length() > message_length) {
+      return false;
+    }
+
+    have_integrity = have_integrity || attribute.type == MESSAGE_INTEGRITY;
+    have_fingerprint = have_fingerprint || attribute.type == FINGERPRINT;
+  }
+
+  return true;
+}
+
+bool operator<<(DCPS::Serializer& serializer, const Message& message)
+{
+  uint16_t message_class = message.class_;
+  uint16_t message_method = message.method;
+  uint16_t message_type =
+    ((message_method & 0xF80) << 2) |
+    ((message_class & 0x2) << 7) |
+    ((message_method & 0x0070) << 1) |
+    ((message_class & 0x1) << 4) |
+    (message_method & 0x000F);
+  serializer << message_type;
+
+  uint16_t message_length = message.length();
+  serializer << message_length;
+  serializer << MAGIC_COOKIE;
+  serializer.write_octet_array(message.transaction_id.data, sizeof(message.transaction_id.data));
+
+  for (Message::const_iterator pos = message.begin(), limit = message.end();
+       pos != limit; ++pos) {
+    const Attribute& attribute = *pos;
+
+    if (attribute.type == MESSAGE_INTEGRITY) {
+      // Compute the hash.
+      message.compute_message_integrity(message.password, const_cast<Attribute&>(attribute).message_integrity);
+    }
+
+    else if (attribute.type == FINGERPRINT) {
+      // Compute the hash.
+      const_cast<Attribute&>(attribute).fingerprint = message.compute_fingerprint();
+    }
+
+    serializer << attribute;
+  }
+
+  return true;
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace STUN
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/ICE/Stun.h
+++ b/dds/DCPS/RTPS/ICE/Stun.h
@@ -1,0 +1,208 @@
+
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_STUN_H
+#define OPENDDS_RTPS_STUN_H
+
+#include <map>
+
+#include "ace/INET_Addr.h"
+#include "dds/DCPS/Serializer.h"
+
+#include "dds/DCPS/RTPS/rtps_export.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace STUN {
+namespace DCPS = OpenDDS::DCPS;
+
+enum Class {
+  REQUEST          = 0,
+  INDICATION       = 1,
+  SUCCESS_RESPONSE = 2,
+  ERROR_RESPONSE   = 3
+};
+
+enum Method {
+  BINDING = 0x001
+};
+
+enum Family {
+  IPv4 = 0x01,
+  IPv6 = 0x02
+};
+
+const uint32_t MAGIC_COOKIE = 0x2112A442;
+
+enum AttributeType {
+  MAPPED_ADDRESS     = 0x0001,
+  USERNAME           = 0x0006,
+  MESSAGE_INTEGRITY  = 0x0008,
+  ERROR_CODE         = 0x0009,
+  UNKNOWN_ATTRIBUTES = 0x000A,
+  // REALM              = 0x0014,
+  // NONCE              = 0x0015,
+  XOR_MAPPED_ADDRESS = 0x0020,
+  PRIORITY           = 0x0024,
+  USE_CANDIDATE      = 0x0025,
+
+  // SOFTWARE           = 0x8022,
+  // ALTERNATE_SERVER   = 0x8023,
+  FINGERPRINT        = 0x8028,
+  ICE_CONTROLLED     = 0x8029,
+  ICE_CONTROLLING    = 0x802A
+};
+
+struct Attribute {
+  AttributeType type;
+
+  ACE_INET_Addr mapped_address; // MAPPED_ADDRESS, XOR_MAPPED_ADDRESS
+  std::string username; // USERNAME
+  union {
+    unsigned char message_integrity[20]; // MESSAGE_INTEGRITY
+    uint32_t fingerprint; // FINGERPRINT
+    uint32_t priority; // PRIORITY
+    ACE_UINT64 ice_tie_breaker; // ICE_CONTROLLED, ICE_CONTROLLING
+  };
+  struct {
+    uint16_t code;
+    std::string reason;
+  } error;
+  std::vector<AttributeType> unknown_attributes;
+
+  uint16_t unknown_length;
+
+  uint16_t length() const;
+};
+
+Attribute make_mapped_address(const ACE_INET_Addr& addr);
+Attribute make_username(const std::string& username);
+Attribute make_message_integrity();
+Attribute make_error_code(uint16_t code, const std::string& reason);
+Attribute make_unknown_attributes(const std::vector<AttributeType>& unknown_attributes);
+Attribute make_xor_mapped_address(const ACE_INET_Addr& addr);
+Attribute make_unknown_attribute(uint16_t type, uint16_t length);
+Attribute make_priority(uint32_t priority);
+Attribute make_use_candidate();;
+
+Attribute make_fingerprint();
+Attribute make_ice_controlling(ACE_UINT64 ice_tie_breaker);
+Attribute make_ice_controlled(ACE_UINT64 ice_tie_breaker);
+
+bool operator>>(DCPS::Serializer& serializer, Attribute& attribute);
+bool operator<<(DCPS::Serializer& serializer, const Attribute& attribute);
+
+struct TransactionId {
+  uint8_t data[12];
+  bool operator<(const TransactionId& other) const;
+  bool operator==(const TransactionId& other) const;
+  bool operator!=(const TransactionId& other) const;
+};
+
+struct Message {
+  typedef std::vector<Attribute> AttributesType;
+  typedef AttributesType::const_iterator const_iterator;
+
+  Class class_;
+  Method method;
+  TransactionId transaction_id;
+
+  Message()
+  : block(0), length_(0), length_for_message_integrity_(0) {}
+
+  void generate_transaction_id();
+
+  void append_attribute(const Attribute& attribute)
+  {
+    attributes_.push_back(attribute);
+    length_ += (4 + attribute.length() + 3) & ~3;
+
+    if (attribute.type == MESSAGE_INTEGRITY) {
+      length_for_message_integrity_ = length_;
+    }
+  }
+
+  const_iterator begin() const
+  {
+    return attributes_.begin();
+  }
+  const_iterator end() const
+  {
+    return attributes_.end();
+  }
+  uint16_t length() const
+  {
+    return length_;
+  }
+  uint16_t length_for_message_integrity() const
+  {
+    return length_for_message_integrity_;
+  }
+
+  std::vector<AttributeType> unknown_comprehension_required_attributes() const;
+  bool get_mapped_address(ACE_INET_Addr& address) const;
+  bool get_priority(uint32_t& priority) const;
+  bool get_username(std::string& username) const;
+  bool has_message_integrity() const;
+  bool verify_message_integrity(const std::string& password) const;
+  void compute_message_integrity(const std::string& password, unsigned char message_integrity[20]) const;
+  bool has_error_code() const;
+  uint16_t get_error_code() const;
+  std::string get_error_reason() const;
+  bool has_unknown_attributes() const;
+  std::vector<AttributeType> get_unknown_attributes() const;
+  bool has_fingerprint() const;
+  uint32_t compute_fingerprint() const;
+  bool has_ice_controlled() const;
+  bool has_ice_controlling() const;
+  bool has_use_candidate() const;
+
+  ACE_Message_Block* block;
+  std::string password; // For integrity hashing.
+
+private:
+  AttributesType attributes_;
+  uint16_t length_;
+  uint16_t length_for_message_integrity_;
+};
+
+OpenDDS_Rtps_Export bool operator>>(DCPS::Serializer& serializer, Message& message);
+OpenDDS_Rtps_Export bool operator<<(DCPS::Serializer& serializer, const Message& message);
+
+class Sender {
+public:
+  virtual void send(const ACE_INET_Addr& address, const Message& message) = 0;
+  virtual ~Sender() {}
+};
+
+class OpenDDS_Rtps_Export Participant {
+public:
+  Participant(Sender* a_sender) : sender_(a_sender) {}
+
+  void receive(const ACE_INET_Addr& address, const Message& message);
+
+private:
+  Sender* sender_;
+
+  void request(const ACE_INET_Addr& address, const Message& message);
+  void indication(const ACE_INET_Addr& /*address*/, const Message& message);
+  void success_response(const ACE_INET_Addr& /*address*/, const Message& /*message*/);
+  void error_response(const ACE_INET_Addr& /*address*/, const Message& /*message*/);
+};
+
+} // namespace STUN
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_STUN_H */

--- a/dds/DCPS/RTPS/ICE/Task.cpp
+++ b/dds/DCPS/RTPS/ICE/Task.cpp
@@ -1,0 +1,30 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Task.h"
+
+#include "AgentImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+#if OPENDDS_SECURITY
+
+void Task::enqueue(const ACE_Time_Value& a_release_time)
+{
+  release_time_ = a_release_time;
+  agent_impl_->enqueue(this);
+}
+
+#endif /* OPENDDS_SECURITY */
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/ICE/Task.h
+++ b/dds/DCPS/RTPS/ICE/Task.h
@@ -1,0 +1,42 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_RTPS_ICE_TASK_H
+#define OPENDDS_RTPS_ICE_TASK_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "dds/Versioned_Namespace.h"
+#include <ace/Time_Value.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace ICE {
+
+class AgentImpl;
+
+struct Task {
+  Task(AgentImpl* a_agent_impl) : agent_impl_(a_agent_impl), in_queue_(false) {}
+  virtual ~Task() {};
+  virtual void execute(const ACE_Time_Value& a_now) = 0;
+  void enqueue(const ACE_Time_Value& release_time);
+private:
+  friend class AgentImpl;
+  AgentImpl* agent_impl_;
+  ACE_Time_Value release_time_;
+  bool in_queue_;
+};
+
+} // namespace ICE
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_RTPS_ICE_TASK_H */

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1507,7 +1507,7 @@ int from_param_list(const ParameterList& param_list,
   return 0;
 }
 
-int to_param_list(const DiscoveredWriterData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map)
 {
@@ -1520,7 +1520,7 @@ int to_param_list(const DiscoveredWriterData_SecurityWrapper& wrapper,
 }
 
 int from_param_list(const ParameterList& param_list,
-                    DiscoveredWriterData_SecurityWrapper& wrapper)
+                    DiscoveredPublication_SecurityWrapper& wrapper)
 {
   int result = from_param_list(param_list, wrapper.data) ||
                from_param_list(param_list, wrapper.security_info) ||
@@ -1529,7 +1529,7 @@ int from_param_list(const ParameterList& param_list,
   return result;
 }
 
-int to_param_list(const DiscoveredReaderData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map)
 {
@@ -1542,7 +1542,7 @@ int to_param_list(const DiscoveredReaderData_SecurityWrapper& wrapper,
 }
 
 int from_param_list(const ParameterList& param_list,
-                    DiscoveredReaderData_SecurityWrapper& wrapper)
+                    DiscoveredSubscription_SecurityWrapper& wrapper)
 {
   int result = from_param_list(param_list, wrapper.data) ||
                from_param_list(param_list, wrapper.security_info) ||
@@ -1551,6 +1551,77 @@ int from_param_list(const ParameterList& param_list,
   return result;
 }
 #endif
+
+int to_param_list(const ICE::AgentInfo& agent_info,
+                  ParameterList& param_list)
+{
+  IceGeneral_t ice_general;
+  ice_general.agent_type = agent_info.type;
+  ice_general.username = agent_info.username.c_str();
+  ice_general.password = agent_info.password.c_str();
+
+  Parameter param_general;
+  param_general.ice_general(ice_general);
+  add_param(param_list, param_general);
+
+  for (ICE::AgentInfo::CandidatesType::const_iterator pos = agent_info.candidates.begin(),
+         limit = agent_info.candidates.end(); pos != limit; ++pos) {
+    IceCandidate_t ice_candidate;
+    ice_candidate.locator.kind = LOCATOR_KIND_UDPv4;
+    const sockaddr_in* in = static_cast<const sockaddr_in*>(pos->address.get_addr());
+    std::memset(&ice_candidate.locator.address[0], 0, 12);
+    std::memcpy(&ice_candidate.locator.address[12], &in->sin_addr, 4);
+    ice_candidate.locator.port = pos->address.get_port_number();
+    ice_candidate.foundation = pos->foundation.c_str();
+    ice_candidate.priority = pos->priority;
+    ice_candidate.type = pos->type;
+
+    Parameter param;
+    param.ice_candidate(ice_candidate);
+    add_param(param_list, param);
+  }
+
+  return 0;
+}
+
+int from_param_list(const ParameterList& param_list,
+                    ICE::AgentInfo& agent_info,
+                    bool& have_agent_info)
+{
+  have_agent_info = false;
+  for (size_t idx = 0, count = param_list.length(); idx != count; ++idx) {
+    const Parameter& parameter = param_list[idx];
+    switch (parameter._d()) {
+    case PID_OPENDDS_ICE_GENERAL: {
+      have_agent_info = true;
+      const IceGeneral_t& ice_general = parameter.ice_general();
+      agent_info.type = static_cast<ICE::AgentType>(ice_general.agent_type);
+      agent_info.username = ice_general.username;
+      agent_info.password = ice_general.password;
+      break;
+    }
+    case PID_OPENDDS_ICE_CANDIDATE: {
+      have_agent_info = true;
+      const IceCandidate_t& ice_candidate = parameter.ice_candidate();
+      ICE::Candidate candidate;
+      candidate.address.set_type(AF_INET);
+      if (candidate.address.set_address(reinterpret_cast<const char*>(parameter.locator().address) + 12, 4, 0 /*network order*/) != 0) {
+        return -1;
+      }
+      candidate.address.set_port_number(parameter.locator().port);
+      candidate.foundation = ice_candidate.foundation;
+      candidate.priority = ice_candidate.priority;
+      candidate.type = static_cast<ICE::CandidateType>(ice_candidate.type);
+      agent_info.candidates.push_back(candidate);
+      break;
+    }
+    default:
+      // Do nothing.
+      break;
+    }
+  }
+  return 0;
+}
 
 } // ParameterListConverter
 } // RTPS

--- a/dds/DCPS/RTPS/ParameterListConverter.h
+++ b/dds/DCPS/RTPS/ParameterListConverter.h
@@ -10,6 +10,8 @@
 #include "dds/DCPS/RTPS/rtps_export.h"
 #include "dds/DCPS/RTPS/RtpsCoreC.h"
 
+#include "dds/DCPS/RTPS/ICE/Ice.h"
+
 #ifdef OPENDDS_SECURITY
 #include "dds/DCPS/RTPS/RtpsSecurityC.h"
 #endif
@@ -20,8 +22,8 @@ namespace OpenDDS {
 namespace RTPS {
 
 #ifdef OPENDDS_SECURITY
-struct DiscoveredWriterData_SecurityWrapper;
-struct DiscoveredReaderData_SecurityWrapper;
+struct DiscoveredPublication_SecurityWrapper;
+struct DiscoveredSubscription_SecurityWrapper;
 #endif
 
 namespace ParameterListConverter {
@@ -120,7 +122,7 @@ int to_param_list(const DCPS::DiscoveredReaderData& reader_data,
 
 OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
-                   DCPS::DiscoveredReaderData& reader_data);
+                    DCPS::DiscoveredReaderData& reader_data);
 
 #ifdef OPENDDS_SECURITY
 // DDS::Security::EndpointSecurityInfo
@@ -143,28 +145,40 @@ OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
                     DDS::Security::DataTags& tags);
 
-// DiscoveredWriterData_SecurityWrapper
+// DiscoveredPublication_SecurityWrapper
 
 OpenDDS_Rtps_Export
-int to_param_list(const DiscoveredWriterData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
-                   DiscoveredWriterData_SecurityWrapper& wrapper);
+                    DiscoveredPublication_SecurityWrapper& wrapper);
 
-// DiscoveredReaderData_SecurityWrapper
+// DiscoveredSubscription_SecurityWrapper
 
 OpenDDS_Rtps_Export
-int to_param_list(const DiscoveredReaderData_SecurityWrapper& wrapper,
+int to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
                   ParameterList& param_list,
                   bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
 int from_param_list(const ParameterList& param_list,
-                   DiscoveredReaderData_SecurityWrapper& wrapper);
+                    DiscoveredSubscription_SecurityWrapper& wrapper);
 #endif
+
+
+// Extensions for ICE
+
+OpenDDS_Rtps_Export
+int to_param_list(const ICE::AgentInfo& agent_info,
+                  ParameterList& param_list);
+
+OpenDDS_Rtps_Export
+int from_param_list(const ParameterList& param_list,
+                    ICE::AgentInfo& agent_info,
+                    bool& have_agent_info);
 
 }
 }

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -19,6 +19,7 @@ module OpenDDS {
 
     typedef octet OctetArray2[2];
     typedef octet OctetArray4[4];
+    typedef octet OctetArray16[16];
 
     /* A list of filters that were applied to the sample.
        See section 9.6.3.1 for the signature-generation algorithm. */
@@ -156,6 +157,29 @@ module OpenDDS {
     };
     // see VENDORID_* constants in BaseMessageTypes.h
 
+    typedef unsigned long IceAgentType_t;
+    const IceAgentType_t ICE_FULL = 0x0;
+    const IceAgentType_t ICE_LITE = 0x1;
+
+    struct IceGeneral_t {
+      IceAgentType_t agent_type;
+      string username;
+      string password;
+    };
+
+    typedef unsigned long IceCandidateType_t;
+    const IceCandidateType_t ICE_HOST = 0x0;
+    const IceCandidateType_t ICE_SERVER_REFLEXIVE = 0x1;
+    const IceCandidateType_t ICE_PEER_REFLEXIVE = 0x2;
+    const IceCandidateType_t ICE_RELAYED = 0x3;
+
+    struct IceCandidate_t {
+      DCPS::Locator_t locator;
+      string foundation;
+      unsigned long priority;
+      IceCandidateType_t type;
+    };
+
     typedef unsigned long BuiltinEndpointSet_t;
     const BuiltinEndpointSet_t DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER =
       1 << 0;
@@ -272,6 +296,8 @@ module OpenDDS {
     const ParameterId_t PID_OPENDDS_BASE = PIDMASK_VENDOR_SPECIFIC + 0x3000;
     const ParameterId_t PID_OPENDDS_LOCATOR           = PID_OPENDDS_BASE + 1;
     const ParameterId_t PID_OPENDDS_ASSOCIATED_WRITER = PID_OPENDDS_BASE + 2;
+    const ParameterId_t PID_OPENDDS_ICE_GENERAL       = PID_OPENDDS_BASE + 3;
+    const ParameterId_t PID_OPENDDS_ICE_CANDIDATE     = PID_OPENDDS_BASE + 4;
 
 
     /* Always used inside a ParameterList */
@@ -430,6 +456,12 @@ module OpenDDS {
       case DDS::Security::PID_IDENTITY_STATUS_TOKEN:
         DDS::Security::IdentityStatusToken identity_status_token;
 #endif
+
+      case PID_OPENDDS_ICE_GENERAL:
+        IceGeneral_t ice_general;
+
+      case PID_OPENDDS_ICE_CANDIDATE:
+        IceCandidate_t ice_candidate;
 
       default:
         DDS::OctetSeq unknown_data;

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -50,7 +50,11 @@ RtpsDiscovery::RtpsDiscovery(const RepoKey& key)
   , dx_(2)
   , ttl_(1)
   , sedp_multicast_(true)
-  , default_multicast_group_("239.255.0.1")
+  , default_multicast_group_("239.255.0.1") /*RTPS v2.1 9.6.1.4.1*/
+  , use_ice_(false)
+  , max_spdp_timer_period_(0, 10000)
+  , max_auth_time_(300, 0)
+  , auth_resend_period_(1, 0)
 {
 }
 
@@ -93,22 +97,11 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
          it != keys.end(); ++it) {
       const OPENDDS_STRING& rtps_name = it->first;
 
-      int resend = 0;
-      u_short pb = 0, dg = 0, pg = 0, d0 = 0, d1 = 0, dx = 0;
-      unsigned char ttl = 0;
-      AddrVec spdp_send_addrs;
-      OPENDDS_STRING default_multicast_group = "239.255.0.1" /*RTPS v2.1 9.6.1.4.1*/;
-      OPENDDS_STRING mi, sla, gi;
-      OPENDDS_STRING spdpaddr;
-      ACE_INET_Addr spdp_rtps_relay_address;
-      ACE_INET_Addr sedp_rtps_relay_address;
-      bool has_resend = false, has_pb = false, has_dg = false, has_pg = false,
-        has_d0 = false, has_d1 = false, has_dx = false, has_sm = false,
-        has_ttl = false, sm = false;
+      RtpsDiscovery_rch discovery = OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name);
 
       // spdpaddr defaults to DCPSDefaultAddress if set
       if (!TheServiceParticipant->default_address().empty()) {
-        spdpaddr = TheServiceParticipant->default_address().c_str();
+        discovery->spdp_local_address(TheServiceParticipant->default_address().c_str());
       }
 
       DCPS::ValueMap values;
@@ -118,110 +111,116 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
         const OPENDDS_STRING& name = it->first;
         if (name == "ResendPeriod") {
           const OPENDDS_STRING& value = it->second;
-          has_resend = DCPS::convertToInteger(value, resend);
-          if (!has_resend) {
+          int resend;
+          if (!DCPS::convertToInteger(value, resend)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for ResendPeriod in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->resend_period(ACE_Time_Value(resend));
         } else if (name == "PB") {
           const OPENDDS_STRING& value = it->second;
-          has_pb = DCPS::convertToInteger(value, pb);
-          if (!has_pb) {
+          u_short pb;
+          if (!DCPS::convertToInteger(value, pb)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for PB in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->pb(pb);
         } else if (name == "DG") {
           const OPENDDS_STRING& value = it->second;
-          has_dg = DCPS::convertToInteger(value, dg);
-          if (!has_dg) {
+          u_short dg;
+          if (!DCPS::convertToInteger(value, dg)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for DG in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->dg(dg);
         } else if (name == "PG") {
           const OPENDDS_STRING& value = it->second;
-          has_pg = DCPS::convertToInteger(value, pg);
-          if (!has_pg) {
+          u_short pg;
+          if (!DCPS::convertToInteger(value, pg)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for PG in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->pg(pg);
         } else if (name == "D0") {
           const OPENDDS_STRING& value = it->second;
-          has_d0 = DCPS::convertToInteger(value, d0);
-          if (!has_d0) {
+          u_short d0;
+          if (!DCPS::convertToInteger(value, d0)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for D0 in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->d0(d0);
         } else if (name == "D1") {
           const OPENDDS_STRING& value = it->second;
-          has_d1 = DCPS::convertToInteger(value, d1);
-          if (!has_d1) {
+          u_short d1;
+          if (!DCPS::convertToInteger(value, d1)) {
             ACE_ERROR_RETURN((LM_ERROR,
               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
               ACE_TEXT("Invalid entry (%C) for D1 in ")
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->d1(d1);
         } else if (name == "DX") {
           const OPENDDS_STRING& value = it->second;
-          has_dx = DCPS::convertToInteger(value, dx);
-          if (!has_dx) {
+          u_short dx;
+          if (!DCPS::convertToInteger(value, dx)) {
             ACE_ERROR_RETURN((LM_ERROR,
                ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
                ACE_TEXT("Invalid entry (%C) for DX in ")
                ACE_TEXT("[rtps_discovery/%C] section.\n"),
                value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->dx(dx);
         } else if (name == "TTL") {
           const OPENDDS_STRING& value = it->second;
           unsigned short ttl_us;
-          has_ttl = DCPS::convertToInteger(value, ttl_us);
-          ttl = static_cast<unsigned char>(ttl_us);
-          if (!has_ttl || ttl_us > UCHAR_MAX) {
+          if (!DCPS::convertToInteger(value, ttl_us) || ttl_us > UCHAR_MAX) {
             ACE_ERROR_RETURN((LM_ERROR,
                ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
                ACE_TEXT("Invalid entry (%C) for TTL in ")
                ACE_TEXT("[rtps_discovery/%C] section.\n"),
                value.c_str(), rtps_name.c_str()), -1);
           }
+          discovery->ttl(static_cast<unsigned char>(ttl_us));
         } else if (name == "SedpMulticast") {
           const OPENDDS_STRING& value = it->second;
           int smInt;
-          has_sm = DCPS::convertToInteger(value, smInt);
-          if (!has_sm) {
+          if (!DCPS::convertToInteger(value, smInt)) {
             ACE_ERROR_RETURN((LM_ERROR,
                ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config ")
                ACE_TEXT("Invalid entry (%C) for SedpMulticast in ")
                ACE_TEXT("[rtps_discovery/%C] section.\n"),
                value.c_str(), rtps_name.c_str()), -1);
           }
-          sm = bool(smInt);
+          discovery->sedp_multicast(bool(smInt));
         } else if (name == "MulticastInterface") {
-          mi = it->second;
+          discovery->multicast_interface(it->second);
         } else if (name == "SedpLocalAddress") {
-          sla = it->second;
+          discovery->sedp_local_address(it->second);
         } else if (name == "SpdpLocalAddress") {
-          spdpaddr = it->second;
+          discovery->spdp_local_address(it->second);
         } else if (name == "GuidInterface") {
-          gi = it->second;
+          discovery->guid_interface(it->second);
         } else if (name == "InteropMulticastOverride") {
           /// FUTURE: handle > 1 group.
-          default_multicast_group = it->second;
+          discovery->default_multicast_group(it->second);
         } else if (name == "SpdpSendAddrs") {
+          AddrVec spdp_send_addrs;
           const OPENDDS_STRING& value = it->second;
           size_t i = 0;
           do {
@@ -230,11 +229,182 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
             spdp_send_addrs.push_back(value.substr(i, (n == OPENDDS_STRING::npos) ? n : n - i));
             i = value.find(',', i);
           } while (i++ != OPENDDS_STRING::npos); // skip past comma if there is one
+          discovery->spdp_send_addrs().swap(spdp_send_addrs);
         } else if (name == "SpdpRtpsRelayAddress") {
-          spdp_rtps_relay_address = ACE_INET_Addr(it->second.c_str());
+          discovery->spdp_rtps_relay_address(ACE_INET_Addr(it->second.c_str()));
         } else if (name == "SedpRtpsRelayAddress") {
-          sedp_rtps_relay_address = ACE_INET_Addr(it->second.c_str());
-        } else {
+          discovery->sedp_rtps_relay_address(ACE_INET_Addr(it->second.c_str()));
+#if OPENDDS_SECURITY
+        } else if (name == "SedpStunServerAddress") {
+          discovery->sedp_stun_server_address(ACE_INET_Addr(it->second.c_str()));
+        } else if (name == "UseIce") {
+          const OPENDDS_STRING& value = it->second;
+          int smInt;
+          if (!DCPS::convertToInteger(value, smInt)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config ")
+                              ACE_TEXT("Invalid entry (%C) for UseIce in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              value.c_str(), rtps_name.c_str()), -1);
+          }
+          discovery->use_ice(bool(smInt));
+        } else if (name == "IceTa") {
+          // In milliseconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().T_a(ACE_Time_Value(0, int_value * 1000));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceTa in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceConnectivityCheckTTL") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().connectivity_check_ttl(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceConnectivityCheckTTL in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceChecklistPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().checklist_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceChecklistPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceIndicationPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().indication_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceIndicationPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceNominatedTTL") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().nominated_ttl(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceNominatedTTL in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceServerReflexiveAddressPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().server_reflexive_address_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceServerReflexiveAddressPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceServerReflexiveIndicationCount") {
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().server_reflexive_indication_count(int_value);
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceServerReflexiveIndicationCount in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceDeferredTriggeredCheckTTL") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().deferred_triggered_check_ttl(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceDeferredTriggeredCheckTTL in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "IceChangePasswordPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            ICE::Agent::instance()->get_configuration().change_password_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for IceChangePasswordPeriod in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "MaxAuthTime") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            discovery->max_auth_time(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("Invalid entry (%C) for MaxAuthTime in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        } else if (name == "AuthResendPeriod") {
+          // In seconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            discovery->auth_resend_period(ACE_Time_Value(int_value));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("Invalid entry (%C) for AuthResendPeriod in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              string_value.c_str(), rtps_name.c_str()), -1);
+          }
+#endif /* OPENDDS_SECURITY */
+        } else if (name == "MaxSpdpTimerPeriod") {
+          // In milliseconds.
+          const OPENDDS_STRING& string_value = it->second;
+          int int_value;
+          if (DCPS::convertToInteger(string_value, int_value)) {
+            discovery->max_spdp_timer_period(ACE_Time_Value(0, int_value * 1000));
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("Invalid entry (%C) for MaxSpdpTimerPeriod in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              string_value.c_str(), rtps_name.c_str()), -1);
+          }
+        }  else {
           ACE_ERROR_RETURN((LM_ERROR,
                             ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
                             ACE_TEXT("Unexpected entry (%C) in [rtps_discovery/%C] section.\n"),
@@ -243,24 +413,6 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
         }
       }
 
-      RtpsDiscovery_rch discovery (OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name));
-      if (has_resend) discovery->resend_period(ACE_Time_Value(resend));
-      if (has_pb) discovery->pb(pb);
-      if (has_dg) discovery->dg(dg);
-      if (has_pg) discovery->pg(pg);
-      if (has_d0) discovery->d0(d0);
-      if (has_d1) discovery->d1(d1);
-      if (has_dx) discovery->dx(dx);
-      if (has_ttl) discovery->ttl(ttl);
-      if (has_sm) discovery->sedp_multicast(sm);
-      discovery->multicast_interface(mi);
-      discovery->default_multicast_group(default_multicast_group);
-      discovery->spdp_send_addrs().swap(spdp_send_addrs);
-      discovery->spdp_rtps_relay_address(spdp_rtps_relay_address);
-      discovery->sedp_rtps_relay_address(sedp_rtps_relay_address);
-      discovery->sedp_local_address(sla);
-      discovery->guid_interface(gi);
-      discovery->spdp_local_address(spdpaddr);
       TheServiceParticipant->add_discovery(discovery);
     }
   }

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -151,6 +151,25 @@ public:
     sedp_rtps_relay_address_ = address;
   }
 
+  const ACE_INET_Addr& sedp_stun_server_address() const { return sedp_stun_server_address_; }
+  void sedp_stun_server_address(const ACE_INET_Addr& address) {
+    sedp_stun_server_address_ = address;
+  }
+
+  bool use_ice() const { return use_ice_; }
+  void use_ice(bool ui) {
+    use_ice_ = ui;
+  }
+
+  const ACE_Time_Value& max_spdp_timer_period() const { return max_spdp_timer_period_; }
+  void max_spdp_timer_period(const ACE_Time_Value& x) { max_spdp_timer_period_ = x; }
+
+  const ACE_Time_Value& max_auth_time() const { return max_auth_time_; }
+  void max_auth_time(const ACE_Time_Value& x) { max_auth_time_ = x; }
+
+  const ACE_Time_Value& auth_resend_period() const { return auth_resend_period_; }
+  void auth_resend_period(const ACE_Time_Value& x) { auth_resend_period_ = x; }
+
 private:
   ACE_Time_Value resend_period_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
@@ -162,6 +181,12 @@ private:
   AddrVec spdp_send_addrs_;
   ACE_INET_Addr spdp_rtps_relay_address_;
   ACE_INET_Addr sedp_rtps_relay_address_;
+  ACE_INET_Addr sedp_stun_server_address_;
+  bool use_ice_;
+  ACE_Time_Value max_spdp_timer_period_;
+  ACE_Time_Value max_auth_time_;
+  ACE_Time_Value auth_resend_period_;
+
 
   /// Guids will be unique within this RTPS configuration
   GuidGenerator guid_gen_;

--- a/dds/DCPS/RTPS/SecurityHelpers.h
+++ b/dds/DCPS/RTPS/SecurityHelpers.h
@@ -103,16 +103,26 @@ handle_to_octets(DDS::Security::NativeCryptoHandle handle)
   return handleOctets;
 }
 
-struct DiscoveredWriterData_SecurityWrapper {
+struct DiscoveredPublication_SecurityWrapper {
   DCPS::DiscoveredWriterData data;
   DDS::Security::EndpointSecurityInfo security_info;
   DDS::Security::DataTags data_tags;
+  bool have_ice_agent_info;
+  ICE::AgentInfo ice_agent_info;
+
+  DiscoveredPublication_SecurityWrapper()
+    : have_ice_agent_info(false) {}
 };
 
-struct DiscoveredReaderData_SecurityWrapper {
+struct DiscoveredSubscription_SecurityWrapper {
   DCPS::DiscoveredReaderData data;
   DDS::Security::EndpointSecurityInfo security_info;
   DDS::Security::DataTags data_tags;
+  bool have_ice_agent_info;
+  ICE::AgentInfo ice_agent_info;
+
+  DiscoveredSubscription_SecurityWrapper()
+    : have_ice_agent_info(false) {}
 };
 
 }

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -16,6 +16,8 @@
 #include "dds/DCPS/RTPS/BaseMessageTypes.h"
 #include "dds/DCPS/RTPS/BaseMessageUtils.h"
 
+#include "dds/DCPS/RTPS/ICE/Ice.h"
+
 #include "dds/DCPS/RcHandle_T.h"
 #include "dds/DCPS/GuidUtils.h"
 #include "dds/DCPS/DataReaderCallbacks.h"
@@ -55,8 +57,8 @@ class Spdp;
 class WaitForAcks;
 
 #ifdef OPENDDS_SECURITY
-struct DiscoveredWriterData_SecurityWrapper;
-struct DiscoveredReaderData_SecurityWrapper;
+struct DiscoveredPublication_SecurityWrapper;
+struct DiscoveredSubscription_SecurityWrapper;
 typedef Security::SPDPdiscoveredParticipantData ParticipantData_t;
 #else
 typedef SPDPdiscoveredParticipantData ParticipantData_t;
@@ -153,6 +155,9 @@ public:
 #endif
 
   static const bool host_is_bigendian_;
+
+  ICE::Endpoint* get_ice_endpoint();
+
 private:
   Spdp& spdp_;
 
@@ -187,16 +192,16 @@ private:
     union {
       const ParticipantData_t* dpdata_;
 
-      const DCPS::DiscoveredWriterData* wdata_;
+      const DiscoveredPublication* wdata_;
 
 #ifdef OPENDDS_SECURITY
-      const DiscoveredWriterData_SecurityWrapper* wdata_secure_;
+      const DiscoveredPublication_SecurityWrapper* wdata_secure_;
 #endif
 
-      const DCPS::DiscoveredReaderData* rdata_;
+      const DiscoveredSubscription* rdata_;
 
 #ifdef OPENDDS_SECURITY
-      const DiscoveredReaderData_SecurityWrapper* rdata_secure_;
+      const DiscoveredSubscription_SecurityWrapper* rdata_secure_;
 #endif
 
       const ParticipantMessageData* pmdata_;
@@ -210,19 +215,19 @@ private:
     Msg(MsgType mt, DCPS::MessageId id, const ParticipantData_t* dpdata)
       : type_(mt), id_(id), dpdata_(dpdata) {}
 
-    Msg(MsgType mt, DCPS::MessageId id, const DCPS::DiscoveredWriterData* wdata)
+    Msg(MsgType mt, DCPS::MessageId id, const DiscoveredPublication* wdata)
       : type_(mt), id_(id), wdata_(wdata) {}
 
 #ifdef OPENDDS_SECURITY
-    Msg(MsgType mt, DCPS::MessageId id, const DiscoveredWriterData_SecurityWrapper* wdata)
+    Msg(MsgType mt, DCPS::MessageId id, const DiscoveredPublication_SecurityWrapper* wdata)
       : type_(mt), id_(id), wdata_secure_(wdata) {}
 #endif
 
-    Msg(MsgType mt, DCPS::MessageId id, const DCPS::DiscoveredReaderData* rdata)
+    Msg(MsgType mt, DCPS::MessageId id, const DiscoveredSubscription* rdata)
       : type_(mt), id_(id), rdata_(rdata) {}
 
 #ifdef OPENDDS_SECURITY
-    Msg(MsgType mt, DCPS::MessageId id, const DiscoveredReaderData_SecurityWrapper* rdata)
+    Msg(MsgType mt, DCPS::MessageId id, const DiscoveredSubscription_SecurityWrapper* rdata)
       : type_(mt), id_(id), rdata_secure_(rdata) {}
 #endif
 
@@ -500,12 +505,12 @@ private:
 
     void enqueue(DCPS::MessageId id, DCPS::unique_ptr<ParticipantData_t> pdata);
 
-    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DCPS::DiscoveredWriterData> wdata);
-    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DCPS::DiscoveredReaderData> rdata);
+    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DiscoveredPublication> wdata);
+    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DiscoveredSubscription> rdata);
 
 #ifdef OPENDDS_SECURITY
-    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DiscoveredWriterData_SecurityWrapper> wrapper);
-    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DiscoveredReaderData_SecurityWrapper> wrapper);
+    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DiscoveredPublication_SecurityWrapper> wrapper);
+    void enqueue(DCPS::MessageId id, DCPS::unique_ptr<DiscoveredSubscription_SecurityWrapper> wrapper);
 #endif
 
     void enqueue(DCPS::MessageId id, DCPS::unique_ptr<ParticipantMessageData> data);
@@ -530,12 +535,12 @@ private:
     void svc_secure_i(DCPS::MessageId id, const Security::SPDPdiscoveredParticipantData* pdata);
 #endif
 
-    void svc_i(DCPS::MessageId id, const DCPS::DiscoveredWriterData* wdata);
-    void svc_i(DCPS::MessageId id, const DCPS::DiscoveredReaderData* rdata);
+    void svc_i(DCPS::MessageId id, const DiscoveredPublication* wdata);
+    void svc_i(DCPS::MessageId id, const DiscoveredSubscription* rdata);
 
 #ifdef OPENDDS_SECURITY
-    void svc_i(DCPS::MessageId id, const DiscoveredWriterData_SecurityWrapper* wrapper);
-    void svc_i(DCPS::MessageId id, const DiscoveredReaderData_SecurityWrapper* wrapper);
+    void svc_i(DCPS::MessageId id, const DiscoveredPublication_SecurityWrapper* wrapper);
+    void svc_i(DCPS::MessageId id, const DiscoveredSubscription_SecurityWrapper* wrapper);
 #endif
 
     void svc_i(DCPS::MessageId id, const ParticipantMessageData* data);
@@ -584,32 +589,38 @@ private:
                                       const DCPS::DiscoveredWriterData& wdata,
                                       const DCPS::RepoId& guid
 #ifdef OPENDDS_SECURITY
-                                      , const DDS::Security::EndpointSecurityInfo* security_info = NULL
+                                      ,
+                                      bool have_ice_agent_info,
+                                      const ICE::AgentInfo& ice_agent_info,
+                                      const DDS::Security::EndpointSecurityInfo* security_info = NULL
 #endif
                                       );
 
   void data_received(DCPS::MessageId message_id,
-                     const DCPS::DiscoveredWriterData& wdata);
+                     const DiscoveredPublication& wdata);
 
 #ifdef OPENDDS_SECURITY
   void data_received(DCPS::MessageId message_id,
-                     const DiscoveredWriterData_SecurityWrapper& wrapper);
+                     const DiscoveredPublication_SecurityWrapper& wrapper);
 #endif
 
   void process_discovered_reader_data(DCPS::MessageId message_id,
                                       const DCPS::DiscoveredReaderData& rdata,
                                       const DCPS::RepoId& guid
 #ifdef OPENDDS_SECURITY
-                                      , const DDS::Security::EndpointSecurityInfo* security_info = NULL
+                                      ,
+                                      bool have_ice_agent_info,
+                                      const ICE::AgentInfo& ice_agent_info,
+                                      const DDS::Security::EndpointSecurityInfo* security_info = NULL
 #endif
                                       );
 
   void data_received(DCPS::MessageId message_id,
-                     const DCPS::DiscoveredReaderData& rdata);
+                     const DiscoveredSubscription& rdata);
 
 #ifdef OPENDDS_SECURITY
   void data_received(DCPS::MessageId message_id,
-                     const DiscoveredReaderData_SecurityWrapper& wrapper);
+                     const DiscoveredSubscription_SecurityWrapper& wrapper);
 #endif
 
   void data_received(DCPS::MessageId message_id,
@@ -630,12 +641,12 @@ private:
                                         const DDS::Security::ParticipantVolatileMessageSecure& data);
 #endif
 
-  typedef std::pair<DCPS::MessageId, DCPS::DiscoveredWriterData> MsgIdWtrDataPair;
+  typedef std::pair<DCPS::MessageId, DiscoveredPublication> MsgIdWtrDataPair;
   typedef OPENDDS_MAP_CMP(DCPS::RepoId, MsgIdWtrDataPair,
                    DCPS::GUID_tKeyLessThan) DeferredPublicationMap;
   DeferredPublicationMap deferred_publications_;  // Publications that Spdp has not discovered.
 
-  typedef std::pair<DCPS::MessageId, DCPS::DiscoveredReaderData> MsgIdRdrDataPair;
+  typedef std::pair<DCPS::MessageId, DiscoveredSubscription> MsgIdRdrDataPair;
   typedef OPENDDS_MAP_CMP(DCPS::RepoId, MsgIdRdrDataPair,
                    DCPS::GUID_tKeyLessThan) DeferredSubscriptionMap;
   DeferredSubscriptionMap deferred_subscriptions_; // Subscriptions that Sedp has not discovered.
@@ -649,8 +660,8 @@ private:
   void remove_from_bit_i(const DiscoveredPublication& pub);
   void remove_from_bit_i(const DiscoveredSubscription& sub);
 
-  virtual DDS::ReturnCode_t remove_publication_i(const DCPS::RepoId& publicationId);
-  virtual DDS::ReturnCode_t remove_subscription_i(const DCPS::RepoId& subscriptionId);
+  virtual DDS::ReturnCode_t remove_publication_i(const DCPS::RepoId& publicationId, LocalPublication& pub);
+  virtual DDS::ReturnCode_t remove_subscription_i(const DCPS::RepoId& subscriptionId, LocalSubscription& sub);
 
   // Topic:
 
@@ -695,6 +706,9 @@ private:
 
   void write_durable_participant_message_data(const DCPS::RepoId& reader);
 
+  DDS::ReturnCode_t add_publication_i(const DCPS::RepoId& rid,
+                                      LocalPublication& pub);
+
   DDS::ReturnCode_t write_publication_data(const DCPS::RepoId& rid,
                                            LocalPublication& pub,
                                            const DCPS::RepoId& reader = DCPS::GUID_UNKNOWN);
@@ -708,6 +722,10 @@ private:
   DDS::ReturnCode_t write_publication_data_unsecure(const DCPS::RepoId& rid,
                                                     LocalPublication& pub,
                                                     const DCPS::RepoId& reader = DCPS::GUID_UNKNOWN);
+
+  DDS::ReturnCode_t add_subscription_i(const DCPS::RepoId& rid,
+                                       LocalSubscription& sub);
+
 
   DDS::ReturnCode_t write_subscription_data(const DCPS::RepoId& rid,
                                             LocalSubscription& pub,
@@ -775,6 +793,39 @@ protected:
   DDS::DomainId_t get_domain_id() const;
 #endif
 
+#ifdef OPENDDS_SECURITY
+  struct PublicationAgentInfoListener : public ICE::AgentInfoListener
+  {
+    Sedp& sedp;
+    PublicationAgentInfoListener(Sedp& a_sedp) : sedp(a_sedp) {}
+    void update_agent_info(const DCPS::RepoId& a_local_guid,
+                           const ICE::AgentInfo& a_agent_info);
+
+  } publication_agent_info_listener_;
+
+  struct SubscriptionAgentInfoListener : public ICE::AgentInfoListener
+  {
+    Sedp& sedp;
+    SubscriptionAgentInfoListener(Sedp& a_sedp) : sedp(a_sedp) {}
+    void update_agent_info(const DCPS::RepoId& a_local_guid,
+                           const ICE::AgentInfo& a_agent_info);
+  } subscription_agent_info_listener_;
+#endif
+
+  void add_assoc_i(const DCPS::RepoId& local_guid, const LocalPublication& lpub,
+                   const DCPS::RepoId& remote_guid, const DiscoveredSubscription& dsub);
+  void remove_assoc_i(const DCPS::RepoId& local_guid, const LocalPublication& lpub,
+                      const DCPS::RepoId& remote_guid);
+  void add_assoc_i(const DCPS::RepoId& local_guid, const LocalSubscription& lsub,
+                   const DCPS::RepoId& remote_guid, const DiscoveredPublication& dpub);
+  void remove_assoc_i(const DCPS::RepoId& local_guid, const LocalSubscription& lsub,
+                      const DCPS::RepoId& remote_guid);
+  void start_ice(const DCPS::RepoId& guid, const LocalPublication& lpub);
+  void start_ice(const DCPS::RepoId& guid, const LocalSubscription& lsub);
+  void start_ice(const DCPS::RepoId& guid, const DiscoveredPublication& dpub);
+  void start_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub);
+  void stop_ice(const DCPS::RepoId& guid, const DiscoveredPublication& dpub);
+  void stop_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub);
 };
 
 /// A class to wait on acknowledgments from other threads

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -18,7 +18,10 @@
 #include "dds/DCPS/Service_Participant.h"
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/GuidConverter.h"
+#include "dds/DCPS/GuidUtils.h"
 #include "dds/DCPS/Qos_Helper.h"
+
+#include "dds/DCPS/RTPS/ICE/Ice.h"
 
 #ifdef OPENDDS_SECURITY
 #include "SecurityHelpers.h"
@@ -30,6 +33,8 @@
 
 #include <cstring>
 #include <stdexcept>
+
+#include "ace/Auto_Ptr.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -44,10 +49,6 @@ namespace {
   const int LEASE_MULT = 10;
   const CORBA::UShort encap_LE = 0x0300; // {PL_CDR_LE} in LE
   const CORBA::UShort encap_BE = 0x0200; // {PL_CDR_BE} in LE
-
-  const ACE_Time_Value MAX_SPDP_TIMER_PERIOD(0, 10000);
-  const ACE_Time_Value MAX_AUTH_TIME(3, 0);
-  const ACE_Time_Value AUTH_RESEND_PERIOD(0, 25000);
 
   bool disposed(const ParameterList& inlineQos)
   {
@@ -280,6 +281,10 @@ Spdp::~Spdp()
     {
       DiscoveredParticipantIter part = participants_.find(*participant_id);
       if (part != participants_.end()) {
+        ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+        if (endpoint) {
+          stop_ice(endpoint, part->first, part->second.pdata_.participantProxy.availableBuiltinEndpoints);
+        }
         remove_discovered_participant(part);
       }
     }
@@ -461,6 +466,10 @@ Spdp::handle_participant_data(DCPS::MessageId id, const ParticipantData_t& cpdat
 #endif
 
     if (id == DCPS::DISPOSE_INSTANCE || id == DCPS::DISPOSE_UNREGISTER_INSTANCE) {
+      ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+      if (endpoint) {
+        stop_ice(endpoint, iter->first, iter->second.pdata_.participantProxy.availableBuiltinEndpoints);
+      }
       remove_discovered_participant(iter);
       return;
     }
@@ -517,6 +526,26 @@ Spdp::data_received(const DataSubmessage& data, const ParameterList& plist)
   DCPS::MessageId msg_id = (data.inlineQos.length() && disposed(data.inlineQos)) ? DCPS::DISPOSE_INSTANCE : DCPS::SAMPLE_DATA;
 
   handle_participant_data(msg_id, pdata);
+
+  ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+  if (!endpoint) {
+    return;
+  }
+
+  ICE::AgentInfo agent_info;
+  bool have_agent_info;
+  if (ParameterListConverter::from_param_list(plist, agent_info, have_agent_info) < 0) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::data_received - ")
+      ACE_TEXT("failed to convert from ParameterList to ")
+      ACE_TEXT("ICE::AgentInfo\n")));
+    return;
+  }
+
+  if (have_agent_info) {
+    start_ice(endpoint, guid, pdata.participantProxy.availableBuiltinEndpoints, agent_info);
+  } else {
+    stop_ice(endpoint, guid, pdata.participantProxy.availableBuiltinEndpoints);
+  }
 }
 
 void
@@ -767,9 +796,9 @@ Spdp::check_auth_states(const ACE_Time_Value& tv) {
     switch (pi->second.auth_state_) {
       case DCPS::AS_HANDSHAKE_REQUEST_SENT:
       case DCPS::AS_HANDSHAKE_REPLY_SENT:
-        if (tv > pi->second.auth_started_time_ + MAX_AUTH_TIME) {
+        if (tv > pi->second.auth_started_time_ + disco_->max_auth_time()) {
           to_erase.insert(pi->first);
-        } else if (pi->second.has_last_stateless_msg_ && (tv > (pi->second.last_stateless_msg_time_ + AUTH_RESEND_PERIOD))) {
+        } else if (pi->second.has_last_stateless_msg_ && (tv > (pi->second.last_stateless_msg_time_ + disco_->auth_resend_period()))) {
           RepoId reader = pi->first;
           reader.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
           pi->second.last_stateless_msg_time_ = tv;
@@ -794,6 +823,10 @@ Spdp::check_auth_states(const ACE_Time_Value& tv) {
     if (pit != participants_.end()) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DEBUG: Spdp::check_auth_states()      - Removing discovered participant due to authentication timeout: %C\n"), std::string(DCPS::GuidConverter(*it)).c_str()));
       if (participant_sec_attr_.allow_unauthenticated_participants == false) {
+        ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+        if (endpoint) {
+          stop_ice(endpoint, pit->first, pit->second.pdata_.participantProxy.availableBuiltinEndpoints);
+        }
         remove_discovered_participant(pit);
       } else {
         pit->second.auth_state_ = DCPS::AS_UNAUTHENTICATED;
@@ -1117,6 +1150,11 @@ Spdp::remove_expired_participants()
             ACE_TEXT("participant %C exceeded lease duration, removing\n"),
             OPENDDS_STRING(conv).c_str()));
         }
+        ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
+        if (endpoint) {
+          stop_ice(endpoint, part->first, part->second.pdata_.participantProxy.availableBuiltinEndpoints);
+
+        }
         remove_discovered_participant(part);
       }
     }
@@ -1388,10 +1426,6 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer, bool securityGuids)
        end = outer_->disco_->spdp_send_addrs().end(); it != end; ++it) {
     send_addrs_.insert(ACE_INET_Addr(it->c_str()));
   }
-
-  if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
-    send_addrs_.insert(outer_->disco_->spdp_rtps_relay_address());
-  }
 }
 
 void
@@ -1411,7 +1445,7 @@ Spdp::SpdpTransport::open()
   disco_resend_period_ = outer_->disco_->resend_period();
   last_disco_resend_ = 0;
 
-  ACE_Time_Value timer_period = disco_resend_period_ < MAX_SPDP_TIMER_PERIOD ? disco_resend_period_ : MAX_SPDP_TIMER_PERIOD;
+  ACE_Time_Value timer_period = disco_resend_period_ < outer_->disco_->max_spdp_timer_period() ? disco_resend_period_ : outer_->disco_->max_spdp_timer_period();
 
   if (-1 == reactor->schedule_timer(this, 0, ACE_Time_Value(0), timer_period)) {
     throw std::runtime_error("failed to schedule timer with reactor");
@@ -1483,6 +1517,17 @@ Spdp::SpdpTransport::dispose_unregister()
         ACE_TEXT("destination %s failed %p\n"), addr_buff, ACE_TEXT("send")));
     }
   }
+  if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
+    const ssize_t res =
+      unicast_socket_.send(wbuff_.rd_ptr(), wbuff_.length(), outer_->disco_->spdp_rtps_relay_address());
+    if (res < 0) {
+      ACE_TCHAR addr_buff[256] = {};
+      outer_->disco_->spdp_rtps_relay_address().addr_to_string(addr_buff, 256, 0);
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::dispose_unregister() - ")
+                 ACE_TEXT("destination %s failed %p\n"), addr_buff, ACE_TEXT("send")));
+    }
+  }
 }
 
 void
@@ -1549,6 +1594,43 @@ Spdp::SpdpTransport::write_i()
       ACE_ERROR((LM_ERROR,
         ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::write() - ")
         ACE_TEXT("destination %s failed %p\n"), addr_buff, ACE_TEXT("send")));
+    }
+  }
+
+  if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
+#if OPENDDS_SECURITY
+    ICE::Endpoint* endpoint = outer_->sedp_.get_ice_endpoint();
+    if (endpoint) {
+      const ICE::AgentInfo& agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+      if (ParameterListConverter::to_param_list(agent_info, plist) < 0) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+                   ACE_TEXT("Spdp::SpdpTransport::write() - ")
+                   ACE_TEXT("failed to convert from ICE::AgentInfo ")
+                   ACE_TEXT("to ParameterList\n")));
+        return;
+      }
+    }
+#endif
+
+    wbuff_.reset();
+    CORBA::UShort options = 0;
+    DCPS::Serializer ser(&wbuff_, false, DCPS::Serializer::ALIGN_CDR);
+    if (!(ser << hdr_) || !(ser << data_) || !(ser << encap_LE) || !(ser << options)
+        || !(ser << plist)) {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::write() - ")
+                 ACE_TEXT("failed to serialize headers for SPDP\n")));
+      return;
+    }
+
+    const ssize_t res =
+      unicast_socket_.send(wbuff_.rd_ptr(), wbuff_.length(), outer_->disco_->spdp_rtps_relay_address());
+    if (res < 0) {
+      ACE_TCHAR addr_buff[256] = {};
+      outer_->disco_->spdp_rtps_relay_address().addr_to_string(addr_buff, 256, 0);
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::write() - ")
+                 ACE_TEXT("destination %s failed %p\n"), addr_buff, ACE_TEXT("send")));
     }
   }
 }
@@ -1703,6 +1785,18 @@ Spdp::SpdpTransport::acknowledge()
 {
   ACE_Reactor* reactor = outer_->reactor();
   reactor->notify(this);
+}
+
+void
+Spdp::SpdpTransport::remove_send_addr(const ACE_INET_Addr& addr)
+{
+  send_addrs_.erase(addr);
+}
+
+void
+Spdp::SpdpTransport::insert_send_addr(const ACE_INET_Addr& addr)
+{
+  send_addrs_.insert(addr);
 }
 
 void
@@ -1883,6 +1977,274 @@ Spdp::lookup_participant_auth_state(const DCPS::RepoId& id) const
   return result;
 }
 #endif
+
+void
+Spdp::remove_send_addr(const ACE_INET_Addr& addr)
+{
+  tport_->remove_send_addr(addr);
+}
+
+void
+Spdp::add_send_addr(const ACE_INET_Addr& addr)
+{
+  tport_->insert_send_addr(addr);
+}
+
+bool
+operator==(const DCPS::Locator_t& x, const DCPS::Locator_t& y)
+{
+  return x.kind == y.kind && x.port == y.port && x.address == y.address;
+}
+
+bool
+operator!=(const DCPS::Locator_t& x, const DCPS::Locator_t& y)
+{
+  return x.kind != y.kind && x.port != y.port && x.address != y.address;
+}
+
+void
+Spdp::remove_sedp_unicast(const ACE_INET_Addr& addr)
+{
+  DCPS::Locator_t locator;
+  locator.kind = address_to_kind(addr);
+  locator.port = addr.get_port_number();
+  RTPS::address_to_bytes(locator.address, addr);
+
+  DCPS::LocatorSeq new_sedp_unicast;
+  for (size_t idx = 0; idx != sedp_unicast_.length(); ++idx) {
+    if (sedp_unicast_[idx] != locator) {
+      size_t out_idx = new_sedp_unicast.length();
+      new_sedp_unicast.length(out_idx + 1);
+      new_sedp_unicast[out_idx] = sedp_unicast_[idx];
+    }
+  }
+
+  sedp_unicast_ = new_sedp_unicast;
+}
+
+void
+Spdp::add_sedp_unicast(const ACE_INET_Addr& addr)
+{
+  DCPS::Locator_t locator;
+  locator.kind = address_to_kind(addr);
+  locator.port = addr.get_port_number();
+  RTPS::address_to_bytes(locator.address, addr);
+
+  size_t idx = sedp_unicast_.length();
+  sedp_unicast_.length(idx + 1);
+  sedp_unicast_[idx] = locator;
+}
+
+void Spdp::start_ice(ICE::Endpoint* endpoint, RepoId r, const BuiltinEndpointSet_t& avail, const ICE::AgentInfo& agent_info) {
+#ifdef OPENDDS_SECURITY
+  RepoId l = guid_;
+
+  // See RTPS v2.1 section 8.5.5.1
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+
+  using namespace DDS::Security;
+  // See DDS-Security v1.1 section 7.3.7.1
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
+  }
+#else
+  ACE_UNUSED_ARG(endpoint);
+  ACE_UNUSED_ARG(r);
+  ACE_UNUSED_ARG(avail);
+  ACE_UNUSED_ARG(agent_info);
+#endif
+}
+
+void Spdp::stop_ice(ICE::Endpoint* endpoint, DCPS::RepoId r, const BuiltinEndpointSet_t& avail) {
+#ifdef OPENDDS_SECURITY
+  RepoId l = guid_;
+
+  // See RTPS v2.1 section 8.5.5.1
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+
+  using namespace DDS::Security;
+  // See DDS-Security v1.1 section 7.3.7.1
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+    l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
+    l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
+    r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
+    l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
+  }
+#else
+  ACE_UNUSED_ARG(endpoint);
+  ACE_UNUSED_ARG(r);
+  ACE_UNUSED_ARG(avail);
+#endif
+}
 
 }
 }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -123,6 +123,11 @@ public:
   DCPS::AuthState lookup_participant_auth_state(const DCPS::RepoId& id) const;
 #endif
 
+  void remove_send_addr(const ACE_INET_Addr& addr);
+  void add_send_addr(const ACE_INET_Addr& addr);
+  void remove_sedp_unicast(const ACE_INET_Addr& addr);
+  void add_sedp_unicast(const ACE_INET_Addr& addr);
+
 protected:
   Sedp& endpoint_manager() { return sedp_; }
 
@@ -178,6 +183,8 @@ private:
     void dispose_unregister();
     bool open_unicast_socket(u_short port_common, u_short participant_id);
     void acknowledge();
+    void remove_send_addr(const ACE_INET_Addr& addr);
+    void insert_send_addr(const ACE_INET_Addr& addr);
 
     Spdp* outer_;
     Header hdr_;
@@ -221,6 +228,9 @@ private:
 
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
 #endif
+
+  void start_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail, const ICE::AgentInfo& agent_info);
+  void stop_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail);
 };
 
 }

--- a/dds/DCPS/RTPS/rtps.mpc
+++ b/dds/DCPS/RTPS/rtps.mpc
@@ -5,6 +5,11 @@ project(OpenDDS_Rtps): dcpslib, install, rtps_optional_safety {
   IDL_Files {
   }
 
+  Source_Files {
+    .
+    ICE
+  }
+
   specific {
     install_dir = dds/DCPS/RTPS
   }

--- a/dds/DCPS/RecorderImpl.h
+++ b/dds/DCPS/RecorderImpl.h
@@ -135,6 +135,8 @@ public:
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/);
 
+  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -157,6 +157,8 @@ public:
                                      const RepoId& writerid,
                                      const RepoId& readerid);
 
+  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+
   DDS::ReturnCode_t enable();
 
   DomainParticipantImpl*          participant() {

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -346,15 +346,8 @@ StaticEndpointManager::add_publication_i(const RepoId& writerid,
 }
 
 DDS::ReturnCode_t
-StaticEndpointManager::remove_publication_i(const RepoId& writerid)
+StaticEndpointManager::remove_publication_i(const RepoId& writerid, LocalPublication& pub)
 {
-  LocalPublicationMap::const_iterator lp_pos = local_publications_.find(writerid);
-  if (lp_pos == local_publications_.end()) {
-    return DDS::RETCODE_ERROR;
-  }
-
-  const LocalPublication& pub = lp_pos->second;
-
   EndpointRegistry::WriterMapType::const_iterator pos = registry_.writer_map.find(writerid);
   if (pos == registry_.writer_map.end()) {
     return DDS::RETCODE_ERROR;
@@ -422,15 +415,9 @@ StaticEndpointManager::add_subscription_i(const RepoId& readerid,
 }
 
 DDS::ReturnCode_t
-StaticEndpointManager::remove_subscription_i(const RepoId& readerid)
+StaticEndpointManager::remove_subscription_i(const RepoId& readerid,
+                                             LocalSubscription& sub)
 {
-  LocalSubscriptionMap::const_iterator ls_pos = local_subscriptions_.find(readerid);
-  if (ls_pos == local_subscriptions_.end()) {
-    return DDS::RETCODE_ERROR;
-  }
-
-  const LocalSubscription& sub = ls_pos->second;
-
   EndpointRegistry::ReaderMapType::const_iterator pos = registry_.reader_map.find(readerid);
   if (pos == registry_.reader_map.end()) {
     return DDS::RETCODE_ERROR;

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -172,12 +172,14 @@ public:
   virtual DDS::ReturnCode_t add_publication_i(const RepoId& /*rid*/,
                                               LocalPublication& /*pub*/);
 
-  virtual DDS::ReturnCode_t remove_publication_i(const RepoId& /*publicationId*/);
+  virtual DDS::ReturnCode_t remove_publication_i(const RepoId& /*publicationId*/,
+                                                 LocalPublication& /*pub*/);
 
   virtual DDS::ReturnCode_t add_subscription_i(const RepoId& /*rid*/,
                                                LocalSubscription& /*pub*/);
 
-  virtual DDS::ReturnCode_t remove_subscription_i(const RepoId& /*subscriptionId*/);
+  virtual DDS::ReturnCode_t remove_subscription_i(const RepoId& /*subscriptionId*/,
+                                                  LocalSubscription& /*sub*/);
 
   virtual bool shutting_down() const;
 

--- a/dds/DCPS/security/BuiltInSecurityPluginInst.cpp
+++ b/dds/DCPS/security/BuiltInSecurityPluginInst.cpp
@@ -9,6 +9,7 @@
 #include "dds/DCPS/security/AccessControlBuiltInImpl.h"
 #include "dds/DCPS/security/AuthenticationBuiltInImpl.h"
 #include "dds/DCPS/security/CryptoBuiltInImpl.h"
+#include "dds/DCPS/security/UtilityImpl.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -25,12 +26,14 @@ BuiltInSecurityPluginInst::BuiltInSecurityPluginInst()
   , key_factory_(new CryptoBuiltInImpl)
   , key_exchange_(CryptoKeyExchange::_narrow(key_factory_))
   , transform_(CryptoTransform::_narrow(key_factory_))
+  , utility_(new UtilityImpl())
 #endif
 {
 }
 
 BuiltInSecurityPluginInst::~BuiltInSecurityPluginInst()
 {
+  delete utility_;
 }
 
 #ifdef OPENDDS_SECURITY
@@ -58,6 +61,12 @@ CryptoTransform_var BuiltInSecurityPluginInst::create_crypto_transform()
 {
   return transform_;
 }
+
+Utility* BuiltInSecurityPluginInst::create_utility()
+{
+  return utility_;
+}
+
 #endif
 
 void BuiltInSecurityPluginInst::shutdown()

--- a/dds/DCPS/security/BuiltInSecurityPluginInst.h
+++ b/dds/DCPS/security/BuiltInSecurityPluginInst.h
@@ -33,6 +33,7 @@ public:
   virtual CryptoKeyFactory_var create_crypto_key_factory();
   virtual CryptoKeyExchange_var create_crypto_key_exchange();
   virtual CryptoTransform_var create_crypto_transform();
+  virtual Utility* create_utility();
 #endif
 
   virtual void shutdown();
@@ -44,6 +45,7 @@ private:
   CryptoKeyFactory_var key_factory_;
   CryptoKeyExchange_var key_exchange_;
   CryptoTransform_var transform_;
+  Utility* utility_;
 #endif
 
   BuiltInSecurityPluginInst(const BuiltInSecurityPluginInst&);

--- a/dds/DCPS/security/Utility.h
+++ b/dds/DCPS/security/Utility.h
@@ -1,0 +1,38 @@
+/*
+*
+*
+* Distributed under the OpenDDS License.
+* See: http://www.OpenDDS.org/license.html
+*/
+
+#ifndef DDS_DCPS_UTILITY_H
+#define DDS_DCPS_UTILITY_H
+
+#include "dds/DCPS/security/DdsSecurity_Export.h"
+#include "dds/DCPS/SequenceIterator.h"
+#include "dds/DdsSecurityCoreC.h"
+#include "dds/Versioned_Namespace.h"
+#include "TokenReader.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Security {
+
+class DdsSecurity_Export Utility {
+public:
+  virtual ~Utility() {}
+  virtual void generate_random_bytes(void* ptr, size_t size) = 0;
+  virtual void hmac(void* out, void const* in, size_t size, const std::string& password) const = 0;
+};
+
+} // namespace Security
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif

--- a/dds/DCPS/security/UtilityImpl.cpp
+++ b/dds/DCPS/security/UtilityImpl.cpp
@@ -1,0 +1,37 @@
+#include "dds/DCPS/security/UtilityImpl.h"
+
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+#include <openssl/err.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Security {
+
+UtilityImpl::~UtilityImpl() {}
+
+void UtilityImpl::generate_random_bytes(void* ptr, size_t size)
+{
+  int rc = RAND_bytes(static_cast<unsigned char*>(ptr), size);
+
+  if (rc != 1) {
+    unsigned long err = ERR_get_error();
+    char msg[256] = { 0 };
+    ERR_error_string_n(err, msg, sizeof(msg));
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) Service_Participant::generate_random_bytes: ERROR '%C' returned by RAND_bytes(...)\n"),
+               msg));
+  }
+}
+
+void UtilityImpl::hmac(void* out, void const* in, size_t size, const std::string& password) const
+{
+  unsigned char* digest = HMAC(EVP_sha1(), password.c_str(), password.size(), static_cast<const unsigned char*>(in),size, NULL, NULL);
+  memcpy(out, digest, 20);
+}
+
+} // Security
+} // OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/security/UtilityImpl.h
+++ b/dds/DCPS/security/UtilityImpl.h
@@ -1,0 +1,36 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_UTILITY_IMPL_H
+#define OPENDDS_UTILITY_IMPL_H
+
+#include "DdsSecurity_Export.h"
+#include "dds/DCPS/security/Utility.h"
+
+#include "dds/Versioned_Namespace.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Security {
+
+class DdsSecurity_Export UtilityImpl
+  : public virtual OpenDDS::Security::Utility {
+public:
+  virtual ~UtilityImpl();
+  virtual void generate_random_bytes(void* ptr, size_t size);
+  virtual void hmac(void* out, void const* in, size_t size, const std::string& password) const;
+};
+
+} // Security
+} // OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif

--- a/dds/DCPS/security/framework/SecurityConfig.h
+++ b/dds/DCPS/security/framework/SecurityConfig.h
@@ -17,6 +17,7 @@
 
 #ifdef OPENDDS_SECURITY
 #include "dds/DdsSecurityCoreC.h"
+#include "dds/DCPS/security/Utility.h"
 #endif
 
 #include "dds/DdsDcpsCoreC.h"
@@ -72,6 +73,11 @@ class OpenDDS_Dcps_Export SecurityConfig : public DCPS::RcObject {
   {
     return transform_plugin_;
   }
+
+  Utility* get_utility() const
+  {
+    return utility_plugin_;
+  }
 #endif
 
   void get_properties(DDS::PropertyQosPolicy& properties) const;
@@ -102,6 +108,7 @@ class OpenDDS_Dcps_Export SecurityConfig : public DCPS::RcObject {
   CryptoKeyExchange_var key_exchange_plugin_;
   CryptoKeyFactory_var key_factory_plugin_;
   CryptoTransform_var transform_plugin_;
+  Utility* utility_plugin_;
 #endif
 
   ConfigPropertyList properties_;

--- a/dds/DCPS/security/framework/SecurityPluginInst.h
+++ b/dds/DCPS/security/framework/SecurityPluginInst.h
@@ -10,6 +10,7 @@
 
 #ifdef OPENDDS_SECURITY
 #include "dds/DdsSecurityCoreC.h"
+#include "dds/DCPS/security/Utility.h"
 #endif
 
 #include "dds/DCPS/dcps_export.h"
@@ -53,6 +54,7 @@ public:
   virtual CryptoKeyExchange_var create_crypto_key_exchange() = 0;
   virtual CryptoKeyFactory_var create_crypto_key_factory() = 0;
   virtual CryptoTransform_var create_crypto_transform() = 0;
+  virtual Utility* create_utility() = 0;
 #endif
 
   // Perform any logic needed when shutting down the plugin

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -39,6 +39,11 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
+
+namespace ICE {
+  class Endpoint;
+}
+
 namespace DCPS {
 
 
@@ -254,6 +259,8 @@ public:
   void set_scheduling_release(bool scheduling_release);
 
   virtual void send_final_acks (const RepoId& readerid);
+
+  virtual ICE::Endpoint* get_ice_endpoint() const { return 0; }
 
 protected:
 

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -688,6 +688,24 @@ TransportClient::unregister_for_writer(const RepoId& participant,
   }
 }
 
+ICE::Endpoint*
+TransportClient::get_ice_endpoint()
+{
+  // The one-to-many relationship with impls implies that this should
+  // return a set of endpoints instead of a single endpoint or null.
+  // For now, we will assume a single impl.
+
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, lock_, 0);
+  for (ImplsType::iterator pos = impls_.begin(), limit = impls_.end();
+       pos != limit;
+       ++pos) {
+    ICE::Endpoint* endpoint = (*pos)->get_ice_endpoint();
+    if (endpoint) { return endpoint; }
+  }
+
+  return 0;
+}
+
 bool
 TransportClient::send_response(const RepoId& peer,
                                const DataSampleHeader& header,

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -101,6 +101,8 @@ public:
                              const RepoId& readerid,
                              const RepoId& writerid);
 
+  ICE::Endpoint* get_ice_endpoint();
+
   // Data transfer:
 
   bool send_response(const RepoId& peer,

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -153,6 +153,8 @@ public:
     DataLink_rch link_;
   };
 
+  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+
 protected:
   TransportImpl(TransportInst& config);
 

--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -156,4 +156,10 @@ OpenDDS::DCPS::TransportInst::set_port_in_addr_string(OPENDDS_STRING& addr_str, 
   addr_str = result;
 }
 
+OpenDDS::ICE::Endpoint*
+OpenDDS::DCPS::TransportInst::get_ice_endpoint()
+{
+  return impl()->get_ice_endpoint();
+}
+
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -29,6 +29,11 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
+
+namespace ICE {
+  class Endpoint;
+}
+
 namespace DCPS {
 
 /**
@@ -105,6 +110,8 @@ public:
   /// Populate a transport locator sequence.  Return the number of "locators."
   virtual size_t populate_locator(OpenDDS::DCPS::TransportLocator& trans_info) const = 0;
 
+  ICE::Endpoint* get_ice_endpoint();
+
 protected:
 
   TransportInst(const char* type,
@@ -126,7 +133,9 @@ private:
   void shutdown();
 
   friend class TransportClient;
+ protected:
   TransportImpl* impl();
+ private:
   virtual TransportImpl_rch new_impl() = 0;
 
   const OPENDDS_STRING name_;

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -302,10 +302,16 @@ TransportReceiveStrategy<TH, DSH>::handle_dds_input(ACE_HANDLE fd)
   // Read into the buffers.
   //
   ACE_INET_Addr remote_address;
+  bool stop = false;
   ssize_t bytes_remaining = this->receive_bytes(iov,
                                                 static_cast<int>(vec_index),
                                                 remote_address,
-                                                fd);
+                                                fd,
+                                                stop);
+
+  if (stop) {
+    return 0;
+  }
 
   if (bytes_remaining < 0) {
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Problem ")

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -61,7 +61,8 @@ protected:
   virtual ssize_t receive_bytes(iovec          iov[],
                                 int            n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE     fd) = 0;
+                                ACE_HANDLE     fd,
+                                bool&          stop) = 0;
 
   /// Check the transport header for suitability.
   virtual bool check_header(const TH& header);

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
@@ -43,7 +43,8 @@ ssize_t
 MulticastReceiveStrategy::receive_bytes(iovec iov[],
                                         int n,
                                         ACE_INET_Addr& remote_address,
-                                        ACE_HANDLE /*fd*/)
+                                        ACE_HANDLE /*fd*/,
+                                        bool& /*stop*/)
 {
   ACE_SOCK_Dgram_Mcast& socket = this->link_->socket();
   return socket.recv(iov, n, remote_address);

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
@@ -34,7 +34,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual bool check_header(const TransportHeader& header);
   virtual bool check_header(const DataSampleHeader& header);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -44,6 +44,11 @@ class DDS_TEST;
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
+
+namespace ICE {
+  class Endpoint;
+}
+
 namespace DCPS {
 
 class RtpsUdpInst;
@@ -98,13 +103,11 @@ public:
   void add_locator(const RepoId& remote_id, const ACE_INET_Addr& address,
                    bool requires_inline_qos);
 
-  /// Given a 'local_id' of a publication or subscription, populate the set of
-  /// 'addrs' with the network addresses of any remote peers (or if 'local_id'
-  /// is GUID_UNKNOWN, all known addresses).
-  void get_locators(const RepoId& local_id,
-                    OPENDDS_SET(ACE_INET_Addr)& addrs) const;
-
-  ACE_INET_Addr get_locator(const RepoId& remote_id) const;
+  /// Given a 'local' id and a 'remote' id of a publication or
+  /// subscription, return the set of addresses of the remote peers.
+  OPENDDS_SET(ACE_INET_Addr) get_addresses(const RepoId& local, const RepoId& remote) const;
+  /// Given a 'local' id, return the set of address for all remote peers.
+  OPENDDS_SET(ACE_INET_Addr) get_addresses(const RepoId& local) const;
 
   void associated(const RepoId& local, const RepoId& remote,
                   bool local_reliable, bool remote_reliable,
@@ -131,6 +134,8 @@ public:
   virtual void pre_stop_i();
 
   virtual void send_final_acks(const RepoId& readerid);
+
+  virtual ICE::Endpoint* get_ice_endpoint() const;
 
 #ifdef OPENDDS_SECURITY
   Security::SecurityConfig_rch security_config() const
@@ -326,7 +331,7 @@ private:
                                   const DisjointSequence& gaps,
                                   bool durable = false);
 
-  void send_nackfrag_replies(RtpsWriter& writer, DisjointSequence& gaps,
+  void send_nackfrag_replies(RtpsWriterMap::iterator rw_iter, DisjointSequence& gaps,
                              OPENDDS_SET(ACE_INET_Addr)& gap_recipients);
 
   template<typename T, typename FN>
@@ -546,6 +551,7 @@ private:
                           GUID_tKeyLessThan)::const_iterator PeerHandlesCIter;
 #endif
 
+  void accumulate_addresses(const RepoId& local, const RepoId& remote, OPENDDS_SET(ACE_INET_Addr)& addresses) const;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -13,6 +13,8 @@
 #include "dds/DCPS/transport/framework/TransportInst.h"
 #include "dds/DCPS/SafetyProfileStreams.h"
 
+#include "dds/DCPS/RTPS/ICE/Ice.h"
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -69,10 +71,12 @@ public:
     set_port_in_addr_string(local_address_config_str_, port_number);
   }
 
-  /// Relay address may change, these use a mutex
+  /// Relay address and stun server address may change, these use a mutex
   ///{
   void rtps_relay_address(const ACE_INET_Addr& address);
   ACE_INET_Addr rtps_relay_address() const;
+  void stun_server_address(const ACE_INET_Addr& address);
+  ACE_INET_Addr stun_server_address() const;
   ///}
 
 private:
@@ -91,6 +95,10 @@ private:
   ACE_INET_Addr local_address_;
   OPENDDS_STRING local_address_config_str_;
   ACE_INET_Addr rtps_relay_address_;
+  bool use_ice_;
+  ACE_INET_Addr stun_server_address_;
+
+  ICE::AddressListType host_addresses() const;
 };
 
 inline void RtpsUdpInst::rtps_relay_address(const ACE_INET_Addr& address)
@@ -103,6 +111,18 @@ inline ACE_INET_Addr RtpsUdpInst::rtps_relay_address() const
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
   return rtps_relay_address_;
+}
+
+inline void RtpsUdpInst::stun_server_address(const ACE_INET_Addr& address)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  stun_server_address_ = address;
+}
+
+inline ACE_INET_Addr RtpsUdpInst::stun_server_address() const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+  return stun_server_address_;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -21,7 +21,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix)
+  RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix)
   : link_(link)
   , last_received_()
   , recvd_sample_(0)
@@ -42,10 +42,62 @@ RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
 }
 
 ssize_t
+RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
+                                             int n,
+                                             const ACE_SOCK_Dgram& socket,
+                                             ACE_INET_Addr& remote_address,
+                                             ICE::Endpoint* endpoint,
+                                             bool& stop)
+{
+  ACE_INET_Addr local_address;
+  const ssize_t ret = socket.recv(iov, n, remote_address, 0, &local_address);
+
+  if (ret == -1) {
+    return ret;
+  }
+
+#if OPENDDS_SECURITY
+  if (endpoint && n > 0 && ret > 0 && iov[0].iov_len >= 4 && memcmp(iov[0].iov_base, "RTPS", 4) != 0) {
+    // Assume STUN
+    stop = true;
+    size_t bytes = ret;
+    size_t block_size = std::min(bytes, static_cast<size_t>(iov[0].iov_len));
+    ACE_Message_Block* head = new ACE_Message_Block(static_cast<const char*>(iov[0].iov_base), block_size);
+    head->length(block_size);
+    bytes -= block_size;
+
+    ACE_Message_Block* tail = head;
+    for (int i = 1; i < n && bytes != 0; ++i) {
+      block_size = std::min(bytes, static_cast<size_t>(iov[i].iov_len));
+      ACE_Message_Block* mb = new ACE_Message_Block(static_cast<const char*>(iov[i].iov_base), block_size);
+      mb->length(block_size);
+      tail->cont(mb);
+      tail = mb;
+      bytes -= block_size;
+    }
+
+    DCPS::Serializer serializer(head, true);
+    STUN::Message message;
+    message.block = head;
+    if (serializer >> message) {
+      ICE::Agent::instance()->receive(endpoint, local_address, remote_address, message);
+    }
+    head->release();
+  }
+#else
+  ACE_UNUSED_ARG(endpoint);
+  ACE_UNUSED_ARG(stop);
+#endif
+
+  return ret;
+}
+
+ssize_t
 RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
                                       int n,
                                       ACE_INET_Addr& remote_address,
-                                      ACE_HANDLE fd)
+                                      ACE_HANDLE fd,
+                                      bool& stop)
 {
   const ACE_SOCK_Dgram& socket =
     (fd == link_->unicast_socket().get_handle())
@@ -63,9 +115,10 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
   }
   const ssize_t ret = (scatter < 0) ? scatter : (iter - buffer);
 #else
-  const ssize_t ret = socket.recv(iov, n, remote_address);
+  const ssize_t ret = receive_bytes_helper(iov, n, socket, remote_address, link_->get_ice_endpoint(), stop);
 #endif
   remote_address_ = remote_address;
+
   return ret;
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -18,12 +18,18 @@
 #include "dds/DCPS/RcEventHandler.h"
 
 #include "ace/INET_Addr.h"
+#include "ace/SOCK_Dgram.h"
 
 #include <cstring>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
+
+namespace ICE {
+  class Endpoint;
+}
+
 namespace DCPS {
 
 class RtpsUdpDataLink;
@@ -62,11 +68,19 @@ public:
   const ReceivedDataSample* withhold_data_from(const RepoId& sub_id);
   void do_not_withhold_data_from(const RepoId& sub_id);
 
+  static ssize_t receive_bytes_helper(iovec iov[],
+                                      int n,
+                                      const ACE_SOCK_Dgram& socket,
+                                      ACE_INET_Addr& remote_address,
+                                      ICE::Endpoint* endpoint,
+                                      bool& stop);
+
 private:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -84,9 +84,6 @@ ssize_t
 RtpsUdpSendStrategy::send_bytes_i_helper(const iovec iov[], int n)
 {
   if (override_single_dest_) {
-    if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
-      send_single_i(iov, n, link_->config().rtps_relay_address());
-    }
     return send_single_i(iov, n, *override_single_dest_);
   }
 
@@ -101,18 +98,11 @@ RtpsUdpSendStrategy::send_bytes_i_helper(const iovec iov[], int n)
     return -1;
   }
 
-  const RepoId remote_id = elem->subscription_id();
   OPENDDS_SET(ACE_INET_Addr) addrs;
-
-  if (remote_id != GUID_UNKNOWN) {
-    const ACE_INET_Addr remote = link_->get_locator(remote_id);
-    if (remote != ACE_INET_Addr()) {
-      addrs.insert(remote);
-    }
-  }
-
-  if (addrs.empty()) {
-    link_->get_locators(elem->publication_id(), addrs);
+  if (elem->subscription_id() != GUID_UNKNOWN) {
+    addrs = link_->get_addresses(elem->publication_id(), elem->subscription_id());
+  } else {
+    addrs = link_->get_addresses(elem->publication_id());
   }
 
   if (addrs.empty()) {
@@ -165,9 +155,6 @@ RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
 
   iovec iov[MAX_SEND_BLOCKS];
   const int num_blocks = mb_to_iov(use_mb, iov);
-  if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
-    send_single_i(iov, num_blocks, link_->config().rtps_relay_address());
-  }
   const ssize_t result = send_single_i(iov, num_blocks, addr);
   if (result < 0) {
     const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
@@ -206,9 +193,6 @@ ssize_t
 RtpsUdpSendStrategy::send_multi_i(const iovec iov[], int n,
                                   const OPENDDS_SET(ACE_INET_Addr)& addrs)
 {
-  if (link_->config().rtps_relay_address() != ACE_INET_Addr()) {
-    send_single_i(iov, n, link_->config().rtps_relay_address());
-  }
   ssize_t result = -1;
   typedef OPENDDS_SET(ACE_INET_Addr)::const_iterator iter_t;
   for (iter_t iter = addrs.begin(); iter != addrs.end(); ++iter) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -33,6 +33,9 @@ RtpsUdpTransport::RtpsUdpTransport(RtpsUdpInst& inst)
 #if defined(OPENDDS_SECURITY)
   , local_crypto_handle_(DDS::HANDLE_NIL)
 #endif
+#if OPENDDS_SECURITY
+  , ice_endpoint_(*this)
+#endif
 {
   if (! (configure_i(inst) && open())) {
     throw Transport::UnableToCreate();
@@ -45,6 +48,16 @@ RtpsUdpTransport::config() const
   return static_cast<RtpsUdpInst&>(TransportImpl::config());
 }
 
+ICE::Endpoint*
+RtpsUdpTransport::get_ice_endpoint()
+{
+#if OPENDDS_SECURITY
+  return (config().use_ice_) ? &ice_endpoint_ : 0;
+#else
+  return 0;
+#endif
+}
+
 RtpsUdpDataLink_rch
 RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 {
@@ -55,6 +68,17 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
   link->local_crypto_handle(local_crypto_handle_);
 #endif
 
+  if (config().use_ice_) {
+    if (reactor()->remove_handler(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("(%P|%t) ERROR: ")
+                        ACE_TEXT("RtpsUdpReceiveStrategy::start_i: ")
+                        ACE_TEXT("failed to unregister handler for unicast ")
+                        ACE_TEXT("socket %d\n"),
+                        unicast_socket_.get_handle()),
+                       RtpsUdpDataLink_rch());
+    }
+  }
   if (!link->open(unicast_socket_)) {
     ACE_ERROR((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
@@ -290,6 +314,17 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
                       false);
   }
 
+#if defined (ACE_RECVPKTINFO)
+  int sockopt = 1;
+  if (unicast_socket_.set_option(IPPROTO_IP, ACE_RECVPKTINFO, &sockopt, sizeof sockopt) == -1) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("(%P|%t) ERROR: ")
+                      ACE_TEXT("RtpsUdpTransport::configure_i: set_option:")
+                      ACE_TEXT("%m\n")),
+                     false);
+  }
+#endif
+
   if (config.local_address().get_port_number() == 0) {
 
     ACE_INET_Addr address;
@@ -302,6 +337,22 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
   }
 
   create_reactor_task();
+
+#if OPENDDS_SECURITY
+  if (config.use_ice_) {
+    ICE::Agent::instance()->add_endpoint(&ice_endpoint_);
+    if (reactor()->register_handler(unicast_socket_.get_handle(), &ice_endpoint_,
+                                    ACE_Event_Handler::READ_MASK) != 0) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("(%P|%t) ERROR: ")
+                        ACE_TEXT("RtpsUdpReceiveStrategy::start_i: ")
+                        ACE_TEXT("failed to register handler for unicast ")
+                        ACE_TEXT("socket %d\n"),
+                        unicast_socket_.get_handle()),
+                       false);
+    }
+  }
+#endif
 
   if (config.opendds_discovery_default_listener_) {
     link_= make_datalink(config.opendds_discovery_guid_.guidPrefix);
@@ -318,6 +369,12 @@ RtpsUdpTransport::shutdown_i()
     link_->transport_shutdown();
   }
   link_.reset();
+
+#if OPENDDS_SECURITY
+  if(config().use_ice_) {
+    ICE::Agent::instance()->remove_endpoint(&ice_endpoint_);
+  }
+#endif
 }
 
 void
@@ -339,6 +396,91 @@ RtpsUdpTransport::map_ipv4_to_ipv6() const
   }
   return map;
 }
+
+#if OPENDDS_SECURITY
+int
+RtpsUdpTransport::IceEndpoint::handle_input(ACE_HANDLE /*fd*/)
+{
+  struct iovec        iov[1];
+  char buffer[0x10000];
+  iov[0].iov_base = buffer;
+  iov[0].iov_len  = sizeof buffer;
+  ACE_INET_Addr remote_address;
+
+  bool stop;
+  RtpsUdpReceiveStrategy::receive_bytes_helper(iov, 1, transport.unicast_socket_, remote_address, transport.get_ice_endpoint(), stop);
+
+  return 0;
+}
+
+namespace {
+  bool shouldWarn(int code) {
+    return code == EPERM || code == EACCES || code == EINTR || code == ENOBUFS || code == ENOMEM;
+  }
+
+  ssize_t
+  send_single_i(ACE_SOCK_Dgram& socket, const iovec iov[], int n, const ACE_INET_Addr& addr)
+  {
+#ifdef ACE_LACKS_SENDMSG
+    char buffer[UDP_MAX_MESSAGE_SIZE];
+    char *iter = buffer;
+    for (int i = 0; i < n; ++i) {
+      if (size_t(iter - buffer + iov[i].iov_len) > UDP_MAX_MESSAGE_SIZE) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "
+                   "message too large at index %d size %d\n", i, iov[i].iov_len));
+        return -1;
+      }
+      std::memcpy(iter, iov[i].iov_base, iov[i].iov_len);
+      iter += iov[i].iov_len;
+    }
+    const ssize_t result = socket.send(buffer, iter - buffer, addr);
+#else
+    const ssize_t result = socket.send(iov, n, addr);
+#endif
+    if (result < 0) {
+      ACE_TCHAR addr_buff[256] = {};
+      int err = errno;
+      addr.addr_to_string(addr_buff, 256, 0);
+      errno = err;
+      const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
+      ACE_ERROR((prio, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "
+                 "destination %s failed %p\n", addr_buff, ACE_TEXT("send")));
+    }
+    return result;
+  }
+}
+
+ICE::AddressListType
+RtpsUdpTransport::IceEndpoint::host_addresses() const {
+  return transport.config().host_addresses();
+}
+
+void
+RtpsUdpTransport::IceEndpoint::send(const ACE_INET_Addr& destination, const STUN::Message& message)
+{
+  ACE_SOCK_Dgram& socket = (!transport.link_.is_nil()) ? transport.link_->unicast_socket() : transport.unicast_socket_;
+
+  ACE_Message_Block block(20 + message.length());
+  DCPS::Serializer serializer(&block, true);
+  const_cast<STUN::Message&>(message).block = &block;
+  serializer << message;
+
+  iovec iov[MAX_SEND_BLOCKS];
+  const int num_blocks = RtpsUdpSendStrategy::mb_to_iov(block, iov);
+  const ssize_t result = send_single_i(socket, iov, num_blocks, destination);
+  if (result < 0) {
+    const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
+    ACE_ERROR((prio, "(%P|%t) RtpsUdpTransport::send() - "
+               "failed to send STUN message\n"));
+  }
+}
+
+ACE_INET_Addr
+RtpsUdpTransport::IceEndpoint::stun_server_address() const {
+  return transport.config().stun_server_address();
+}
+#endif
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -20,6 +20,8 @@
 
 #include "dds/DCPS/RTPS/RtpsCoreC.h"
 
+#include "dds/DCPS/RTPS/ICE/Ice.h"
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -31,6 +33,8 @@ class OpenDDS_Rtps_Udp_Export RtpsUdpTransport : public TransportImpl {
 public:
   RtpsUdpTransport(RtpsUdpInst& inst);
   RtpsUdpInst& config() const;
+  virtual ICE::Endpoint* get_ice_endpoint();
+
 private:
   virtual AcceptConnectResult connect_datalink(const RemoteTransport& remote,
                                                const ConnectionAttribs& attribs,
@@ -121,6 +125,20 @@ private:
   DDS::Security::ParticipantCryptoHandle local_crypto_handle_;
 #endif
 
+#if OPENDDS_SECURITY
+  struct IceEndpoint : public ACE_Event_Handler, public ICE::Endpoint {
+    RtpsUdpTransport& transport;
+
+    IceEndpoint(RtpsUdpTransport& a_transport)
+      : transport(a_transport) {}
+
+    virtual int handle_input(ACE_HANDLE fd);
+    virtual ICE::AddressListType host_addresses() const;
+    virtual void send(const ACE_INET_Addr& address, const STUN::Message& message);
+    virtual ACE_INET_Addr stun_server_address() const;
+  };
+  IceEndpoint ice_endpoint_;
+#endif
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
@@ -77,7 +77,8 @@ ssize_t
 ShmemReceiveStrategy::receive_bytes(iovec iov[],
                                     int n,
                                     ACE_INET_Addr& /*remote_address*/,
-                                    ACE_HANDLE /*fd*/)
+                                    ACE_HANDLE /*fd*/,
+                                    bool& /*stop*/)
 {
   VDBG((LM_DEBUG,
         "(%P|%t) ShmemReceiveStrategy::receive_bytes link %@\n", link_));

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
@@ -33,7 +33,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
@@ -39,7 +39,8 @@ OpenDDS::DCPS::TcpReceiveStrategy::receive_bytes(
   iovec iov[],
   int   n,
   ACE_INET_Addr& /*remote_address*/,
-  ACE_HANDLE /*fd*/)
+  ACE_HANDLE /*fd*/,
+  bool& /*stop*/)
 {
   DBG_ENTRY_LVL("TcpReceiveStrategy", "receive_bytes", 6);
 

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
@@ -43,7 +43,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int   n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
@@ -38,7 +38,8 @@ ssize_t
 UdpReceiveStrategy::receive_bytes(iovec iov[],
                                   int n,
                                   ACE_INET_Addr& remote_address,
-                                  ACE_HANDLE /*fd*/)
+                                  ACE_HANDLE /*fd*/,
+                                  bool& /*stop*/)
 {
   const ssize_t ret = this->link_->socket().recv(iov, n, remote_address);
   remote_address_ = remote_address;

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.h
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.h
@@ -36,7 +36,8 @@ protected:
   virtual ssize_t receive_bytes(iovec iov[],
                                 int n,
                                 ACE_INET_Addr& remote_address,
-                                ACE_HANDLE fd);
+                                ACE_HANDLE fd,
+                                bool& stop);
 
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -35,6 +35,7 @@ project(OpenDDS_Dcps): core, coverage_optional, \
     DCPS
     DCPS/transport/framework
     DCPS/security/framework
+    DCPS/ICE
   }
 
   Header_Files {

--- a/dds/InfoRepo/FederatorManagerImpl.cpp
+++ b/dds/InfoRepo/FederatorManagerImpl.cpp
@@ -712,7 +712,7 @@ ManagerImpl::initialize()
     // Install ior multicast handler.
     //
     // Get reactor instance from TAO.
-    ACE_Reactor *reactor = this->orb_->orb_core()->reactor();
+    ACE_Reactor* reactor = this->orb_->orb_core()->reactor();
 
     // See if the -ORBMulticastDiscoveryEndpoint option was specified.
     ACE_CString mde(this->orb_->orb_core()->orb_params()->mcast_discovery_endpoint());

--- a/docs/design/ICE.rst
+++ b/docs/design/ICE.rst
@@ -1,0 +1,163 @@
+Interactive Connectivity Establishment (ICE) for RTPS
+=====================================================
+
+ICE is a protocol that allows two peers to exchange datagrams when one
+or both are behind a firewall that performs network address
+translation.  ICE is documented in IETF RFC 8445
+https://www.rfc-editor.org/info/rfc8445.  ICE relies on the Session
+Traversal Utilities for NAT (STUN) protocol which is documented in
+IETF RFC 5389 https://www.rfc-editor.org/info/rfc5389.
+
+ICE can be used for UDP and TCP connections.  The implementation in
+OpenDDS is only concerned with UDP as it is used for the UDP variant
+of RTPS.  Currently, OpenDDS uses three sockets for RTPS: one for
+SPDP, one for SEDP, and another for the transport.  ICE could be used
+for all three but is currently only implemented for SEDP and the
+transport since they share the transport code.  Furthermore, there is
+not a clear need to run ICE for SPDP.  ICE can also be used with a
+TURN server as a generic approach to providing point-to-point
+connectivity.  Instead of using a TURN server, developers are advised
+to the RtpsRelay to provide similar functionality.
+
+Overview of Network Address Translation (NAT)
+=============================================
+
+When a firewall that performs network address translation receives an
+outbound packet from a host, it substitutes the source IP and port
+with one of its external IPs and a port that it assigns.  The
+relationship between the internal host IP and port and the external IP
+and port is called a NAT binding.  When the firewall receives an
+inbound packet, it performs the reverse operation substituting the
+host's IP address and port for the destination address assuming that a
+NAT binding exists.
+
+Some approaches to NAT are compatible with ICE and some are not.  The
+most permissive NATs forward any packet sent to the public side of the
+binding to the host.  A more restrictive NAT records the destination IP
+that caused the NAT binding to be generated and only accepts packets
+from the same IP.  An even more restrictive NAT may record and enforce
+the port as well.  Due to the way NAT is implemented, ICE may not work
+in every scenario.
+
+NAT bindings are limited in time.  First, a firewall may rate limit
+the creation of NAT bindings.  The ICE documentation recommends at
+least 50ms between transactions that may create NAT bindings.  Second,
+a firewall will eventually purge the NAT binding after a timeout.
+Most sources report that most firewalls use a timeout of 15 to 30
+seconds.
+
+Overview of STUN
+================
+
+STUN is a simple protocol consisting of a single message class
+(binding) and four message types.  A *binding request* illicits either
+a *binding response* or an *error*.  A binding response contains the
+source IP address and port as perceived by the STUN server when it
+received the binding request.  If there are no NATting firewalls on
+the route the STUN server, then the address returned by the STUN
+server corresponds to the address of the host.  If there is a NATting
+firewall on the route, then the IP address that is returned belongs to
+the outer-most NATting firewall that separates the client from the
+server.  A *binding indication* is used to refresh a NAT binding and
+is dropped by the server.
+
+Overview of ICE
+===============
+
+The ICE protocol begins with the assumption that the peers know they
+should communicate.  The portion of the peer that is responsible for
+executing the ICE protocol is called the *ICE agent*.  A agent is
+either the controlling agent or the controlled agent with the
+difference being that the controlling agent can nominate.  First, the
+peers generate *candidates* which, among other things, contain a type,
+a priority, and an IP address and port.  There are four candidate
+types, three of which are collected in this phase.
+
+* A *host candidate* is based on the IP addresses of the network interfaces of the host
+* A *server reflexive candidate* represent the public address of the host (described below)
+* A *relayed candidate* is acquired from a TURN server and not used in OpenDDS
+
+A server reflexive candidate is determined by sending a STUN binding
+request to a public STUN server.  When the STUN server receives the
+request, it copies the source address of the request into the binding
+response.  This allows the host to determine its public IP address,
+i.e., the public IP address of the outer-most NATting firewall.
+
+The peers exchange candidates using a side channel.  Once a peer
+receives the candidates, it pairs the candidates with its own to
+create prioritized candidate pairs and starts performing connectivity
+checks on the candidate pairs.  The connectivity checks may generate a
+fourth type of candidate called a *peer reflexive address*.  The
+follow diagram illustrates how this happens.
+
+::
+
+    +--------+     +------------+     +------------+     +--------+
+    | Peer A |<--->| Firewall A |<--->| Firewall B |<--->| Peer B |
+    +--------+     +------------+     +------------+     +--------+
+
+  1 --------------------------------->
+
+  2 <--------------------------------------------------------------
+    -------------------------------------------------------------->
+
+  3 -------------------------------------------------------------->
+    <--------------------------------------------------------------
+
+Peer A sends a binding request to the server reflexive address of Peer B (1).
+This is most likely dropped by Firewall B since no NAT binding exists.
+However, it creates a NAT binding in Firewall A.
+Peer B sends a binding request to the server reflexive address of Peer A (2).
+Assuming a compatible firewall, Firewall A forwards the packet to Peer A based on the NAT binding created in (1) and Peer A sends a binding response.
+The binding response contains the public IP and port for Peer B.
+Finally, Peer A sends a binding request back to Peer B and receives a binding response.
+
+Once the connectivity checks complete, the controlling agent nominates
+a candidate pair and indicates this to the contolled agent.  Finally,
+the peers use their respective nominated candidate to exchange data.
+Also, the peers may send binding indications and/or requests to keep
+the NAT bindings in place.
+
+Implementation
+==============
+
+To apply ICE to OpenDDS, we determined that SPDP would be the
+side-channel for SEDP and that SEDP would be the side-channel for the
+normal RTPS port.  To do this, we added two parameters to the RTPS
+protocol for exchanging general ICE information (``IceGeneral_t``) and
+candidates (``IceCandidate_t``).
+
+ICE is compiled into the RTPS library when security is enabled due a
+dependency on random number generation and HMAC.  There is a singleton
+ICE agent that works with endpoints.  Each endpoint corresponds to a
+RTPS UDP transport instance which services both SEDP and normal RTPS.
+The agent is a singleton to rate limit outgoing STUN messages
+according to the recommendation in ICE.
+
+Security
+========
+
+ICE mandates the use of short-term credentials.  As part of the
+candidate exchange, each agent includes a username and password.  A
+STUN message sent to an agent must be signed (see the Message
+Integrity attribute in STUN) with the password of the agent.  This
+creates a dependency on OpenSSL.  The password should be changed
+periodically, e.g., 5 minutes, to prevent replay attacks.  Since the
+password is sensitive, it should not be sent in the clear.  This is
+not a problem for SEDP with security but does present a problem for
+SPDP.  We can consider the two scenarios of using the RtpsRelay and
+ordinary local multicast.  For the RtpsRelay, DTLS should be used to
+secure the SPDP messages.  This has not been implemented yet.  The
+local multicast scenario is a bit more interesting since we can
+consider both secure and unsecure deployments.  However, if the agent
+is received via local multicast, then ICE is probably not necessary.
+To summarize, the agent info is only necessary when sending to the
+RtpsRelay and it should be secured by DTLS.
+
+Limitations
+===========
+
+* A writer or reader that is using ICE can only be associated with one
+  (RTPS UDP) transport.  The RTPD UDP data link code is at the crux of
+  the problem.
+* There is no support for IPV6.

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -302,3 +302,7 @@ If not it will turn into a link to that object.
 
 For more information, see [the Doxygen manual](http://www.doxygen.nl/manual/).
 
+### Preprocessor Macros
+
+* Use `#ifdef MACRO` to test if `MACRO` is defined.
+* Use `#ifndef MACRO` to test if `MACRO` is not defined.

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
@@ -57,6 +57,8 @@ public:
   DDS::DomainId_t domainId_;
   ::OpenDDS::DCPS::RepoId participantId_;
 
+  OpenDDS::ICE::Endpoint* get_ice_endpoint() { return 0; }
+
 private:
   DiscReceivedCalls received_;
 };

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
@@ -51,6 +51,8 @@ public:
       return received_;
     }
 
+  OpenDDS::ICE::Endpoint* get_ice_endpoint() { return 0; }
+
 private:
   DiscReceivedCalls received_;
 };

--- a/tests/DCPS/unit/MyTypeSupportImpl.h
+++ b/tests/DCPS/unit/MyTypeSupportImpl.h
@@ -82,8 +82,8 @@ public:
   virtual void release_instance_i(DDS::InstanceHandle_t) {}
   virtual void dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample&,
                              OpenDDS::DCPS::SubscriptionInstance_rch &,
-                             bool &,
-                             bool &,
+                             bool&,
+                             bool&,
                              OpenDDS::DCPS::MarshalingType) {}
   virtual void dec_ref_data_element(OpenDDS::DCPS::ReceivedDataElement *) {}
   virtual void delete_instance_map (void *) {}


### PR DESCRIPTION
Problem: Participants cannot communicate directly when behing NATs

Participants that are behind NATs cannot communicate directly.  The
RtpsRelay solves the problem of enabling communication.  However, all
of the data transferred between the participants must pass through the
relay.  This solution provides an optimization where participants can
communicate directly after bootstrapping discovery with the RtpsRelay.

Solution: Implement ICE for RTPS.  ICE involves exchanging candidate
information and then performing connectivity checks to determine a
pair of candidates that can be used to exchange data.  Candidate
information is exchange via SPDP; presumably by using the RtpsRelay.
ICE is then attempted for SEDP.  Similarly, SEDP is used to exchange
candidate information for the data transport.  ICE is then attempted
for the data transports.