### PR TITLE
Install/java: Fix classpath for i2jrt.jar and i2jrt_compact.jar in .mpbs

### DIFF
--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -110,6 +110,7 @@ project: idl2jni, dcpslib, optional_jni_check, dcps_java_optional, dcps_tcp, dcp
 
   verbatim(gnuace, postinstall) {
 "	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(INSTALL_PREFIX)/lib"
+"	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/idl2jni.mpb"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/dcps_java.mpb"
 "	rm $(INSTALL_PREFIX)/dds/*.idl && rmdir $(INSTALL_PREFIX)/dds"
   }


### PR DESCRIPTION
Similar to previous issue for OpenDDS_DCPS.jar, need to update the class path for these two jar files.