### PR TITLE
Updated Dissector for Wireshark 3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ Released %TIMESTAMP%
 ### Additions:
 - Monitor and the ishapes demo now use Qt5
 - Expanded Android Documentation in `docs/android.md`
+- Updated dissector to work with Wireshark 3.0
 
 ### Fixes:
 - Java API can now be used on Android

--- a/tools/dissector/README.md
+++ b/tools/dissector/README.md
@@ -4,7 +4,7 @@ The OpenDDS DCPS Wireshark dissector supports the TCP/IP, UDP/IP, and IP
 multicast transports. Dissection of transport headers and encapsulated sample
 headers are fully supported. Optional dissection of sample payloads is also
 supported from Wireshark 1.12 on. The dissector is compatible with Wireshark
-1.2 up to at least 2.6 and has been tested with Windows, macOS, and Linux.
+1.2 up to at least 3.0 and has been tested with Windows, macOS, and Linux.
 
 If you need to dissect packets in RTPS DDS systems, all recent versions of
 Wireshark have a built-in RTPS dissector. This dissector, at least for the
@@ -46,8 +46,8 @@ from within Wireshark.
 <a name="building"></a>
 ## Building
 
-Follow the steps in the INSTALL file in the root of OpenDDS directory, along
-with the steps here.
+Follow the steps in the `INSTALL.md` file in the root of OpenDDS directory,
+along with the steps here.
 
 In addition, the Wireshark sources must be available and built locally
 according to the [Wireshark Developer's Guide](https://www.wireshark.org/docs/wsdg_html_chunked/)
@@ -56,6 +56,9 @@ like:
 
  - `wireshark-devel` on Fedora derived Linux distributions.
  - `wireshark-dev` on Debian derived Linux distributions.
+ - `wireshark-cli` on Arch Linux. This is the base Wireshark package, so the
+   development package is already installed if you installed the normal
+   Wireshark package, `wireshark-qt`.
 
 ### Configure
 
@@ -69,8 +72,8 @@ was built or was acquired:
   Wireshark headers and libraries. This should be used with:
 
    - Any version of Wireshark built with autoconf, which is try if you
-     ran autogen.sh. This is the recommended way to build on Linux as
-     of Wireshark 2.6.
+     ran `autogen.sh`. This is the recommended way to build on Linux before
+     Wireshark 3.0.
 
    - Wireshark 1.x built on Windows. Also `%WIRETAP_VERSION%` should also
      be set to the version of wiretap in the build.
@@ -83,10 +86,12 @@ was built or was acquired:
 
 - The newer out-of-source method, `--wireshark_cmake`, should be used if
   Wireshark was built using CMake, which can put "config.h" header and
-  the Wireshark libraries somewhere other than the source tree. This is
-  Wireshark's recommended method for Windows and macOS and can optionally
-  be used on Linux. This complicates things somewhat so two more
-  options with arguments provided:
+  the Wireshark libraries somewhere other than the source tree. Before 3.0
+  this was Wireshark's recommended method for Windows and macOS and can
+  optionally be used on Linux. After 3.0 CMake is the only way to build
+  Wireshark.
+  CMake complicates things somewhat so two more options with arguments
+  provided:
 
   - `--wireshark_build`
     - Is the build directory the user choose before building Wireshark.
@@ -100,7 +105,7 @@ was built or was acquired:
       - On Windows the default is `run\RelWithDebInfo`.
       - On macOS the default is `run/Wireshark.app/Contents/Frameworks`.
       - On Linux the default is an empty string as the libraries are in
-        the build directory.
+        the build directory. For Wireshark 3.0 you should set this to `run`.
 
 Glib is also required to build the dissector, so `--glib` must be passed.
 If Wireshark was not built with the system Glib or Glib is not installed,
@@ -122,11 +127,11 @@ library at `DDS_ROOT/tools/IntermediateTypeLang/cpp/rapidjson`.
 
 ### Build
 
-Build normally as described in the `$DDS_ROOT/INSTALL document`.
+Build normally as described in the `$DDS_ROOT/INSTALL.md` document.
 
 ### Install Plugin
 
-To install the dissector plugin, copy the plugin file  from
+To install the dissector plugin, copy the plugin file from
 `DDS_ROOT/tools/dissector` to one of the plugin directories listed in the
 Folders section in Wireshark's "About" dialog which can be found in the "Help"
 menu. On Windows, the plugin file will be named `OpenDDS_Dissector.dll` or
@@ -135,7 +140,7 @@ On UNIX-like systems it will be named `OpenDDS_Dissector.so`.
 
 See [Wireshark User's Guide Page on Plugins Folders](
 https://www.wireshark.org/docs/wsug_html_chunked/ChPluginFolders.html)
-for details on where Wireshark looks for plugins. This page, if working
+for details on where Wireshark looks for plugins. This page, if working,
 will be accurate for the latest stable version, but maybe not previous
 versions.
 

--- a/tools/dissector/packet-repo.cpp
+++ b/tools/dissector/packet-repo.cpp
@@ -375,7 +375,14 @@ namespace OpenDDS
               TopicStatus status = instance().add_topic_status (hf_topicStatus);
               const RepoId *rid = instance().add_repo_id (hf_topicId);
 
-              if (instance().pinfo_->fd->flags.visited)
+              frame_data* fd = instance().pinfo_->fd;
+              bool visited;
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(3, 0, 0)
+              visited = fd->visited;
+#else
+              visited = fd->flags.visited;
+#endif
+              if (visited)
                 {
                   return true;
                 }
@@ -406,7 +413,14 @@ namespace OpenDDS
           instance().add_string (hf_topicName);
           const char * dname = instance().add_string (hf_dataTypeName);
 //           instance().add_topic_qos (hf_qos, instance().ett_topic_qos_);
-          if (instance().pinfo_->fd->flags.visited)
+          frame_data* fd = instance().pinfo_->fd;
+          bool visited;
+#if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(3, 0, 0)
+          visited = fd->visited;
+#else
+          visited = fd->flags.visited;
+#endif
+          if (visited)
             {
               return true;
             }

--- a/tools/dissector/plugin.cpp
+++ b/tools/dissector/plugin.cpp
@@ -31,7 +31,13 @@ extern "C" {
  */
 #if WIRESHARK_VERSION >= WIRESHARK_VERSION_NUMBER(2, 5, 0)
   extern "C" dissector_Export const gchar plugin_version[] = DDS_VERSION;
+
+#  if WIRESHARK_VERSION < WIRESHARK_VERSION_NUMBER(3, 0, 0)
   extern "C" dissector_Export const gchar plugin_release[] = VERSION_RELEASE;
+#  else
+  extern "C" dissector_Export const int plugin_want_major = VERSION_MAJOR;
+  extern "C" dissector_Export const int plugin_want_minor = VERSION_MINOR;
+#  endif
 #else
   extern "C" dissector_Export const gchar version[] = DDS_VERSION;
 #endif


### PR DESCRIPTION
Wireshark lied in the 3.0 changelog when they said there was no major API changes. I wouldn't call changing the required symbols for all plugins a minor API change...