### PR TITLE
Service Participant, Transport Registry, RTPS libs updated to support certain Restart scenarios

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -107,6 +107,7 @@ tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE 
 tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl bp_timeout: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/sub_init_loop/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2214,7 +2214,7 @@ DomainParticipantImpl::LivelinessTimer::LivelinessTimer(DomainParticipantImpl& i
 
 DomainParticipantImpl::LivelinessTimer::~LivelinessTimer()
 {
-  if (scheduled_) {
+  if (scheduled_ && TheServiceParticipant->timer()) {
     TheServiceParticipant->timer()->cancel_timer(this);
   }
 }

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -318,60 +318,59 @@ Sedp::init(const RepoId& guid,
   OPENDDS_STRING config_name = DCPS::TransportRegistry::DEFAULT_INST_PREFIX +
                             OPENDDS_STRING("_SEDP_TransportCfg_") + key +
                             domainStr;
-  DCPS::TransportConfig_rch transport_cfg =
-    TheTransportRegistry->create_config(config_name.c_str());
-  transport_cfg->instances_.push_back(transport_inst_);
+  transport_cfg_ = TheTransportRegistry->create_config(config_name.c_str());
+  transport_cfg_->instances_.push_back(transport_inst_);
 
   // Configure and enable each reader/writer
   rtps_inst->opendds_discovery_default_listener_ = publications_reader_;
   rtps_inst->opendds_discovery_guid_ = guid;
-  const bool reliability = true, durability = true;
+  const bool reliable = true, durable = true;
 
 #ifdef OPENDDS_SECURITY
   const bool besteffort = false, nondurable = false;
 #endif
 
-  publications_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  publications_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  publications_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  publications_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 
 #ifdef OPENDDS_SECURITY
   publications_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   publications_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  publications_secure_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  publications_secure_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  publications_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  publications_secure_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 #endif
 
-  subscriptions_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  subscriptions_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  subscriptions_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  subscriptions_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 
 #ifdef OPENDDS_SECURITY
   subscriptions_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   subscriptions_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  subscriptions_secure_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  subscriptions_secure_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  subscriptions_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  subscriptions_secure_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 #endif
 
-  participant_message_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  participant_message_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  participant_message_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  participant_message_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 
 #ifdef OPENDDS_SECURITY
   participant_message_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   participant_message_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  participant_message_secure_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  participant_message_secure_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  participant_message_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  participant_message_secure_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 
-  participant_stateless_message_writer_.enable_transport_using_config(besteffort, nondurable, transport_cfg);
-  participant_stateless_message_reader_->enable_transport_using_config(besteffort, nondurable, transport_cfg);
+  participant_stateless_message_writer_.enable_transport_using_config(besteffort, nondurable, transport_cfg_);
+  participant_stateless_message_reader_->enable_transport_using_config(besteffort, nondurable, transport_cfg_);
 
   participant_volatile_message_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   participant_volatile_message_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  participant_volatile_message_secure_writer_.enable_transport_using_config(reliability, nondurable, transport_cfg);
-  participant_volatile_message_secure_reader_->enable_transport_using_config(reliability, nondurable, transport_cfg);
+  participant_volatile_message_secure_writer_.enable_transport_using_config(reliable, nondurable, transport_cfg_);
+  participant_volatile_message_secure_reader_->enable_transport_using_config(reliable, nondurable, transport_cfg_);
 
   dcps_participant_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   dcps_participant_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  dcps_participant_secure_writer_.enable_transport_using_config(reliability, durability, transport_cfg);
-  dcps_participant_secure_reader_->enable_transport_using_config(reliability, durability, transport_cfg);
+  dcps_participant_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  dcps_participant_secure_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 #endif
 
   return DDS::RETCODE_OK;
@@ -601,6 +600,12 @@ DDS::ReturnCode_t Sedp::init_security(DDS::Security::IdentityHandle /* id_handle
   return result;
 }
 #endif
+
+Sedp::~Sedp()
+{
+  TheTransportRegistry->remove_config(transport_cfg_);
+  TheTransportRegistry->remove_inst(transport_inst_);
+}
 
 void
 Sedp::unicast_locators(DCPS::LocatorSeq& locators) const

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -296,7 +296,7 @@ Sedp::init(const RepoId& guid,
     if (rtps_inst->multicast_group_address_.set(mc_port, mc_addr.c_str())) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::init - ")
-                 ACE_TEXT("failed setting multicast local_addr to port %hd\n"),
+                 ACE_TEXT("failed setting multicast local_addr to port %hu\n"),
                           mc_port));
       return DDS::RETCODE_ERROR;
     }

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -68,6 +68,8 @@ public:
        Spdp& owner,
        ACE_Thread_Mutex& lock);
 
+  ~Sedp();
+
   DDS::ReturnCode_t init(const DCPS::RepoId& guid,
                          const RtpsDiscovery& disco,
                          DDS::DomainId_t domainId);
@@ -493,6 +495,7 @@ private:
 
   // Transport
   DCPS::TransportInst_rch transport_inst_;
+  DCPS::TransportConfig_rch transport_cfg_;
 
 #ifndef DDS_HAS_MINIMUM_BIT
   DCPS::TopicBuiltinTopicDataDataReaderImpl* topic_bit();

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1343,7 +1343,7 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer, bool securityGuids)
     ACE_DEBUG((
           LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::SpdpTransport() - ")
-          ACE_TEXT("failed setting default_multicast address %C:%hd %p\n"),
+          ACE_TEXT("failed setting default_multicast address %C:%hu %p\n"),
           mc_addr.c_str(), mc_port, ACE_TEXT("ACE_INET_Addr::set")));
     throw std::runtime_error("failed to set default_multicast address");
   }
@@ -1353,7 +1353,7 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer, bool securityGuids)
   if (DCPS::DCPS_debug_level > 3) {
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("(%P|%t) Spdp::SpdpTransport::SpdpTransport ")
-               ACE_TEXT("joining group %C %C:%hd\n"),
+               ACE_TEXT("joining group %C %C:%hu\n"),
                net_if.c_str (),
                mc_addr.c_str (),
                mc_port));
@@ -1369,7 +1369,7 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer, bool securityGuids)
                                   ACE_TEXT_CHAR_TO_TCHAR(net_if.c_str()))) {
     ACE_ERROR((LM_ERROR,
         ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::SpdpTransport() - ")
-        ACE_TEXT("failed to join multicast group %C:%hd %p\n"),
+        ACE_TEXT("failed to join multicast group %C:%hu %p\n"),
         mc_addr.c_str(), mc_port, ACE_TEXT("ACE_SOCK_Dgram_Mcast::join")));
     throw std::runtime_error("failed to join multicast group");
   }
@@ -1746,7 +1746,7 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket() - ")
                ACE_TEXT("failed to set TTL value to %d ")
-               ACE_TEXT("for port:%hd %p\n"),
+               ACE_TEXT("for port:%hu %p\n"),
                outer_->disco_->ttl(), uni_port, ACE_TEXT("DCPS::set_socket_multicast_ttl:")));
     throw std::runtime_error("failed to set TTL");
   }

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -44,7 +44,9 @@ void ReactorInterceptor::wait()
 
   if (should_execute_immediately()) {
     handle_exception_i(guard);
-    reactor()->purge_pending_notifications(this);
+    if (!reactor_is_shut_down()) {
+      reactor()->purge_pending_notifications(this);
+    }
   } else {
     while (!command_queue_.empty()) {
       condition_.wait();

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -271,7 +271,7 @@ Service_Participant::shutdown()
       if (reactor_) {
         reactor_->end_reactor_event_loop();
         reactor_task_.wait();
-        reactor_ = 0;
+        reactor_.reset();
       }
 
       discoveryMap_.clear();

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -264,12 +264,14 @@ Service_Participant::shutdown()
 
       if (dp_factory_servant_)
         dp_factory_servant_->cleanup();
+      dp_factory_servant_.reset();
 
       domainRepoMap_.clear();
 
       if (reactor_) {
         reactor_->end_reactor_event_loop();
         reactor_task_.wait();
+        reactor_ = 0;
       }
 
       discoveryMap_.clear();
@@ -280,6 +282,7 @@ Service_Participant::shutdown()
   #endif
 
       discovery_types_.clear();
+      monitor_factory_ = 0;
     }
     TransportRegistry::close();
   } catch (const CORBA::Exception& ex) {
@@ -308,6 +311,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
                      this->factory_lock_,
                      DDS::DomainParticipantFactory::_nil());
 
+    shut_down_ = false;
     if (!dp_factory_servant_) {
       // This used to be a call to ORB_init().  Since the ORB is now managed
       // by InfoRepoDiscovery, just save the -ORB* args for later use.
@@ -394,6 +398,8 @@ Service_Participant::get_domain_participant_factory(int &argc,
 
       if (!reactor_)
         reactor_.reset(new ACE_Reactor(new ACE_Select_Reactor, true));
+
+      reactor_task_.thr_mgr(ACE_Thread_Manager::instance());
 
       if (reactor_task_.activate(THR_NEW_LWP | THR_JOINABLE) == -1) {
         ACE_ERROR((LM_ERROR,

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -485,6 +485,14 @@ TransportRegistry::register_type(const TransportType_rch& type)
   }
 }
 
+bool TransportRegistry::has_type(const TransportType_rch& type) const
+{
+  DBG_ENTRY_LVL("TransportRegistry", "has_type", 6);
+  const OPENDDS_STRING name = type->name();
+  GuardType guard(lock_);
+  return type_map_.count(name);
+}
+
 
 void
 TransportRegistry::release()

--- a/dds/DCPS/transport/framework/TransportRegistry.h
+++ b/dds/DCPS/transport/framework/TransportRegistry.h
@@ -83,6 +83,10 @@ public:
   /// and registers it with TransportRegistry singleton.
   void register_type(const TransportType_rch& type);
 
+  /// SPI (Service Provider Interface) for specific transport types:
+  /// Check if a type with this type's name has been registered
+  bool has_type(const TransportType_rch& type) const;
+
   /// For internal use by OpenDDS DCPS layer:
   /// Transfer the configuration in ACE_Configuration_Heap object to
   /// the TransportRegistry.  This is called by the Service_Participant

--- a/dds/DCPS/transport/framework/TransportRegistry.h
+++ b/dds/DCPS/transport/framework/TransportRegistry.h
@@ -58,6 +58,10 @@ public:
   TransportInst_rch create_inst(const OPENDDS_STRING& name,
                                 const OPENDDS_STRING& transport_type);
   TransportInst_rch get_inst(const OPENDDS_STRING& name) const;
+
+  /// Removing a TransportInst from the registry shuts down the underlying
+  /// transport implementation (if one was started) and therefore should only
+  /// be attempted after DDS Entities using this transport have been deleted.
   void remove_inst(const TransportInst_rch& inst);
 
   static const char DEFAULT_CONFIG_NAME[];

--- a/dds/DCPS/transport/framework/TransportRegistry.inl
+++ b/dds/DCPS/transport/framework/TransportRegistry.inl
@@ -63,7 +63,14 @@ void
 TransportRegistry::remove_inst(const TransportInst_rch& inst)
 {
   GuardType guard(this->lock_);
-  this->inst_map_.erase(inst->name());
+  InstMap::iterator iter = inst_map_.find(inst->name());
+  if (iter == inst_map_.end()) {
+    return;
+  }
+  if (iter->second) {
+    iter->second->shutdown();
+  }
+  this->inst_map_.erase(iter);
 }
 
 ACE_INLINE

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
@@ -33,12 +33,19 @@ public:
 int
 RtpsUdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 {
-  static bool initialized(false);
+  load();
+  return 0;
+}
 
-  if (initialized) return 0;  // already initialized
-
+void RtpsUdpLoader::load()
+{
   TransportRegistry* registry = TheTransportRegistry;
-  registry->register_type(make_rch<RtpsUdpType>());
+  TransportType_rch type = make_rch<RtpsUdpType>();
+  if (registry->has_type(type)) {
+    return;
+  }
+
+  registry->register_type(type);
   // Don't create a default for RTPS.  At least for the initial implementation,
   // the user needs to explicitly configure it...
 #ifdef OPENDDS_SAFETY_PROFILE
@@ -50,9 +57,6 @@ RtpsUdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
     ->sorted_insert(default_inst);
 #endif
-  initialized = true;
-
-  return 0;
 }
 
 ACE_FACTORY_DEFINE(OpenDDS_Rtps_Udp, RtpsUdpLoader);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.h
@@ -24,6 +24,8 @@ class OpenDDS_Rtps_Udp_Export RtpsUdpLoader
   : public ACE_Service_Object {
 public:
   virtual int init(int argc, ACE_TCHAR* argv[]);
+
+  static void load();
 };
 
 ACE_STATIC_SVC_DECLARE_EXPORT(OpenDDS_Rtps_Udp, RtpsUdpLoader)

--- a/java/tests/hello/conditional_idlflags.mpb
+++ b/java/tests/hello/conditional_idlflags.mpb
@@ -1,4 +1,0 @@
-//This feature is disabled for 1.4a, which doesn't recognize -SS
-feature(dds_suppress_anys) {
-  idlflags     += -SS
-}

--- a/java/tests/hello/hello_java_client.mpc
+++ b/java/tests/hello/hello_java_client.mpc
@@ -1,5 +1,6 @@
-project: idl2jni, conditional_idlflags {
+project: idl2jni {
 
+  idlflags += -SS
   idl2jniflags += -SS
 
   IDL_Files {
@@ -12,18 +13,11 @@ project: idl2jni, conditional_idlflags {
   }
 
   Java_Files {
-      Client.java << Test/Hello.java
+    Client.java << Test/Hello.java
   }
 
   specific {
-    jarname  = hello_java_client
-  }
-
-  // Older versions of Visual Studio will create the intermediate directories
-  // in all-lowercase, so we have to create them first to get the correct case.
-  specific(vc71, vc8) {
-    prebuild   += <%mkdir%> Test 2<%gt%> <%nul%> <%or%> <%cat%> <%nul%> <%gt%> <%nul%>
-    prebuild   += <%mkdir%> classes<%slash%>Test 2<%gt%> <%nul%> <%or%> <%cat%> <%nul%> <%gt%> <%nul%>
+    jarname = hello_java_client
   }
 
   postclean += <%rm%> Test

--- a/tests/DCPS/Restart/.gitignore
+++ b/tests/DCPS/Restart/.gitignore
@@ -1,0 +1,14 @@
+/MessengerC.cpp
+/MessengerC.h
+/MessengerC.inl
+/MessengerS.cpp
+/MessengerS.h
+/MessengerTypeSupport.idl
+/MessengerTypeSupportC.cpp
+/MessengerTypeSupportC.h
+/MessengerTypeSupportC.inl
+/MessengerTypeSupportImpl.cpp
+/MessengerTypeSupportImpl.h
+/MessengerTypeSupportS.cpp
+/MessengerTypeSupportS.h
+/RestartTest

--- a/tests/DCPS/Restart/Messenger.idl
+++ b/tests/DCPS/Restart/Messenger.idl
@@ -1,0 +1,9 @@
+module Messenger {
+
+#pragma DCPS_DATA_TYPE "Messenger::Message"
+#pragma DCPS_DATA_KEY "Messenger::Message subject_id"
+
+  struct Message {
+    long subject_id;
+  };
+};

--- a/tests/DCPS/Restart/RestartTest.cpp
+++ b/tests/DCPS/Restart/RestartTest.cpp
@@ -1,0 +1,101 @@
+#define ACE_DOESNT_DEFINE_MAIN
+
+#include "MessengerTypeSupportImpl.h"
+
+#include "dds/DCPS/Marked_Default_Qos.h"
+#include "dds/DCPS/Service_Participant.h"
+#include "dds/DCPS/transport/framework/TransportRegistry.h"
+#include "dds/DCPS/transport/rtps_udp/RtpsUdpLoader.h"
+#include "dds/DCPS/RTPS/RtpsDiscovery.h"
+
+#include "ace/Init_ACE.h"
+
+#include <cstdlib>
+#include <sstream>
+#include <string>
+
+struct Application {
+  Application()
+  {
+    ACE::init();
+    ++instances_;
+    OpenDDS::DCPS::RtpsUdpLoader::load();
+    OpenDDS::RTPS::RtpsDiscovery::StaticInitializer initialize_rtps;
+    TheServiceParticipant->set_default_discovery(OpenDDS::DCPS::Discovery::DEFAULT_RTPS);
+
+    std::stringstream ss;
+    ss << "Config" << instances_;
+    transport_config_name_ = ss.str();
+    ss.str("");
+    ss << "Inst" << instances_;
+    const std::string transport_instance_name = ss.str();
+
+    OpenDDS::DCPS::TransportInst_rch ti = TheTransportRegistry->create_inst(transport_instance_name, "rtps_udp");
+    OpenDDS::DCPS::TransportConfig_rch cfg = TheTransportRegistry->create_config(transport_config_name_);
+    cfg->instances_.push_back(ti);
+
+    DDS::DomainParticipantFactory_var dpf = TheServiceParticipant->get_domain_participant_factory();
+    DDS::DomainParticipantFactoryQos factory_qos;
+    dpf->get_qos(factory_qos);
+    factory_qos.entity_factory.autoenable_created_entities = false;
+    dpf->set_qos(factory_qos);
+    participant_ = dpf->create_participant(0, PARTICIPANT_QOS_DEFAULT, 0, 0);
+    TheTransportRegistry->bind_config(cfg, participant_);
+    participant_->enable();
+
+    DDS::TypeSupport_var ts = new Messenger::MessageTypeSupportImpl;
+    CORBA::String_var tn = ts->get_type_name();
+    ts->register_type(participant_, tn);
+    DDS::Topic_var topic = participant_->create_topic("Topic", tn, TOPIC_QOS_DEFAULT, 0, 0);
+
+    DDS::Publisher_var pub = participant_->create_publisher(PUBLISHER_QOS_DEFAULT, 0, 0);
+    DDS::DataWriter_var dw = pub->create_datawriter(topic, DATAWRITER_QOS_DEFAULT, 0, 0);
+    DDS::Subscriber_var sub = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT, 0, 0);
+    DDS::DataReaderQos reader_qos;
+    sub->get_default_datareader_qos(reader_qos);
+    reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    DDS::DataReader_var dr = sub->create_datareader(topic, reader_qos, 0, 0);
+  }
+
+  ~Application()
+  {
+    {
+      DDS::DomainParticipantFactory_var dpf = TheParticipantFactory;
+      participant_->delete_contained_entities();
+      dpf->delete_participant(participant_);
+      participant_ = 0;
+    }
+
+    OpenDDS::DCPS::TransportConfig_rch cfg = TheTransportRegistry->get_config(transport_config_name_);
+    TheTransportRegistry->remove_config(cfg);
+    TheTransportRegistry->remove_inst(cfg->instances_[0]);
+
+    if (--instances_ == 0) {
+      TheServiceParticipant->shutdown();
+    }
+    ACE::fini();
+  }
+
+  static int instances_;
+
+  std::string transport_config_name_;
+  DDS::DomainParticipant_var participant_;
+};
+
+int Application::instances_ = 0;
+
+int main()
+{
+  {
+    Application a1;
+    {
+      Application a2;
+    }
+    {
+      Application a3;
+    }
+  }
+  Application a4;
+
+  return EXIT_SUCCESS;
+}

--- a/tests/DCPS/Restart/RestartTest.mpc
+++ b/tests/DCPS/Restart/RestartTest.mpc
@@ -1,4 +1,5 @@
 project: dcpsexe, dcps_rtps_udp {
+  requires += no_opendds_safety_profile
   TypeSupport_Files {
     Messenger.idl
   }

--- a/tests/DCPS/Restart/RestartTest.mpc
+++ b/tests/DCPS/Restart/RestartTest.mpc
@@ -1,0 +1,5 @@
+project: dcpsexe, dcps_rtps_udp {
+  TypeSupport_Files {
+    Messenger.idl
+  }
+}

--- a/tests/DCPS/Restart/run_test.pl
+++ b/tests/DCPS/Restart/run_test.pl
@@ -1,0 +1,15 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+
+# -*- perl -*-
+
+use lib "$ENV{ACE_ROOT}/bin";
+use lib "$ENV{DDS_ROOT}/bin";
+use PerlDDS::Run_Test;
+use strict;
+
+my $test = new PerlDDS::TestFramework();
+$test->process('rt', 'RestartTest');
+$test->start_process('rt');
+exit $test->finish(60);


### PR DESCRIPTION
Related to #1005 and possibly #991 

- Support restarting the same Service_Participant object after shutdown() 
- Updated RtpsUdpLoader to have an easy way to reload the transport (from application)
- Sedp: remove transport when we're done 
- TransportRegistry::remove_inst() calls shutdown on the transport