### PR TITLE
Correct broken links in About-Intro.html

### DIFF
--- a/about/articles/Article-Intro.html
+++ b/about/articles/Article-Intro.html
@@ -1745,12 +1745,12 @@ without making any code changes.
 <h2><a name="References"></a>References</h2>
 <ul>
 <li>Sample Code is located in the OpenDDS source code distribution at examples/DCPS/IntroductionToOpenDDS</li>
-<li>OMG Data Distribution Service (DDS) for Real-Time Systems (<a href="http://www.omg.org/docs/formal/07-05-02">http://www.omg.org/docs/formal/07-05-02</a>)</li>
-<li>OMG "Introduction to DDS" Whitepaper (<a href="http://www.omg.org/news/whitepapers/Intro_To_DDS.pdf">http://www.omg.org/news/whitepapers/Intro_To_DDS.pdf</a>)</li>
+<li>OMG Data Distribution Service (DDS) for Real-Time Systems (<a href="https://www.omg.org/spec/DDS/">https://www.omg.org/spec/DDS/</a>)</li>
+<li>OMG DDS Portal (<a href="https://www.omgwiki.org/dds/#">https://www.omgwiki.org/dds</a>)</li>
 <li>OpenDDS Home Page (<a href="..">http://www.opendds.org</a>)</li>
 <li>TAO Developer's Guide Home Page (<a href="http://www.theaceorb.com/product/index.html#TAO%20Developers%20Guide">http://www.theaceorb.com/product/index.html</a></li>
 <li>OpenDDS Developer's Guide (<a href="http://download.objectcomputing.com/OpenDDS/OpenDDS-latest.pdf">http://download.objectcomputing.com/OpenDDS/OpenDDS-latest.pdf</a>)</li>
-<li>MPC (<a href="http://www.objectcomputing.com/products/mpc">http://www.objectcomputing.com/products/mpc</a>)</li>
+<li>MPC (<a href="https://github.com/objectcomputing/MPC">https://github.com/objectcomputing/MPC</a>)</li>
 </ul>
 
       </div>


### PR DESCRIPTION
Broken:
OMG Data Distribution Service (DDS) for Real-Time Systems (http://www.omg.org/docs/formal/07-05-02)
OMG "Introduction to DDS" Whitepaper (http://www.omg.org/news/whitepapers/Intro_To_DDS.pdf)

First link moved to DDS Spec page.
Broken link to Introduction to DDS is now to the OMG DDS Portal that has all of the introductory material.
Also fixed the MPC link to the Object Computing GitHub page for MPC.