### PR TITLE
Unit tests and valgrind issues cleanup

### DIFF
--- a/dds/DCPS/DataSampleHeader.cpp
+++ b/dds/DCPS/DataSampleHeader.cpp
@@ -426,7 +426,7 @@ DataSampleHeader::split(const ACE_Message_Block& orig, size_t size,
     hdr.content_filter_ = (hdr.content_filter_entries_.length() > 0);
     hdr.message_length_ = static_cast<ACE_UINT32>(payload->total_length());
     *tail << hdr;
-    tail->cont(payload);
+    tail->cont(payload_head.release());
     if (hdr.content_filter_) {
       add_cfentries(&hdr.content_filter_entries_, tail.get());
     }

--- a/dds/DCPS/DisjointSequence.cpp
+++ b/dds/DCPS/DisjointSequence.cpp
@@ -248,11 +248,9 @@ DisjointSequence::fill_bitmap_range(CORBA::ULong low, CORBA::ULong high,
                      idx_low = low / 32, bit_low = low % 32,
                      idx_high = high / 32, bit_high = high % 32;
 
-  static const CORBA::Long MNSLI = 0x80000000; // most negative signed long integer
-
   // handle idx_nb zeros
   if (bit_nb) {
-    bitmap[idx_nb] &= (MNSLI >> (bit_nb - 1));
+    bitmap[idx_nb] &= ~((0x1u << (32 - bit_nb)) - 1);
   } else {
     bitmap[idx_nb] = 0;
   }
@@ -265,9 +263,9 @@ DisjointSequence::fill_bitmap_range(CORBA::ULong low, CORBA::ULong high,
   // handle idx_nb ones
   if (bit_low) {
     if (idx_low > idx_nb) {
-      bitmap[idx_low] = ~(MNSLI >> (bit_low - 1));
+      bitmap[idx_low] = (0x1u << (32 - bit_low)) - 1;
     } else {
-      bitmap[idx_low] |= ~(MNSLI >> (bit_low - 1));
+      bitmap[idx_low] |= (0x1u << (32 - bit_low)) - 1;
     }
   } else {
     bitmap[idx_low] = 0xFFFFFFFF;
@@ -279,10 +277,12 @@ DisjointSequence::fill_bitmap_range(CORBA::ULong low, CORBA::ULong high,
   }
 
   // handle idx_high
-  if (idx_high > idx_low) {
-    bitmap[idx_high] = MNSLI >> (bit_high);
-  } else {
-    bitmap[idx_high] &= MNSLI >> (bit_high);
+  if (bit_high < 31) {
+    if (idx_high > idx_low) {
+      bitmap[idx_high] = ~((0x1u << (31 - bit_high)) - 1);
+    } else {
+      bitmap[idx_high] &= ~((0x1u << (31 - bit_high)) - 1);
+    }
   }
 
   num_bits = high + 1;

--- a/dds/DCPS/DisjointSequence.cpp
+++ b/dds/DCPS/DisjointSequence.cpp
@@ -236,20 +236,17 @@ DisjointSequence::fill_bitmap_range(CORBA::ULong low, CORBA::ULong high,
                                     CORBA::ULong& num_bits)
 {
   bool clamped = false;
-  CORBA::ULong idx_nb = num_bits / 32, bit_nb = num_bits % 32,
-               idx_low = low / 32, bit_low = low % 32,
-               idx_high = high / 32, bit_high = high % 32;
-
-  if (idx_low >= length) {
+  if ((low / 32) >= length) {
     return false;
   }
-  if (idx_high >= length) {
-    // clamp to largest number we can represent
+  if ((high / 32) >= length) {
     high = length * 32 - 1;
-    idx_high = length - 1;
-    bit_high = high % 32;
     clamped = true;
   }
+
+  const CORBA::ULong idx_nb = num_bits / 32, bit_nb = num_bits % 32,
+                     idx_low = low / 32, bit_low = low % 32,
+                     idx_high = high / 32, bit_high = high % 32;
 
   static const CORBA::Long MNSLI = 0x80000000; // most negative signed long integer
 

--- a/dds/DCPS/DisjointSequence.cpp
+++ b/dds/DCPS/DisjointSequence.cpp
@@ -129,7 +129,7 @@ DisjointSequence::insert(SequenceNumber value, CORBA::ULong num_bits,
         // skip ahead: next gap in sequence must be past iter->second
         CORBA::ULong next_i = CORBA::ULong(iter->second.getValue() - val);
         bit = next_i % 32;
-        if (next_i / 32 != i / 32) {
+        if (next_i / 32 != i / 32 && next_i < num_bits) {
           x = static_cast<CORBA::ULong>(bits[next_i / 32]);
         }
         i = next_i;
@@ -254,11 +254,10 @@ DisjointSequence::fill_bitmap_range(CORBA::ULong low, CORBA::ULong high,
   for (CORBA::ULong i = (num_bits + 31) / 32; i < idx_low; ++i) {
     bitmap[i] = 0;
   }
-
   // write the Long at idx_low, preserving bits that may already be there
-  CORBA::ULong x = bitmap[idx_low]; // use unsigned for bitwise operators
+  CORBA::ULong x = ((num_bits / 32) < idx_low) ? 0 : bitmap[idx_low]; // use unsigned for bitwise operators
   //    clear the bits in x in the range [bit_last, bit_low)
-  if (num_bits > 0) {
+  if ((num_bits % 32) != 0) {
     const size_t bit_last = ((num_bits - 1) / 32 == idx_low)
                             ? ((num_bits - 1) % 32 + 1) : 0;
     for (size_t m = bit_last; m < bit_low; ++m) {

--- a/dds/DCPS/transport/framework/TransportReassembly.cpp
+++ b/dds/DCPS/transport/framework/TransportReassembly.cpp
@@ -72,6 +72,8 @@ TransportReassembly::insert(OPENDDS_LIST(FragRange)& flist,
         for (last = data.sample_.get(); last->cont(); last = last->cont()) ;
         last->cont(fr.rec_ds_.sample_.release());
         fr.rec_ds_.sample_.reset(data.sample_.release());
+      } else {
+        fr.rec_ds_.sample_.reset();
       }
       data.sample_.reset();
       fr.transport_seq_.first = seqRange.first;

--- a/tests/DCPS/UnitTests/DisjointSequence.cpp
+++ b/tests/DCPS/UnitTests/DisjointSequence.cpp
@@ -396,6 +396,20 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
     }
     {
       DisjointSequence sequence;
+      CORBA::Long bits[] = { 3 << 30 }; // high bit is logical index '0'
+      TEST_CHECK(sequence.insert(0, 2 /*num_bits*/, bits));
+      TEST_CHECK(!sequence.empty() && !sequence.disjoint());
+      TEST_CHECK(sequence.low() == 0 && sequence.high() == 1);
+    }
+    {
+      DisjointSequence sequence;
+      CORBA::Long bits[] = { 3 << 29 }; // high bit is logical index '0'
+      TEST_CHECK(sequence.insert(0, 3 /*num_bits*/, bits));
+      TEST_CHECK(!sequence.empty() && !sequence.disjoint());
+      TEST_CHECK(sequence.low() == 1 && sequence.high() == 2);
+    }
+    {
+      DisjointSequence sequence;
       CORBA::Long bits[] = { 1 << 31 }; // high bit is logical index '0'
       TEST_CHECK(sequence.insert(5, 1 /*num_bits*/, bits));
       TEST_CHECK(!sequence.empty() && !sequence.disjoint());

--- a/tests/DCPS/UnitTests/DisjointSequence.cpp
+++ b/tests/DCPS/UnitTests/DisjointSequence.cpp
@@ -21,8 +21,6 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
   {
     // Construction (default)
     {
-      TEST_CHECK(SequenceNumber(SequenceNumber::MIN_VALUE) == SequenceNumber());
-
       DisjointSequence sequence;
 
       // ASSERT initial value is empty:
@@ -626,6 +624,87 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
       TEST_CHECK(static_cast<unsigned int>(anti_bitmap[0]) == 0xFFC00FFF);
       TEST_CHECK(static_cast<unsigned int>(anti_bitmap[1]) == 0xFFFFFFFF);
       TEST_CHECK((anti_bitmap[2] & 0xF0000000) == 0xF0000000);
+    }
+    {
+      DisjointSequence sequence;
+      sequence.insert(0);
+      sequence.insert(SequenceRange(3, 3));
+      CORBA::Long bitmap[1];
+      CORBA::ULong num_bits;
+      TEST_CHECK(sequence.to_bitmap(bitmap, 1, num_bits));
+      TEST_CHECK(num_bits == 3);
+      TEST_CHECK((bitmap[0] & 0xE0000000) == 0x20000000);
+
+      CORBA::Long anti_bitmap[1];
+      CORBA::ULong anti_num_bits;
+      TEST_CHECK(sequence.to_bitmap(anti_bitmap, 1, anti_num_bits, true));
+      TEST_CHECK(anti_num_bits == 2);
+      TEST_CHECK((anti_bitmap[0] & 0xE0000000) == 0xC0000000);
+    }
+    {
+      DisjointSequence sequence;
+      sequence.insert(0);
+      sequence.insert(SequenceRange(16, 16));
+      sequence.insert(SequenceRange(32, 38));
+      CORBA::Long bitmap[2];
+      CORBA::ULong num_bits;
+      TEST_CHECK(sequence.to_bitmap(bitmap, 2, num_bits));
+      TEST_CHECK(num_bits == 38);
+      TEST_CHECK(bitmap[0] == 0x00010001);
+      TEST_CHECK((bitmap[1] & 0xFC000000) == 0xFC000000);
+
+      CORBA::Long anti_bitmap[1];
+      CORBA::ULong anti_num_bits;
+      TEST_CHECK(sequence.to_bitmap(anti_bitmap, 1, anti_num_bits, true));
+      TEST_CHECK(anti_num_bits == 31);
+      TEST_CHECK((anti_bitmap[0] & 0xFFFFFFFE) == 0xFFFEFFFE);
+    }
+    {
+      DisjointSequence sequence;
+      sequence.insert(0);
+      sequence.insert(SequenceRange(55, 84));
+      sequence.insert(SequenceRange(96, 100));
+      CORBA::Long bitmap[4];
+      CORBA::ULong num_bits;
+      TEST_CHECK(sequence.to_bitmap(bitmap, 4, num_bits));
+      TEST_CHECK(num_bits == 100);
+      TEST_CHECK(bitmap[0] == 0x00000000);
+      TEST_CHECK(bitmap[1] == 0x000003FF);
+      TEST_CHECK(static_cast<unsigned int>(bitmap[2]) == 0xFFFFF001);
+      TEST_CHECK((bitmap[3] & 0xF0000000) == 0xF0000000);
+
+      CORBA::Long anti_bitmap[3];
+      CORBA::ULong anti_num_bits;
+      TEST_CHECK(sequence.to_bitmap(anti_bitmap, 3, anti_num_bits, true));
+      TEST_CHECK(anti_num_bits == 95);
+      TEST_CHECK(static_cast<unsigned int>(anti_bitmap[0]) == 0xFFFFFFFF);
+      TEST_CHECK(static_cast<unsigned int>(anti_bitmap[1]) == 0xFFFFFC00);
+      TEST_CHECK((anti_bitmap[2] & 0x00000FFE) == 0x00000FFE);
+    }
+    {
+      DisjointSequence sequence;
+      sequence.insert(SequenceRange( 0, 22));
+      sequence.insert(SequenceRange(27, 32));
+      sequence.insert(SequenceRange(35, 38));
+      sequence.insert(SequenceRange(42, 53));
+      sequence.insert(SequenceRange(55, 76));
+      sequence.insert(SequenceRange(81, 87));
+      sequence.insert(SequenceRange(95, 96));
+      CORBA::Long bitmap[3];
+      CORBA::ULong num_bits;
+      TEST_CHECK(sequence.to_bitmap(bitmap, 3, num_bits));
+      TEST_CHECK(num_bits == 74);
+      TEST_CHECK(bitmap[0] == 0x0FCF1FFE);
+      TEST_CHECK(static_cast<unsigned int>(bitmap[1]) == 0xFFFFFC3F);
+      TEST_CHECK((bitmap[2] & 0xFFC00000) == 0x80C00000);
+
+      CORBA::Long anti_bitmap[3];
+      CORBA::ULong anti_num_bits;
+      TEST_CHECK(sequence.to_bitmap(anti_bitmap, 3, anti_num_bits, true));
+      TEST_CHECK(anti_num_bits == 72);
+      TEST_CHECK(static_cast<unsigned int>(anti_bitmap[0]) == 0xF030E001);
+      TEST_CHECK(anti_bitmap[1] == 0x000003C0);
+      TEST_CHECK((anti_bitmap[2] & 0xFF000000) == 0x7F000000);
     }
     {
       DisjointSequence sequence;

--- a/tests/DCPS/UnitTests/SequenceNumber.cpp
+++ b/tests/DCPS/UnitTests/SequenceNumber.cpp
@@ -15,16 +15,17 @@
 using namespace OpenDDS::DCPS;
 
 namespace {
+  const SequenceNumber::Value INITIAL  = SequenceNumber::INITIAL_VALUE;
   const SequenceNumber::Value SN_MAX   = SequenceNumber::MAX_VALUE;
   const SequenceNumber::Value SN_MIN   = SequenceNumber::MIN_VALUE;
-  const SequenceNumber::Value SN_SEAM  = ACE_INT32_MAX;
+  const SequenceNumber::Value SN_SEAM  = ACE_UINT32_MAX;
 }
 
 int
 ACE_TMAIN(int, ACE_TCHAR*[])
 {
   // Construction (default)
-  TEST_CHECK(SequenceNumber(SN_MIN) == SequenceNumber());
+  TEST_CHECK(SequenceNumber(INITIAL) == SequenceNumber());
 
   TEST_CHECK(SequenceNumber::ZERO().getValue() == 0);
   TEST_CHECK(SequenceNumber::ZERO() < SequenceNumber());
@@ -55,10 +56,10 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   {
     SequenceNumber num(SN_MAX);
     TEST_CHECK(num.getValue() == SN_MAX);
-    TEST_CHECK((++num).getValue() == SN_MIN);
+    TEST_CHECK((++num).getValue() == INITIAL);
     // test post-incrementer
-    TEST_CHECK((num++).getValue() == SN_MIN);
-    TEST_CHECK(num.getValue() == SN_MIN+1);
+    TEST_CHECK((num++).getValue() == INITIAL);
+    TEST_CHECK(num.getValue() == INITIAL+1);
   }
 
   // Test SEQUENCENUMBER_UNKNOWN

--- a/tests/DCPS/UnitTests/run_test.pl
+++ b/tests/DCPS/UnitTests/run_test.pl
@@ -13,6 +13,9 @@ use lib "$ACE_ROOT/bin";
 use PerlDDS::Run_Test;
 use FileHandle;
 use Cwd;
+use strict;
+
+my $single_test;
 
 if(defined $ARGV[0])
 {
@@ -23,6 +26,7 @@ if(defined $ARGV[0])
 }
 
 my $something_ran = 0;
+my $status = 0;
 
 sub run_unit_tests {
   if($single_test ne '') {
@@ -43,14 +47,15 @@ sub run_unit_tests {
     if (opendir($fh, $dir)) {
       foreach my $file (readdir($fh)) {
         my $test = new PerlDDS::TestFramework();
+        my $executable;
         if ($file =~ /$testExe/o) {
-          my $executable = $1;
+          $executable = $1;
           # each process runs to completion before the next starts
           my $LONE_PROCESS = 1;
           if ($executable eq "UnitTests_BIT_DataReader") {
-            $test->process ("$executable", "$executable", "-DCPSConfigFile rtps.ini", $LONE_PROCESS);
+            $test->process("$executable", "$executable", "-DCPSConfigFile rtps.ini", $LONE_PROCESS);
           } else {
-            $test->process ("$executable", "$executable", "", $LONE_PROCESS);
+            $test->process("$executable", "$executable", "", $LONE_PROCESS);
           }
         }
         else {
@@ -58,8 +63,10 @@ sub run_unit_tests {
         }
         $something_ran = 1;
         print STDOUT "Running $file\n";
+        $test->start_process("$executable");
         my $retcode = $test->finish(60);
         if ($retcode != 0) {
+          print STDOUT "BOGUS\n";
           ++$status;
         }
       }

--- a/tests/DCPS/UnitTests/run_test.pl
+++ b/tests/DCPS/UnitTests/run_test.pl
@@ -66,7 +66,6 @@ sub run_unit_tests {
         $test->start_process("$executable");
         my $retcode = $test->finish(60);
         if ($retcode != 0) {
-          print STDOUT "BOGUS\n";
           ++$status;
         }
       }

--- a/tests/DCPS/common/TestSupport.h
+++ b/tests/DCPS/common/TestSupport.h
@@ -4,7 +4,7 @@
 // if COND fails then log error and abort with -1.
 #define TEST_CHECK(COND) \
   if (!( COND )) \
-      ACE_ERROR((LM_ERROR,"(%P|%t) TEST_ASSERT(%C) FAILED at %N:%l%a\n",\
+      ACE_ERROR((LM_ERROR,"(%P|%t) TEST_ASSERT(%C) FAILED at %N:%l\n%a\n",\
         #COND , -1));
 
 // if COND fails then log error and throw.


### PR DESCRIPTION
It turns out that $(DDS_ROOT)/tests/DCPS/UnitTests/run_test.pl had a bug in it which prevented it from running any of the unit tests in that directory (despite printing their names and printing "test PASSED"). The tests now run and several bugs that would have been caught have now been caught and fixed. In addition, a few vaguely-related valgrind issues have been caught and cleaned up, as these were the motivating reason behind revisiting the unit tests.