### PR TITLE
Visual Studio /clr leads to linking errors

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1850,6 +1850,13 @@ CORBA::Long DataReaderImpl::total_samples() const
   return count;
 }
 
+void
+DataReaderImpl::LivelinessTimer::check_liveliness()
+{
+  CheckLivelinessCommand c(this);
+  execute_or_enqueue(c);
+}
+
 int
 DataReaderImpl::LivelinessTimer::handle_timeout(const ACE_Time_Value& tv,
                                                 const void * /*arg*/)

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -763,11 +763,7 @@ private:
       , liveliness_timer_id_(-1)
     { }
 
-    void check_liveliness()
-    {
-     CheckLivelinessCommand c(this);
-     execute_or_enqueue(c);
-    }
+	void check_liveliness();
 
     void cancel_timer()
     {

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -763,7 +763,7 @@ private:
       , liveliness_timer_id_(-1)
     { }
 
-	void check_liveliness();
+    void check_liveliness();
 
     void cancel_timer()
     {

--- a/dds/DCPS/unique_ptr.h
+++ b/dds/DCPS/unique_ptr.h
@@ -132,7 +132,7 @@ public:
   }
 
 private:
-  unique_ptr(const unique_ptr&);
+  unique_ptr(const unique_ptr&) {};
   unique_ptr& operator=(const unique_ptr&);
 
   T* ptr_;

--- a/dds/DCPS/unique_ptr.h
+++ b/dds/DCPS/unique_ptr.h
@@ -132,7 +132,7 @@ public:
   }
 
 private:
-  unique_ptr(const unique_ptr&) {};
+  unique_ptr(const unique_ptr&);
   unique_ptr& operator=(const unique_ptr&);
 
   T* ptr_;


### PR DESCRIPTION
Changes needed to avoid linking errors when compiling with C++/CLI.

Related Issue: #962