### PR TITLE
Fixing a deadlock issue encountered under heavy discovery load

### DIFF
--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -432,9 +432,12 @@ private:
   Reader_rch dcps_participant_secure_reader_;
 #endif
 
+  static const size_t TASK_MQ_BYTES = sizeof(Msg) * 1024 * 32;
+
   struct Task : ACE_Task_Ex<ACE_MT_SYNCH, Msg> {
     explicit Task(Sedp* sedp)
-      : spdp_(&sedp->spdp_)
+      : ACE_Task_Ex<ACE_MT_SYNCH, Msg>(0, new ACE_Message_Queue_Ex<Msg, ACE_MT_SYNCH>(TASK_MQ_BYTES, TASK_MQ_BYTES))
+      , spdp_(&sedp->spdp_)
       , sedp_(sedp)
       , shutting_down_(false)
     {


### PR DESCRIPTION
Fixing a deadlock issue encountered when datalink.cpp tries to call default listener while holding pub_sub_maps_lock_ mutex and encounters a full sedp task queue