### PR TITLE
Security Registry and cleanup

### DIFF
--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -441,6 +441,7 @@ private:
       , sedp_(sedp)
       , shutting_down_(false)
     {
+      delete_msg_queue_ = true;
       activate();
     }
     ~Task();

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -18,6 +18,9 @@
 #include "RecorderImpl.h"
 #include "ReplayerImpl.h"
 #include "StaticDiscovery.h"
+#if defined(OPENDDS_SECURITY)
+#include "security/framework/SecurityRegistry.h"
+#endif
 
 #include "ace/Singleton.h"
 #include "ace/Arg_Shifter.h"
@@ -258,6 +261,9 @@ Service_Participant::shutdown()
 
   shut_down_ = true;
   try {
+#if defined(OPENDDS_SECURITY)
+    OpenDDS::Security::SecurityRegistry::instance()->release();
+#endif
     TransportRegistry::instance()->release();
     {
       ACE_GUARD(TAO_SYNCH_MUTEX, guard, this->factory_lock_);
@@ -285,6 +291,9 @@ Service_Participant::shutdown()
       monitor_factory_ = 0;
     }
     TransportRegistry::close();
+#if defined(OPENDDS_SECURITY)
+    OpenDDS::Security::SecurityRegistry::close();
+#endif
   } catch (const CORBA::Exception& ex) {
     ex._tao_print_exception("ERROR: Service_Participant::shutdown");
   }

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -1944,13 +1944,15 @@ AccessControlBuiltInImpl::RevokePermissionsTimer::RevokePermissionsTimer(AccessC
     : impl_(impl)
     , scheduled_(false)
     , timer_id_(0)
-    , reactor_(0)
 { }
 
 AccessControlBuiltInImpl::RevokePermissionsTimer::~RevokePermissionsTimer()
 {
-  if (scheduled_) {
-      reactor_->cancel_timer(this);
+  ACE_Reactor_Timer_Interface* reactor = TheServiceParticipant->timer();
+
+  if (scheduled_ && reactor != NULL) {
+    reactor->cancel_timer(this);
+    scheduled_ = false;
   }
 }
 
@@ -1964,10 +1966,10 @@ bool AccessControlBuiltInImpl::RevokePermissionsTimer::start_timer(const ACE_Tim
   ::DDS::Security::PermissionsHandle *eh_params_ptr =
       new ::DDS::Security::PermissionsHandle(pm_handle);
 
-  reactor_ = TheServiceParticipant->timer();
+  ACE_Reactor_Timer_Interface* reactor = TheServiceParticipant->timer();
 
-  if (reactor_ != NULL) {
-    timer_id_ = reactor_->schedule_timer(this, eh_params_ptr, length);
+  if (reactor != NULL) {
+    timer_id_ = reactor->schedule_timer(this, eh_params_ptr, length);
 
     if (timer_id_ != -1) {
       scheduled_ = true;

--- a/dds/DCPS/security/AccessControlBuiltInImpl.h
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.h
@@ -269,7 +269,6 @@ private:
     bool scheduled_;
     long timer_id_;
     ACE_Thread_Mutex lock_;
-    ACE_Reactor_Timer_Interface* reactor_;
   };
 
   RevokePermissionsTimer local_rp_timer_;


### PR DESCRIPTION
Fixing leak in SEDP's Task MQ allocation (caused by previous pull request to increase MQ size to help alleviate deadlock issues), and also a singleton "leak" from SecurityRegistry.