### PR TITLE
Improve GUID lookup / comparison performance

### DIFF
--- a/dds/DCPS/GuidUtils.h
+++ b/dds/DCPS/GuidUtils.h
@@ -91,44 +91,12 @@ enum EntityKind {     // EntityId_t.entityKind value(s)
 struct OpenDDS_Dcps_Export GUID_tKeyLessThan {
   static bool entity_less(const EntityId_t& v1, const EntityId_t& v2)
   {
-    if (v1.entityKey[2] < v2.entityKey[2]) return true;
-    if (v2.entityKey[2] < v1.entityKey[2]) return false;
-    if (v1.entityKey[1] < v2.entityKey[1]) return true;
-    if (v2.entityKey[1] < v1.entityKey[1]) return false;
-    if (v1.entityKey[0] < v2.entityKey[0]) return true;
-    if (v2.entityKey[0] < v1.entityKey[0]) return false;
-    if (v1.entityKind < v2.entityKind) return true;
-    if (v2.entityKind < v1.entityKind) return false;
-    return false;
+    return std::memcmp(&v1, &v2, sizeof(EntityId_t)) < 0;
   }
 
   bool operator()(const GUID_t& v1, const GUID_t& v2) const
   {
-    if (v1.guidPrefix[11] < v2.guidPrefix[11]) return true;
-    if (v2.guidPrefix[11] < v1.guidPrefix[11]) return false;
-    if (v1.guidPrefix[10] < v2.guidPrefix[10]) return true;
-    if (v2.guidPrefix[10] < v1.guidPrefix[10]) return false;
-    if (v1.guidPrefix[ 9] < v2.guidPrefix[ 9]) return true;
-    if (v2.guidPrefix[ 9] < v1.guidPrefix[ 9]) return false;
-    if (v1.guidPrefix[ 8] < v2.guidPrefix[ 8]) return true;
-    if (v2.guidPrefix[ 8] < v1.guidPrefix[ 8]) return false;
-    if (v1.guidPrefix[ 7] < v2.guidPrefix[ 7]) return true;
-    if (v2.guidPrefix[ 7] < v1.guidPrefix[ 7]) return false;
-    if (v1.guidPrefix[ 6] < v2.guidPrefix[ 6]) return true;
-    if (v2.guidPrefix[ 6] < v1.guidPrefix[ 6]) return false;
-    if (v1.guidPrefix[ 5] < v2.guidPrefix[ 5]) return true;
-    if (v2.guidPrefix[ 5] < v1.guidPrefix[ 5]) return false;
-    if (v1.guidPrefix[ 4] < v2.guidPrefix[ 4]) return true;
-    if (v2.guidPrefix[ 4] < v1.guidPrefix[ 4]) return false;
-    if (v1.guidPrefix[ 3] < v2.guidPrefix[ 3]) return true;
-    if (v2.guidPrefix[ 3] < v1.guidPrefix[ 3]) return false;
-    if (v1.guidPrefix[ 2] < v2.guidPrefix[ 2]) return true;
-    if (v2.guidPrefix[ 2] < v1.guidPrefix[ 2]) return false;
-    if (v1.guidPrefix[ 1] < v2.guidPrefix[ 1]) return true;
-    if (v2.guidPrefix[ 1] < v1.guidPrefix[ 1]) return false;
-    if (v1.guidPrefix[ 0] < v2.guidPrefix[ 0]) return true;
-    if (v2.guidPrefix[ 0] < v1.guidPrefix[ 0]) return false;
-    return entity_less(v1.entityId, v2.entityId);
+    return std::memcmp(&v1, &v2, sizeof(GUID_t)) < 0;
   }
 };
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1438,7 +1438,8 @@ RtpsUdpDataLink::send_ack_nacks(RtpsReaderMap::value_type& rr, bool finalFlag)
         ser << nack_frags[i]; // always 4-byte aligned
       }
 
-      if (!locators_.count(wi->first)) {
+      const OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter = locators_.find(wi->first);
+      if (iter == locators_.end()) {
         if (Transport_debug_level) {
           const GuidConverter conv(wi->first);
           ACE_ERROR((LM_ERROR,
@@ -1447,7 +1448,7 @@ RtpsUdpDataLink::send_ack_nacks(RtpsReaderMap::value_type& rr, bool finalFlag)
         }
       } else {
         send_strategy()->send_rtps_control(mb_acknack,
-                                          locators_[wi->first].addr_);
+                                           iter->second.addr_);
       }
     }
   }
@@ -1976,8 +1977,9 @@ RtpsUdpDataLink::send_nack_replies()
       process_requested_changes(requests, writer, ri->second);
 
       if (!ri->second.requested_changes_.empty()) {
-        if (locators_.count(ri->first)) {
-          recipients.insert(locators_[ri->first].addr_);
+        const OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter = locators_.find(ri->first);
+        if (iter != locators_.end()) {
+          recipients.insert(iter->second.addr_);
           if (Transport_debug_level > 5) {
             const GuidConverter local_conv(rw->first), remote_conv(ri->first);
             ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::send_nack_replies "
@@ -2044,11 +2046,15 @@ RtpsUdpDataLink::send_nackfrag_replies(RtpsWriter& writer,
   const ri_iter end = writer.remote_readers_.end();
   for (ri_iter ri = writer.remote_readers_.begin(); ri != end; ++ri) {
 
-    if (ri->second.requested_frags_.empty() || !locators_.count(ri->first)) {
-      continue;
+    OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter;
+    if (ri->second.requested_frags_.empty()) {
+      iter = locators_.find(ri->first);
+      if (iter == locators_.end()) {
+        continue;
+      }
     }
 
-    const ACE_INET_Addr& remote_addr = locators_[ri->first].addr_;
+    const ACE_INET_Addr& remote_addr = iter->second.addr_;
 
     typedef OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumberSet)::iterator rf_iter;
     const rf_iter rf_end = ri->second.requested_frags_.end();
@@ -2113,7 +2119,8 @@ RtpsUdpDataLink::send_directed_nack_replies(const RepoId& writerId,
                                             const RepoId& readerId,
                                             ReaderInfo& reader)
 {
-  if (!locators_.count(readerId)) {
+  const OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter = locators_.find(readerId);
+  if (iter == locators_.end()) {
     return;
   }
 
@@ -2122,7 +2129,7 @@ RtpsUdpDataLink::send_directed_nack_replies(const RepoId& writerId,
   reader.requested_changes_.clear();
 
   DisjointSequence gaps;
-  ACE_INET_Addr addr = locators_[readerId].addr_;
+  ACE_INET_Addr addr = iter->second.addr_;
 
   if (!requests.empty()) {
     if (writer.send_buff_.is_nil() || writer.send_buff_->empty()) {
@@ -2409,11 +2416,13 @@ RtpsUdpDataLink::send_heartbeats()
       typedef ReaderInfoMap::iterator ri_iter;
       const ri_iter end = rw->second.remote_readers_.end();
       for (ri_iter ri = rw->second.remote_readers_.begin(); ri != end; ++ri) {
-        if ((has_data || !ri->second.handshake_done_)
-            && locators_.count(ri->first)) {
-          recipients.insert(locators_[ri->first].addr_);
-          if (final && !ri->second.handshake_done_) {
-            final = false;
+        if (has_data || !ri->second.handshake_done_) {
+          const OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter = locators_.find(ri->first);
+          if (iter != locators_.end()) {
+            recipients.insert(iter->second.addr_);
+            if (final && !ri->second.handshake_done_) {
+              final = false;
+            }
           }
         }
         if (!ri->second.durable_data_.empty()) {
@@ -2438,8 +2447,9 @@ RtpsUdpDataLink::send_heartbeats()
             if (ri->second.durable_data_.rbegin()->first > durable_max) {
               durable_max = ri->second.durable_data_.rbegin()->first;
             }
-            if (locators_.count(ri->first)) {
-              recipients.insert(locators_[ri->first].addr_);
+            const OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter = locators_.find(ri->first);
+            if (iter != locators_.end()) {
+              recipients.insert(iter->second.addr_);
             }
           }
         }


### PR DESCRIPTION
Also includes cleanup for a few double-lookup situations in RtpsUdpDataLink where it was using both std::map::count() followed by std::map::operator[] instead of just using find().