### PR TITLE
Issue 1100: Domain Participant interaction with Monitoring library

### DIFF
--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1633,14 +1633,6 @@ DomainParticipantImpl::enable()
     return DDS::RETCODE_OK;
   }
 
-  if (monitor_) {
-    monitor_->report();
-  }
-
-  if (TheServiceParticipant->monitor_) {
-    TheServiceParticipant->monitor_->report();
-  }
-
 #ifdef OPENDDS_SECURITY
   if (!security_config_ && TheServiceParticipant->get_security()) {
     security_config_ = TheSecurityRegistry->default_config();
@@ -1767,6 +1759,14 @@ DomainParticipantImpl::enable()
 
   dp_id_ = value.id;
   federated_ = value.federated;
+
+  if (monitor_) {
+    monitor_->report();
+  }
+
+  if (TheServiceParticipant->monitor_) {
+    TheServiceParticipant->monitor_->report();
+  }
 
   const DDS::ReturnCode_t ret = this->set_enabled();
 


### PR DESCRIPTION
When using the monitor GUI a segmentation fault was occurring.  It was determined that the monitor's report functions were being called before a GUID was assigned in the DomainParticipantImpl::enable() function.  The calls were moved so that they did not execute until after a value GUID was obtained.

