### PR TITLE
Fix build problems due to ICE code

### DIFF
--- a/dds/DCPS/RTPS/ICE/EndpointManager.cpp
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.cpp
@@ -383,8 +383,8 @@ Checklist* EndpointManager::create_checklist(const AgentInfo& remote_agent_info)
   if (pos != deferred_triggered_checks_.end()) {
     const DeferredTriggeredCheckListType& list = pos->second;
 
-    for (DeferredTriggeredCheckListType::const_iterator pos = list.begin(), limit = list.end(); pos != limit; ++pos) {
-      checklist->generate_triggered_check(pos->local_address, pos->remote_address, pos->priority, pos->use_candidate);
+    for (DeferredTriggeredCheckListType::const_iterator pos2 = list.begin(), limit2 = list.end(); pos2 != limit2; ++pos2) {
+      checklist->generate_triggered_check(pos2->local_address, pos2->remote_address, pos2->priority, pos2->use_candidate);
     }
 
     deferred_triggered_checks_.erase(pos);

--- a/dds/DCPS/RTPS/ICE/Stun.cpp
+++ b/dds/DCPS/RTPS/ICE/Stun.cpp
@@ -497,7 +497,8 @@ std::vector<AttributeType> Message::unknown_comprehension_required_attributes() 
 {
   std::vector<AttributeType> retval;
 
-  for (const AttributesType::value_type& attribute : attributes_) {
+  for (AttributesType::const_iterator pos = attributes_.begin(), limit = attributes_.end(); pos != limit; ++pos) {
+    const AttributesType::value_type& attribute = *pos;
     switch (attribute.type) {
     case MAPPED_ADDRESS:
     case USERNAME:

--- a/dds/DCPS/RTPS/ICE/Stun.h
+++ b/dds/DCPS/RTPS/ICE/Stun.h
@@ -10,6 +10,7 @@
 #define OPENDDS_RTPS_STUN_H
 
 #include <map>
+#include <vector>
 
 #include "ace/INET_Addr.h"
 #include "dds/DCPS/Serializer.h"


### PR DESCRIPTION
Problem: ICE code contains C++11 features and name lookup problems

Solution:  Rewrite to avoid compiler problems and warnings.