### PR TITLE
Modified the configure script so subsequent runs are easier to identify

### DIFF
--- a/configure
+++ b/configure
@@ -18,6 +18,7 @@ require File::Temp;
 use File::Temp ();
 use FileHandle;
 use Cwd;
+use POSIX;
 use strict;
 use warnings;
 
@@ -832,7 +833,8 @@ sub clone_host_and_target {
 sub backup_and_open {
   my $file = shift;
   if (!$opts{'dry-run'} && -r $file) {
-    my $backup = (-e $file . '.bak') ? ($file . '.bak') : $file . ".bak.$$";
+    my $date = strftime "%Y-%m-%d-%H-%M-%S", localtime time;
+    my $backup = (-e $file . '.bak') ? ($file . '.bak') : $file . ".bak.$date";
     copy($file, $backup);
     print "WARNING: overwriting existing $file (saved a backup copy as " .
       "$backup)\n";


### PR DESCRIPTION
Currently when there are multiple runs of configure, old setenv and other scripts are saved as what the current PID is.

The problem is, PIDs may not be predictable and as an average developer, I want to know exactly when my setenv was modified.

An alternative is to do a `ls -ltra ./setenv*`, but this way is cleaner and avoids any possible confusion. The date format chosen is based on ISO 8601, although the time aspect is modified to avoid having a ':' in the filename