### PR TITLE
Updates for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ lib*.dylib
 .idea/
 .vs/
 /tags
+/host_tools.mwc*

--- a/configure
+++ b/configure
@@ -106,6 +106,7 @@ my %platforminfo =
        "Defaults to armeabi-v7a which is 32-bit ARMv7.",
        "See docs/android.md for details.",
      ],
+     'needs_i2jrt_corba' => 1,
    },
   );
 
@@ -435,6 +436,10 @@ if ($platforminfo{$opts{'target'}}->{'compiler_root_env'}) {
   my $newpath = join($specific{'pathsep'}, grep {!/^$root_dir/} @oldpath);
   $hostEnv{'PATH'} =~
     s/\Q$specific{'refpre'}\EPATH\Q$specific{'refpost'}\E/$newpath/;
+}
+
+if (!exists $platforminfo{$opts{'target'}}->{'needs_i2jrt_corba'}) {
+  $platforminfo{$opts{'target'}}->{'needs_i2jrt_corba'} = 0;
 }
 
 ## compiler
@@ -1677,6 +1682,7 @@ my $buildtao;
 sub generate_workspace {
   my $buildEnv = shift;
   $buildtao = 0;
+  my $is_target = $buildEnv->{'build'} eq 'target';
 
   for my $feat (qw/built-in-topics ownership-profile/) {
     if (exists $opts{$feat} && !$opts{$feat}) {
@@ -1703,12 +1709,7 @@ sub generate_workspace {
     }
   }
 
-  if ($cross_compile && $opts{'java'} && $buildEnv->{'build'} eq 'target') {
-    disable_feature(\@features, "full_jre");
-  }
-
-  my $mpctype = (!$is_windows ||
-                  ($cross_compile && $buildEnv->{'build'} eq 'target'))
+  my $mpctype = (!$is_windows || ($cross_compile && $is_target))
                 ? 'gnuace' : $opts{'compiler_version'};
 
   if ($mpctype eq 'gnuace') {
@@ -1718,7 +1719,7 @@ sub generate_workspace {
         if $opts{'verbose'};
       $UM = backup_and_open($buildEnv->{'DDS_ROOT'} . '/user_macros.GNU');
     }
-    if ($buildEnv->{'build'} eq 'target') {
+    if ($is_target) {
       for my $feat (@features) {
         my $key = $feat;
         $key =~ s/=.*//;
@@ -1735,16 +1736,11 @@ CROSS-COMPILE = 1
 EOT
       }
     }
-    elsif ($buildEnv->{'build'} eq 'host') {
-      if ($cross_compile && $opts{'java'}) {
-        print $UM "java:=1\n";
-      }
-    }
     $UM->close if $UM;
     dump_and_unlink($UM) if $UM && $opts{'dry-run'};
   }
 
-  if ($opts{'safety-profile'} && $buildEnv->{'build'} eq 'target') {
+  if ($opts{'safety-profile'} && $is_target) {
     $buildtao = 0; # TAO will be built seperately
   }
   else {
@@ -1755,8 +1751,25 @@ EOT
   locate_mpc($ace_src);
 
   # Append to default.features
-  if ($buildEnv->{'build'} eq 'target') {
+  if ($is_target) {
     push(@features, 'cross_compile') if $cross_compile;
+
+    if ($platforminfo{$opts{'target'}}->{'needs_i2jrt_corba'} && $opts{'java'}) {
+      if ($opts{'verbose'}) {
+        print "Target platform needs i2jrt_corba.jar, forcing java_pre_jpms=0 to get it\n";
+      }
+      my $found = 0;
+      for my $i (0 .. scalar $#features) {
+        if ($features[$i] =~ /^java_pre_jpms/) {
+          $features[$i] = 'java_pre_jpms=0';
+          my $found = 1;
+        }
+      }
+      if (!$found) {
+        push(@features, "java_pre_jpms=0");
+      }
+    }
+
     if ($buildtao && @features) {
       my $df_file = $buildEnv->{'ACE_ROOT'} .
         '/bin/MakeProjectCreator/config/default.features';

--- a/configure
+++ b/configure
@@ -40,7 +40,7 @@ sub perlOS_to_java_platform {
   return $^O;
 }
 
-my $targetUsageIndent = "\n\t\t";
+my $targetUsageIndent = "\t\t";
 
 my %platforminfo =
   ('win32' => {
@@ -102,9 +102,9 @@ my %platforminfo =
      'aceconfig' => 'android',
      'no_host' => 1,
      'usage' => [
-       "Use --macros=ANDROID_ABI=<ARCH> to specify the target archtecture." .
-       "${targetUsageIndent}Defaults to armeabi-v7a which is 32-bit ARMv7." .
-       "${targetUsageIndent}See docs/android.md for details."
+       "Use --macros=ANDROID_ABI=<ARCH> to specify the target archtecture.",
+       "Defaults to armeabi-v7a which is 32-bit ARMv7.",
+       "See docs/android.md for details.",
      ],
    },
   );
@@ -151,6 +151,7 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'target-compiler=s', 'Compiler for target (if req\'d): see --target-help',
     'host-tools=s', 'DDS_ROOT of host tools for cross compile' .
       $argIndent . '(build them)',
+    'host-tools-only!', 'Just build the host tools (no)',
     'prefix=s', 'Installation prefix (none)',
    ],
    ['Build flags:',
@@ -1015,6 +1016,15 @@ my %optdep =
    'openssl' =>   ['SSL_ROOT',        'include/openssl/opensslv.h',    'ssl'],
   );
 
+my $host_tools_only = exists $opts{'host-tools-only'} && $opts{'host-tools-only'};
+if ($host_tools_only) {
+  print "--host-tools-only implies --static\n" if $opts{'verbose'};
+  $opts{'static'} = 1;
+  if ($cross_compile) {
+    die "ERROR: Can't use --host-tools-only for cross compile\nStopped";
+  }
+}
+
 # Use this to check if tests are enabled (instead of $opts{'tests'} directly).
 my $tests = !exists $opts{'tests'} || $opts{'tests'};
 
@@ -1027,7 +1037,7 @@ if ($tests) {
 my @ace_features = ('xerces3');
 
 if (exists $opts{'java'}) {
-  if ($opts{'static'}) {
+  if ($opts{'static'} && !$host_tools_only) {
     die "ERROR: --static can't be used with --java\nStopped";
   }
   setEnv('JAVA_PLATFORM', perlOS_to_java_platform());
@@ -2123,6 +2133,10 @@ else { # does not require cloned builds
     push_libpath(\%targetEnv, $targetEnv{'DDS_ROOT'} . $slash . 'lib');
 
     add_dependency_paths();
+  }
+
+  if ($host_tools_only) {
+    write_host_workspace(\%targetEnv);
   }
 
   configure_build(\%targetEnv);

--- a/dds/idl/be_produce.cpp
+++ b/dds/idl/be_produce.cpp
@@ -93,7 +93,9 @@ using namespace std;
 void
 BE_cleanup()
 {
-  idl_global->destroy();
+  if (idl_global) {
+    idl_global->destroy();
+  }
 }
 
 // Abort this run of the BE.

--- a/java/idl2jni/codegen/be_global.cpp
+++ b/java/idl2jni/codegen/be_global.cpp
@@ -201,6 +201,18 @@ BE_GlobalData::spawn_options()
   return /*this->orb_args_ +*/ idl_global->idl_flags();
 }
 
+void invalid_option(char * option)
+{
+  ACE_ERROR((LM_ERROR,
+    ACE_TEXT("IDL: I don't understand the '%C' option\n"), option));
+#ifdef TAO_IDL_HAS_PARSE_ARGS_EXIT
+  idl_global->parse_args_exit(1);
+#else
+  idl_global->set_compile_flags(
+    idl_global->compile_flags() | IDL_CF_ONLY_USAGE);
+#endif
+}
+
 void
 BE_GlobalData::parse_args(long &i, char **av)
 {
@@ -219,23 +231,12 @@ BE_GlobalData::parse_args(long &i, char **av)
       this->do_server_side(0);
 
     } else {
-      ACE_ERROR((
-                  LM_ERROR,
-                  ACE_TEXT("IDL: I don't understand the '%s' option\n"),
-                  av[i]));
-      ACE_OS::exit(99);
+      invalid_option(av[i]);
     }
 
     break;
   default:
-    ACE_ERROR((
-                LM_ERROR,
-                ACE_TEXT("IDL: I don't understand the '%s' option\n"),
-                av[i]));
-
-    idl_global->set_compile_flags(idl_global->compile_flags()
-                                  | IDL_CF_ONLY_USAGE);
-    break;
+    invalid_option(av[i]);
   }
 }
 

--- a/java/idl2jni/codegen/be_produce.cpp
+++ b/java/idl2jni/codegen/be_produce.cpp
@@ -87,7 +87,9 @@ using namespace std;
 void
 BE_cleanup()
 {
-  idl_global->destroy();
+  if (idl_global) {
+    idl_global->destroy();
+  }
 }
 
 // Abort this run of the BE.

--- a/java/idl2jni/codegen/im_java.cpp
+++ b/java/idl2jni/codegen/im_java.cpp
@@ -232,8 +232,6 @@ std::string param_type(AST_Type *t, AST_Argument::Direction dir)
     case AST_PredefinedType::PT_double:
       builtin = true;
       capitalize = true;
-    default:
-      ;
     }
 
     break;
@@ -251,8 +249,6 @@ std::string param_type(AST_Type *t, AST_Argument::Direction dir)
 
     break;
   }
-  default:
-    ;
   }
 
   if (capitalize) type[0] = toupper(type[0]);
@@ -292,7 +288,6 @@ std::string idl_mapping_java::type(AST_Type *decl)
       return "float";
     case AST_PredefinedType::PT_double:
       return "double";
-    default:                                ;//fall through
     }
   }
   case AST_Decl::NT_string:
@@ -317,7 +312,6 @@ std::string idl_mapping_java::type(AST_Type *decl)
     AST_Array *arr = AST_Array::narrow_from_decl(decl);
     return type(arr->base_type()) + "[]";
   }
-  default: ;//fall through
   }
 
   cerr << "ERROR - unknown Java type " << decl->node_type()


### PR DESCRIPTION
- Update configure script and `android.md` for #1136 and #1137 
- Fix segfault in `i2jrt_codegen` and `opendds_idl` when no arguments are passed.
- Update `i2jrt_codegen` argument handing to match `opendds_idl`.
- Added `--host-tools-only` option to configure script that just builds the host tools.
- Fix compilation warnings in `idl2jni_codegen` by removing empty `default` cases.