### PR TITLE
Build Warnings

### DIFF
--- a/MPC/modules/IDLBase.pm
+++ b/MPC/modules/IDLBase.pm
@@ -197,7 +197,7 @@ sub get_component_name {
 
 sub get_dependencies {
   my($self, $filenames, $fwdarray) = @_;
-  
+
   ## There aren't any additional dependencies if there were no forward
   ## declarations.
   return undef if (scalar(@$fwdarray) == 0);

--- a/MPC/modules/IDLBase.pm
+++ b/MPC/modules/IDLBase.pm
@@ -324,7 +324,7 @@ sub parse {
   my $included;
   ($str, $ts_str, $ts_pragma, $included) =
      $self->preprocess($file, $includes, $macros, $mparams) if (!defined $str);
-  my @forwards = @$included;
+  my @forwards = (defined $included ? @$included : []);
 
   ## Keep track of const's and typedef's with these variables
   my $single;

--- a/MPC/modules/IDLBase.pm
+++ b/MPC/modules/IDLBase.pm
@@ -197,7 +197,7 @@ sub get_component_name {
 
 sub get_dependencies {
   my($self, $filenames, $fwdarray) = @_;
-
+  
   ## There aren't any additional dependencies if there were no forward
   ## declarations.
   return undef if (scalar(@$fwdarray) == 0);
@@ -212,8 +212,16 @@ sub get_dependencies {
     ## .java files are truly dependent upon.
     my @genfiles;
     foreach my $file (@$fwdarray) {
-      my $of = $self->{'creator'}->get_first_custom_output($file, 'java_files');
-      push(@genfiles, $of) if (defined $of && $of ne '');
+      if ($file =~ /\.java$/) {
+        my $of = $self->{'creator'}->get_first_custom_output($file, 'java_files');
+        push(@genfiles, $of) if (defined $of && $of ne '');
+      }
+      elsif ($file =~ /\.idl$/) {
+        my @gen = $self->{'creator'}->generated_filenames(
+                     $self->{'creator'}->remove_wanted_extension($file, []),
+                     'idl2jni_files', 'header_files', $file);
+        push(@genfiles, $gen[0]) if ($#gen >= 0);
+      }
     }
 
     ## Now that we have the .class files that each of the files listed in
@@ -309,14 +317,14 @@ sub cached_parse {
 
 sub parse {
   my($self, $file, $includes, $macros, $mparams, $str) = @_;
-  my @forwards;
 
   ## Preprocess the file into one huge string
   my $ts_str;
   my $ts_pragma;
-  ($str, $ts_str, $ts_pragma) = $self->preprocess($file, $includes,
-                                                  $macros, $mparams)
-                                                            if (!defined $str);
+  my $included;
+  ($str, $ts_str, $ts_pragma, $included) =
+     $self->preprocess($file, $includes, $macros, $mparams) if (!defined $str);
+  my @forwards = @$included;
 
   ## Keep track of const's and typedef's with these variables
   my $single;
@@ -518,6 +526,7 @@ sub preprocess {
   my $skip = [];
   my $ts_str = '';
   my $ts_pragma = '';
+  my @related;
 
   if (open($fh, $file)) {
     my $line;
@@ -665,6 +674,7 @@ sub preprocess {
               }
               else {
                 $self->include_file($file, $includes, $macros, $mparams);
+                push(@related, $file);
               }
             }
             elsif ($pline =~ /^define\s+(([a-z_]\w+)(\(([^\)]+)\))?)(\s+(.*))?$/i) {
@@ -723,6 +733,7 @@ sub preprocess {
           $file .= '.idl';
 
           $self->include_file($file, $includes, $macros, $mparams);
+          push(@related, $file);
         }
 
         if (!$$skip[scalar(@$skip) - 1] && !$included) {
@@ -737,7 +748,7 @@ sub preprocess {
     delete $self->{'strs'}->{$file};
   }
 
-  return $contents, $ts_str, $ts_pragma;
+  return $contents, $ts_str, $ts_pragma, \@related;
 }
 
 sub include_file {

--- a/dds/DCPS/RTPS/ICE/Checklist.cpp
+++ b/dds/DCPS/RTPS/ICE/Checklist.cpp
@@ -152,7 +152,7 @@ void Checklist::generate_candidate_pairs()
 
   if (frozen_.size() != 0) {
     check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
-    double s = frozen_.size();
+    double s = static_cast<double>(frozen_.size());
     max_check_interval_ = endpoint_manager_->agent_impl->get_configuration().checklist_period() * (1.0 / s);
     enqueue(ACE_Time_Value().now());
   }

--- a/dds/DCPS/RTPS/ICE/Stun.cpp
+++ b/dds/DCPS/RTPS/ICE/Stun.cpp
@@ -25,16 +25,16 @@ ACE_UINT16 Attribute::length() const
     return 8;
 
   case USERNAME:
-    return username.size();
+    return static_cast<ACE_UINT16>(username.size());
 
   case MESSAGE_INTEGRITY:
     return 20;
 
   case ERROR_CODE:
-    return 4 + error.reason.size();
+    return static_cast<ACE_UINT16>(4 + error.reason.size());
 
   case UNKNOWN_ATTRIBUTES:
-    return 2 * unknown_attributes.size();
+    return static_cast<ACE_UINT16>(2 * unknown_attributes.size());
 
   case XOR_MAPPED_ADDRESS:
     // TODO(jrw972):  Handle IPv6.

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1589,7 +1589,7 @@ int from_param_list(const ParameterList& param_list,
                     bool& have_agent_info)
 {
   have_agent_info = false;
-  for (size_t idx = 0, count = param_list.length(); idx != count; ++idx) {
+  for (CORBA::ULong idx = 0, count = param_list.length(); idx != count; ++idx) {
     const Parameter& parameter = param_list[idx];
     switch (parameter._d()) {
     case PID_OPENDDS_ICE_GENERAL: {

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2013,9 +2013,9 @@ Spdp::remove_sedp_unicast(const ACE_INET_Addr& addr)
   RTPS::address_to_bytes(locator.address, addr);
 
   DCPS::LocatorSeq new_sedp_unicast;
-  for (size_t idx = 0; idx != sedp_unicast_.length(); ++idx) {
+  for (CORBA::ULong idx = 0; idx != sedp_unicast_.length(); ++idx) {
     if (sedp_unicast_[idx] != locator) {
-      size_t out_idx = new_sedp_unicast.length();
+      const CORBA::ULong out_idx = new_sedp_unicast.length();
       new_sedp_unicast.length(out_idx + 1);
       new_sedp_unicast[out_idx] = sedp_unicast_[idx];
     }
@@ -2032,7 +2032,7 @@ Spdp::add_sedp_unicast(const ACE_INET_Addr& addr)
   locator.port = addr.get_port_number();
   RTPS::address_to_bytes(locator.address, addr);
 
-  size_t idx = sedp_unicast_.length();
+  const CORBA::ULong idx = sedp_unicast_.length();
   sedp_unicast_.length(idx + 1);
   sedp_unicast_[idx] = locator;
 }

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1562,7 +1562,7 @@ StaticDiscovery::parse_endpoints(ACE_Configuration_Heap& cf)
 #ifdef __SUNPRO_CC
         int count = 0; std::count_if(value.begin(), value.end(), isxdigit, count);
 #else
-        int count = std::count_if(value.begin(), value.end(), isxdigit);
+        OPENDDS_STRING::difference_type count = std::count_if(value.begin(), value.end(), isxdigit);
 #endif
         if (value.size() != HEX_DIGITS_IN_PARTICIPANT || static_cast<size_t>(count) != HEX_DIGITS_IN_PARTICIPANT) {
           ACE_ERROR_RETURN((LM_ERROR,
@@ -1580,7 +1580,7 @@ StaticDiscovery::parse_endpoints(ACE_Configuration_Heap& cf)
 #ifdef __SUNPRO_CC
         int count = 0; std::count_if(value.begin(), value.end(), isxdigit, count);
 #else
-        int count = std::count_if(value.begin(), value.end(), isxdigit);
+        OPENDDS_STRING::difference_type count = std::count_if(value.begin(), value.end(), isxdigit);
 #endif
         if (value.size() != HEX_DIGITS_IN_ENTITY || static_cast<size_t>(count) != HEX_DIGITS_IN_ENTITY) {
           ACE_ERROR_RETURN((LM_ERROR,

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1522,8 +1522,8 @@ StaticDiscovery::parse_endpoints(ACE_Configuration_Heap& cf)
     ValueMap values;
     pullValues(cf, it->second, values);
     int domain = 0;
-    unsigned char participant[6];
-    unsigned char entity[3];
+    unsigned char participant[6] = { 0 };
+    unsigned char entity[3] = { 0 };
     enum Type {
       Reader,
       Writer
@@ -1562,7 +1562,7 @@ StaticDiscovery::parse_endpoints(ACE_Configuration_Heap& cf)
 #ifdef __SUNPRO_CC
         int count = 0; std::count_if(value.begin(), value.end(), isxdigit, count);
 #else
-        OPENDDS_STRING::difference_type count = std::count_if(value.begin(), value.end(), isxdigit);
+        const OPENDDS_STRING::difference_type count = std::count_if(value.begin(), value.end(), isxdigit);
 #endif
         if (value.size() != HEX_DIGITS_IN_PARTICIPANT || static_cast<size_t>(count) != HEX_DIGITS_IN_PARTICIPANT) {
           ACE_ERROR_RETURN((LM_ERROR,
@@ -1580,7 +1580,7 @@ StaticDiscovery::parse_endpoints(ACE_Configuration_Heap& cf)
 #ifdef __SUNPRO_CC
         int count = 0; std::count_if(value.begin(), value.end(), isxdigit, count);
 #else
-        OPENDDS_STRING::difference_type count = std::count_if(value.begin(), value.end(), isxdigit);
+        const OPENDDS_STRING::difference_type count = std::count_if(value.begin(), value.end(), isxdigit);
 #endif
         if (value.size() != HEX_DIGITS_IN_ENTITY || static_cast<size_t>(count) != HEX_DIGITS_IN_ENTITY) {
           ACE_ERROR_RETURN((LM_ERROR,

--- a/dds/DCPS/ZeroCopyAllocator_T.inl
+++ b/dds/DCPS/ZeroCopyAllocator_T.inl
@@ -10,12 +10,20 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+#if defined (_MSC_VER) && (_MSC_VER >= 1400)
+# pragma warning (push)
+# pragma warning (disable:4351)
+#endif
+
 template<class T, std::size_t N> ACE_INLINE
 FirstTimeFastAllocator<T, N>::FirstTimeFastAllocator()
   : firstTime_(true)
   , pool_()
 {
 }
+#if defined (_MSC_VER) && (_MSC_VER >= 1400)
+# pragma warning (pop)
+#endif
 
 template<class T, std::size_t N> ACE_INLINE
 void *

--- a/dds/DCPS/security/UtilityImpl.cpp
+++ b/dds/DCPS/security/UtilityImpl.cpp
@@ -13,7 +13,8 @@ UtilityImpl::~UtilityImpl() {}
 
 void UtilityImpl::generate_random_bytes(void* ptr, size_t size)
 {
-  int rc = RAND_bytes(static_cast<unsigned char*>(ptr), size);
+  int rc = RAND_bytes(static_cast<unsigned char*>(ptr),
+                      static_cast<int>(size));
 
   if (rc != 1) {
     unsigned long err = ERR_get_error();
@@ -27,7 +28,10 @@ void UtilityImpl::generate_random_bytes(void* ptr, size_t size)
 
 void UtilityImpl::hmac(void* out, void const* in, size_t size, const std::string& password) const
 {
-  unsigned char* digest = HMAC(EVP_sha1(), password.c_str(), password.size(), static_cast<const unsigned char*>(in),size, NULL, NULL);
+  unsigned char* digest = HMAC(EVP_sha1(), password.c_str(),
+                               static_cast<int>(password.size()),
+                               static_cast<const unsigned char*>(in),
+                               static_cast<int>(size), NULL, NULL);
   memcpy(out, digest, 20);
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2948,6 +2948,7 @@ OpenDDS::DCPS::RtpsUdpDataLink::get_addresses(const RepoId& local) const {
 void
 OpenDDS::DCPS::RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
                                                      OPENDDS_SET(ACE_INET_Addr)& addresses) const {
+  ACE_UNUSED_ARG(local);
   OPENDDS_ASSERT(local != GUID_UNKNOWN);
   OPENDDS_ASSERT(remote != GUID_UNKNOWN);
 

--- a/java/dds/dcps_java_optional.mpb
+++ b/java/dds/dcps_java_optional.mpb
@@ -39,8 +39,7 @@ feature (built_in_topics): dcps_ts_defaults, idl2jni {
     idl2jniflags += -SS -I$(TAO_ROOT) -I$(DDS_ROOT) -I$(DDS_ROOT)/dds \
                     -Wb,stub_export_include=dcps_java_export.h \
                     -Wb,stub_export_macro=dcps_java_Export
-    $(DDS_ROOT)/dds/DdsDcpsCoreTypeSupport.idl << DdsDcpsTypeSupportExtJC.h
-    //$(DDS_ROOT)/dds/DdsDcpsInfrastructureTypeSupport.idl << DdsDcpsTypeSupportExtJC.h
+    $(DDS_ROOT)/dds/DdsDcpsCoreTypeSupport.idl
   }
 
   Define_Custom(TypeSupportJavaOnly) {

--- a/performance-tests/DCPS/InfoRepo_population/SyncServer.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/SyncServer.cpp
@@ -19,7 +19,7 @@ public:
 private:
   bool parse_args (int argc, ACE_TCHAR *argv[]);
 
-  std::auto_ptr<SyncExt_i> sync_server_;
+  std::unique_ptr<SyncExt_i> sync_server_;
 
   size_t pub_count_;
   size_t sub_count_;

--- a/performance-tests/DCPS/InfoRepo_population/SyncServer.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/SyncServer.cpp
@@ -19,7 +19,11 @@ public:
 private:
   bool parse_args (int argc, ACE_TCHAR *argv[]);
 
+#if defined (ACE_HAS_CPP11)
   std::unique_ptr<SyncExt_i> sync_server_;
+#else
+  std::auto_ptr<SyncExt_i> sync_server_;
+#endif
 
   size_t pub_count_;
   size_t sub_count_;

--- a/performance-tests/DCPS/Sync/SyncServer.cpp
+++ b/performance-tests/DCPS/Sync/SyncServer.cpp
@@ -20,7 +20,11 @@ public:
 private:
   bool parse_args (int argc, ACE_TCHAR *argv[]);
 
+#if defined (ACE_HAS_CPP11)
   std::unique_ptr<SyncServer_i> sync_server_;
+#else
+  std::auto_ptr<SyncServer_i> sync_server_;
+#endif
 
   size_t pub_count_;
   size_t sub_count_;

--- a/performance-tests/DCPS/Sync/SyncServer.cpp
+++ b/performance-tests/DCPS/Sync/SyncServer.cpp
@@ -20,7 +20,7 @@ public:
 private:
   bool parse_args (int argc, ACE_TCHAR *argv[]);
 
-  std::auto_ptr<SyncServer_i> sync_server_;
+  std::unique_ptr<SyncServer_i> sync_server_;
 
   size_t pub_count_;
   size_t sub_count_;

--- a/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
+++ b/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
@@ -446,7 +446,7 @@ bool run_single_dispose_filter_test(const DomainParticipant_var& dp,
   }
   unsigned num_valid = 0;
   unsigned num_invalid = 0;
-  for (size_t i = 0; i < infoseq.length(); i++) {
+  for (CORBA::ULong i = 0; i < infoseq.length(); i++) {
     if (infoseq[i].valid_data) {
       num_valid++;
     } else {

--- a/tests/DCPS/LivelinessTimeout/publisher.cpp
+++ b/tests/DCPS/LivelinessTimeout/publisher.cpp
@@ -54,9 +54,7 @@ int parse_args(int argc, ACE_TCHAR *argv[])
     }
     else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-x"))) != 0)
     {
-      float temp = ACE_OS::atof(currentArg);
-      TEST_DURATION_SEC.sec(std::floor(temp));
-      TEST_DURATION_SEC.usec((temp - static_cast<float>(TEST_DURATION_SEC.sec())) * 1e6);
+      TEST_DURATION_SEC.set(ACE_OS::atof(currentArg));
       arg_shifter.consume_arg();
     }
     else if (arg_shifter.cur_arg_strncasecmp(ACE_TEXT("-z")) == 0)

--- a/tests/DCPS/LivelinessTimeout/subscriber.cpp
+++ b/tests/DCPS/LivelinessTimeout/subscriber.cpp
@@ -60,9 +60,7 @@ int parse_args(int argc, ACE_TCHAR *argv[])
     }
     else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-x"))) != 0)
     {
-      float temp = ACE_OS::atof(currentArg);
-      TEST_DURATION_SEC.sec(std::floor(temp));
-      TEST_DURATION_SEC.usec((temp - static_cast<float>(TEST_DURATION_SEC.sec())) * 1e6);
+      TEST_DURATION_SEC.set(ACE_OS::atof(currentArg));
       arg_shifter.consume_arg();
     }
     else if (arg_shifter.cur_arg_strncasecmp(ACE_TEXT("-z")) == 0)

--- a/tests/security/AccessControlTest.cpp
+++ b/tests/security/AccessControlTest.cpp
@@ -279,7 +279,7 @@ public:
 
   void add_property(Property_t p) {
       PropertySeq& seq = domain_participant_qos.property.value;
-      size_t len = seq.length();
+      const CORBA::ULong len = seq.length();
       seq.length(len + 1);
       seq[len] = p;
   }
@@ -394,12 +394,12 @@ TEST_F(AccessControlTest, validate_remote_permissions_Success)
   remote_apc_token.class_id = Expected_Permissions_Cred_Token_Class_Id;
   remote_apc_token.binary_properties.length(2);
   remote_apc_token.binary_properties[0].name = "c.id";
-  remote_apc_token.binary_properties[0].value.length(id.size());
+  remote_apc_token.binary_properties[0].value.length(static_cast<CORBA::ULong>(id.size()));
   memcpy(remote_apc_token.binary_properties[0].value.get_buffer(), id.c_str(), id.size());
   remote_apc_token.binary_properties[0].propagate = true;
 
   remote_apc_token.binary_properties[1].name = "c.perm";
-  remote_apc_token.binary_properties[1].value.length(pf.size());
+  remote_apc_token.binary_properties[1].value.length(static_cast<CORBA::ULong>(pf.size()));
   memcpy(remote_apc_token.binary_properties[1].value.get_buffer(), pf.c_str(), pf.size());
   remote_apc_token.binary_properties[1].propagate = true;
 
@@ -810,12 +810,12 @@ TEST_F(AccessControlTest, check_remote_participant_Success_Governance)
   remote_apc_token.class_id = Expected_Permissions_Cred_Token_Class_Id;
   remote_apc_token.binary_properties.length(2);
   remote_apc_token.binary_properties[0].name = "c.id";
-  remote_apc_token.binary_properties[0].value.length(id.size());
+  remote_apc_token.binary_properties[0].value.length(static_cast<CORBA::ULong>(id.size()));
   memcpy(remote_apc_token.binary_properties[0].value.get_buffer(), id.c_str(), id.size());
   remote_apc_token.binary_properties[0].propagate = true;
 
   remote_apc_token.binary_properties[1].name = "c.perm";
-  remote_apc_token.binary_properties[1].value.length(pf.size());
+  remote_apc_token.binary_properties[1].value.length(static_cast<CORBA::ULong>(pf.size()));
   memcpy(remote_apc_token.binary_properties[1].value.get_buffer(),pf.c_str(), pf.size());
   remote_apc_token.binary_properties[1].propagate = true;
 
@@ -851,12 +851,12 @@ TEST_F(AccessControlTest, check_remote_participant_Success_Permissions)
   remote_apc_token.class_id = Expected_Permissions_Cred_Token_Class_Id;
   remote_apc_token.binary_properties.length(2);
   remote_apc_token.binary_properties[0].name = "c.id";
-  remote_apc_token.binary_properties[0].value.length(id.size());
+  remote_apc_token.binary_properties[0].value.length(static_cast<CORBA::ULong>(id.size()));
   memcpy(remote_apc_token.binary_properties[0].value.get_buffer(), id.c_str(), id.size());
   remote_apc_token.binary_properties[0].propagate = true;
 
   remote_apc_token.binary_properties[1].name = "c.perm";
-  remote_apc_token.binary_properties[1].value.length(pf.size());
+  remote_apc_token.binary_properties[1].value.length(static_cast<CORBA::ULong>(pf.size()));
   memcpy(remote_apc_token.binary_properties[1].value.get_buffer(), pf.c_str(), pf.size());
   remote_apc_token.binary_properties[1].propagate = true;
 
@@ -899,11 +899,11 @@ TEST_F(AccessControlTest, check_remote_datawriter_Success)
   remote_apc_token.class_id = Expected_Permissions_Cred_Token_Class_Id;
   remote_apc_token.binary_properties.length(2);
   remote_apc_token.binary_properties[0].name = "c.id";
-  remote_apc_token.binary_properties[0].value.length(id.size());
+  remote_apc_token.binary_properties[0].value.length(static_cast<CORBA::ULong>(id.size()));
   memcpy(remote_apc_token.binary_properties[0].value.get_buffer(), id.c_str(), id.size());
   remote_apc_token.binary_properties[0].propagate = true;
   remote_apc_token.binary_properties[1].name = "c.perm";
-  remote_apc_token.binary_properties[1].value.length(pf.size());
+  remote_apc_token.binary_properties[1].value.length(static_cast<CORBA::ULong>(pf.size()));
   memcpy(remote_apc_token.binary_properties[1].value.get_buffer(), pf.c_str(), pf.size());
   remote_apc_token.binary_properties[1].propagate = true;
   get_inst().validate_local_permissions(auth_plugin_.get(), 1, 1, domain_participant_qos, ex);
@@ -950,11 +950,11 @@ TEST_F(AccessControlTest, check_remote_datareader_Success)
   remote_apc_token.class_id = Expected_Permissions_Cred_Token_Class_Id;
   remote_apc_token.binary_properties.length(2);
   remote_apc_token.binary_properties[0].name = "c.id";
-  remote_apc_token.binary_properties[0].value.length(id.size());
+  remote_apc_token.binary_properties[0].value.length(static_cast<CORBA::ULong>(id.size()));
   memcpy(remote_apc_token.binary_properties[0].value.get_buffer(), id.c_str(), id.size());
   remote_apc_token.binary_properties[0].propagate = true;
   remote_apc_token.binary_properties[1].name = "c.perm";
-  remote_apc_token.binary_properties[1].value.length(pf.size());
+  remote_apc_token.binary_properties[1].value.length(static_cast<CORBA::ULong>(pf.size()));
   memcpy(remote_apc_token.binary_properties[1].value.get_buffer(), pf.c_str(), pf.size());
   remote_apc_token.binary_properties[1].propagate = true;
   get_inst().validate_local_permissions(auth_plugin_.get(), 1, 1, domain_participant_qos, ex);
@@ -1005,12 +1005,12 @@ TEST_F(AccessControlTest, check_remote_topic_Success)
   remote_apc_token.class_id = Expected_Permissions_Cred_Token_Class_Id;
   remote_apc_token.binary_properties.length(2);
   remote_apc_token.binary_properties[0].name = "c.id";
-  remote_apc_token.binary_properties[0].value.length(id.size());
+  remote_apc_token.binary_properties[0].value.length(static_cast<CORBA::ULong>(id.size()));
   memcpy(remote_apc_token.binary_properties[0].value.get_buffer(), id.c_str(), id.size());
   remote_apc_token.binary_properties[0].propagate = true;
 
   remote_apc_token.binary_properties[1].name = "c.perm";
-  remote_apc_token.binary_properties[1].value.length(pf.size());
+  remote_apc_token.binary_properties[1].value.length(static_cast<CORBA::ULong>(pf.size()));
   memcpy(remote_apc_token.binary_properties[1].value.get_buffer(), pf.c_str(), pf.size());
   remote_apc_token.binary_properties[1].propagate = true;
 

--- a/tests/security/Authentication/AuthenticationTest.cpp
+++ b/tests/security/Authentication/AuthenticationTest.cpp
@@ -82,14 +82,14 @@ struct MockParticipantData
 
   void add_property(Property_t p) {
     PropertySeq& seq = qos.property.value;
-    size_t len = seq.length();
+    const CORBA::ULong len = seq.length();
     seq.length(len + 1);
     seq[len] = p;
   }
 
   void add_binary_property(BinaryProperty_t p) {
     BinaryPropertySeq& seq = qos.property.binary_value;
-    size_t len = seq.length();
+    const CORBA::ULong len = seq.length();
     seq.length(len + 1);
     seq[len] = p;
   }
@@ -184,8 +184,8 @@ struct AuthenticationTest : public ::testing::Test
 
   static std::string value_of(const std::string& key, const PropertySeq& s)
   {
-    size_t n = s.length();
-    for (size_t i = 0; i < n; ++i) {
+    const CORBA::ULong n = s.length();
+    for (CORBA::ULong i = 0; i < n; ++i) {
         if (strcmp(s[i].name, key.c_str()) == 0)
           return static_cast<const char*>(s[i].value);
     }
@@ -194,8 +194,8 @@ struct AuthenticationTest : public ::testing::Test
 
   static const DDS::OctetSeq& value_of(const std::string& key, const BinaryPropertySeq& s)
   {
-    size_t n = s.length();
-    for (size_t i = 0; i < n; ++i) {
+    const CORBA::ULong n = s.length();
+    for (CORBA::ULong i = 0; i < n; ++i) {
         if (strcmp(s[i].name, key.c_str()) == 0)
           return s[i].value;
     }
@@ -229,7 +229,7 @@ struct AuthenticationTest : public ::testing::Test
 
     ASSERT_TRUE(serializer << params);
 
-    dst.length(buffer.length());
+    dst.length(static_cast<CORBA::ULong>(buffer.length()));
     std::memcpy(dst.get_buffer(), buffer.rd_ptr(), dst.length());
   }
 

--- a/tests/security/Authentication/LocalCredentialDataTest.cpp
+++ b/tests/security/Authentication/LocalCredentialDataTest.cpp
@@ -30,7 +30,7 @@ struct LocalAuthCredentialDataTest : public ::testing::Test
 
   void add_property(Property_t p) {
     PropertySeq& seq = properties;
-    size_t len = seq.length();
+    const CORBA::ULong len = seq.length();
     seq.length(len + 1);
     seq[len] = p;
   }

--- a/tests/security/IDL_Serialization/PropertyTest.cpp
+++ b/tests/security/IDL_Serialization/PropertyTest.cpp
@@ -31,7 +31,7 @@ public:
 TEST_F(SerializePropertyTest, PropertySeq_OnePropagateFalse_TwoPropagateTrue)
 {
   inseq.length(3);
-  for (size_t i = 0; i < inseq.length(); ++i) {
+  for (CORBA::ULong i = 0; i < inseq.length(); ++i) {
 
     std::stringstream name, value;
     name << "name " << i;

--- a/tests/security/RTPS/ParameterListConverterTest.cpp
+++ b/tests/security/RTPS/ParameterListConverterTest.cpp
@@ -98,8 +98,8 @@ namespace {
   }
 
   Token token(string classid = "Test-Class-Id",
-              size_t proplen = 1,
-              size_t bproplen = 1,
+              CORBA::ULong proplen = 1,
+              CORBA::ULong bproplen = 1,
               bool propagate = true)
   {
     Token t;
@@ -107,7 +107,7 @@ namespace {
     t.class_id = classid.c_str();
 
     t.properties.length(proplen);
-    for (size_t i = 0; i < proplen; ++i) {
+    for (CORBA::ULong i = 0; i < proplen; ++i) {
         stringstream name, value;
         name << "Property " << i;
         value << "PropertyValue " << i;
@@ -118,7 +118,7 @@ namespace {
     }
 
     t.binary_properties.length(bproplen);
-    for (size_t i = 0; i < bproplen; ++i) {
+    for (CORBA::ULong i = 0; i < bproplen; ++i) {
         stringstream name, value;
         name << "BinaryProperty " << i;
         value << "BinaryPropertyValue " << i;

--- a/tests/security/SSL/PrivateKeyTest.cpp
+++ b/tests/security/SSL/PrivateKeyTest.cpp
@@ -98,11 +98,11 @@ public:
     empty_()
   {
     size_t hello_len = std::strlen("hello");
-    hello_.length(hello_len);
+    hello_.length(static_cast<CORBA::ULong>(hello_len));
     std::memcpy(hello_.get_buffer(), "hello", hello_len);
 
     size_t world_len = std::strlen("world");
-    world_.length(world_len);
+    world_.length(static_cast<CORBA::ULong>(world_len));
     std::memcpy(world_.get_buffer(), "world", world_len);
   }
 

--- a/tests/security/SSL/SignedDocumentTest.cpp
+++ b/tests/security/SSL/SignedDocumentTest.cpp
@@ -78,7 +78,8 @@ TEST_F(SignedDocumentTest, LoadFromMemory)
   std::ostringstream mem;
   mem << file.rdbuf();
   const std::string str = mem.str();
-  DDS::OctetSeq seq(str.size(), str.size(),
+  DDS::OctetSeq seq(static_cast<CORBA::ULong>(str.size()),
+                    static_cast<CORBA::ULong>(str.size()),
                     reinterpret_cast<unsigned char*>(
                       const_cast<char*>(str.c_str())));
 


### PR DESCRIPTION
Change type or use static_cast where necessary to address 64-bit build warnings.
Additional changes include replacing std::auto_ptr with std::unique_ptr.
