### PR TITLE
Fix inconsistent topic test

### DIFF
--- a/dds/DCPS/DataReaderCallbacks.h
+++ b/dds/DCPS/DataReaderCallbacks.h
@@ -51,8 +51,6 @@ public:
 
   virtual void update_incompatible_qos(const IncompatibleQosStatus& status) = 0;
 
-  virtual void inconsistent_topic() = 0;
-
   virtual void signal_liveliness(const RepoId& remote_participant) = 0;
 
   virtual void register_for_writer(const RepoId& /*participant*/,

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -737,12 +737,6 @@ DataReaderImpl::update_incompatible_qos(const IncompatibleQosStatus& status)
 }
 
 void
-DataReaderImpl::inconsistent_topic()
-{
-  topic_servant_->inconsistent_topic();
-}
-
-void
 DataReaderImpl::signal_liveliness(const RepoId& remote_participant)
 {
   RepoId prefix = remote_participant;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -223,8 +223,6 @@ public:
 
   virtual void update_incompatible_qos(const IncompatibleQosStatus& status);
 
-  virtual void inconsistent_topic();
-
   virtual void signal_liveliness(const RepoId& remote_participant);
 
   /**

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -53,8 +53,6 @@ public:
   virtual void update_subscription_params(const RepoId& readerId,
                                           const DDS::StringSeq& exprParams) = 0;
 
-  virtual void inconsistent_topic() = 0;
-
   virtual void register_for_reader(const RepoId& /*participant*/,
                                    const RepoId& /*writerid*/,
                                    const RepoId& /*readerid*/,

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -854,12 +854,6 @@ DataWriterImpl::update_subscription_params(const RepoId& readerId,
 #endif
 }
 
-void
-DataWriterImpl::inconsistent_topic()
-{
-  topic_servant_->inconsistent_topic();
-}
-
 DDS::ReturnCode_t
 DataWriterImpl::set_qos(const DDS::DataWriterQos & qos)
 {

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -189,8 +189,6 @@ public:
   virtual void update_subscription_params(const RepoId& readerId,
                                           const DDS::StringSeq& params);
 
-  virtual void inconsistent_topic();
-
 
   /**
    * cleanup the DataWriter.

--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -15,6 +15,7 @@
 
 #include "dds/DCPS/DataReaderCallbacks.h"
 #include "dds/DCPS/DataWriterCallbacks.h"
+#include "dds/DCPS/TopicCallbacks.h"
 #include "dds/DdsDcpsSubscriptionC.h"
 
 #include "dds/DCPS/PoolAllocator.h"
@@ -128,7 +129,8 @@ public:
     const char* topicName,
     const char* dataTypeName,
     const DDS::TopicQos& qos,
-    bool hasDcpsKey) = 0;
+    bool hasDcpsKey,
+    TopicCallbacks* topic_callbacks) = 0;
 
   virtual TopicStatus find_topic(
     DDS::DomainId_t domainId,

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -204,6 +204,8 @@ namespace OpenDDS {
                        const DDS::TopicQos& qos,
                        bool has_dcps_key,
                        TopicCallbacks* topic_callbacks) {
+          assert(topic_callbacks != 0);
+
           local_data_type_name_ = data_type_name;
           local_qos_ = qos;
           has_dcps_key_ = has_dcps_key;
@@ -233,7 +235,9 @@ namespace OpenDDS {
             }
           }
 
-          topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
+          if (inconsistent_topic_count_ != 0) {
+            topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
+          }
         }
 
         void unset_local() {
@@ -350,6 +354,7 @@ namespace OpenDDS {
         const DDS::TopicQos local_qos() const { return local_qos_; }
         DCPS::RepoId topic_id() const { return topic_id_; }
         bool has_dcps_key() const { return has_dcps_key_; }
+        bool local_is_set() const { return topic_callbacks_; }
         const RepoIdSet& endpoints() const { return endpoints_; }
 
         bool is_dead() const {
@@ -485,7 +490,7 @@ namespace OpenDDS {
         typename OPENDDS_MAP(OPENDDS_STRING, TopicDetails)::iterator iter =
           topics_.find(topicName);
         if (iter != topics_.end()) {
-          if (iter->second.local_data_type_name() != dataTypeName) {
+          if (iter->second.local_is_set() && iter->second.local_data_type_name() != dataTypeName) {
             return DCPS::CONFLICTING_TYPENAME;
           }
           topicId = iter->second.topic_id();

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -6,6 +6,7 @@
 #ifndef OPENDDS_DDS_DCPS_DISCOVERYBASE_H
 #define OPENDDS_DDS_DCPS_DISCOVERYBASE_H
 
+#include "dds/DCPS/TopicDetails.h"
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/DataReaderImpl_T.h"
 #include "dds/DCPS/DCPS_Utils.h"
@@ -18,7 +19,6 @@
 #include "dds/DCPS/SubscriberImpl.h"
 
 #include "dds/DdsDcpsCoreTypeSupportImpl.h"
-#include "dds/DCPS/TopicCallbacks.h"
 
 #ifdef OPENDDS_SECURITY
 #include "dds/DdsSecurityCoreC.h"
@@ -190,196 +190,7 @@ namespace OpenDDS {
 
     public:
       typedef DiscoveredParticipantData_ DiscoveredParticipantData;
-
-      struct TopicDetails {
-        TopicDetails() : topic_callbacks_(0) {}
-
-        void init(const OPENDDS_STRING& name,
-                  DCPS::RepoId topic_id) {
-          name_ = name;
-          topic_id_ = topic_id;
-        }
-
-        void set_local(const OPENDDS_STRING& data_type_name,
-                       const DDS::TopicQos& qos,
-                       bool has_dcps_key,
-                       TopicCallbacks* topic_callbacks) {
-          assert(topic_callbacks != 0);
-
-          local_data_type_name_ = data_type_name;
-          local_qos_ = qos;
-          has_dcps_key_ = has_dcps_key;
-          topic_callbacks_ = topic_callbacks;
-
-          endpoints_.clear();
-          inconsistent_topic_count_ = 0;
-
-          for (typename TopicDetails::RemoteTopicMap::iterator pos = remote_topics_.begin(), limit = remote_topics_.end();
-               pos != limit; ++pos) {
-            RemoteTopic& remote = pos->second;
-            remote.inconsistent_ = local_data_type_name_ != remote.data_type_name_;
-            if (remote.inconsistent_) {
-              ++inconsistent_topic_count_;
-              if (DCPS::DCPS_debug_level) {
-                ACE_DEBUG((LM_WARNING,
-                           ACE_TEXT("(%P|%t) EndpointManager::check_inconsistent_topic - WARNING ")
-                           ACE_TEXT("topic %C discovered data type %C doesn't ")
-                           ACE_TEXT("match known data type %C, ignoring ")
-                           ACE_TEXT("discovered topic.\n"),
-                           name_.c_str(),
-                           remote.data_type_name_.c_str(),
-                           local_data_type_name_.c_str()));
-              }
-            } else {
-              endpoints_.insert(remote.endpoints_.begin(), remote.endpoints_.end());
-            }
-          }
-
-          if (inconsistent_topic_count_ != 0) {
-            topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
-          }
-        }
-
-        void unset_local() {
-          topic_callbacks_ = 0;
-        }
-
-        void update(const DDS::TopicQos& qos) {
-          local_qos_ = qos;
-        }
-
-        // Local
-        void add_pub_sub(DCPS::RepoId guid) {
-          endpoints_.insert(guid);
-        }
-
-        // Remote
-        void add_pub_sub(DCPS::RepoId guid,
-                         const OPENDDS_STRING& type_name,
-                         const DDS::TopicDataQosPolicy& topic_data) {
-          // This function can be called before the local side of the
-          // topic is initialized.  If this happens, the topic will
-          // always be inconsistent meaning the inconsistent count
-          // will be incremented and the guid will not be in the
-          // endpoints.
-
-          RepoId participant_id = guid;
-          participant_id.entityId = ENTITYID_PARTICIPANT;
-
-          endpoints_.insert(guid);
-
-          typename RemoteTopicMap::iterator remote_topic_iter = remote_topics_.find(participant_id);
-          bool inconsistent_before;
-          if (remote_topic_iter == remote_topics_.end()) {
-            // Insert.
-            remote_topic_iter = remote_topics_.insert(std::make_pair(participant_id, TopicDetails::RemoteTopic())).first;
-            inconsistent_before = false;
-          } else {
-            inconsistent_before = remote_topic_iter->second.inconsistent_;
-          }
-
-          // Initialize.
-          RemoteTopic& remote = remote_topic_iter->second;
-          remote.data_type_name_ = type_name;
-          remote.qos_.topic_data = topic_data;
-          remote.inconsistent_ = local_data_type_name_ != remote.data_type_name_;
-          remote.endpoints_.insert(guid);
-
-          if (!inconsistent_before && remote.inconsistent_) {
-            ++inconsistent_topic_count_;
-            if (DCPS::DCPS_debug_level) {
-              ACE_DEBUG((LM_WARNING,
-                         ACE_TEXT("(%P|%t) EndpointManager::check_inconsistent_topic - WARNING ")
-                         ACE_TEXT("topic %C discovered data type %C doesn't ")
-                         ACE_TEXT("match known data type %C, ignoring ")
-                         ACE_TEXT("discovered topic.\n"),
-                         name_.c_str(),
-                         remote.data_type_name_.c_str(),
-                         local_data_type_name_.c_str()));
-            }
-            if (topic_callbacks_) {
-              topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
-            }
-          } else if (inconsistent_before && !remote.inconsistent_) {
-            --inconsistent_topic_count_;
-            if (DCPS::DCPS_debug_level) {
-              ACE_DEBUG((LM_WARNING,
-                         ACE_TEXT("(%P|%t) EndpointManager::check_inconsistent_topic - WARNING ")
-                         ACE_TEXT("topic %C discovered data type %C now ")
-                         ACE_TEXT("matches known data type %C\n"),
-                         name_.c_str(),
-                         remote.data_type_name_.c_str(),
-                         local_data_type_name_.c_str()));
-            }
-            if (topic_callbacks_) {
-              topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
-            }
-          }
-
-          if (remote.inconsistent_) {
-            endpoints_.erase(guid);
-          }
-        }
-
-        // Local and remote
-        void remove_pub_sub(DCPS::RepoId guid) {
-          endpoints_.erase(guid);
-
-          RepoId participant_id = guid;
-          participant_id.entityId = ENTITYID_PARTICIPANT;
-
-          typename RemoteTopicMap::iterator remote_topic_iter = remote_topics_.find(participant_id);
-
-          if (remote_topic_iter == remote_topics_.end()) {
-            // It was local.
-            return;
-          }
-
-          RemoteTopic& remote = remote_topic_iter->second;
-          remote.endpoints_.erase(guid);
-
-          if (remote.inconsistent_) {
-            --inconsistent_topic_count_;
-            if (topic_callbacks_) {
-              topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
-            }
-          }
-
-          if (remote.endpoints_.empty()) {
-            remote_topics_.erase(remote_topic_iter);
-          }
-        }
-
-        const OPENDDS_STRING local_data_type_name() const { return local_data_type_name_; }
-        const DDS::TopicQos local_qos() const { return local_qos_; }
-        DCPS::RepoId topic_id() const { return topic_id_; }
-        bool has_dcps_key() const { return has_dcps_key_; }
-        bool local_is_set() const { return topic_callbacks_; }
-        const RepoIdSet& endpoints() const { return endpoints_; }
-
-        bool is_dead() const {
-          return topic_callbacks_ == 0 && remote_topics_.empty();
-        }
-
-      private:
-        OPENDDS_STRING name_;
-        OPENDDS_STRING local_data_type_name_;
-        DDS::TopicQos local_qos_;
-        DCPS::RepoId topic_id_;
-        bool has_dcps_key_;
-        TopicCallbacks* topic_callbacks_;
-        RepoIdSet endpoints_;
-
-        struct RemoteTopic {
-          OPENDDS_STRING data_type_name_;
-          DDS::TopicQos qos_;
-          bool inconsistent_;
-          RepoIdSet endpoints_;
-        };
-        typedef OPENDDS_MAP_CMP(DCPS::RepoId, RemoteTopic, DCPS::GUID_tKeyLessThan) RemoteTopicMap;
-        RemoteTopicMap remote_topics_;
-        size_t inconsistent_topic_count_;
-      };
+      typedef TopicDetails TopicDetails;
 
       EndpointManager(const RepoId& participant_id, ACE_Thread_Mutex& lock)
         : lock_(lock)

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -190,7 +190,7 @@ namespace OpenDDS {
 
     public:
       typedef DiscoveredParticipantData_ DiscoveredParticipantData;
-      typedef TopicDetails TopicDetails;
+      typedef OpenDDS::DCPS::TopicDetails TopicDetails;
 
       EndpointManager(const RepoId& participant_id, ACE_Thread_Mutex& lock)
         : lock_(lock)

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -400,7 +400,6 @@ private:
     int                    topic_mask);
 
   DDS::Topic_ptr create_new_topic(
-    const RepoId                   topic_id,
     const char *                   topic_name,
     const char *                   type_name,
     const DDS::TopicQos &          qos,

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -526,7 +526,7 @@ DCPS::TopicStatus
 InfoRepoDiscovery::assert_topic(DCPS::RepoId_out topicId, DDS::DomainId_t domainId,
                                 const RepoId& participantId, const char* topicName,
                                 const char* dataTypeName, const DDS::TopicQos& qos,
-                                bool hasDcpsKey)
+                                bool hasDcpsKey, TopicCallbacks* /*topic_callbacks*/)
 {
   try {
     return get_dcps_info()->assert_topic(topicId, domainId, participantId, topicName,

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
@@ -122,7 +122,8 @@ public:
     const char* topicName,
     const char* dataTypeName,
     const DDS::TopicQos& qos,
-    bool hasDcpsKey);
+    bool hasDcpsKey,
+    TopicCallbacks* topic_callbacks);
 
   virtual OpenDDS::DCPS::TopicStatus find_topic(
     DDS::DomainId_t domainId,

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1753,7 +1753,7 @@ void Sedp::process_discovered_writer_data(DCPS::MessageId message_id,
         TopicDetails& td = top_it->second;
 
         // Upsert the remote topic.
-        td.add_pub_sub(guid, wdata.ddsPublicationData.type_name.in(), wdata.ddsPublicationData.topic_data);
+        td.add_pub_sub(guid, wdata.ddsPublicationData.type_name.in());
 
         std::memcpy(pub.writer_data_.ddsPublicationData.participant_key.value,
                     guid.guidPrefix, sizeof(DDS::BuiltinTopicKey_t));
@@ -2062,7 +2062,7 @@ void Sedp::process_discovered_reader_data(DCPS::MessageId message_id,
         TopicDetails& td = top_it->second;
 
         // Upsert the remote topic.
-        td.add_pub_sub(guid, rdata.ddsSubscriptionData.type_name.in(), rdata.ddsSubscriptionData.topic_data);
+        td.add_pub_sub(guid, rdata.ddsSubscriptionData.type_name.in());
 
         std::memcpy(sub.reader_data_.ddsSubscriptionData.participant_key.value,
                     guid.guidPrefix, sizeof(DDS::BuiltinTopicKey_t));

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -666,8 +666,6 @@ private:
 
   DCPS::RepoIdSet defer_match_endpoints_, associated_participants_;
 
-  void inconsistent_topic(const DCPS::RepoIdSet& endpoints) const;
-
   virtual bool shutting_down() const;
 
   virtual void populate_transport_locator_sequence(DCPS::TransportLocatorSeq*& tls,

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -790,12 +790,6 @@ RecorderImpl::update_incompatible_qos(const IncompatibleQosStatus& status)
 }
 
 void
-RecorderImpl::inconsistent_topic()
-{
-  topic_servant_->inconsistent_topic();
-}
-
-void
 RecorderImpl::signal_liveliness(const RepoId& remote_participant)
 {
   RepoId prefix = remote_participant;

--- a/dds/DCPS/RecorderImpl.h
+++ b/dds/DCPS/RecorderImpl.h
@@ -88,7 +88,6 @@ public:
                                    CORBA::Boolean     callback);
 
   virtual void update_incompatible_qos(const IncompatibleQosStatus& status);
-  virtual void inconsistent_topic();
 
   virtual void signal_liveliness(const RepoId& remote_participant);
 

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -825,12 +825,6 @@ ReplayerImpl::update_subscription_params(const RepoId&         readerId,
   ACE_UNUSED_ARG(params);
 }
 
-void
-ReplayerImpl::inconsistent_topic()
-{
-  topic_servant_->inconsistent_topic();
-}
-
 bool
 ReplayerImpl::check_transport_qos(const TransportInst&)
 {

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -143,8 +143,6 @@ public:
   virtual void update_subscription_params(const RepoId&         readerId,
                                           const DDS::StringSeq& exprParams);
 
-  virtual void inconsistent_topic();
-
   void remove_all_associations();
 
   virtual void register_for_reader(const RepoId& participant,

--- a/dds/DCPS/TopicCallbacks.h
+++ b/dds/DCPS/TopicCallbacks.h
@@ -1,0 +1,45 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_TOPICCALLBACKS_H
+#define OPENDDS_DCPS_TOPICCALLBACKS_H
+
+#include "dds/DCPS/Definitions.h"
+#include "dds/DCPS/DiscoveryListener.h"
+#include "dds/DCPS/RcObject.h"
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+/**
+* @class TopicCallbacks
+*
+* @brief Defines the interface for Discovery callbacks into the Topic.
+*
+*/
+class TopicCallbacks
+  : public virtual RcObject {
+public:
+
+  TopicCallbacks() {}
+
+  virtual ~TopicCallbacks() {}
+
+  virtual void inconsistent_topic(size_t count) = 0;
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_TOPICCALLBACKS_H  */

--- a/dds/DCPS/TopicCallbacks.h
+++ b/dds/DCPS/TopicCallbacks.h
@@ -8,8 +8,6 @@
 #ifndef OPENDDS_DCPS_TOPICCALLBACKS_H
 #define OPENDDS_DCPS_TOPICCALLBACKS_H
 
-#include "dds/DCPS/Definitions.h"
-#include "dds/DCPS/DiscoveryListener.h"
 #include "dds/DCPS/RcObject.h"
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -34,7 +32,8 @@ public:
 
   virtual ~TopicCallbacks() {}
 
-  virtual void inconsistent_topic(size_t count) = 0;
+  // Report the current number of inconsistent topics.
+  virtual void inconsistent_topic(int count) = 0;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/TopicDetails.h
+++ b/dds/DCPS/TopicDetails.h
@@ -1,0 +1,227 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DDS_DCPS_TOPICDETAILS_H
+#define OPENDDS_DDS_DCPS_TOPICDETAILS_H
+
+#include "dds/DCPS/TopicCallbacks.h"
+#include "dds/DCPS/GuidUtils.h"
+#include "dds/DCPS/debug.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+  namespace DCPS {
+
+    struct TopicDetails {
+      TopicDetails() : topic_callbacks_(0) {}
+
+      void init(const OPENDDS_STRING& name,
+                const DCPS::RepoId& topic_id) {
+        name_ = name;
+        topic_id_ = topic_id;
+      }
+
+      void set_local(const OPENDDS_STRING& data_type_name,
+                     const DDS::TopicQos& qos,
+                     bool has_dcps_key,
+                     TopicCallbacks* topic_callbacks) {
+        assert(topic_callbacks != 0);
+
+        local_data_type_name_ = data_type_name;
+        local_qos_ = qos;
+        has_dcps_key_ = has_dcps_key;
+        topic_callbacks_ = topic_callbacks;
+
+        endpoints_.clear();
+        inconsistent_topic_count_ = 0;
+
+        for (typename TopicDetails::RemoteTopicMap::iterator pos = remote_topics_.begin(), limit = remote_topics_.end();
+             pos != limit; ++pos) {
+          RemoteTopic& remote = pos->second;
+          remote.inconsistent_ = !remote.data_type_name_.empty() && local_data_type_name_ != remote.data_type_name_;
+          if (!remote.inconsistent_) {
+            remote.data_type_name_.clear();
+          }
+          if (remote.inconsistent_) {
+            ++inconsistent_topic_count_;
+            if (DCPS::DCPS_debug_level) {
+              ACE_DEBUG((LM_WARNING,
+                         ACE_TEXT("(%P|%t) EndpointManager::check_inconsistent_topic - WARNING ")
+                         ACE_TEXT("topic %C discovered data type %C doesn't ")
+                         ACE_TEXT("match known data type %C, ignoring ")
+                         ACE_TEXT("discovered topic.\n"),
+                         name_.c_str(),
+                         remote.data_type_name_.c_str(),
+                         local_data_type_name_.c_str()));
+            }
+          } else {
+            endpoints_.insert(remote.endpoints_.begin(), remote.endpoints_.end());
+          }
+        }
+
+        if (inconsistent_topic_count_ != 0) {
+          topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
+        }
+      }
+
+      void unset_local() {
+        topic_callbacks_ = 0;
+
+        for (typename TopicDetails::RemoteTopicMap::iterator pos = remote_topics_.begin(), limit = remote_topics_.end();
+             pos != limit; ++pos) {
+          RemoteTopic& remote = pos->second;
+          if (remote.data_type_name_.empty()) {
+            remote.data_type_name_ = local_data_type_name_;
+          }
+        }
+      }
+
+      void update(const DDS::TopicQos& qos) {
+        local_qos_ = qos;
+      }
+
+      // Local
+      void add_pub_sub(const DCPS::RepoId& guid) {
+        endpoints_.insert(guid);
+      }
+
+      // Remote
+      void add_pub_sub(const DCPS::RepoId& guid,
+                       const OPENDDS_STRING& type_name) {
+        // This function can be called before the local side of the
+        // topic is initialized.  If this happens, the topic will
+        // always be inconsistent meaning the inconsistent count
+        // will be incremented and the guid will not be in the
+        // endpoints.
+
+        RepoId participant_id = guid;
+        participant_id.entityId = ENTITYID_PARTICIPANT;
+
+        endpoints_.insert(guid);
+
+        typename RemoteTopicMap::iterator remote_topic_iter = remote_topics_.find(participant_id);
+        bool inconsistent_before;
+        if (remote_topic_iter == remote_topics_.end()) {
+          // Insert.
+          remote_topic_iter = remote_topics_.insert(std::make_pair(participant_id, TopicDetails::RemoteTopic())).first;
+          inconsistent_before = false;
+        } else {
+          inconsistent_before = remote_topic_iter->second.inconsistent_;
+        }
+
+        // Initialize.
+        RemoteTopic& remote = remote_topic_iter->second;
+        remote.data_type_name_ = type_name;
+        remote.inconsistent_ = local_data_type_name_ != remote.data_type_name_;
+        if (!remote.inconsistent_) {
+          remote.data_type_name_.clear();
+        }
+        remote.endpoints_.insert(guid);
+
+        if (!inconsistent_before && remote.inconsistent_) {
+          ++inconsistent_topic_count_;
+          if (DCPS::DCPS_debug_level) {
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("(%P|%t) EndpointManager::check_inconsistent_topic - WARNING ")
+                       ACE_TEXT("topic %C discovered data type %C doesn't ")
+                       ACE_TEXT("match known data type %C, ignoring ")
+                       ACE_TEXT("discovered topic.\n"),
+                       name_.c_str(),
+                       remote.data_type_name_.c_str(),
+                       local_data_type_name_.c_str()));
+          }
+          if (topic_callbacks_) {
+            topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
+          }
+        } else if (inconsistent_before && !remote.inconsistent_) {
+          --inconsistent_topic_count_;
+          if (DCPS::DCPS_debug_level) {
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("(%P|%t) EndpointManager::check_inconsistent_topic - WARNING ")
+                       ACE_TEXT("topic %C discovered data type now ")
+                       ACE_TEXT("matches known data type %C\n"),
+                       name_.c_str(),
+                       local_data_type_name_.c_str()));
+          }
+          if (topic_callbacks_) {
+            topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
+          }
+        }
+
+        if (remote.inconsistent_) {
+          endpoints_.erase(guid);
+        }
+      }
+
+      // Local and remote
+      void remove_pub_sub(const DCPS::RepoId& guid) {
+        endpoints_.erase(guid);
+
+        RepoId participant_id = guid;
+        participant_id.entityId = ENTITYID_PARTICIPANT;
+
+        typename RemoteTopicMap::iterator remote_topic_iter = remote_topics_.find(participant_id);
+
+        if (remote_topic_iter == remote_topics_.end()) {
+          // It was local.
+          return;
+        }
+
+        RemoteTopic& remote = remote_topic_iter->second;
+        remote.endpoints_.erase(guid);
+
+        if (remote.inconsistent_) {
+          --inconsistent_topic_count_;
+          if (topic_callbacks_) {
+            topic_callbacks_->inconsistent_topic(inconsistent_topic_count_);
+          }
+        }
+
+        if (remote.endpoints_.empty()) {
+          remote_topics_.erase(remote_topic_iter);
+        }
+      }
+
+      const OPENDDS_STRING local_data_type_name() const { return local_data_type_name_; }
+      const DDS::TopicQos local_qos() const { return local_qos_; }
+      const DCPS::RepoId& topic_id() const { return topic_id_; }
+      bool has_dcps_key() const { return has_dcps_key_; }
+      bool local_is_set() const { return topic_callbacks_; }
+      const RepoIdSet& endpoints() const { return endpoints_; }
+
+      bool is_dead() const {
+        return topic_callbacks_ == 0 && remote_topics_.empty();
+      }
+
+    private:
+      OPENDDS_STRING name_;
+      OPENDDS_STRING local_data_type_name_;
+      DDS::TopicQos local_qos_;
+      DCPS::RepoId topic_id_;
+      bool has_dcps_key_;
+      TopicCallbacks* topic_callbacks_;
+      RepoIdSet endpoints_;
+
+      struct RemoteTopic {
+        OPENDDS_STRING data_type_name_;
+        bool inconsistent_;
+        RepoIdSet endpoints_;
+      };
+      typedef OPENDDS_MAP_CMP(DCPS::RepoId, RemoteTopic, DCPS::GUID_tKeyLessThan) RemoteTopicMap;
+      RemoteTopicMap remote_topics_;
+      size_t inconsistent_topic_count_;
+    };
+
+  } // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_TOPICDETAILS_H  */

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -146,7 +146,7 @@ TopicImpl::enable()
                                              topic_name_.c_str(),
                                              type_name_.c_str(),
                                              qos_,
-                                             type_support_->has_dcps_key(),
+                                             type_support_ ? type_support_->has_dcps_key() : false,
                                              this);
     if (status != CREATED && status != FOUND) {
       ACE_ERROR((LM_ERROR,

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -37,7 +37,6 @@ TopicImpl::TopicImpl(const char*                    topic_name,
     id_(GUID_UNKNOWN),
     monitor_(0)
 {
-  last_inconsistent_topic_count_ = 0;
   inconsistent_topic_status_.total_count = 0;
   inconsistent_topic_status_.total_count_change = 0;
   monitor_ =
@@ -188,10 +187,10 @@ TopicImpl::transport_config(const TransportConfig_rch&)
 }
 
 void
-TopicImpl::inconsistent_topic(size_t count)
+TopicImpl::inconsistent_topic(int count)
 {
+  inconsistent_topic_status_.total_count_change += count - inconsistent_topic_status_.total_count;
   inconsistent_topic_status_.total_count = count;
-  inconsistent_topic_status_.total_count_change = inconsistent_topic_status_.total_count - last_inconsistent_topic_count_;
 
   set_status_changed_flag(DDS::INCONSISTENT_TOPIC_STATUS, true);
 
@@ -202,7 +201,6 @@ TopicImpl::inconsistent_topic(size_t count)
 
   if (listener) {
     listener->on_inconsistent_topic(this, inconsistent_topic_status_);
-    last_inconsistent_topic_count_ = inconsistent_topic_status_.total_count;
     inconsistent_topic_status_.total_count_change = 0;
   }
 

--- a/dds/DCPS/TopicImpl.h
+++ b/dds/DCPS/TopicImpl.h
@@ -12,6 +12,7 @@
 #include "dds/DdsDcpsInfoUtilsC.h"
 #include "EntityImpl.h"
 #include "TopicDescriptionImpl.h"
+#include "TopicCallbacks.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -36,11 +37,11 @@ class Monitor;
 class OpenDDS_Dcps_Export TopicImpl
   : public virtual LocalObject<DDS::Topic>,
     public virtual EntityImpl,
+    public virtual TopicCallbacks,
     public virtual TopicDescriptionImpl {
 public:
 
-  TopicImpl(const RepoId                   topic_id,
-            const char*                    topic_name,
+  TopicImpl(const char*                    topic_name,
             const char*                    type_name,
             OpenDDS::DCPS::TypeSupport_ptr type_support,
             const DDS::TopicQos &          qos,
@@ -78,7 +79,7 @@ public:
 
   virtual void transport_config(const TransportConfig_rch& cfg);
 
-  void inconsistent_topic();
+  void inconsistent_topic(size_t count);
 
 private:
   /// The topic qos
@@ -99,6 +100,8 @@ private:
 
   /// Pointer to the monitor object for this entity
   Monitor* monitor_;
+
+  size_t last_inconsistent_topic_count_;
 };
 
 

--- a/dds/DCPS/TopicImpl.h
+++ b/dds/DCPS/TopicImpl.h
@@ -79,7 +79,7 @@ public:
 
   virtual void transport_config(const TransportConfig_rch& cfg);
 
-  void inconsistent_topic(size_t count);
+  void inconsistent_topic(int count);
 
 private:
   /// The topic qos
@@ -100,8 +100,6 @@ private:
 
   /// Pointer to the monitor object for this entity
   Monitor* monitor_;
-
-  size_t last_inconsistent_topic_count_;
 };
 
 

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
@@ -45,8 +45,6 @@ public:
   virtual void update_incompatible_qos (
       const OpenDDS::DCPS::IncompatibleQosStatus & status);
 
-  virtual void inconsistent_topic() {}
-
   virtual void signal_liveliness(const OpenDDS::DCPS::RepoId& /*remote_participant*/) { }
 
   DiscReceivedCalls& received()

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
@@ -44,8 +44,6 @@ public:
   virtual void update_subscription_params(
     const OpenDDS::DCPS::RepoId&, const DDS::StringSeq &);
 
-  void inconsistent_topic() {}
-
   DiscReceivedCalls& received()
     {
       return received_;

--- a/tests/DCPS/DCPSInfoRepo/pubsub.cpp
+++ b/tests/DCPS/DCPSInfoRepo/pubsub.cpp
@@ -112,20 +112,24 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   ::DDS::TopicQos_var topicQos = new ::DDS::TopicQos;
   *topicQos = TheServiceParticipant->initial_TopicQos();
 
+  struct Callbacks : public OpenDDS::DCPS::TopicCallbacks {
+    void inconsistent_topic(int /*count*/) {}
+  } callbacks;
+
   if (use_rtps) { // check that topic/type name string bounds are enforced
     const std::string longname(300, 'a');
     OpenDDS::DCPS::RepoId topicId;
     const bool key = false;
     OpenDDS::DCPS::TopicStatus ts =
       disc->assert_topic(topicId, domain, pubPartId,
-                         longname.c_str(), "shortname", topicQos, key, 0);
+                         longname.c_str(), "shortname", topicQos, key, &callbacks);
     if (ts != OpenDDS::DCPS::PRECONDITION_NOT_MET) {
       failed = true;
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("ERROR: expected long topic name to be rejected\n")));
     }
     ts = disc->assert_topic(topicId, domain, pubPartId,
-                            "shortname", longname.c_str(), topicQos, key, 0);
+                            "shortname", longname.c_str(), topicQos, key, &callbacks);
     if (ts != OpenDDS::DCPS::PRECONDITION_NOT_MET) {
       failed = true;
       ACE_ERROR((LM_ERROR,
@@ -136,10 +140,6 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   // add a topic
   const char* tname = "MYtopic";
   const char* dname = "MYdataname";
-
-  struct Callbacks : public OpenDDS::DCPS::TopicCallbacks {
-    void inconsistent_topic(size_t /*count*/) {}
-  } callbacks;
 
   OpenDDS::DCPS::TopicStatus topicStatus = disc->assert_topic(pubTopicId,
                                                               domain,

--- a/tests/DCPS/DCPSInfoRepo/pubsub.cpp
+++ b/tests/DCPS/DCPSInfoRepo/pubsub.cpp
@@ -118,14 +118,14 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
     const bool key = false;
     OpenDDS::DCPS::TopicStatus ts =
       disc->assert_topic(topicId, domain, pubPartId,
-                         longname.c_str(), "shortname", topicQos, key);
+                         longname.c_str(), "shortname", topicQos, key, 0);
     if (ts != OpenDDS::DCPS::PRECONDITION_NOT_MET) {
       failed = true;
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("ERROR: expected long topic name to be rejected\n")));
     }
     ts = disc->assert_topic(topicId, domain, pubPartId,
-                            "shortname", longname.c_str(), topicQos, key);
+                            "shortname", longname.c_str(), topicQos, key, 0);
     if (ts != OpenDDS::DCPS::PRECONDITION_NOT_MET) {
       failed = true;
       ACE_ERROR((LM_ERROR,
@@ -137,12 +137,13 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   const char* tname = "MYtopic";
   const char* dname = "MYdataname";
   OpenDDS::DCPS::TopicStatus topicStatus = disc->assert_topic(pubTopicId,
-                                                       domain,
-                                                       pubPartId,
-                                                       tname,
-                                                       dname,
-                                                       topicQos.in(),
-                                                       false);
+                                                              domain,
+                                                              pubPartId,
+                                                              tname,
+                                                              dname,
+                                                              topicQos.in(),
+                                                              false,
+                                                              0);
 
   if (topicStatus != OpenDDS::DCPS::CREATED)
     {
@@ -196,7 +197,8 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
                                    tnameIncompatible,
                                    dnameIncompatible,
                                    topicQosIncompatible.in(),
-                                   false);
+                                   false,
+                                   0);
 
   if (topicStatus != OpenDDS::DCPS::CONFLICTING_TYPENAME)
     {
@@ -244,7 +246,8 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
                                    tname,
                                    dname,
                                    topicQos.in(),
-                                   false);
+                                   false,
+                                   0);
 
   if (topicStatus != OpenDDS::DCPS::CREATED)
     {

--- a/tests/DCPS/DCPSInfoRepo/pubsub.cpp
+++ b/tests/DCPS/DCPSInfoRepo/pubsub.cpp
@@ -136,6 +136,11 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   // add a topic
   const char* tname = "MYtopic";
   const char* dname = "MYdataname";
+
+  struct Callbacks : public OpenDDS::DCPS::TopicCallbacks {
+    void inconsistent_topic(size_t /*count*/) {}
+  } callbacks;
+
   OpenDDS::DCPS::TopicStatus topicStatus = disc->assert_topic(pubTopicId,
                                                               domain,
                                                               pubPartId,
@@ -143,7 +148,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
                                                               dname,
                                                               topicQos.in(),
                                                               false,
-                                                              0);
+                                                              &callbacks);
 
   if (topicStatus != OpenDDS::DCPS::CREATED)
     {
@@ -247,7 +252,7 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
                                    dname,
                                    topicQos.in(),
                                    false,
-                                   0);
+                                   &callbacks);
 
   if (topicStatus != OpenDDS::DCPS::CREATED)
     {

--- a/tests/DCPS/InconsistentTopic/pubsub.cpp
+++ b/tests/DCPS/InconsistentTopic/pubsub.cpp
@@ -145,7 +145,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
         test_error = true;
       }
       if (status.total_count_change != 0) {
-        cerr << "ERROR: (alpha) participant 1 total_count_chnage should be 0 but is " << status.total_count_change << endl;
+        cerr << "ERROR: (alpha) participant 1 total_count_change should be 0 but is " << status.total_count_change << endl;
         test_error = true;
       }
 

--- a/tests/DCPS/InconsistentTopic/pubsub.cpp
+++ b/tests/DCPS/InconsistentTopic/pubsub.cpp
@@ -140,8 +140,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
         cerr << "ERROR: not able to retrieve topic status." << endl;
         exit(1);
       }
+      if (status.total_count != 0) {
+        cerr << "ERROR: (alpha) participant 1 total_count should be 0 but is " << status.total_count << endl;
+        test_error = true;
+      }
       if (status.total_count_change != 0) {
-        cerr << "ERROR: participant 1 saw an inconsistent topic when it should not (first)" << endl;
+        cerr << "ERROR: (alpha) participant 1 total_count_chnage should be 0 but is " << status.total_count_change << endl;
         test_error = true;
       }
 
@@ -150,8 +154,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
         cerr << "ERROR: not able to retrieve topic status." << endl;
         exit(1);
       }
-      if (status.total_count_change == 0) {
-        cerr << "ERROR: participant 2 did not see an inconsistent topic when it should have (first)" << endl;
+      if (status.total_count != 1) {
+        cerr << "ERROR: (alpha) participant 2 total_count should be 1 but is " << status.total_count << endl;
+        test_error = true;
+      }
+      if (status.total_count_change != 1) {
+        cerr << "ERROR: (alpha) participant 2 total_count_change should be 1 but is " << status.total_count_change << endl;
         test_error = true;
       }
 
@@ -173,7 +181,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
         exit(1);
       }
 
-      // Wait for p2 to see p1's datareader.
+      // Wait for p1 to see p2's datareader.
 
       for (;;) {
         DDS::SubscriptionBuiltinTopicDataSeq sub_data;
@@ -192,8 +200,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
         cerr << "ERROR: not able to retrieve topic status." << endl;
         exit(1);
       }
-      if (status.total_count_change == 0) {
-        cerr << "ERROR: participant 1 should have seen an inconsistent topic but did not (second)" << endl;
+      if (status.total_count != 1) {
+        cerr << "ERROR: (beta) participant 1 total_count should be 1 but is " << status.total_count << endl;
+        test_error = true;
+      }
+      if (status.total_count_change != 1) {
+        cerr << "ERROR: (beta) participant 1 total_count_change should be 1 but is " << status.total_count_change << endl;
         test_error = true;
       }
 
@@ -202,8 +214,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
         cerr << "ERROR: not able to retrieve topic status." << endl;
         exit(1);
       }
-      if (status.total_count_change == 0) {
-        cerr << "ERROR: participant 2 should have seen an inconsistent topic but did not (second)" << endl;
+      if (status.total_count != 1) {
+        cerr << "ERROR: (beta) participant 2 total_count should be 1 but is " << status.total_count << endl;
+        test_error = true;
+      }
+      if (status.total_count_change != 0) {
+        cerr << "ERROR: (beta) participant 2 total_count_change should be 0 but is " << status.total_count_change << endl;
         test_error = true;
       }
 


### PR DESCRIPTION
Problem: Inconsistent topic only discovered with local reader/writer

A participant can only get inconconsistent topic when it has a local
reader or writer on that topic.  While usual, a participant should be
able to create a topic and then get inconsistent topic on it without
creating readers and writers.  This also lead to a race condition in
earlier versions of the InconsistentTopic test which made it fail
sporadically.  This is a fix for #995.

Solution: Track local and remote topics and link the local topic to
its impl through callbacks so that inconsistent topic can be reported
without a reader or writer.