### PR TITLE
Resolve Access Violations caused by uninitialized data

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -742,6 +742,7 @@ RtpsUdpReceiveStrategy::has_fragments(const SequenceRange& range,
         p.first = sn;
         frag_info->push_back(p);
         RTPS::FragmentNumberSet& missing_frags = frag_info->back().second;
+        missing_frags.numBits = 0; // make sure this is a valid number before passing to get_gaps
         missing_frags.bitmap.length(8); // start at max length
         missing_frags.bitmapBase.value =
           reassembly_.get_gaps(sn, pub_id, missing_frags.bitmap.get_buffer(),


### PR DESCRIPTION
Initialized the numBits value before passing it to the get_gaps function.