### PR TITLE
Fixes for Bugs Introduced in 1094

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2914,6 +2914,7 @@ DataReaderImpl::update_ownership_strength (const PublicationId& pub_id,
 bool DataReaderImpl::verify_coherent_changes_completion (WriterInfo* writer)
 {
   Coherent_State state = COMPLETED;
+  bool accept_here = true;
 
   if (subqos_.presentation.access_scope != ::DDS::INSTANCE_PRESENTATION_QOS &&
       subqos_.presentation.coherent_access) {
@@ -2924,6 +2925,7 @@ bool DataReaderImpl::verify_coherent_changes_completion (WriterInfo* writer)
       if (subscriber && state != NOT_COMPLETED_YET) {
         // verify if all readers received complete coherent changes in a group.
         subscriber->coherent_change_received(writer->publisher_id_, this, state);
+        accept_here = false; // coherent_change_received does that itself
       }
     } else if (state != NOT_COMPLETED_YET) { // TOPIC coherent with final state
       if (state == REJECTED) {
@@ -2933,8 +2935,7 @@ bool DataReaderImpl::verify_coherent_changes_completion (WriterInfo* writer)
     }
   }
 
-  if (state == COMPLETED && !writer->group_coherent_) {
-    // If group, sub.coherent_change_received did this already
+  if (state == COMPLETED && accept_here) {
     accept_coherent(writer->writer_id_, writer->publisher_id_);
     coherent_changes_completed(this);
   }

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -275,7 +275,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
         GuidConverter converter(dr_servant->get_subscription_id());
         ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader(%C): ")
           ACE_TEXT("will return \"%C\" because datareader %s"),
-          OPENDDS_STRING(converter).c_str(), retcode_to_string(rc),
+          OPENDDS_STRING(converter).c_str(), retcode_to_string(rc).c_str(),
           reason));
       }
       return rc;

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -254,33 +254,31 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
   DataReaderImpl_rch dr_servant = rchandle_from(dynamic_cast<DataReaderImpl*>(a_datareader));
 
   if (dr_servant) { // for MultiTopic this will be false
+    const ACE_TCHAR* reason = 0;
+    DDS::ReturnCode_t rc = DDS::RETCODE_OK;
     DDS::Subscriber_var dr_subscriber(dr_servant->get_subscriber());
-
     if (dr_subscriber.in() != this) {
-      GuidConverter converter(dr_servant->get_subscription_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader: ")
-                 ACE_TEXT("data reader %C doesn't belong to this subscriber.\n"),
-                 OPENDDS_STRING(converter).c_str()));
-      return DDS::RETCODE_PRECONDITION_NOT_MET;
+      reason = ACE_TEXT("doesn't belong to this subscriber.");
+      rc = DDS::RETCODE_PRECONDITION_NOT_MET;
+    } else if (dr_servant->has_zero_copies()) {
+      reason = ACE_TEXT("has outstanding zero-copy samples loaned out.");
+      rc = DDS::RETCODE_PRECONDITION_NOT_MET;
+    } else if (!dr_servant->read_conditions_.empty()) {
+      reason = ACE_TEXT("has read conditions attached.");
+      rc = DDS::RETCODE_PRECONDITION_NOT_MET;
     }
-
-    if (dr_servant->has_zero_copies()) {
-      GuidConverter converter(dr_servant->get_subscription_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader: ")
-                 ACE_TEXT("data reader %C has outstanding zero-copy samples loaned out\n"),
-                 OPENDDS_STRING(converter).c_str()));
-      return DDS::RETCODE_PRECONDITION_NOT_MET;
-    }
-
-    if (!dr_servant->read_conditions_.empty()) {
-      GuidConverter converter(dr_servant->get_subscription_id());
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader: ")
-                 ACE_TEXT("data reader %C has attached read conditions\n"),
-                 OPENDDS_STRING(converter).c_str()));
-      return DDS::RETCODE_PRECONDITION_NOT_MET;
+    if (rc != DDS::RETCODE_OK) {
+      if (DCPS_debug_level) {
+        if (!reason) {
+          reason = ACE_TEXT(" (unknown reason)");
+        }
+        GuidConverter converter(dr_servant->get_subscription_id());
+        ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader(%C): ")
+          ACE_TEXT("will return \"%C\" because datareader %s"),
+          OPENDDS_STRING(converter).c_str(), retcode_to_string(rc),
+          reason));
+      }
+      return rc;
     }
   }
   if (dr_servant) {

--- a/tests/DCPS/GroupPresentation/DataReaderListener.cpp
+++ b/tests/DCPS/GroupPresentation/DataReaderListener.cpp
@@ -10,6 +10,7 @@
 
 #include <dds/DdsDcpsSubscriptionC.h>
 #include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
 
 #include "DataReaderListener.h"
 #include "MessengerTypeSupportC.h"
@@ -17,10 +18,12 @@
 
 #include <iostream>
 
+using OpenDDS::DCPS::retcode_to_string;
+
 extern int acess_scope;
 
 DataReaderListenerImpl::DataReaderListenerImpl(const char* /*reader_id*/)
-  : num_reads_(0), verify_result_ (true)
+  : num_reads_(0), verify_result_(true)
 {
 }
 
@@ -77,8 +80,8 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     } else {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("%N:%l: on_data_available()")
-                 ACE_TEXT(" ERROR: unexpected status: %d\n"),
-                 status));
+                 ACE_TEXT(" ERROR: take_next_sample unexpected status: %C\n"),
+                 retcode_to_string(status).c_str()));
       this->verify_result_ = false;
     }
 

--- a/tests/DCPS/ReadCondition/ReadConditionTest.cpp
+++ b/tests/DCPS/ReadCondition/ReadConditionTest.cpp
@@ -177,8 +177,10 @@ int run_test_next_instance(DDS::DomainParticipant_ptr dp)
   ws->attach_condition(dr_rc2);
   MessageDataReader_var mdr = MessageDataReader::_narrow(dr);
   bool passed = true, done = false;
-  if (sub->delete_datareader(dr) != DDS::RETCODE_PRECONDITION_NOT_MET) {
-    cout << "ERROR: the deletion of a DataReader is not allowed if there are any existing ReadCondition objects that are attached to the DataReader." << endl;
+  ret = sub->delete_datareader(dr);
+  if (ret != DDS::RETCODE_PRECONDITION_NOT_MET) {
+    cerr << "ERROR: expected delete_datareader to return RETCODE_PRECONDITION_NOT_MET, "
+      "but it returned " << retcode_to_string(ret) << endl;
     passed = false;
     done = true;
   }

--- a/tests/DCPS/ZeroCopyRead/main.cpp
+++ b/tests/DCPS/ZeroCopyRead/main.cpp
@@ -17,6 +17,7 @@
 #include "dds/DCPS/PublisherImpl.h"
 #include "SimpleTypeSupportImpl.h"
 #include "dds/DCPS/transport/framework/EntryExit.h"
+#include "dds/DCPS/SafetyProfileStreams.h"
 
 #include "dds/DCPS/StaticIncludes.h"
 
@@ -24,6 +25,8 @@
 #include "ace/OS_NS_unistd.h"
 
 #include <string.h>
+
+using OpenDDS::DCPS::retcode_to_string;
 
 class TestException
 {
@@ -1609,13 +1612,12 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             test_failed = 1;
         }
 
-        status =   sub->delete_datareader(dr.in ());
-
-        if (status != ::DDS::RETCODE_PRECONDITION_NOT_MET)
-        {
-            ACE_ERROR ((LM_ERROR,
-                    ACE_TEXT("(%P|%t) t10 ERROR: delete_datawrite should have returned PRECONDITION_NOT_MET but returned retcode %d.\n"), status ));
-            test_failed = 1;
+        status = sub->delete_datareader(dr.in());
+        if (status != ::DDS::RETCODE_PRECONDITION_NOT_MET) {
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) t10 ERROR: ")
+            ACE_TEXT("expected PRECONDITION_NOT_MET from delete_datareader, ")
+            ACE_TEXT("but it returned: %C\n"), retcode_to_string(status)));
+          test_failed = 1;
         }
 
         // Return the "loan" of read samples to datareader.
@@ -1630,16 +1632,13 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
         check_return_loan_status(status, data1, 0, 0, "t10 return_loan");
 
-        status =   sub->delete_datareader(dr.in ());
-
-        if (status != ::DDS::RETCODE_OK)
-        {
-            ACE_ERROR ((LM_ERROR,
-                    ACE_TEXT("(%P|%t) t10 ERROR: delete_datawrite failed with retcode %d.\n"), status ));
-            test_failed = 1;
+        status = sub->delete_datareader(dr.in ());
+        if (status != ::DDS::RETCODE_OK) {
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) t10 ERROR: ")
+            ACE_TEXT("delete_datareader returned: %C\n"),
+            retcode_to_string(status)));
+          test_failed = 1;
         }
-
-
       }
       {
         //=====================================================

--- a/tests/DCPS/ZeroCopyRead/main.cpp
+++ b/tests/DCPS/ZeroCopyRead/main.cpp
@@ -1616,7 +1616,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         if (status != ::DDS::RETCODE_PRECONDITION_NOT_MET) {
           ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) t10 ERROR: ")
             ACE_TEXT("expected PRECONDITION_NOT_MET from delete_datareader, ")
-            ACE_TEXT("but it returned: %C\n"), retcode_to_string(status)));
+            ACE_TEXT("but it returned: %C\n"), retcode_to_string(status).c_str()));
           test_failed = 1;
         }
 
@@ -1636,7 +1636,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         if (status != ::DDS::RETCODE_OK) {
           ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) t10 ERROR: ")
             ACE_TEXT("delete_datareader returned: %C\n"),
-            retcode_to_string(status)));
+            retcode_to_string(status).c_str()));
           test_failed = 1;
         }
       }


### PR DESCRIPTION
Link: #1094

- Fixed leak in presentation test.
- Changed some of the errors in delete_datareader to be warnings for ZeroCopyRead and Readcondition tests which cause errors on purpose.
- Fix Instance Group Presentation test by allowing group coherent sets by instance to be accepted again.