### PR TITLE
Increase size of the RTPS relay beacon message

### DIFF
--- a/dds/DCPS/RTPS/BaseMessageTypes.h
+++ b/dds/DCPS/RTPS/BaseMessageTypes.h
@@ -64,6 +64,10 @@ namespace OpenDDS {
     const char BLOB_PROP_PART_CRYPTO_HANDLE[] = "ParticipantCryptoHandle";
     const char BLOB_PROP_DW_CRYPTO_HANDLE[] = "DatawriterCryptoHandle";
     const char BLOB_PROP_DR_CRYPTO_HANDLE[] = "DatareaderCryptoHandle";
+
+    const ::CORBA::Octet BEACON_MSG_ID = PAD;
+    const ::CORBA::Octet BEACON_MESSAGE[] = { BEACON_MSG_ID, 0, 0, 0 };
+    const size_t BEACON_MESSAGE_LENGTH = sizeof(BEACON_MESSAGE);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2587,6 +2587,9 @@ RtpsUdpDataLink::check_heartbeats()
 void
 RtpsUdpDataLink::send_relay_beacon()
 {
+  static const char beacon_msg[4] = { '\0', '\0', '\0', '\0' };
+  static const size_t beacon_msg_size = sizeof(beacon_msg);
+  
   const bool no_relay = config().rtps_relay_address() == ACE_INET_Addr();
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
@@ -2596,7 +2599,9 @@ RtpsUdpDataLink::send_relay_beacon()
     }
   }
 
-  ACE_Message_Block mb(static_cast<size_t>(0));
+  // Create a message with a few bytes of data for the beacon
+  ACE_Message_Block mb(beacon_msg, beacon_msg_size);
+  mb.wr_ptr(beacon_msg_size);
   send_strategy()->send_rtps_control(mb, config().rtps_relay_address());
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2587,10 +2587,6 @@ RtpsUdpDataLink::check_heartbeats()
 void
 RtpsUdpDataLink::send_relay_beacon()
 {
-  // Use a pad submessage with for the beacon
-  static const ::CORBA::Octet beacon_msg[] = { 1, 0, 0, 0 };
-  static const size_t beacon_msg_size = sizeof(beacon_msg);
-  
   const bool no_relay = config().rtps_relay_address() == ACE_INET_Addr();
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
@@ -2601,8 +2597,8 @@ RtpsUdpDataLink::send_relay_beacon()
   }
 
   // Create a message with a few bytes of data for the beacon
-  ACE_Message_Block mb(reinterpret_cast<const char*>(beacon_msg), beacon_msg_size);
-  mb.wr_ptr(beacon_msg_size);
+  ACE_Message_Block mb(reinterpret_cast<const char*>(OpenDDS::RTPS::BEACON_MESSAGE), OpenDDS::RTPS::BEACON_MESSAGE_LENGTH);
+  mb.wr_ptr(OpenDDS::RTPS::BEACON_MESSAGE_LENGTH);
   send_strategy()->send_rtps_control(mb, config().rtps_relay_address());
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2587,7 +2587,8 @@ RtpsUdpDataLink::check_heartbeats()
 void
 RtpsUdpDataLink::send_relay_beacon()
 {
-  static const char beacon_msg[4] = { '\0', '\0', '\0', '\0' };
+  // Use a pad submessage with for the beacon
+  static const ::CORBA::Octet beacon_msg[] = { 1, 0, 0, 0 };
   static const size_t beacon_msg_size = sizeof(beacon_msg);
   
   const bool no_relay = config().rtps_relay_address() == ACE_INET_Addr();
@@ -2600,7 +2601,7 @@ RtpsUdpDataLink::send_relay_beacon()
   }
 
   // Create a message with a few bytes of data for the beacon
-  ACE_Message_Block mb(beacon_msg, beacon_msg_size);
+  ACE_Message_Block mb(reinterpret_cast<const char*>(beacon_msg), beacon_msg_size);
   mb.wr_ptr(beacon_msg_size);
   send_strategy()->send_rtps_control(mb, config().rtps_relay_address());
 }

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -1,5 +1,6 @@
 #include "RelayHandler.h"
 
+#include <dds/DCPS/RTPS/BaseMessageTypes.h>
 #include <dds/DCPS/RTPS/MessageTypes.h>
 #include <dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h>
 
@@ -16,8 +17,6 @@
 namespace {
   const CORBA::UShort encap_LE = 0x0300; // {PL_CDR_LE} in LE
   const CORBA::UShort encap_BE = 0x0200; // {PL_CDR_BE} in LE
-  const CORBA::Octet beacon_message[] = { 1, 0, 0, 0 };
-  const size_t beacon_message_length = sizeof(beacon_message);
 
   std::string guid_to_string(const OpenDDS::DCPS::GUID_t& a_guid)
   {
@@ -119,10 +118,10 @@ int RelayHandler::handle_input(ACE_HANDLE)
     return 0;
   }
 
-  // Detect beacon messages and flag them as empty
+  //
   bool is_beacon_message = false;
-  if ((buffer->length() == beacon_message_length)
-    && (static_cast<CORBA::Octet>(buffer->rd_ptr()[0]) == OpenDDS::RTPS::PAD)) {
+  if ((buffer->length() == OpenDDS::RTPS::BEACON_MESSAGE_LENGTH)
+    && (static_cast<CORBA::Octet>(buffer->rd_ptr()[0]) == OpenDDS::RTPS::BEACON_MSG_ID)) {
     is_beacon_message = true;
   }
 

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -16,6 +16,7 @@
 namespace {
   const CORBA::UShort encap_LE = 0x0300; // {PL_CDR_LE} in LE
   const CORBA::UShort encap_BE = 0x0200; // {PL_CDR_BE} in LE
+  const size_t beacon_message_length = static_cast<size_t>(4);
 
   std::string guid_to_string(const OpenDDS::DCPS::GUID_t& a_guid)
   {
@@ -116,7 +117,9 @@ int RelayHandler::handle_input(ACE_HANDLE)
     ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: RelayHandler::handle_input failed to deserialize RTPS header\n"));
     return 0;
   }
-  const auto empty_message = buffer->length() == 0;
+
+  // Beacon messages will be considered empty
+  const auto empty_message = buffer->length() == beacon_message_length;
 
   OpenDDS::DCPS::RepoId src_guid;
   std::memcpy(src_guid.guidPrefix, header.guidPrefix, sizeof(OpenDDS::DCPS::GuidPrefix_t));

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -31,7 +31,7 @@ protected:
                                const ACE_Time_Value& a_now,
                                const std::string& a_src_guid,
                                ACE_Message_Block* a_msg,
-                               bool a_empty_message) = 0;
+                               bool is_beacon_message) = 0;
 
 private:
   std::string relay_address_;
@@ -57,7 +57,7 @@ protected:
                        const ACE_Time_Value& a_now,
                        const std::string& a_src_guid,
                        ACE_Message_Block* a_msg,
-                       bool a_empty_message) override;
+                       bool is_beacon_message) override;
 };
 
 // Sends to and receives from other relays.
@@ -73,7 +73,7 @@ private:
                        const ACE_Time_Value& a_now,
                        const std::string& a_src_guid,
                        ACE_Message_Block* a_msg,
-                       bool a_empty_message) override;
+                       bool is_beacon_message) override;
 };
 
 class SpdpHandler : public VerticalHandler {
@@ -86,7 +86,7 @@ private:
                        const ACE_Time_Value& a_now,
                        const std::string& a_src_guid,
                        ACE_Message_Block* a_msg,
-                       bool a_empty_message) override;
+                       bool is_beacon_message) override;
 };
 
 #endif /* RTPSRELAY_RELAY_HANDLER_H_ */


### PR DESCRIPTION
The beacon message size was increased to be 4 bytes.  The content of the message
is just zeriozed data.