### PR TITLE
Backwards-Compatible Removal of "Associated Writers" from SEDP Datareader Announcements

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1161,7 +1161,7 @@ namespace OpenDDS {
           }
 
           // change this if 'writer_active' (above) changes
-          if (call_writer && !call_reader) {
+          if (call_writer && !call_reader && !is_expectant_opendds(reader)) {
             if (DCPS::DCPS_debug_level > 3) {
               ACE_DEBUG((LM_DEBUG,
                          ACE_TEXT("(%P|%t) EndpointManager::match - ")
@@ -1217,6 +1217,8 @@ namespace OpenDDS {
           }
         }
       }
+
+      virtual bool is_expectant_opendds(const GUID_t& endpoint) const = 0;
 
       virtual bool shutting_down() const = 0;
 

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -633,7 +633,7 @@ namespace OpenDDS {
         DCPS::TransportLocatorSeq trans_info_;
         RepoIdSet matched_endpoints_;
         DCPS::SequenceNumber sequence_;
-        RepoIdSet remote_opendds_associations_;
+        RepoIdSet remote_expectant_opendds_associations_;
 #ifdef OPENDDS_SECURITY
         bool have_ice_agent_info;
         ICE::AgentInfo ice_agent_info;
@@ -779,7 +779,7 @@ namespace OpenDDS {
             DCPS::WriterIdSeq writer_seq(1);
             writer_seq.length(1);
             writer_seq[0] = removing;
-            lsi->second.remote_opendds_associations_.erase(removing);
+            lsi->second.remote_expectant_opendds_associations_.erase(removing);
             lsi->second.subscription_->remove_associations(writer_seq,
                                                            false /*notify_lost*/);
             remove_assoc_i(remove_from, lsi->second, removing);
@@ -794,7 +794,7 @@ namespace OpenDDS {
             DCPS::ReaderIdSeq reader_seq(1);
             reader_seq.length(1);
             reader_seq[0] = removing;
-            lpi->second.remote_opendds_associations_.erase(removing);
+            lpi->second.remote_expectant_opendds_associations_.erase(removing);
             lpi->second.publication_->remove_associations(reader_seq,
                                                           false /*notify_lost*/);
             remove_assoc_i(remove_from, lpi->second, removing);
@@ -1161,7 +1161,7 @@ namespace OpenDDS {
           }
 
           // change this if 'writer_active' (above) changes
-          if (call_writer && !call_reader && !is_opendds(reader)) {
+          if (call_writer && !call_reader) {
             if (DCPS::DCPS_debug_level > 3) {
               ACE_DEBUG((LM_DEBUG,
                          ACE_TEXT("(%P|%t) EndpointManager::match - ")
@@ -1173,11 +1173,11 @@ namespace OpenDDS {
         } else if (already_matched) { // break an existing associtaion
           if (writer_local) {
             lpi->second.matched_endpoints_.erase(reader);
-            lpi->second.remote_opendds_associations_.erase(reader);
+            lpi->second.remote_expectant_opendds_associations_.erase(reader);
           }
           if (reader_local) {
             lsi->second.matched_endpoints_.erase(writer);
-            lsi->second.remote_opendds_associations_.erase(writer);
+            lsi->second.remote_expectant_opendds_associations_.erase(writer);
           }
           if (writer_local && !reader_local) {
             remove_assoc_i(writer, lpi->second, reader);
@@ -1216,12 +1216,6 @@ namespace OpenDDS {
             drr->update_incompatible_qos(readerStatus);
           }
         }
-      }
-
-      virtual bool is_opendds(const GUID_t& endpoint) const
-      {
-        return !std::memcmp(endpoint.guidPrefix, DCPS::VENDORID_OCI,
-                            sizeof(DCPS::VENDORID_OCI));
       }
 
       virtual bool shutting_down() const = 0;

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -779,12 +779,14 @@ namespace OpenDDS {
             DCPS::WriterIdSeq writer_seq(1);
             writer_seq.length(1);
             writer_seq[0] = removing;
-            lsi->second.remote_expectant_opendds_associations_.erase(removing);
+            const size_t count = lsi->second.remote_expectant_opendds_associations_.erase(removing);
             lsi->second.subscription_->remove_associations(writer_seq,
                                                            false /*notify_lost*/);
             remove_assoc_i(remove_from, lsi->second, removing);
             // Update writer
-            write_subscription_data(remove_from, lsi->second);
+            if (count) {
+              write_subscription_data(remove_from, lsi->second);
+            }
           }
 
         } else {

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -272,6 +272,11 @@ namespace {
     return std::strlen(cfprop.filterExpression);
   }
 
+  bool not_default(const ParticipantFlags_t& flags)
+  {
+    return flags.bits != PFLAGS_EMPTY;
+  }
+
   void normalize(DDS::Duration_t& dur)
   {
     // Interoperability note:
@@ -548,6 +553,12 @@ int to_param_list(const ParticipantProxy_t& proxy,
     add_param(param_list, param_p);
   }
 
+  if (not_default(proxy.opendds_participant_flags)) {
+    Parameter param_opf;
+    param_opf.participant_flags(proxy.opendds_participant_flags);
+    add_param(param_list, param_opf);
+  }
+
   return 0;
 }
 
@@ -653,6 +664,9 @@ int from_param_list(const ParameterList& param_list,
         break;
       case PID_PROPERTY_LIST:
         proxy.property = param.property();
+        break;
+      case PID_OPENDDS_PARTICIPANT_FLAGS:
+        proxy.opendds_participant_flags = param.participant_flags();
         break;
       case PID_SENTINEL:
       case PID_PAD:

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -272,7 +272,7 @@ namespace {
     return std::strlen(cfprop.filterExpression);
   }
 
-  bool not_default(const ParticipantFlags_t& flags)
+  bool not_default(const OpenDDSParticipantFlags_t& flags)
   {
     return flags.bits != PFLAGS_EMPTY;
   }

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -287,12 +287,12 @@ module OpenDDS {
     const ParameterId_t PIDMASK_VENDOR_SPECIFIC = 0x8000;
     const ParameterId_t PIDMASK_INCOMPATIBLE = 0x4000;
 
-    typedef unsigned long ParticipantFlagsBits_t;
-    const ParticipantFlagsBits_t PFLAGS_EMPTY = 0x0;
-    const ParticipantFlagsBits_t PFLAGS_NO_ASSOCIATED_WRITERS = 0x1;
+    typedef unsigned long OpenDDSParticipantFlagsBits_t;
+    const OpenDDSParticipantFlagsBits_t PFLAGS_EMPTY = 0x0;
+    const OpenDDSParticipantFlagsBits_t PFLAGS_NO_ASSOCIATED_WRITERS = 0x1;
 
-    struct ParticipantFlags_t {
-      ParticipantFlagsBits_t bits;
+    struct OpenDDSParticipantFlags_t {
+      OpenDDSParticipantFlagsBits_t bits;
     };
 
     // Vendor-specific parameters
@@ -409,7 +409,7 @@ module OpenDDS {
         DCPS::GUID_t guid;
 
       case PID_OPENDDS_PARTICIPANT_FLAGS:
-        ParticipantFlags_t participant_flags;
+        OpenDDSParticipantFlags_t participant_flags;
 
       case PID_PARTICIPANT_ENTITYID:
       case PID_GROUP_ENTITYID:
@@ -567,7 +567,7 @@ module OpenDDS {
       DCPS::LocatorSeq defaultUnicastLocatorList;
       Count_t manualLivelinessCount;
       DDS::PropertyQosPolicy property;
-      ParticipantFlags_t opendds_participant_flags;
+      OpenDDSParticipantFlags_t opendds_participant_flags;
     };
 
     // top-level data type for SPDP

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -287,6 +287,14 @@ module OpenDDS {
     const ParameterId_t PIDMASK_VENDOR_SPECIFIC = 0x8000;
     const ParameterId_t PIDMASK_INCOMPATIBLE = 0x4000;
 
+    typedef unsigned long ParticipantFlagsBits_t;
+    const ParticipantFlagsBits_t PFLAGS_EMPTY = 0x0;
+    const ParticipantFlagsBits_t PFLAGS_NO_ASSOCIATED_WRITERS = 0x1;
+
+    struct ParticipantFlags_t {
+      ParticipantFlagsBits_t bits;
+    };
+
     // Vendor-specific parameters
     // PID_OPENDDS_BASE won't be used as an actual PID, it's just the starting
     // point for ones we assign.  This is deliberately a larger number so as
@@ -297,6 +305,7 @@ module OpenDDS {
     const ParameterId_t PID_OPENDDS_ASSOCIATED_WRITER = PID_OPENDDS_BASE + 2;
     const ParameterId_t PID_OPENDDS_ICE_GENERAL       = PID_OPENDDS_BASE + 3;
     const ParameterId_t PID_OPENDDS_ICE_CANDIDATE     = PID_OPENDDS_BASE + 4;
+    const ParameterId_t PID_OPENDDS_PARTICIPANT_FLAGS = PID_OPENDDS_BASE + 5;
 
 
     /* Always used inside a ParameterList */
@@ -398,6 +407,9 @@ module OpenDDS {
       case PID_GROUP_GUID:
       case PID_OPENDDS_ASSOCIATED_WRITER:
         DCPS::GUID_t guid;
+
+      case PID_OPENDDS_PARTICIPANT_FLAGS:
+        ParticipantFlags_t participant_flags;
 
       case PID_PARTICIPANT_ENTITYID:
       case PID_GROUP_ENTITYID:
@@ -555,6 +567,7 @@ module OpenDDS {
       DCPS::LocatorSeq defaultUnicastLocatorList;
       Count_t manualLivelinessCount;
       DDS::PropertyQosPolicy property;
+      ParticipantFlags_t opendds_participant_flags;
     };
 
     // top-level data type for SPDP

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -744,7 +744,7 @@ private:
                                                    LocalParticipantMessage& part,
                                                    const DCPS::RepoId& reader = DCPS::GUID_UNKNOWN);
 
-  bool is_expectant_opendds(const GUID_t& endpoint) const;
+  virtual bool is_expectant_opendds(const GUID_t& endpoint) const;
 
 #ifdef OPENDDS_SECURITY
   DCPS::SequenceNumber secure_automatic_liveliness_seq_;

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -744,7 +744,7 @@ private:
                                                    LocalParticipantMessage& part,
                                                    const DCPS::RepoId& reader = DCPS::GUID_UNKNOWN);
 
-  bool is_opendds(const GUID_t& endpoint) const;
+  bool is_expectant_opendds(const GUID_t& endpoint) const;
 
 #ifdef OPENDDS_SECURITY
   DCPS::SequenceNumber secure_automatic_liveliness_seq_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1207,14 +1207,15 @@ Spdp::wait_for_acks()
 }
 
 bool
-Spdp::is_opendds(const GUID_t& participant) const
+Spdp::is_expectant_opendds(const GUID_t& participant) const
 {
   const DiscoveredParticipantConstIter iter = participants_.find(participant);
   if (iter == participants_.end()) {
     return false;
   }
-  return 0 == std::memcmp(&iter->second.pdata_.participantProxy.vendorId,
+  bool is_opendds = 0 == std::memcmp(&iter->second.pdata_.participantProxy.vendorId,
                           DCPS::VENDORID_OCI, sizeof(VendorId_t));
+  return is_opendds && ((iter->second.pdata_.participantProxy.opendds_participant_flags.bits & RTPS::PFLAGS_NO_ASSOCIATED_WRITERS) == 0);
 }
 
 ParticipantData_t
@@ -1308,7 +1309,8 @@ Spdp::build_local_pdata(
       nonEmptyList /*defaultMulticastLocatorList*/,
       nonEmptyList /*defaultUnicastLocatorList*/,
       {0 /*manualLivelinessCount*/},   //FUTURE: implement manual liveliness
-      qos_.property
+      qos_.property,
+      {PFLAGS_NO_ASSOCIATED_WRITERS} // opendds_participant_flags
     },
     { // Duration_t (leaseDuration)
       static_cast<CORBA::Long>((disco_->resend_period() * LEASE_MULT).sec()),

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1213,8 +1213,8 @@ Spdp::is_expectant_opendds(const GUID_t& participant) const
   if (iter == participants_.end()) {
     return false;
   }
-  bool is_opendds = 0 == std::memcmp(&iter->second.pdata_.participantProxy.vendorId,
-                          DCPS::VENDORID_OCI, sizeof(VendorId_t));
+  const bool is_opendds = 0 == std::memcmp(&iter->second.pdata_.participantProxy.vendorId,
+                                           DCPS::VENDORID_OCI, sizeof(VendorId_t));
   return is_opendds && ((iter->second.pdata_.participantProxy.opendds_participant_flags.bits & RTPS::PFLAGS_NO_ASSOCIATED_WRITERS) == 0);
 }
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -110,7 +110,7 @@ public:
   bool is_security_enabled() const { return security_enabled_; }
 #endif
 
-  bool is_opendds(const GUID_t& participant) const;
+  bool is_expectant_opendds(const GUID_t& participant) const;
 
 #ifdef OPENDDS_SECURITY
   typedef std::pair<DDS::Security::ParticipantCryptoHandle, DDS::Security::SharedSecretHandle_var> ParticipantCryptoInfoPair;

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -439,6 +439,14 @@ StaticEndpointManager::remove_subscription_i(const RepoId& readerid,
 }
 
 bool
+StaticEndpointManager::is_expectant_opendds(const GUID_t& /*endpoint*/) const
+{
+  // We can't propagate associated writers via SEDP announcments if we're
+  // using static discovery, so nobody ought to be "expecting" them
+  return false;
+}
+
+bool
 StaticEndpointManager::shutting_down() const
 {
   ACE_DEBUG((LM_NOTICE, ACE_TEXT("(%P|%t) StaticEndpointManager::shutting_down TODO\n")));

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -180,6 +180,8 @@ public:
   virtual DDS::ReturnCode_t remove_subscription_i(const RepoId& /*subscriptionId*/,
                                                   LocalSubscription& /*sub*/);
 
+  virtual bool is_expectant_opendds(const GUID_t& endpoint) const;
+
   virtual bool shutting_down() const;
 
   virtual void populate_transport_locator_sequence(TransportLocatorSeq*& /*tls*/,


### PR DESCRIPTION
This patch will safely remove the poorly-scaling vendor-specific extension for datareader announcements by adding new vendor-specific extension (OpenDDS Participant Flags) to participant announcements. The first (and only, so far) flag will indicate that incoming datareader annoucements are not expected to contain associated datawriters, allowing instances of OpenDDS that recognize this flag to refrain from sending these associations for/to this participant and its datawriters.