### PR TITLE
Check that a topic is enabled when enabling data writer/reader

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1159,6 +1159,10 @@ DataReaderImpl::enable()
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 
+  if (!this->topic_servant_->is_enabled()) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
   RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
   if (participant) {
     dp_id_ = participant->get_id();

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1159,7 +1159,7 @@ DataReaderImpl::enable()
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 
-  if (!this->topic_servant_->is_enabled()) {
+  if (!topic_servant_->is_enabled()) {
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1269,6 +1269,10 @@ DataWriterImpl::enable()
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 
+  if (!this->topic_servant_->is_enabled()) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
   RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
   if (participant) {
     dp_id_ = participant->get_id();

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1269,7 +1269,7 @@ DataWriterImpl::enable()
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 
-  if (!this->topic_servant_->is_enabled()) {
+  if (!topic_servant_->is_enabled()) {
     return DDS::RETCODE_PRECONDITION_NOT_MET;
   }
 

--- a/tools/modeling/tests/MessengerDpQos/publisher.cpp
+++ b/tools/modeling/tests/MessengerDpQos/publisher.cpp
@@ -20,6 +20,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     DDS::DataWriter_var writer = model.writer( Elements::DataWriters::writer);
     DDS::Publisher_var publisher = writer->get_publisher();
+    DDS::Topic_var topic = writer->get_topic();
     DDS::DomainParticipant_var participant = publisher->get_participant();
 
     DDS::DomainParticipantQos part_qos;
@@ -51,13 +52,16 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
     } else {
       std::cout << "enabling publisher" << std::endl;
       if (participant->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling participant" << std::endl;
+        std::cout << "ERROR; bad return code enabling participant" << std::endl;
       }
       if (publisher->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling publisher" << std::endl;
+        std::cout << "ERROR: bad return code enabling publisher" << std::endl;
+      }
+      if (topic->enable() != DDS::RETCODE_OK) {
+        std::cout << "ERROR: bad return code enabling topic" << std::endl;
       }
       if (writer->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling writer" << std::endl;
+        std::cout << "ERROR: bad return code enabling writer" << std::endl;
       }
     }
     char* buff = reinterpret_cast<char*>(part_qos.user_data.value.get_buffer());

--- a/tools/modeling/tests/MessengerDpQos/publisher.cpp
+++ b/tools/modeling/tests/MessengerDpQos/publisher.cpp
@@ -52,7 +52,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
     } else {
       std::cout << "enabling publisher" << std::endl;
       if (participant->enable() != DDS::RETCODE_OK) {
-        std::cout << "ERROR; bad return code enabling participant" << std::endl;
+        std::cout << "ERROR: bad return code enabling participant" << std::endl;
       }
       if (publisher->enable() != DDS::RETCODE_OK) {
         std::cout << "ERROR: bad return code enabling publisher" << std::endl;

--- a/tools/modeling/tests/MessengerPubQos/publisher.cpp
+++ b/tools/modeling/tests/MessengerPubQos/publisher.cpp
@@ -19,6 +19,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
     using OpenDDS::Model::MessengerPubQos::Elements;
 
     DDS::DataWriter_var writer = model.writer( Elements::DataWriters::writer);
+    DDS::Topic_var topic = writer->get_topic();
     DDS::Publisher_var publisher = writer->get_publisher();
 
     DDS::PublisherQos pub_qos;
@@ -50,10 +51,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
                          -1);
     } else {
       if (publisher->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling publisher" << std::endl;
+        std::cout << "ERROR: bad return code enabling publisher" << std::endl;
+      }
+      if (topic->enable() != DDS::RETCODE_OK) {
+        std::cout << "ERROR: bad return code enabling topic" << std::endl;
       }
       if (writer->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling writer" << std::endl;
+        std::cout << "ERROR: bad return code enabling writer" << std::endl;
       }
     }
 

--- a/tools/modeling/tests/SubscriberQos/publisher.cpp
+++ b/tools/modeling/tests/SubscriberQos/publisher.cpp
@@ -20,12 +20,17 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     DDS::DataWriter_var writer = model.writer( Elements::DataWriters::writer);
 
+    DDS::Topic_var topic = writer->get_topic();
+
     DDS::Publisher_var publisher = writer->get_publisher();
     if (publisher->enable() != DDS::RETCODE_OK) {
-      std::cout << "bad return code enabling publisher" << std::endl;
+      std::cout << "ERROR: bad return code enabling publisher" << std::endl;
+    }
+    if (topic->enable() != DDS::RETCODE_OK) {
+      std::cout << "ERROR: bad return code enabling topic" << std::endl;
     }
     if (writer->enable() != DDS::RETCODE_OK) {
-      std::cout << "bad return code enabling writer" << std::endl;
+      std::cout << "ERROR: bad return code enabling writer" << std::endl;
     }
 
     // START OF EXISTING MESSENGER EXAMPLE CODE

--- a/tools/modeling/tests/SubscriberQos/subscriber.cpp
+++ b/tools/modeling/tests/SubscriberQos/subscriber.cpp
@@ -77,7 +77,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     DDS::DataReader_var reader = model.reader( Elements::DataReaders::reader);
     DDS::Subscriber_var subscriber = reader->get_subscriber();
-    DDS::Topic_var topic = DDS::Topic::_narrow(reader->get_topicdescription());
+    DDS::TopicDescription_var topic_description = reader->get_topicdescription()
+    DDS::Topic_var topic = DDS::Topic::_narrow(topic_description);
 
     ACE_SYNCH_MUTEX lock;
     ACE_Condition<ACE_SYNCH_MUTEX> condition(lock);

--- a/tools/modeling/tests/SubscriberQos/subscriber.cpp
+++ b/tools/modeling/tests/SubscriberQos/subscriber.cpp
@@ -77,6 +77,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     DDS::DataReader_var reader = model.reader( Elements::DataReaders::reader);
     DDS::Subscriber_var subscriber = reader->get_subscriber();
+    DDS::Topic_var topic = DDS::Topic::_narrow(reader->get_topicdescription());
 
     ACE_SYNCH_MUTEX lock;
     ACE_Condition<ACE_SYNCH_MUTEX> condition(lock);
@@ -116,10 +117,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR** argv)
                          -1);
     } else {
       if (subscriber->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling subscriber" << std::endl;
+        std::cout << "ERROR: bad return code enabling subscriber" << std::endl;
+      }
+      if (topic->enable() != DDS::RETCODE_OK) {
+        std::cout << "ERROR: bad return code enabling topic" << std::endl;
       }
       if (reader->enable() != DDS::RETCODE_OK) {
-        std::cout << "bad return code enabling reader" << std::endl;
+        std::cout << "ERROR: bad return code enabling reader" << std::endl;
       }
     }
 


### PR DESCRIPTION
Problem: Data(Reader|Writer)Impl don't check that topic is enabled

Solution: Return PRECONDITION_NOT_MET if the topic is not enabled.