### PR TITLE
Pull all non-IDL related settings from dcps

### DIFF
--- a/MPC/config/dcps.mpb
+++ b/MPC/config/dcps.mpb
@@ -1,8 +1,3 @@
-project: dds_taolib, dcps_ts_defaults, dcps_optional_features, dds_suppress_any_support, taoidldefaults, coverage_optional, dds_macros, dds_vc_warnings {
-  libs        += OpenDDS_Dcps
-  after       += OpenDDS_Dcps
-  libpaths    += $(DDS_ROOT)/lib
-
-  includes    += $(DDS_ROOT)
-  idlflags    += -I$(DDS_ROOT)
+project: dcps_no_idl, dcps_ts_defaults, dcps_optional_features, dds_suppress_any_support, taoidldefaults {
+  idlflags += -I$(DDS_ROOT)
 }

--- a/MPC/config/dcps_no_idl.mpb
+++ b/MPC/config/dcps_no_idl.mpb
@@ -1,0 +1,6 @@
+project: dds_taolib, dds_macros, dcps_optional_bidir_giop, dds_any_support, coverage_optional, dds_vc_warnings {
+  libs        += OpenDDS_Dcps
+  after       += OpenDDS_Dcps
+  libpaths    += $(DDS_ROOT)/lib
+  includes    += $(DDS_ROOT)
+}

--- a/MPC/config/dcps_optional_bidir_giop.mpb
+++ b/MPC/config/dcps_optional_bidir_giop.mpb
@@ -1,0 +1,2 @@
+feature (no_opendds_safety_profile) : bidir_giop {
+}

--- a/MPC/config/dcps_optional_features.mpb
+++ b/MPC/config/dcps_optional_features.mpb
@@ -53,11 +53,12 @@ feature (!no_opendds_safety_profile) : taoidldefaults, dcps_ts_defaults {
   dcps_ts_flags += -DOPENDDS_SAFETY_PROFILE
 }
 
-feature (no_opendds_safety_profile) : bidir_giop {
-}
-
 feature (!no_opendds_security) : taoidldefaults, dcps_ts_defaults {
   macros   += OPENDDS_SECURITY
   idlflags += -DOPENDDS_SECURITY
   dcps_ts_flags += -DOPENDDS_SECURITY
 }
+
+project: dcps_optional_bidir_giop {
+}
+

--- a/MPC/config/dds_any_support.mpb
+++ b/MPC/config/dds_any_support.mpb
@@ -1,0 +1,2 @@
+feature (!dds_suppress_anys) : anytypecode {
+}

--- a/MPC/config/dds_suppress_any_support.mpb
+++ b/MPC/config/dds_suppress_any_support.mpb
@@ -4,5 +4,5 @@ feature (dds_suppress_anys) : taoidldefaults, dcps_ts_defaults {
   dcps_ts_flags += -Sa -St
 }
 
-feature (!dds_suppress_anys) : taoidldefaults, anytypecode {
+feature (!dds_suppress_anys) : taoidldefaults, dds_any_support {
 }


### PR DESCRIPTION
Pull all non-IDL related settings from dcps and inherited base projects into a separate set of base projects to allow for linking in OpenDDS without defining IDL compilation rules.