### PR TITLE
Fix pass/fail criteria for the Monitor test

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -329,6 +329,8 @@ tests/DCPS/ManyTopicTest/run_test.pl rtps: !DCPS_MIN RTPS
 
 tests/DCPS/ManyTopicMultiProcess/run_test.pl: !DCPS_MIN
 
+tests/DCPS/Monitor/run_test.pl: !DCPS_MIN
+
 tests/DCPS/QoS_XML/dump/run_test.pl: XERCES3
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS

--- a/tests/DCPS/Monitor/run_test.pl
+++ b/tests/DCPS/Monitor/run_test.pl
@@ -97,7 +97,7 @@ open(MONOUT,"mon.out");
 my @monout=<MONOUT>;close MONOUT;
 my $mon_count = grep /Report/,@monout;
 print STDOUT "mon_count=$mon_count\n";
-if ($mon_count < 150) {
+if ($mon_count < 145) {
     print STDERR "ERROR: Insufficient number of monitor messages seen\n";
     $status = 1;
 }


### PR DESCRIPTION
A recent change removed some instances where samples of some Monitor
topics were being sent twice.  The passing threshold was lowered to account for
this.  The Monitor test was also added to the list of tests to run.