### PR TITLE
Disable Monitor tests for some configurations

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -333,7 +333,7 @@ tests/DCPS/ManyTopicTest/run_test.pl rtps: !DCPS_MIN RTPS
 
 tests/DCPS/ManyTopicMultiProcess/run_test.pl: !DCPS_MIN
 
-tests/DCPS/Monitor/run_test.pl: !DCPS_MIN
+tests/DCPS/Monitor/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !NO_BUILT_IN_TOPICS
 
 tests/DCPS/QoS_XML/dump/run_test.pl: XERCES3
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS

--- a/tests/DCPS/Monitor/Messenger.mpc
+++ b/tests/DCPS/Monitor/Messenger.mpc
@@ -1,5 +1,5 @@
 project(Monitor*Publisher): dcpsexe, dcps_cm, dcps_tcp, dcps_monitor {
-  requires += no_opendds_safety_profile
+  requires += no_opendds_safety_profile built_in_topics
   exename   = publisher
 
   Idl_Files {
@@ -12,7 +12,7 @@ project(Monitor*Publisher): dcpsexe, dcps_cm, dcps_tcp, dcps_monitor {
 }
 
 project(Monitor*Subscriber): dcpsexe, dcps_cm, dcps_tcp, dcps_monitor {
-  requires += no_opendds_safety_profile
+  requires += no_opendds_safety_profile built_in_topics
   exename   = subscriber
 
   Idl_Files {
@@ -25,7 +25,7 @@ project(Monitor*Subscriber): dcpsexe, dcps_cm, dcps_tcp, dcps_monitor {
 }
 
 project(Monitor*monitor): dcpsexe, dcps_cm, dcps_tcp, dcps_monitor {
-  requires += no_opendds_safety_profile
+  requires += no_opendds_safety_profile built_in_topics
   exename   = monitor
 
   specific (vc9, vc10, vc11, vc12, vc14, vs2017, vs2019, nmake) {


### PR DESCRIPTION
The monitor test has been disabled for configurations with no built-in-topics
and the safety profile.  The test will not be built in these configurations.