### PR TITLE
Reactor task in Service Participant has stale reference

### DIFF
--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -209,6 +209,9 @@ OpenDDS::DCPS::ReactorTask::stop()
   // Let's wait for the reactor task's thread to complete before we
   // leave this stop method.
   wait();
+
+  // Reset the thread manager in case it goes away before the next open.
+  this->thr_mgr(0);
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
A ReactorTask is an ACE::Task_Base which caches a references to its
Thread_Manager.  If the Service_Participant is shutdown and ACE is
restarted (ACE::fini, ACE::init), then this reference is stale and
shows up as an access violation in the Restart test.

Solution: Reset the reference when the ReactorTask is stop so that it
will use the correct Thread_Mananger when restarted.