### PR TITLE
Use LocalEndpoint to store endpoint security attribs, init them

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -620,8 +620,20 @@ namespace OpenDDS {
         LocalEndpoint() : topic_id_(DCPS::GUID_UNKNOWN), sequence_(DCPS::SequenceNumber::SEQUENCENUMBER_UNKNOWN())
 #ifdef OPENDDS_SECURITY
           , have_ice_agent_info(false)
-#endif
+        {
+          security_attribs_.base.is_read_protected = false;
+          security_attribs_.base.is_write_protected = false;
+          security_attribs_.base.is_discovery_protected = false;
+          security_attribs_.base.is_liveliness_protected = false;
+          security_attribs_.is_submessage_protected = false;
+          security_attribs_.is_payload_protected = false;
+          security_attribs_.is_key_protected = false;
+          security_attribs_.plugin_endpoint_attributes = 0;
+        }
+#else
         {}
+#endif
+
         DCPS::RepoId topic_id_;
         DCPS::TransportLocatorSeq trans_info_;
         RepoIdSet matched_endpoints_;
@@ -630,6 +642,7 @@ namespace OpenDDS {
 #ifdef OPENDDS_SECURITY
         bool have_ice_agent_info;
         ICE::AgentInfo ice_agent_info;
+        DDS::Security::EndpointSecurityAttributes security_attribs_;
 #endif
       };
 
@@ -637,11 +650,6 @@ namespace OpenDDS {
         DCPS::DataWriterCallbacks* publication_;
         DDS::DataWriterQos qos_;
         DDS::PublisherQos publisher_qos_;
-
-#ifdef OPENDDS_SECURITY
-        DDS::Security::EndpointSecurityAttributes security_attribs_;
-#endif
-
       };
 
       struct LocalSubscription : LocalEndpoint {
@@ -649,11 +657,6 @@ namespace OpenDDS {
         DDS::DataReaderQos qos_;
         DDS::SubscriberQos subscriber_qos_;
         OpenDDS::DCPS::ContentFilterProperty_t filterProperties;
-
-#ifdef OPENDDS_SECURITY
-        DDS::Security::EndpointSecurityAttributes security_attribs_;
-#endif
-
       };
 
       typedef OPENDDS_MAP_CMP(DDS::BuiltinTopicKey_t, DCPS::RepoId,


### PR DESCRIPTION
Follow-on to #1227 to make it work when security is enabled in the build but not at runtime.