### PR TITLE
ReadCondition test: restored to its state before consolidating messenger IDL

### DIFF
--- a/tests/DCPS/ReadCondition/.gitignore
+++ b/tests/DCPS/ReadCondition/.gitignore
@@ -1,1 +1,2 @@
 /ReadConditionTest
+/GeneratedCode

--- a/tests/DCPS/ReadCondition/Messenger.idl
+++ b/tests/DCPS/ReadCondition/Messenger.idl
@@ -1,0 +1,9 @@
+module Messenger {
+
+#pragma DCPS_DATA_TYPE "Messenger::Message"
+#pragma DCPS_DATA_KEY "Messenger::Message subject_id"
+
+  struct Message {
+    long subject_id;
+  };
+};

--- a/tests/DCPS/ReadCondition/ReadCondition.mpc
+++ b/tests/DCPS/ReadCondition/ReadCondition.mpc
@@ -1,10 +1,14 @@
-project: dcpsexe, dcps_cm, dcps_transports_for_test {
+project: dcpsexe, dcps_transports_for_test, dcps_ts_subdir {
   exename = ReadConditionTest
+  idlflags += -SS -o GeneratedCode
 
-  Idl_Files {
+  TypeSupport_Files {
+    gendir = GeneratedCode
+    Messenger.idl
   }
 
-  Source_Files {
-    ReadConditionTest.cpp
+  IDL_Files {
+    gendir = GeneratedCode
+    Messenger.idl
   }
 }

--- a/tests/DCPS/ReadCondition/ReadConditionTest.cpp
+++ b/tests/DCPS/ReadCondition/ReadConditionTest.cpp
@@ -6,7 +6,7 @@
 #include "dds/DCPS/SubscriberImpl.h"
 #include "dds/DCPS/StaticIncludes.h"
 
-#include "MessengerTypeSupportImpl.h"
+#include "GeneratedCode/MessengerTypeSupportImpl.h"
 #include <iostream>
 using namespace std;
 
@@ -55,7 +55,7 @@ int run_test_instance(DDS::DomainParticipant_ptr dp)
   if (ret != RETCODE_OK) return ret;
 
   MessageDataWriter_var mdw = MessageDataWriter::_narrow(dw);
-  Message msg = { "", "", 0, "", 0, 0, 0 };
+  Message msg = {0};
   for (int i(0); i < 12; ++i) {
     ++msg.subject_id;
     ret = mdw->write(msg, HANDLE_NIL);
@@ -162,7 +162,7 @@ int run_test_next_instance(DDS::DomainParticipant_ptr dp)
   if (ret != RETCODE_OK) return ret;
 
   MessageDataWriter_var mdw = MessageDataWriter::_narrow(dw);
-  Message msg = { "", "", 0, "", 0, 0, 0 };
+  Message msg = {0};
   for (int i(0); i < 12; ++i) {
     ++msg.subject_id;
     ret = mdw->write(msg, HANDLE_NIL);

--- a/tests/DCPS/ReadCondition/run_test.pl
+++ b/tests/DCPS/ReadCondition/run_test.pl
@@ -9,8 +9,6 @@ use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
 use strict;
 
-PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
-
 my $test = new PerlDDS::TestFramework();
 $test->{'nobits'} = 1;
 


### PR DESCRIPTION
This test is designed to show how to use the code generators differently.