### PR TITLE
Fix for Occasional QueryCondition Test Failure

### DIFF
--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -271,7 +271,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
       if (DCPS_debug_level) {
         GuidConverter converter(dr_servant->get_subscription_id());
         ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader(%C): ")
-          ACE_TEXT("will return \"%C\" because datareader %s"),
+          ACE_TEXT("will return \"%C\" because datareader %s\n"),
           OPENDDS_STRING(converter).c_str(), retcode_to_string(rc).c_str(),
           reason));
       }


### PR DESCRIPTION
Delete DR Listeners in `run_complex_filtering_test` before cleanup to try to fix occasional failures on the scoreboard.