### PR TITLE
switching InstanceState::reader_ from DataReaderImpl* to WeakRcHandle

### DIFF
--- a/dds/DCPS/GroupRakeData.cpp
+++ b/dds/DCPS/GroupRakeData.cpp
@@ -48,8 +48,12 @@ GroupRakeData::get_datareaders(DDS::DataReaderSeq & readers)
   CORBA::ULong i = 0;
   SortedSet::iterator itEnd = this->sorted_.end();
   for (SortedSet::iterator it = this->sorted_.begin(); it != itEnd; ++it) {
-    readers[i++] =
-      DDS::DataReader::_duplicate(it->si_->instance_state_->data_reader());
+    RcHandle<DDS::DataReader> reader = it->si_->instance_state_->data_reader().lock();
+    if (reader) {
+      readers[i++] = DDS::DataReader::_duplicate(reader.in());
+    } else {
+      readers.length(readers.length() - 1);
+    }
   }
 #endif
 }

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -38,7 +38,7 @@ InstanceState::InstanceState(DataReaderImpl* reader,
     empty_(true),
     release_pending_(false),
     release_timer_id_(-1),
-    reader_(reader),
+    reader_(*reader),
     handle_(handle),
     owner_(GUID_UNKNOWN),
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
@@ -51,8 +51,11 @@ InstanceState::~InstanceState()
 {
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   if (registered_) {
-    DataReaderImpl::OwnershipManagerPtr om = reader_->ownership_manager();
-    if (om) om->remove_instance(this);
+    RcHandle<DataReaderImpl> reader = reader_.lock();
+    if (reader) {
+      DataReaderImpl::OwnershipManagerPtr om = reader->ownership_manager();
+      if (om) om->remove_instance(this);
+    }
   }
 #endif
 }
@@ -68,8 +71,13 @@ void InstanceState::sample_info(DDS::SampleInfo& si, const ReceivedDataElement* 
     static_cast<CORBA::Long>(no_writers_generation_count_);
   si.source_timestamp = de->source_timestamp_;
   si.instance_handle = handle_;
-  RcHandle<DomainParticipantImpl> participant = reader_->participant_servant_.lock();
-  si.publication_handle = participant ? participant->id_to_handle(de->pub_) : 0;
+  RcHandle<DataReaderImpl> reader = reader_.lock();
+  if (reader) {
+    RcHandle<DomainParticipantImpl> participant = reader->participant_servant_.lock();
+    si.publication_handle = participant ? participant->id_to_handle(de->pub_) : 0;
+  } else {
+    si.publication_handle = 0;
+  }
   si.valid_data = de->valid_data_;
   /*
    * These are actually calculated later...
@@ -118,14 +126,17 @@ bool InstanceState::dispose_was_received(const PublicationId& writer_id)
   // resume if the writer sends message again.
   if (instance_state_ & DDS::ALIVE_INSTANCE_STATE) {
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
-    DataReaderImpl::OwnershipManagerPtr owner_manager = reader_->ownership_manager();
-    if (! exclusive_
-      || (owner_manager && owner_manager->is_owner (handle_, writer_id))) {
+    RcHandle<DataReaderImpl> reader = reader_.lock();
+    if (reader) {
+      DataReaderImpl::OwnershipManagerPtr owner_manager = reader->ownership_manager();
+      if (! exclusive_
+        || (owner_manager && owner_manager->is_owner (handle_, writer_id))) {
 #endif
-      instance_state_ = DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
-      schedule_release();
-      return true;
+        instance_state_ = DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
+        schedule_release();
+        return true;
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
+      }
     }
 #endif
   }
@@ -148,9 +159,12 @@ bool InstanceState::unregister_was_received(const PublicationId& writer_id)
   if (exclusive_) {
     // If unregistered by owner then the ownership should be transferred to another
     // writer.
-    DataReaderImpl::OwnershipManagerPtr owner_manager = reader_->ownership_manager();
-    if (owner_manager)
-      owner_manager->remove_writer (handle_, writer_id);
+    RcHandle<DataReaderImpl> reader = reader_.lock();
+    if (reader) {
+      DataReaderImpl::OwnershipManagerPtr owner_manager = reader->ownership_manager();
+      if (owner_manager)
+        owner_manager->remove_writer (handle_, writer_id);
+    }
   }
 #endif
 
@@ -189,7 +203,10 @@ void InstanceState::schedule_pending()
 void InstanceState::schedule_release()
 {
   DDS::DataReaderQos qos;
-  reader_->get_qos(qos);
+  RcHandle<DataReaderImpl> reader = reader_.lock();
+  if (reader) {
+    reader->get_qos(qos);
+  }
 
   DDS::Duration_t delay;
 
@@ -247,7 +264,10 @@ bool InstanceState::release_if_empty()
 
 void InstanceState::release()
 {
-  reader_->release_instance(handle_);
+  RcHandle<DataReaderImpl> reader = reader_.lock();
+  if (reader) {
+    reader->release_instance(handle_);
+  }
 }
 
 void InstanceState::set_owner(const PublicationId& owner)
@@ -282,7 +302,10 @@ void InstanceState::reset_ownership(DDS::InstanceHandle_t instance)
   owner_ = GUID_UNKNOWN;
   registered_ = false;
 
-  reader_->reset_ownership(instance);
+  RcHandle<DataReaderImpl> reader = reader_.lock();
+  if (reader) {
+    reader->reset_ownership(instance);
+  }
 }
 
 bool InstanceState::most_recent_generation(ReceivedDataElement* item) const

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -74,9 +74,9 @@ void InstanceState::sample_info(DDS::SampleInfo& si, const ReceivedDataElement* 
   RcHandle<DataReaderImpl> reader = reader_.lock();
   if (reader) {
     RcHandle<DomainParticipantImpl> participant = reader->participant_servant_.lock();
-    si.publication_handle = participant ? participant->id_to_handle(de->pub_) : 0;
+    si.publication_handle = participant ? participant->id_to_handle(de->pub_) : DDS::HANDLE_NIL;
   } else {
-    si.publication_handle = 0;
+    si.publication_handle = DDS::HANDLE_NIL;
   }
   si.valid_data = de->valid_data_;
   /*
@@ -206,6 +206,9 @@ void InstanceState::schedule_release()
   RcHandle<DataReaderImpl> reader = reader_.lock();
   if (reader) {
     reader->get_qos(qos);
+  } else {
+    cancel_release();
+    return;
   }
 
   DDS::Duration_t delay;

--- a/dds/DCPS/InstanceState.h
+++ b/dds/DCPS/InstanceState.h
@@ -119,7 +119,7 @@ public:
                           int num_alive_writers,
                           const ACE_Time_Value& when);
 
-  DataReaderImpl* data_reader() const;
+  WeakRcHandle<OpenDDS::DCPS::DataReaderImpl> data_reader() const;
 
   virtual int handle_timeout(const ACE_Time_Value& current_time,
                              const void* arg);
@@ -213,7 +213,7 @@ private:
    * instance.  It is also queried to determine if the DataReader is
    * empty -- that it contains no more sample data.
    */
-  DataReaderImpl* reader_;
+  WeakRcHandle<DataReaderImpl> reader_;
   DDS::InstanceHandle_t handle_;
 
   RepoIdSet writers_;

--- a/dds/DCPS/InstanceState.inl
+++ b/dds/DCPS/InstanceState.inl
@@ -11,7 +11,7 @@
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_INLINE
-OpenDDS::DCPS::DataReaderImpl*
+OpenDDS::DCPS::WeakRcHandle<OpenDDS::DCPS::DataReaderImpl>
 OpenDDS::DCPS::InstanceState::data_reader() const
 {
   return reader_;


### PR DESCRIPTION
switching InstanceState::reader_ from DataReaderImpl* to WeakRcHandle<DataReaderImpl> to avoid invalid reads when checking ownership, etc