### PR TITLE
ReactorInterceptor wait is broken

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1846,8 +1846,7 @@ CORBA::Long DataReaderImpl::total_samples() const
 void
 DataReaderImpl::LivelinessTimer::check_liveliness()
 {
-  CheckLivelinessCommand c(this);
-  execute_or_enqueue(c);
+  execute_or_enqueue(new CheckLivelinessCommand(this));
 }
 
 int
@@ -3356,15 +3355,13 @@ EndHistoricSamplesMissedSweeper::~EndHistoricSamplesMissedSweeper()
 void EndHistoricSamplesMissedSweeper::schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
 {
   info->waiting_for_end_historic_samples_ = true;
-  ScheduleCommand c(this, info);
-  execute_or_enqueue(c);
+  execute_or_enqueue(new ScheduleCommand(this, info));
 }
 
 void EndHistoricSamplesMissedSweeper::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
 {
   info->waiting_for_end_historic_samples_ = false;
-  CancelCommand c(this, info);
-  execute_or_enqueue(c);
+  execute_or_enqueue(new CancelCommand(this, info));
 }
 
 int EndHistoricSamplesMissedSweeper::handle_timeout(

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -767,8 +767,7 @@ private:
 
     void cancel_timer()
     {
-      CancelCommand c(this);
-      execute_or_enqueue(c);
+      execute_or_enqueue(new CancelCommand(this));
     }
 
     virtual bool reactor_is_shut_down() const

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -234,8 +234,7 @@ void InstanceState::schedule_release()
       delay.nanosec != DDS::DURATION_INFINITE_NSEC) {
     cancel_release();
 
-    ScheduleCommand cmd(this, duration_to_time_value(delay));
-    execute_or_enqueue(cmd);
+    execute_or_enqueue(new ScheduleCommand(this, duration_to_time_value(delay)));
 
   } else {
     // N.B. instance transitions are always followed by a non-valid
@@ -249,8 +248,7 @@ void InstanceState::schedule_release()
 void InstanceState::cancel_release()
 {
   release_pending_ = false;
-  CancelCommand cmd(this);
-  execute_or_enqueue(cmd);
+  execute_or_enqueue(new CancelCommand(this));
 }
 
 bool InstanceState::release_if_empty()

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -46,8 +46,7 @@ void AgentImpl::enqueue(Task* a_task)
 
     if (a_task == tasks_.top()) {
       ACE_Time_Value const delay = std::max(get_configuration().T_a(), a_task->release_time_ - ACE_Time_Value().now());
-      ScheduleTimerCommand c(reactor(), this, delay);
-      execute_or_enqueue(c);
+      execute_or_enqueue(new ScheduleTimerCommand(reactor(), this, delay));
     }
   }
 }
@@ -74,8 +73,7 @@ int AgentImpl::handle_timeout(const ACE_Time_Value& a_now, const void* /*act*/)
 
   if (!tasks_.empty()) {
     ACE_Time_Value const delay = std::max(get_configuration().T_a(), tasks_.top()->release_time_ - a_now);
-    ScheduleTimerCommand c(reactor(), this, delay);
-    execute_or_enqueue(c);
+    execute_or_enqueue(new ScheduleTimerCommand(reactor(), this, delay));
   }
 
   check_invariants();

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -51,11 +51,9 @@ void ReactorInterceptor::process_command_queue_i()
   while (!command_queue_.empty()) {
     CommandPtr command = command_queue_.front();
     command_queue_.pop();
-    {
-      ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock);
-      command->execute();
-      command->signal();
-    }
+    ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock);
+    command->execute();
+    command->executed();
   }
 }
 

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -21,7 +21,6 @@ namespace DCPS {
 ReactorInterceptor::ReactorInterceptor(ACE_Reactor* reactor,
                                        ACE_thread_t owner)
   : owner_(owner)
-  , condition_(mutex_)
 {
   if (reactor == 0) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: ReactorInterceptor initialized with null reactor\n"));
@@ -39,47 +38,25 @@ bool ReactorInterceptor::should_execute_immediately()
     reactor_is_shut_down();
 }
 
-void ReactorInterceptor::wait()
-{
-  ACE_GUARD(ACE_Thread_Mutex, guard, this->mutex_);
-
-  if (should_execute_immediately()) {
-    handle_exception_i();
-    if (!reactor_is_shut_down()) {
-      reactor()->purge_pending_notifications(this);
-    }
-  } else {
-    while (!command_queue_.empty()) {
-      condition_.wait();
-    }
-  }
-}
-
-
 int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, this->mutex_, 0);
-
-  return handle_exception_i();
+  process_command_queue_i();
+  return 0;
 }
 
 void ReactorInterceptor::process_command_queue_i()
 {
+  ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
   ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
   while (!command_queue_.empty()) {
-    CommandPtr command = move(command_queue_.front());
+    CommandPtr command = command_queue_.front();
     command_queue_.pop();
-    ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock)
-    if (command)
+    {
+      ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock);
       command->execute();
+      command->signal();
+    }
   }
-}
-
-int ReactorInterceptor::handle_exception_i()
-{
-  process_command_queue_i();
-  condition_.signal();
-  return 0;
 }
 
 }

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -16,6 +16,7 @@
 #include "RcEventHandler.h"
 #include "dcps_export.h"
 #include "unique_ptr.h"
+#include "RcHandle_T.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -26,39 +27,60 @@ class OpenDDS_Dcps_Export ReactorInterceptor : public RcEventHandler {
 public:
 
   class Command
-  : public PoolAllocationBase
-  , public EnableContainerSupportedUniquePtr<Command> {
+  : public RcObject {
   public:
+    Command() : executed_(false), condition_(mutex_) {}
     virtual ~Command() { }
     virtual void execute() = 0;
+
+    void reset() {
+      ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
+      executed_ = false;
+    }
+
+    void wait() {
+      ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
+      while (!executed_) {
+        condition_.wait();
+      }
+    }
+
+    void signal() {
+      ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
+      executed_ = true;
+      condition_.signal();
+    }
+
+  private:
+    bool executed_;
+    ACE_Thread_Mutex mutex_;
+    ACE_Condition_Thread_Mutex condition_;
   };
-  typedef container_supported_unique_ptr<Command> CommandPtr;
+  typedef RcHandle<Command> CommandPtr;
 
   bool should_execute_immediately();
 
-  template<typename T>
-  void execute_or_enqueue(T& t)
+  CommandPtr execute_or_enqueue(Command* c)
   {
+    const bool immediate = should_execute_immediately();
+    CommandPtr command = enqueue(c, immediate);
     if (should_execute_immediately()) {
-      {
-        ACE_GUARD(ACE_Thread_Mutex, guard, this->mutex_);
-        process_command_queue_i();
-      }
-      t.execute();
-    } else {
-      enqueue(t);
+      process_command_queue_i();
     }
+    return command;
   }
 
-  template<typename T>
-  void enqueue(T& t)
+  CommandPtr enqueue(Command* c, bool immediate = false)
   {
-    ACE_GUARD(ACE_Thread_Mutex, guard, this->mutex_);
-    command_queue_.push(CommandPtr(new T(t)));
-    this->reactor()->notify(this);
+    c->reset();
+    CommandPtr command = rchandle_from(c);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, CommandPtr());
+    command_queue_.push(command);
+    if (!immediate) {
+      reactor()->notify(this);
+    }
+    return command;
   }
-
-  void wait();
 
   virtual bool reactor_is_shut_down() const = 0;
 
@@ -68,12 +90,10 @@ protected:
 
   virtual ~ReactorInterceptor();
   int handle_exception(ACE_HANDLE /*fd*/);
-  int handle_exception_i();
   void process_command_queue_i();
 
   ACE_thread_t owner_;
   ACE_Thread_Mutex mutex_;
-  ACE_Condition_Thread_Mutex condition_;
   OPENDDS_QUEUE(CommandPtr) command_queue_;
 };
 

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -65,7 +65,7 @@ public:
 
   CommandPtr execute_or_enqueue(Command* c)
   {
-    assert(c);
+    OPENDDS_ASSERT(c);
     const bool immediate = should_execute_immediately();
     CommandPtr command = enqueue_i(c, immediate);
     if (immediate) {
@@ -76,7 +76,7 @@ public:
 
   CommandPtr enqueue(Command* c)
   {
-    assert(c);
+    OPENDDS_ASSERT(c);
     return enqueue_i(c, false);
   }
 

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -86,6 +86,8 @@ RecorderImpl::RecorderImpl()
 RecorderImpl::~RecorderImpl()
 {
   DBG_ENTRY_LVL("RecorderImpl","~RecorderImpl",6);
+  ReactorInterceptor::CommandPtr command;
+
   {
     ACE_READ_GUARD(ACE_RW_Thread_Mutex,
                    read_guard,
@@ -93,11 +95,13 @@ RecorderImpl::~RecorderImpl()
     // Cancel any uncancelled sweeper timers to decrement reference count.
     WriterMapType::iterator writer;
     for (writer = writers_.begin(); writer != writers_.end(); ++writer) {
-      remove_association_sweeper_->cancel_timer(writer->second);
+      command = remove_association_sweeper_->cancel_timer(writer->second);
     }
   }
 
-  remove_association_sweeper_->wait();
+  if (command) {
+    command->wait();
+  }
 }
 
 
@@ -121,6 +125,8 @@ RecorderImpl::cleanup()
 
   this->remove_all_associations();
 
+  ReactorInterceptor::CommandPtr command;
+
   {
     ACE_READ_GUARD_RETURN(ACE_RW_Thread_Mutex,
                    read_guard,
@@ -129,11 +135,13 @@ RecorderImpl::cleanup()
     // Cancel any uncancelled sweeper timers
     WriterMapType::iterator writer;
     for (writer = writers_.begin(); writer != writers_.end(); ++writer) {
-      remove_association_sweeper_->cancel_timer(writer->second);
+      command = remove_association_sweeper_->cancel_timer(writer->second);
     }
   }
 
-  remove_association_sweeper_->wait();
+  if (command) {
+    command->wait();
+  }
   return DDS::RETCODE_OK;
 }
 

--- a/dds/DCPS/RemoveAssociationSweeper.h
+++ b/dds/DCPS/RemoveAssociationSweeper.h
@@ -34,7 +34,7 @@ public:
                            T* reader);
 
   void schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info, bool callback);
-  void cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info);
+  ReactorInterceptor::CommandPtr cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info);
 
   // Arg will be PublicationId
   int handle_timeout(const ACE_Time_Value& current_time, const void* arg);
@@ -110,17 +110,15 @@ void RemoveAssociationSweeper<T>::schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS
     time_to_deadline = ACE_Time_Value(10);
 
   info->removal_deadline_ = ACE_OS::gettimeofday() + time_to_deadline;
-  ScheduleCommand c(this, info);
-  execute_or_enqueue(c);
+  execute_or_enqueue(new ScheduleCommand(this, info));
 }
 
 template <typename T>
-void RemoveAssociationSweeper<T>::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
+ReactorInterceptor::CommandPtr RemoveAssociationSweeper<T>::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
 {
   info->scheduled_for_removal_ = false;
   info->removal_deadline_ = ACE_Time_Value::zero;
-  CancelCommand c(this, info);
-  execute_or_enqueue(c);
+  return execute_or_enqueue(new CancelCommand(this, info));
 }
 
 template <typename T>

--- a/dds/DCPS/Watchdog.cpp
+++ b/dds/DCPS/Watchdog.cpp
@@ -115,29 +115,26 @@ long Watchdog::schedule_timer(const void* act, const ACE_Time_Value& interval)
 long Watchdog::schedule_timer(const void* act, const ACE_Time_Value& delay, const ACE_Time_Value& interval)
 {
   long timer_id = -1;
-  ScheduleCommand c(this, act, delay, interval, &timer_id);
-  execute_or_enqueue(c);
-  wait();
+  ReactorInterceptor::CommandPtr command = execute_or_enqueue(new ScheduleCommand(this, act, delay, interval, &timer_id));
+  command->wait();
   return timer_id;
 }
 
 int Watchdog::cancel_timer(long timer_id)
 {
-  CancelCommand c(this, timer_id);
-  execute_or_enqueue(c);
+
+  execute_or_enqueue(new CancelCommand(this, timer_id));
   return 1;
 }
 
 void Watchdog::cancel_all()
 {
-  CancelCommand c(this, -1);
-  execute_or_enqueue(c);
+  execute_or_enqueue(new CancelCommand(this, -1));
 }
 
 int Watchdog::reset_timer_interval(long timer_id)
 {
-  ResetCommand c(this, timer_id, interval_);
-  execute_or_enqueue(c);
+  execute_or_enqueue(new ResetCommand(this, timer_id, interval_));
   return 0;
 }
 

--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -121,8 +121,7 @@ DataLink::add_on_start_callback(const TransportClient_wrch& client, const RepoId
           pending_on_starts_.erase(it);
         }
         guard.release();
-        ImmediateStart cmd(link, client, remote);
-        interceptor_.execute_or_enqueue(cmd);
+        interceptor_.execute_or_enqueue(new ImmediateStart(link, client, remote));
       } else {
         on_start_callbacks_[remote][client_lock->get_repo_id()] = client;
       }

--- a/dds/DCPS/transport/framework/DataLinkWatchdog_T.h
+++ b/dds/DCPS/transport/framework/DataLinkWatchdog_T.h
@@ -27,20 +27,17 @@ class DataLinkWatchdog : public ReactorInterceptor {
 public:
 
   bool schedule(const void* arg = 0) {
-    ScheduleCommand c(this, arg, false);
-    execute_or_enqueue(c);
+    execute_or_enqueue(new ScheduleCommand (this, arg, false));
     return true;
   }
 
   bool schedule_now(const void* arg = 0) {
-    ScheduleCommand c(this, arg, true);
-    execute_or_enqueue(c);
+    execute_or_enqueue(new ScheduleCommand(this, arg, true));
     return true;
   }
 
-  void cancel() {
-    CancelCommand c(this);
-    execute_or_enqueue(c);
+  ReactorInterceptor::CommandPtr cancel() {
+    return execute_or_enqueue(new CancelCommand(this));
   }
 
   int handle_timeout(const ACE_Time_Value& now, const void* arg) {

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -57,6 +57,8 @@ TransportClient::~TransportClient()
 
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
 
+  ReactorInterceptor::CommandPtr command;
+
   for (PendingMap::iterator it = pending_.begin(); it != pending_.end(); ++it) {
     for (size_t i = 0; i < impls_.size(); ++i) {
       RcHandle<TransportImpl> impl = impls_[i].lock();
@@ -65,11 +67,12 @@ TransportClient::~TransportClient()
       }
     }
 
-    pending_assoc_timer_->cancel_timer(this, it->second);
+    command = pending_assoc_timer_->cancel_timer(this, it->second);
   }
 
-  pending_assoc_timer_->wait();
-
+  if (command) {
+    command->wait();
+  }
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -200,14 +200,12 @@ private:
 
     void schedule_timer(TransportClient* transport_client, const PendingAssoc_rch& pend)
     {
-      ScheduleCommand c(this, transport_client, pend);
-      execute_or_enqueue(c);
+      execute_or_enqueue(new ScheduleCommand(this, transport_client, pend));
     }
 
-    void cancel_timer(TransportClient* transport_client, const PendingAssoc_rch& pend)
+    ReactorInterceptor::CommandPtr cancel_timer(TransportClient* transport_client, const PendingAssoc_rch& pend)
     {
-      CancelCommand c(this, transport_client, pend);
-      execute_or_enqueue(c);
+      return execute_or_enqueue(new CancelCommand(this, transport_client, pend));
     }
 
     virtual bool reactor_is_shut_down() const

--- a/dds/DCPS/transport/multicast/MulticastSession.cpp
+++ b/dds/DCPS/transport/multicast/MulticastSession.cpp
@@ -95,8 +95,8 @@ MulticastSession::MulticastSession(ACE_Reactor* reactor,
 
 MulticastSession::~MulticastSession()
 {
-  syn_watchdog_->cancel();
-  syn_watchdog_->wait();
+  ReactorInterceptor::CommandPtr command = syn_watchdog_->cancel();
+  command->wait();
 }
 
 bool

--- a/dds/DCPS/transport/multicast/ReliableSession.cpp
+++ b/dds/DCPS/transport/multicast/ReliableSession.cpp
@@ -69,8 +69,8 @@ ReliableSession::ReliableSession(ACE_Reactor* reactor,
 
 ReliableSession::~ReliableSession()
 {
-  nak_watchdog_->cancel();
-  nak_watchdog_->wait();
+  ReactorInterceptor::CommandPtr command = nak_watchdog_->cancel();
+  command->wait();
 }
 
 bool

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -530,8 +530,7 @@ private:
 
     void schedule_enable(bool reenable)
     {
-      ScheduleEnableCommand c(this, reenable);
-      execute_or_enqueue(c);
+      execute_or_enqueue(new ScheduleEnableCommand(this, reenable));
     }
 
     int handle_timeout(const ACE_Time_Value&, const void*)


### PR DESCRIPTION
To support a straight enqueue while processing commands in the
ReactorInterceptor, it was necessary to release the queue lock before
each command was executed.  This broke the existing semantics of wait
because the following sequence was possible:

Non-reactor thread: execute_or_enqueue (command is placed on the
queue)
Reactor thread: command is take off the queue but not executed yet
Non-reactor thread: wait (returns immediately since the queue is
empty)
... wait returned without the command being executed ...

Solution: enqueue and execute_or_enqueue return a Command with a wait
method.  A thread can use this wait on a specify command to complete.
The ReactorInterceptor signals the Command to unblock any waiting thread.