### PR TITLE
[3.13] Only include DDS Security member when OPENDDS_SECURITY is set

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -600,7 +600,9 @@ namespace OpenDDS {
         RepoIdSet matched_endpoints_;
         DCPS::SequenceNumber sequence_;
         RepoIdSet remote_opendds_associations_;
+#ifdef OPENDDS_SECURITY
         DDS::Security::EndpointSecurityAttributes security_attribs_;
+#endif
       };
 
       struct LocalPublication : LocalEndpoint {


### PR DESCRIPTION
This is handled in every other place, but not here. It prevented me from building on Windows.