### PR TITLE
Make "--no-tests" the Default in the Configure Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_script:
   - if [ "$CXX" == "g++" ]; then CONFIG_OPTIONS+=" --std=c++11"; fi
   - if [ "$VERSIONED_NS" == 1 ]; then CONFIG_OPTIONS+=" --features=versioned_namespace=1"; fi
   - if [ "$DDS_SECURITY" == 1 ]; then CONFIG_OPTIONS+=" --security"; fi
-  - ./configure --mpcopts="-workers 4" --compiler=$COMPILER $CONFIG_OPTIONS
+  - ./configure --mpcopts="-workers 4" --compiler=$COMPILER --tests $CONFIG_OPTIONS
   - tools/scripts/show_build_config.pl
   - if [ "$SAFETY_PROFILE" == "1" ]; then
         export LD_LIBRARY_PATH+=:$TRAVIS_BUILD_DIR/build/target/ACE_TAO/ACE/lib:$TRAVIS_BUILD_DIR/build/target/lib;

--- a/DevGuideExamples/DCPS/Messenger/.gitignore
+++ b/DevGuideExamples/DCPS/Messenger/.gitignore
@@ -15,3 +15,4 @@
 /MessengerTypeSupportS.cpp
 /MessengerS.cpp
 /MessengerS.inl
+/build

--- a/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
+++ b/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
@@ -5,10 +5,6 @@ find_package(OpenDDS)
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
 
-if (NOT OPENDDS_OWNERSHIP_PROFILE)
-  message(FATAL_ERROR "Messenger requires OpenDDS to be built with Ownership Profile enabled")
-endif()
-
 set(opendds_libs
   OpenDDS::Dcps # Core OpenDDS Library
   OpenDDS::InfoRepoDiscovery OpenDDS::Tcp # For run_test.pl

--- a/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
+++ b/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
@@ -1,0 +1,31 @@
+project(OpenDDS_DevGuide_Messenger CXX)
+cmake_minimum_required(VERSION 3.8.2)
+
+find_package(OpenDDS)
+
+set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
+
+if (NOT OPENDDS_OWNERSHIP_PROFILE)
+  message(FATAL_ERROR "Messenger requires OpenDDS to be built with Ownership Profile enabled")
+endif()
+
+set(opendds_libs
+  OpenDDS::Dcps # Core OpenDDS Library
+  OpenDDS::InfoRepoDiscovery OpenDDS::Tcp # For run_test.pl
+  OpenDDS::Rtps OpenDDS::Rtps_Udp # For run_test.pl --rtps
+)
+
+# Publisher
+add_executable(publisher
+  Publisher.cpp
+)
+OPENDDS_TARGET_SOURCES(publisher Messenger.idl)
+target_link_libraries(publisher ${opendds_libs})
+
+# Subscriber
+add_executable(subscriber
+  Subscriber.cpp
+  DataReaderListenerImpl.cpp
+)
+OPENDDS_TARGET_SOURCES(subscriber Messenger.idl)
+target_link_libraries(subscriber ${opendds_libs})

--- a/DevGuideExamples/DCPS/Messenger/DataReaderListenerImpl.cpp
+++ b/DevGuideExamples/DCPS/Messenger/DataReaderListenerImpl.cpp
@@ -52,7 +52,7 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("ERROR: %N:%l: on_data_available() -")
                ACE_TEXT(" _narrow failed!\n")));
-    ACE_OS::exit(-1);
+    ACE_OS::exit(1);
   }
 
   Messenger::Message message;

--- a/DevGuideExamples/DCPS/Messenger/Messenger.mpc
+++ b/DevGuideExamples/DCPS/Messenger/Messenger.mpc
@@ -7,7 +7,7 @@ project(*idl): dcps {
   custom_only = 1
 }
 
-project(*publisher) : dcpsexe, dcps_tcp {
+project(*publisher) : dcpsexe, dcps_tcp, dcps_rtps, dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename   = publisher
   after    += *idl
@@ -21,7 +21,7 @@ project(*publisher) : dcpsexe, dcps_tcp {
   }
 }
 
-project(*subscriber) : dcpsexe, dcps_tcp {
+project(*subscriber) : dcpsexe, dcps_tcp, dcps_rtps, dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename   = subscriber
   after    += *publisher

--- a/DevGuideExamples/DCPS/Messenger/Messenger.mpc
+++ b/DevGuideExamples/DCPS/Messenger/Messenger.mpc
@@ -7,7 +7,7 @@ project(*idl): dcps {
   custom_only = 1
 }
 
-project(*publisher) : dcpsexe, dcps_tcp, dcps_rtps, dcps_rtps_udp {
+project(*publisher) : dcpsexe, dcps_tcp, dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename   = publisher
   after    += *idl
@@ -21,7 +21,7 @@ project(*publisher) : dcpsexe, dcps_tcp, dcps_rtps, dcps_rtps_udp {
   }
 }
 
-project(*subscriber) : dcpsexe, dcps_tcp, dcps_rtps, dcps_rtps_udp {
+project(*subscriber) : dcpsexe, dcps_tcp, dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename   = subscriber
   after    += *publisher

--- a/DevGuideExamples/DCPS/Messenger/Publisher.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Publisher.cpp
@@ -14,7 +14,11 @@
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/WaitSet.h>
 
-#include "dds/DCPS/StaticIncludes.h"
+#include <dds/DCPS/StaticIncludes.h>
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include "MessengerTypeSupportImpl.h"
 

--- a/DevGuideExamples/DCPS/Messenger/Publisher.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Publisher.cpp
@@ -38,7 +38,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" create_participant failed!\n")),
-                       -1);
+                       1);
     }
 
     // Register TypeSupport (Messenger::Message)
@@ -49,7 +49,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" register_type failed!\n")),
-                       -1);
+                       1);
     }
 
     // Create Topic (Movie Discussion List)
@@ -65,7 +65,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" create_topic failed!\n")),
-                       -1);
+                       1);
     }
 
     // Create Publisher
@@ -78,13 +78,18 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" create_publisher failed!\n")),
-                       -1);
+                       1);
     }
 
     // Create DataWriter
+    DDS::DataWriterQos writer_qos;
+    publisher->get_default_datawriter_qos(writer_qos);
+    writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    writer_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+
     DDS::DataWriter_var writer =
       publisher->create_datawriter(topic,
-                                   DATAWRITER_QOS_DEFAULT,
+                                   writer_qos,
                                    0,
                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
@@ -92,7 +97,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" create_datawriter failed!\n")),
-                       -1);
+                       1);
     }
 
     Messenger::MessageDataWriter_var message_writer =
@@ -102,7 +107,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" _narrow failed!\n")),
-                       -1);
+                       1);
     }
 
     // Block until Subscriber is available
@@ -118,7 +123,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")
                           ACE_TEXT(" get_publication_matched_status failed!\n")),
-                         -1);
+                         1);
       }
 
       if (matches.current_count >= 1) {
@@ -131,7 +136,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")
                           ACE_TEXT(" wait failed!\n")),
-                         -1);
+                         1);
       }
     }
 
@@ -164,7 +169,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" wait_for_acknowledgments failed!\n")),
-                       -1);
+                       1);
     }
 
     // Clean-up!
@@ -175,7 +180,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   } catch (const CORBA::Exception& e) {
     e._tao_print_exception("Exception caught in main():");
-    return -1;
+    return 1;
   }
 
   return 0;

--- a/DevGuideExamples/DCPS/Messenger/Publisher.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Publisher.cpp
@@ -86,14 +86,9 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
 
     // Create DataWriter
-    DDS::DataWriterQos writer_qos;
-    publisher->get_default_datawriter_qos(writer_qos);
-    writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
-    writer_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
-
     DDS::DataWriter_var writer =
       publisher->create_datawriter(topic,
-                                   writer_qos,
+                                   DATAWRITER_QOS_DEFAULT,
                                    0,
                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 

--- a/DevGuideExamples/DCPS/Messenger/README.md
+++ b/DevGuideExamples/DCPS/Messenger/README.md
@@ -1,0 +1,27 @@
+# Messenger Example
+
+A very basic OpenDDS example, covered in the OpenDDS Developer's Guide.
+
+If you just want to build and run this, it will be built along with OpenDDS and
+can be run using `perl run_test.pl` assuming the `setenv` file has been sourced
+or OpenDDS has been installed. To have it use the DDS standard RTPS protocol
+instead of the OpenDDS specific InfoRepo/TCP protocols, run `perl run_test.pl
+--rtps` instead.
+
+## CMake
+
+There is an example `CMakeLists.txt` provided, but it can conflict with the
+default MPC-based build system. If you want to build this example with CMake,
+these are the recommend steps:
+
+ - Make sure your environment is set correctly if OpenDDS is not installed.
+ - Clean all the existing build files out of this directory. If this is a git
+   repository you can use `git clean -dfX .` in this directory to do this.
+   Otherwise at least remove all the `Messenger*.h` files, because these will
+   conflict even if you do an "out-of-source" build with CMake.
+ - Next make a `build` directory in this directory and `cd` to it to do an
+   "out-of-source" build.
+ - Run `cmake ..` to generate the build and `cmake --build .` to build.
+ - To run the example you can copy `run_test.pl` to the `build` directory and
+   use that or run `./publisher -DCPSConfigFile ../rtps.ini` and `./subscriber
+   -DCPSConfigFile ../rtps.ini` at the same time.

--- a/DevGuideExamples/DCPS/Messenger/README.md
+++ b/DevGuideExamples/DCPS/Messenger/README.md
@@ -4,9 +4,9 @@ A very basic OpenDDS example, covered in the OpenDDS Developer's Guide.
 
 If you just want to build and run this, it will be built along with OpenDDS and
 can be run using `perl run_test.pl` assuming the `setenv` file has been sourced
-or OpenDDS has been installed. To have it use the DDS standard RTPS protocol
-instead of the OpenDDS specific InfoRepo/TCP protocols, run `perl run_test.pl
---rtps` instead.
+(see [INSTALL.md](../../../INSTALL.md) for details). To have it use the DDS
+standard RTPS discovery and transport instead of the OpenDDS specific InfoRepo
+discovery and TCP transports, run `perl run_test.pl --rtps` instead.
 
 ## CMake
 
@@ -14,7 +14,7 @@ There is an example `CMakeLists.txt` provided, but it can conflict with the
 default MPC-based build system. If you want to build this example with CMake,
 these are the recommend steps:
 
- - Make sure your environment is set correctly if OpenDDS is not installed.
+ - Make sure your environment is set correctly.
  - Clean all the existing build files out of this directory. If this is a git
    repository you can use `git clean -dfX .` in this directory to do this.
    Otherwise at least remove all the `Messenger*.h` files, because these will

--- a/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
@@ -38,7 +38,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     if (!participant) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
-                        ACE_TEXT(" create_participant failed!\n")), -1);
+                        ACE_TEXT(" create_participant failed!\n")),
+                       1);
     }
 
     // Register Type (Messenger::Message)
@@ -48,7 +49,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     if (ts->register_type(participant, "") != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
-                        ACE_TEXT(" register_type failed!\n")), -1);
+                        ACE_TEXT(" register_type failed!\n")),
+                       1);
     }
 
     // Create Topic (Movie Discussion List)
@@ -63,7 +65,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     if (!topic) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
-                        ACE_TEXT(" create_topic failed!\n")), -1);
+                        ACE_TEXT(" create_topic failed!\n")),
+                       1);
     }
 
     // Create Subscriber
@@ -75,22 +78,28 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     if (!subscriber) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
-                        ACE_TEXT(" create_subscriber failed!\n")), -1);
+                        ACE_TEXT(" create_subscriber failed!\n")),
+                       1);
     }
 
     // Create DataReader
     DDS::DataReaderListener_var listener(new DataReaderListenerImpl);
 
+    DDS::DataReaderQos reader_qos;
+    subscriber->get_default_datareader_qos(reader_qos);
+    reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
     DDS::DataReader_var reader =
       subscriber->create_datareader(topic,
-                             DATAREADER_QOS_DEFAULT,
-                             listener,
-                             OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                                    reader_qos,
+                                    listener,
+                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (!reader) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
-                        ACE_TEXT(" create_datareader failed!\n")), -1);
+                        ACE_TEXT(" create_datareader failed!\n")),
+                       1);
     }
 
     Messenger::MessageDataReader_var reader_i =
@@ -100,7 +109,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" _narrow failed!\n")),
-                       -1);
+                       1);
     }
 
     // Block until Publisher completes
@@ -115,7 +124,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       if (reader->get_subscription_matched_status(matches) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")
-                          ACE_TEXT(" get_subscription_matched_status failed!\n")), -1);
+                          ACE_TEXT(" get_subscription_matched_status failed!\n")),
+                         1);
       }
 
       if (matches.current_count == 0 && matches.total_count > 0) {
@@ -127,7 +137,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")
-                          ACE_TEXT(" wait failed!\n")), -1);
+                          ACE_TEXT(" wait failed!\n")),
+                         1);
       }
     }
 
@@ -141,7 +152,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   } catch (const CORBA::Exception& e) {
     e._tao_print_exception("Exception caught in main():");
-    return -1;
+    return 1;
   }
 
   return 0;

--- a/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
@@ -14,7 +14,11 @@
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/WaitSet.h>
 
-#include "dds/DCPS/StaticIncludes.h"
+#include <dds/DCPS/StaticIncludes.h>
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include "DataReaderListenerImpl.h"
 #include "MessengerTypeSupportImpl.h"

--- a/DevGuideExamples/DCPS/Messenger/rtps.ini
+++ b/DevGuideExamples/DCPS/Messenger/rtps.ini
@@ -1,0 +1,6 @@
+[common]
+DCPSDefaultDiscovery=DEFAULT_RTPS
+DCPSGlobalTransportConfig=$file
+
+[transport/the_rtps_transport]
+transport_type=rtps_udp

--- a/DevGuideExamples/DCPS/Messenger/run_test.pl
+++ b/DevGuideExamples/DCPS/Messenger/run_test.pl
@@ -8,60 +8,89 @@ use Env (DDS_ROOT);
 use lib "$DDS_ROOT/bin";
 use Env (ACE_ROOT);
 use lib "$ACE_ROOT/bin";
+
+use Getopt::Long;
 use PerlDDS::Run_Test;
+
 use strict;
 
 my $status = 0;
+
+my $rtps = 0;
+my $help = 0;
+
+my $help_message = "usage: run_test.pl [--rtps]\n";
+if (not GetOptions(
+  "rtps" => \$rtps,
+  "help|h" => \$help
+)) {
+  print STDERR ("Invalid Command Line Argument(s)\n$help_message");
+}
+if ($help) {
+  print $help_message;
+  exit 0;
+}
+
 my $common_opts = "-ORBDebugLevel 10 -DCPSDebugLevel 10";
+
+if ($rtps) {
+  $common_opts .= " -DCPSConfigFile rtps.ini";
+}
 
 my $pub_opts = "$common_opts -ORBLogFile publisher.log";
 my $sub_opts = "$common_opts -DCPSTransportDebugLevel 6 " .
                "-ORBLogFile subscriber.log";
 
+my $DCPSREPO;
 my $dcpsrepo_ior = "repo.ior";
 
-unlink $dcpsrepo_ior;
+my $Subscriber = PerlDDS::create_process("subscriber", " $sub_opts");
+my $Publisher = PerlDDS::create_process("publisher", " $pub_opts");
 
-my $DCPSREPO = PerlDDS::create_process ("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                        "-ORBDebugLevel 10 " .
-                                        "-ORBLogFile DCPSInfoRepo.log " .
-                                        "-o $dcpsrepo_ior");
+if (not $rtps) {
+  unlink $dcpsrepo_ior;
 
-my $Subscriber = PerlDDS::create_process ("subscriber", " $sub_opts");
-my $Publisher = PerlDDS::create_process ("publisher", " $pub_opts");
+  $DCPSREPO = PerlDDS::create_process(
+    "$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
+    "-ORBDebugLevel 10 " .
+    "-ORBLogFile DCPSInfoRepo.log " .
+    "-o $dcpsrepo_ior");
 
-print $DCPSREPO->CommandLine() . "\n";
-$DCPSREPO->Spawn ();
-if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
+  print $DCPSREPO->CommandLine() . "\n";
+  $DCPSREPO->Spawn();
+  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
     print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
+    $DCPSREPO->Kill();
     exit 1;
+  }
 }
 
 print $Publisher->CommandLine() . "\n";
-$Publisher->Spawn ();
+$Publisher->Spawn();
 
 print $Subscriber->CommandLine() . "\n";
-$Subscriber->Spawn ();
+$Subscriber->Spawn();
 
-my $PublisherResult = $Publisher->WaitKill (300);
+my $PublisherResult = $Publisher->WaitKill(300);
 if ($PublisherResult != 0) {
-    print STDERR "ERROR: publisher returned $PublisherResult \n";
-    $status = 1;
+  print STDERR "ERROR: publisher returned $PublisherResult\n";
+  $status = 1;
 }
 
-my $SubscriberResult = $Subscriber->WaitKill (15);
+my $SubscriberResult = $Subscriber->WaitKill(15);
 if ($SubscriberResult != 0) {
-    print STDERR "ERROR: subscriber returned $SubscriberResult \n";
-    $status = 1;
+  print STDERR "ERROR: subscriber returned $SubscriberResult\n";
+  $status = 1;
 }
 
-my $ir = $DCPSREPO->TerminateWaitKill(5);
-if ($ir != 0) {
+if (not $rtps) {
+  my $ir = $DCPSREPO->TerminateWaitKill(5);
+  if ($ir != 0) {
     print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
     $status = 1;
-}
+  }
 
-unlink $dcpsrepo_ior;
+  unlink $dcpsrepo_ior;
+}
 
 exit $status;

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 ADD . /opt/OpenDDS
 
 RUN cd /opt/OpenDDS && \
-    ./configure --prefix=/usr/local --security --doc-group --no-tests --std=c++11 && \
+    ./configure --prefix=/usr/local --security --doc-group --std=c++11 && \
     make && \
     make install && \
     cp -a /opt/OpenDDS/ACE_wrappers/MPC /usr/local/share/ace/MPC && \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,7 @@
 * [Compiling](#compiling)
 * [Test](#test)
 * [Installation](#installation)
+  * [Application Development with an Installed OpenDDS](#application-development-with-an-installed-opendds)
 * [Cross Compiling](#cross-compiling)
   * [Raspberry Pi](#raspberry-pi)
   * [Android](#android)
@@ -86,7 +87,7 @@ bin/auto_run_tests.pl
 **For Windows:**
 
 ```
-perl bin\auto_run_tests.pl
+bin\auto_run_tests.pl
 ```
 
   If you built static libraries, add `-Config STATIC` to this command.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,21 +1,23 @@
 # Building and Installing OpenDDS
 
+**Table of Contents:**
+
 * [Java](#java)
-* [Supported platforms](#supported-platforms)
+* [Supported Platforms](#supported-platforms)
 * [Compiling](#compiling)
 * [Test](#test)
 * [Installation](#installation)
 * [Cross Compiling](#cross-compiling)
   * [Raspberry Pi](#raspberry-pi)
   * [Android](#android)
-* [Building your own applications:](#building-your-own-applications)
+* [Building Your Own Applications](#building-your-own-applications)
 
 ## Java
 
 If you're building OpenDDS for use by Java applications, please see the file
 [java/INSTALL](java/INSTALL) instead of this one.
 
-## Supported platforms
+## Supported Platforms
 
 We have built OpenDDS on number of different platforms and compilers.  See
 [README.md](README.md#supported-platforms) for a complete description of
@@ -43,9 +45,6 @@ supported platforms.
 configure
 ```
 
-**If you don't need the tests, which add Google Test as a dependency and take a
-long time to compile, pass the `--no-tests` option to `configure`.**
-
   Optionally add `--help` to the command line to see the advanced options
   available for this script.  The configure script will download ACE+TAO and
   configure it for your platform.  To use an existing ACE+TAO installation,
@@ -69,6 +68,9 @@ long time to compile, pass the `--no-tests` option to `configure`.**
 
 ## Test
 
+**NOTE: Tests are not built by default, `--tests` must be passed to the
+configure script.**
+
   Optionally, you can run the entire OpenDDS regression test suite with one
   Perl command.
 
@@ -84,7 +86,7 @@ bin/auto_run_tests.pl
 **For Windows:**
 
 ```
-bin\auto_run_tests.pl
+perl bin\auto_run_tests.pl
 ```
 
   If you built static libraries, add `-Config STATIC` to this command.
@@ -151,7 +153,7 @@ The instructions for building for the Raspberry Pi are on
 
 Android support is documented in [`docs/android.md`](docs/android.md).
 
-## Building your own applications:
+## Building Your Own Applications
 
 See the [OpenDDS Developer's Guide](
     http://download.ociweb.com/OpenDDS/OpenDDS-latest.pdf)
@@ -165,8 +167,9 @@ cd $DDS_ROOT/DevGuideExamples/DCPS/Messenger
 ```
 
 **For Windows:**
+
 ```
-cd %DDS_ROOT\DevGuideExamples\DCPS\Messenger
+cd %DDS_ROOT%\DevGuideExamples\DCPS\Messenger
 perl run_test.pl
 ```
 
@@ -177,4 +180,3 @@ See [the notes in section "Test", above](#test), for options to `run_test.pl`.
   are echoed back to standard output.  The options and config files used here
   are helpful starting points for developing and running your own OpenDDS
   applications.
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,8 +173,6 @@ cd %DDS_ROOT%\DevGuideExamples\DCPS\Messenger
 perl run_test.pl
 ```
 
-See [the notes in section "Test", above](#test), for options to `run_test.pl`.
-
   The Perl script will start 3 processes, the DCPSInfoRepo, one publisher, and
   one subscriber.  Note that the command lines used to spawn these processes
   are echoed back to standard output.  The options and config files used here

--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ https://www.activestate.com/activeperl).
 
 * [Google Test](docs/dependencies.md#google-test), for various tests.
   * Starting with OpenDDS 3.14, Google Test is required for OpenDDS tests.
-    Tests are built by default, so that means Google Test is required unless
-    `--no-tests` is passed to `configure`.
 * [CMake](docs/dependencies.md#cmake), for building Google Test and the OpenDDS
   CMake module.
 * [Java](docs/dependencies.md#java), for Java bindings.
@@ -200,11 +198,10 @@ This release of OpenDDS has been tested using the following compilers:
 
 ## Building and Installing
 
-For building and installation instructions
-see the [`INSTALL.md`](INSTALL.md) file in this directory.
+For building and installation instructions see the [`INSTALL.md`](INSTALL.md)
+file in this directory.
 
 ## Quick Start with Docker
 
 See [`docs/docker.md`](docs/docker.md) for how to use the pre-built docker
 image.
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
   - cd ..
   - set MPC_ROOT=%CD%\ext\MPC
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-  - call configure --no-tests --ace=ext\ACE_TAO\ACE
+  - call configure --ace=ext\ACE_TAO\ACE
   - perl ext\ACE_TAO\ACE\bin\mwc.pl -type vs2017 tests\DCPS\Messenger
 
 platform:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
       modifyEnvironment: true
   - script: |
       if %BuildConfiguration%==Release set OPT=--no-tests --no-debug --optimize
-      call configure -v --ace-github-latest --security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst) %OPT%
+      call configure -v --ace-github-latest --tests --security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst) %OPT%
       perl tools\scripts\show_build_config.pl
       if %BuildConfiguration%==Release (set SLN=DDS_TAOv2.sln) else set SLN=DDS_TAOv2_all.sln
       echo ##vso[task.setvariable variable=BuildSolution]%SLN%
@@ -126,7 +126,7 @@ jobs:
       if %BuildConfiguration%==Release set OPT=--no-tests --no-debug --optimize
       set SEC=--security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst)
       if %BuildConfiguration%==Debug if %BuildPlatform%==x64 set SEC= # Debug64 Fills up Disk with Security
-      call configure -v --ace-github-latest %SEC% %OPT%
+      call configure -v --ace-github-latest --tests %SEC% %OPT%
       perl tools\scripts\show_build_config.pl
       if %BuildConfiguration%==Release (set SLN=DDS_TAOv2.sln) else set SLN=DDS_TAOv2_all.sln
       echo ##vso[task.setvariable variable=BuildSolution]%SLN%
@@ -195,7 +195,7 @@ jobs:
       modifyEnvironment: true
   - script: |
       if %BuildConfiguration%==Release set OPT=--no-tests --no-debug --optimize
-      call configure -v --ace-github-latest --security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst) %OPT%
+      call configure -v --ace-github-latest --tests --security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst) %OPT%
       perl tools\scripts\show_build_config.pl
       if %BuildConfiguration%==Release (set SLN=DDS_TAOv2.sln) else set SLN=DDS_TAOv2_all.sln
       echo ##vso[task.setvariable variable=BuildSolution]%SLN%
@@ -274,7 +274,7 @@ jobs:
     displayName: Install system packages
     condition: and(succeeded(), ne(variables['PackageDeps'], ''))
   - script: |
-      ./configure -v --mpcopts="-workers 4" --ace-github-latest $(ConfigOpts)
+      ./configure -v --mpcopts="-workers 4" --ace-github-latest --tests $(ConfigOpts)
       tools/scripts/show_build_config.pl
     displayName: Run configure script
   - script: make -sj6
@@ -300,7 +300,7 @@ jobs:
         ConfigOpts: --no-debug --optimize
   steps:
   - script: |
-      ./configure -v --ace-github-latest $(ConfigOpts)
+      ./configure -v --ace-github-latest --tests $(ConfigOpts)
       tools/scripts/show_build_config.pl
     displayName: Run configure script
   - script: make -sj6

--- a/bin/dcps_short_tests.lst
+++ b/bin/dcps_short_tests.lst
@@ -162,6 +162,7 @@ performance-tests/DCPS/TCPListenerTest/run_test.pl -p 4 -s 1: !DCPS_MIN !OPENDDS
 #performance-tests/DCPS/MulticastListenerTest/run_test.pl -p 2 -s 3: !DCPS_MIN !NO_MCAST
 
 DevGuideExamples/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+DevGuideExamples/DCPS/Messenger/run_test.pl --rtps: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
 DevGuideExamples/DCPS/Messenger_ZeroCopy/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 
 tests/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -176,6 +176,7 @@ performance-tests/DCPS/TCPListenerTest/run_test.pl -p 4 -s 1: !DCPS_MIN !OPENDDS
 #performance-tests/DCPS/MulticastListenerTest/run_test.pl -p 2 -s 3: !DCPS_MIN !NO_MCAST
 
 DevGuideExamples/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+DevGuideExamples/DCPS/Messenger/run_test.pl --rtps: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
 DevGuideExamples/DCPS/Messenger_ZeroCopy/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 
 tests/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/configure
+++ b/configure
@@ -195,7 +195,7 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'wireshark-build|wireshark_build=s', 'Wireshark CMake Build Location',
     'wireshark-lib|wireshark_lib=s',
       'Optional Wireshark CMake libraries location' .
-      $argIndent .'relative to wireshark-build (guesses)',
+      $argIndent . 'relative to wireshark-build (guesses)',
     'glib:s', 'GLib for Wireshark (use GLIB_ROOT or system pkg)',
     '<default>rapidjson:s',
       'RapidJSON for Wireshark dissector and JSON' .
@@ -211,8 +211,9 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'cmake:s', 'Path to cmake binary for compiling Google Test' .
       $argIndent . 'Framework. (Check Path and Check Normal' .
       $argIndent . 'Locations)',
-    'gtest:s', 'Path to Google Test Framework, required for' .
-      $argIndent . 'tests (uses GTEST_ROOT or system package)',
+    'gtest=s', 'Path to Google Test Framework, required for' .
+      $argIndent . 'tests (uses GTEST_ROOT).' .
+      $argIndent . 'If not built, will try to build using CMake.',
    ],
    ['Optional OpenDDS features:',
     'built-in-topics!', 'Built-in Topics (yes)',
@@ -225,9 +226,9 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'object-model-profile!', 'Object Model Profile (yes)',
     'persistence-profile!', 'Persistence Profile (yes)',
     'safety-profile:s', 'Safety Profile: base or extended (none)',
-    'tests!', 'Build tests, examples, and performance tests' .
-      $argIndent . '(yes) Implies --gtest as tests require Google' .
-      $argIndent . 'Test and --cmake',
+    'tests!', 'Build tests and performance tests (no)' .
+      $argIndent . 'Requires --gtest if missing git submodule',
+    'examples!', 'Build examples and DevGuideExamples (yes)',
     'security!', 'DDS Security plugin (no) Implies --openssl and' .
       $argIndent . '--xerces3',
    ],
@@ -373,6 +374,71 @@ sub addCurLibPathRef {
   my $libpathname = $platforminfo{$platform}->{'libpath'};
   my $curLibPathRef = $specific{'refpre'} . $libpathname . $specific{'refpost'};
   $buildEnvRef->{$libpathname} = $curLibPathRef;
+}
+
+sub run_command {
+  my $command = shift;
+  my %args = (
+    DUMP_OUTPUT_ON_ERROR => 0,
+    @_,
+  );
+
+  print "Running $command\n" if $opts{'verbose'};
+  my $saved_stdout;
+  my $saved_stderr;
+  my $tmp_fd;
+  my $tmp_path;
+
+  if ($args{DUMP_OUTPUT_ON_ERROR}) {
+    ($tmp_fd, $tmp_path) = File::Temp::tempfile();
+    open($saved_stdout, '>&', STDOUT);
+    open(STDOUT, '>&', $tmp_fd);
+    open($saved_stderr, '>&', STDERR);
+    open(STDERR, '>&', $tmp_fd);
+  }
+
+  my $failed = system($command) ? 1 : 0;
+  my $system_status = $?;
+  my $system_error = $!;
+
+  if ($args{DUMP_OUTPUT_ON_ERROR}) {
+    open(STDOUT, '>&', $saved_stdout);
+    open(STDERR, '>&', $saved_stderr);
+    close($tmp_fd);
+  }
+
+  if ($failed) {
+    my $error_message;
+    my $ran = 1;
+    if ($system_status == -1) {
+      $error_message = "Failed to Run: $system_error";
+      $ran = 0;
+    }
+    elsif ($system_status & 127) {
+      $error_message = sprintf("Exited on Signal %d", ($system_status & 127));
+      $error_message .= " and Created Coredump" if ($system_status & 128);
+    }
+    else {
+      $error_message = sprintf("Returned %d", $system_status >> 8);
+    }
+    print STDERR "Command \"$command\" $error_message\n";
+
+    if ($ran and $args{DUMP_OUTPUT_ON_ERROR}) {
+      open($tmp_fd, $tmp_path);
+      print STDERR "Dumping Output from Failed Command\n";
+      while (my $line = <$tmp_fd>) {
+        print STDERR "$line";
+      }
+      print STDERR "\nEnd of Dumped Output from Failed Command\n";
+      close($tmp_fd);
+    }
+  }
+
+  if ($args{DUMP_OUTPUT_ON_ERROR}) {
+    unlink($tmp_path);
+  }
+
+  return $failed;
 }
 
 my $curpathRef = $specific{'refpre'} . 'PATH' . $specific{'refpost'};
@@ -671,25 +737,25 @@ if (!$ace_src || !$tao_src) {
     my $urlbase = 'https://github.com/DOCGroup';
 
     print "Cloning git repo: $urlbase/ACE_TAO\n";
-    my $err = system("git clone -q --depth 1 $urlbase/ACE_TAO");
-    die 'ERROR: Failed to clone ACE/TAO from GitHub'
+    my $err = run_command("git clone -q --depth 1 $urlbase/ACE_TAO");
+    die "ERROR: Failed to clone ACE/TAO from GitHub\nStopped"
       if $err ||
         ! -r 'ACE_TAO/ACE/ace/ACE.h' ||
           ! -r 'ACE_TAO/TAO/tao/ORB.h';
 
     my $cur_dir = getcwd;
     chdir('ACE_TAO');
-    system('git --no-pager log -1 --oneline');
+    run_command('git --no-pager log -1 --oneline');
     chdir($cur_dir);
 
     print "Cloning git repo: $urlbase/MPC into ACE_TAO/ACE/MPC\n";
-    $err = system("git clone -q --depth 1 $urlbase/MPC ACE_TAO/ACE/MPC");
-    die 'ERROR: Failed to clone MPC (into ACE_TAO/ACE/MPC) from GitHub'
+    $err = run_command("git clone -q --depth 1 $urlbase/MPC ACE_TAO/ACE/MPC");
+    die "ERROR: Failed to clone MPC (into ACE_TAO/ACE/MPC) from GitHub\nStopped"
       if $err ||
         ! -r 'ACE_TAO/ACE/MPC/mwc.pl';
 
     chdir('ACE_TAO/ACE/MPC');
-    system('git --no-pager log -1 --oneline');
+    run_command('git --no-pager log -1 --oneline');
     chdir($cur_dir);
 
     $ace_src = normalizePath('ACE_TAO/ACE');
@@ -739,7 +805,7 @@ if (!$ace_src || !$tao_src) {
           if ($opts{'dry-run'}) {
             print "Dry-run: would run wget $urlbase$file\n";
           }
-          elsif (system("wget $urlbase$file")) {
+          elsif (run_command("wget $urlbase$file")) {
             die "ERROR from wget, stopped";
           }
         }
@@ -748,7 +814,7 @@ if (!$ace_src || !$tao_src) {
           if ($opts{'dry-run'}) {
             print "Dry-run: would run curl -L $urlbase$file -o $file\n";
           }
-          elsif (system("curl -L $urlbase$file -o $file")) {
+          elsif (run_command("curl -L $urlbase$file -o $file")) {
             die "ERROR: from curl, stopped";
           }
         }
@@ -774,7 +840,7 @@ if (!$ace_src || !$tao_src) {
           $err = 0;
         }
         else {
-          $err = system(($^O eq 'solaris' ? 'g' : '') . "tar xzf $ddsroot/$file");
+          $err = run_command(($^O eq 'solaris' ? 'g' : '') . "tar xzf $ddsroot/$file");
         }
       }
       else {
@@ -840,7 +906,7 @@ sub clone_host_and_target {
   print "cloning build tree\n" if $opts{'verbose'};
   if (!$opts{'dry-run'}) {
     eval {
-      system("$targetEnv{'MPC_ROOT'}/clone_build_tree.pl host target");
+      run_command("$targetEnv{'MPC_ROOT'}/clone_build_tree.pl host target");
     };
   }
   if ($source_dir ne '.') {
@@ -1048,13 +1114,7 @@ if ($host_tools_only) {
 }
 
 # Use this to check if tests are enabled (instead of $opts{'tests'} directly).
-my $tests = !exists $opts{'tests'} || $opts{'tests'};
-
-if ($tests) {
-  print "--tests implies --gtest and --cmake\n" if $opts{'verbose'};
-  $opts{'gtest'} = '' if (!exists $opts{'gtest'});
-  $opts{'cmake'} = '' if (!exists $opts{'cmake'});
-}
+my $tests = exists $opts{'tests'} && $opts{'tests'};
 
 my @ace_features = ('xerces3');
 
@@ -1155,12 +1215,12 @@ sub system_default_install_dir {
 }
 
 my $build_gtest = 0;
-if (exists $opts{'gtest'}) {
-  my $sanity = 'include/gtest/gtest.h';
+if (exists $opts{'gtest'} || $tests) {
+  my $gtest_sanity = 'include/gtest/gtest.h';
 
   if ($opts{'gtest'}) {
-    die "ERROR: '$sanity' not found in supplied gtest directory '$opts{'gtest'}'"
-      if ! -f File::Spec->catfile($opts{'gtest'}, $sanity);
+    die "ERROR: '$gtest_sanity' not found in supplied gtest directory '$opts{'gtest'}'"
+      if ! -f File::Spec->catfile($opts{'gtest'}, $gtest_sanity);
 
     env_from_opt('gtest', 'GTEST_ROOT');
 
@@ -1171,18 +1231,19 @@ if (exists $opts{'gtest'}) {
     my $sys_dir = File::Spec->catdir((system_default_install_dir(),
                               $is_windows ? 'googletest-distribution' : ''));
 
-    if (-f File::Spec->catfile($sm_src, $sanity)) {
+    if (-f File::Spec->catfile($sm_src, $gtest_sanity)) {
       # Check for existing build
       $build_gtest = ! -d File::Spec->catdir($sm_dir, 'build/install');
       $opts{'gtest'} = $sm_dir;
       # No need to set env. variable with submodule.
     }
-    elsif (-f File::Spec->catfile($sys_dir, $sanity)) {
+    elsif (-f File::Spec->catfile($sys_dir, $gtest_sanity)) {
       $opts{'gtest'} = $sys_dir;
       env_from_opt('gtest', 'GTEST_ROOT');
     }
     else {
-      die "ERROR: Google Test '$sanity' not found in submodule src '$sm_src' or default install dir '$sys_dir'\nStopped"
+      die "ERROR: Google Test '$gtest_sanity' not found in submodule src '$sm_src' or " .
+        "default install dir '$sys_dir', please pass a correct version of Google Test to --gtest\nStopped";
     }
   }
 }
@@ -1425,6 +1486,8 @@ sub win32_cmake_generator {
 }
 
 if ($build_gtest) {
+  print("Building Google Test...\n");
+
   my $cwd = Cwd::getcwd();
   my $build_dir = $opts{'gtest'} . $slash . 'build';
   my $install_dir = $build_dir . $slash . 'install';
@@ -1453,13 +1516,14 @@ if ($build_gtest) {
     or  die "ERROR '$!': failed to change into $build_dir from $cwd.\nStopped";
 
   for my $cmd (@cmake_cmds) {
-    print "Running @{$cmd}...\n";
-    system(@{$cmd}) == 0
-      or die "ERROR: Invoking @{$cmd} failed with error '$?'.\nStopped";
+    run_command("@{$cmd}", DUMP_OUTPUT_ON_ERROR => !$opts{'verbose'}) == 0
+      or die "ERROR: Invoking @{$cmd} failed.\nStopped";
   }
 
   chdir($cwd)
     or die "ERROR '$!': failed to change back to $cwd.\nStopped";
+
+  print("Done Building Google Test\n");
 }
 
 if (exists $opts{'jboss'} && !exists $opts{'java'}) {
@@ -1917,11 +1981,10 @@ EOT
     }
   }
 
-  print "OpenDDS mwc command line: $mwcargs\n" if $opts{'verbose'};
   print 'Running MPC to generate ', ($mpctype eq 'gnuace' ? 'makefiles' :
                                      'project files'), ".\n";
   if (!$opts{'dry-run'}) {
-    if (system("perl $ENV{'ACE_ROOT'}/bin/mwc.pl $mwcargs") != 0) {
+    if (run_command("perl $ENV{'ACE_ROOT'}/bin/mwc.pl $mwcargs") != 0) {
       die "ERROR: Error from MPC, stopped";
     }
   }
@@ -1935,7 +1998,7 @@ EOT
     print "ACE mwc command line: $mwcargs\n" if $opts{'verbose'};
 
     if (!$opts{'dry-run'}) {
-      if (system("perl $ENV{'ACE_ROOT'}/bin/mwc.pl $mwcargs") != 0) {
+      if (run_command("perl $ENV{'ACE_ROOT'}/bin/mwc.pl $mwcargs") != 0) {
         die "ERROR: Error from MPC, stopped";
       }
     }

--- a/configure
+++ b/configure
@@ -1950,6 +1950,11 @@ EOT
   my $static = (($opts{'static'} && $is_windows) ||
     ($cross_compile && $buildEnv->{'build'} eq 'host' && $mpctype ne 'gnuace'));
 
+  my @mpcopts = ();
+  if (defined $opts{'mpcopts'}) {
+    @mpcopts = @{$opts{'mpcopts'}};
+  }
+
   # We are not using CIAO or DAnCE, but MPC.cfg expands $CIAO_ROOT and
   # $DANCE_ROOT so leaving them empty/undefined would cause /MPC/config
   # to be on the include path for .mpb files.
@@ -1966,10 +1971,7 @@ EOT
     push(@mwccmd, '-static');
   }
 
-  my @mwcargs = ("$buildEnv->{'DDS_ROOT'}$slash$ws");
-  if (defined $opts{'mpcopts'}) {
-    push(@mwcargs, @{$opts{'mpcopts'}});
-  }
+  my @mwcargs = ("$buildEnv->{'DDS_ROOT'}$slash$ws", @mpcopts);
   if (!$buildtao && @features) {
     for my $feature (@features) {
       push(@mwcargs, '-features', ($feature =~ /=/ ? $feature : "$feature=1"));
@@ -1986,12 +1988,7 @@ EOT
   # If this is a target safety profile build
   if (defined $opts{'no-opendds-safety-profile'}) {
     # Generate ACE workspace separately, to exclude TAO
-    my @cmd = (@mwccmd, "$buildEnv->{'ACE_ROOT'}/ace");
-    if (defined $opts{'mpcopts'}) {
-      push(@cmd, @{$opts{'mpcopts'}});
-    }
-
-    if (run_command(\@cmd)) {
+    if (run_command([@mwccmd, "$buildEnv->{'ACE_ROOT'}/ace", @mpcopts])) {
       die "ERROR: Error from MPC, stopped";
     }
   }

--- a/configure
+++ b/configure
@@ -1952,7 +1952,9 @@ EOT
 
   my @mpcopts = ();
   if (defined $opts{'mpcopts'}) {
-    @mpcopts = @{$opts{'mpcopts'}};
+    for my $i (@{$opts{'mpcopts'}}) {
+      push(@mpcopts, split(/ /, $i));
+    }
   }
 
   # We are not using CIAO or DAnCE, but MPC.cfg expands $CIAO_ROOT and

--- a/configure
+++ b/configure
@@ -226,9 +226,8 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'object-model-profile!', 'Object Model Profile (yes)',
     'persistence-profile!', 'Persistence Profile (yes)',
     'safety-profile:s', 'Safety Profile: base or extended (none)',
-    'tests!', 'Build tests and performance tests (no)' .
+    'tests!', 'Build tests, examples, and performance tests (no)' .
       $argIndent . 'Requires --gtest if missing git submodule',
-    'examples!', 'Build examples and DevGuideExamples (yes)',
     'security!', 'DDS Security plugin (no) Implies --openssl and' .
       $argIndent . '--xerces3',
    ],
@@ -377,13 +376,20 @@ sub addCurLibPathRef {
 }
 
 sub run_command {
-  my $command = shift;
+  my $command_ref = shift;
+  my @command = @{$command_ref};
+  my $command_str = join(' ', @command);
   my %args = (
     DUMP_OUTPUT_ON_ERROR => 0,
     @_,
   );
 
-  print "Running $command\n" if $opts{'verbose'};
+  if ($opts{'dry-run'}) {
+    print "Dry-run: Would run \"$command_str\"\n";
+    return 0;
+  }
+
+  print "Running \"$command_str\"\n" if $opts{'verbose'};
   my $saved_stdout;
   my $saved_stderr;
   my $tmp_fd;
@@ -397,7 +403,7 @@ sub run_command {
     open(STDERR, '>&', $tmp_fd);
   }
 
-  my $failed = system($command) ? 1 : 0;
+  my $failed = system(@command) ? 1 : 0;
   my $system_status = $?;
   my $system_error = $!;
 
@@ -421,7 +427,7 @@ sub run_command {
     else {
       $error_message = sprintf("Returned %d", $system_status >> 8);
     }
-    print STDERR "Command \"$command\" $error_message\n";
+    print STDERR "Command \"$command_str\" $error_message\n";
 
     if ($ran and $args{DUMP_OUTPUT_ON_ERROR}) {
       open($tmp_fd, $tmp_path);
@@ -737,7 +743,7 @@ if (!$ace_src || !$tao_src) {
     my $urlbase = 'https://github.com/DOCGroup';
 
     print "Cloning git repo: $urlbase/ACE_TAO\n";
-    my $err = run_command("git clone -q --depth 1 $urlbase/ACE_TAO");
+    my $err = run_command(['git', 'clone', '-q', '--depth=1', "$urlbase/ACE_TAO"]);
     die "ERROR: Failed to clone ACE/TAO from GitHub\nStopped"
       if $err ||
         ! -r 'ACE_TAO/ACE/ace/ACE.h' ||
@@ -745,17 +751,17 @@ if (!$ace_src || !$tao_src) {
 
     my $cur_dir = getcwd;
     chdir('ACE_TAO');
-    run_command('git --no-pager log -1 --oneline');
+    run_command(['git', '--no-pager', 'log', '-1', '--oneline']);
     chdir($cur_dir);
 
     print "Cloning git repo: $urlbase/MPC into ACE_TAO/ACE/MPC\n";
-    $err = run_command("git clone -q --depth 1 $urlbase/MPC ACE_TAO/ACE/MPC");
+    $err = run_command(['git', 'clone', '-q', '--depth=1', "$urlbase/MPC", 'ACE_TAO/ACE/MPC']);
     die "ERROR: Failed to clone MPC (into ACE_TAO/ACE/MPC) from GitHub\nStopped"
       if $err ||
         ! -r 'ACE_TAO/ACE/MPC/mwc.pl';
 
     chdir('ACE_TAO/ACE/MPC');
-    run_command('git --no-pager log -1 --oneline');
+    run_command(['git', '--no-pager', 'log', '-1', '--oneline']);
     chdir($cur_dir);
 
     $ace_src = normalizePath('ACE_TAO/ACE');
@@ -802,19 +808,13 @@ if (!$ace_src || !$tao_src) {
       if ($@) {
         if (which('wget')) {
           print $download_message . " (using wget)\n";
-          if ($opts{'dry-run'}) {
-            print "Dry-run: would run wget $urlbase$file\n";
-          }
-          elsif (run_command("wget $urlbase$file")) {
+          if (run_command(['wget', "$urlbase$file"])) {
             die "ERROR from wget, stopped";
           }
         }
         elsif (which('curl')) {
           print $download_message . " (using curl)\n";
-          if ($opts{'dry-run'}) {
-            print "Dry-run: would run curl -L $urlbase$file -o $file\n";
-          }
-          elsif (run_command("curl -L $urlbase$file -o $file")) {
+          if (run_command(['curl', '-L', "$urlbase$file", '-o', "$file"])) {
             die "ERROR: from curl, stopped";
           }
         }
@@ -834,14 +834,7 @@ if (!$ace_src || !$tao_src) {
       my $err = 1;
       my $ddsroot = getcwd;
       if (!$is_windows) {
-        if ($opts{'dry-run'}) {
-          print "Dry-run: would run " . ($^O eq 'solaris' ? 'g' : '') .
-            "tar xzf $ddsroot/$file\n";
-          $err = 0;
-        }
-        else {
-          $err = run_command(($^O eq 'solaris' ? 'g' : '') . "tar xzf $ddsroot/$file");
-        }
+        $err = run_command([($^O eq 'solaris' ? 'g' : '') . 'tar', 'xzf', "$ddsroot/$file"]);
       }
       else {
         # Try Archive::Zip
@@ -904,11 +897,7 @@ sub clone_host_and_target {
     chdir($source_dir);
   }
   print "cloning build tree\n" if $opts{'verbose'};
-  if (!$opts{'dry-run'}) {
-    eval {
-      run_command("$targetEnv{'MPC_ROOT'}/clone_build_tree.pl host target");
-    };
-  }
+  run_command(["$targetEnv{'MPC_ROOT'}/clone_build_tree.pl", 'host', 'target']);
   if ($source_dir ne '.') {
     print "Changing dir back to $cur_dir\n" if $opts{'verbose'};
     chdir($cur_dir);
@@ -1516,7 +1505,7 @@ if ($build_gtest) {
     or  die "ERROR '$!': failed to change into $build_dir from $cwd.\nStopped";
 
   for my $cmd (@cmake_cmds) {
-    run_command("@{$cmd}", DUMP_OUTPUT_ON_ERROR => !$opts{'verbose'}) == 0
+    run_command($cmd, DUMP_OUTPUT_ON_ERROR => !$opts{'verbose'}) == 0
       or die "ERROR: Invoking @{$cmd} failed.\nStopped";
   }
 
@@ -1959,8 +1948,7 @@ EOT
   }
 
   my $static = (($opts{'static'} && $is_windows) ||
-    ($cross_compile && $buildEnv->{'build'} eq 'host' && $mpctype ne 'gnuace'))
-    ? '-static' : '';
+    ($cross_compile && $buildEnv->{'build'} eq 'host' && $mpctype ne 'gnuace'));
 
   # We are not using CIAO or DAnCE, but MPC.cfg expands $CIAO_ROOT and
   # $DANCE_ROOT so leaving them empty/undefined would cause /MPC/config
@@ -1973,34 +1961,38 @@ EOT
   print "ENV: saving current environment\n" if $opts{'verbose'};
   mergeToEnv($buildEnv);
 
-  my $mwcargs = "-type $mpctype $buildEnv->{'DDS_ROOT'}$slash$ws $static";
-  $mwcargs .= ' ' . join(' ', @{$opts{'mpcopts'}}) if defined $opts{'mpcopts'};
+  my @mwccmd = ('perl', "$ENV{'ACE_ROOT'}/bin/mwc.pl", '-type', "$mpctype");
+  if ($static) {
+    push(@mwccmd, '-static');
+  }
+
+  my @mwcargs = ("$buildEnv->{'DDS_ROOT'}$slash$ws");
+  if (defined $opts{'mpcopts'}) {
+    push(@mwcargs, @{$opts{'mpcopts'}});
+  }
   if (!$buildtao && @features) {
     for my $feature (@features) {
-      $mwcargs .= " -features " . ($feature =~ /=/ ? $feature : "$feature=1");
+      push(@mwcargs, '-features', ($feature =~ /=/ ? $feature : "$feature=1"));
     }
   }
 
   print 'Running MPC to generate ', ($mpctype eq 'gnuace' ? 'makefiles' :
                                      'project files'), ".\n";
-  if (!$opts{'dry-run'}) {
-    if (run_command("perl $ENV{'ACE_ROOT'}/bin/mwc.pl $mwcargs") != 0) {
-      die "ERROR: Error from MPC, stopped";
-    }
+  if (run_command([@mwccmd, @mwcargs])) {
+    die "ERROR: Error from MPC, stopped";
   }
   $buildEnv->{'mpctype'} = $mpctype;
 
   # If this is a target safety profile build
   if (defined $opts{'no-opendds-safety-profile'}) {
     # Generate ACE workspace separately, to exclude TAO
-    my $mwcargs = "-type $mpctype $static " . $buildEnv->{'ACE_ROOT'}. "/ace";
-    $mwcargs .= ' ' . join(' ', @{$opts{'mpcopts'}}) if defined $opts{'mpcopts'};
-    print "ACE mwc command line: $mwcargs\n" if $opts{'verbose'};
+    my @cmd = (@mwccmd, "$buildEnv->{'ACE_ROOT'}/ace");
+    if (defined $opts{'mpcopts'}) {
+      push(@cmd, @{$opts{'mpcopts'}});
+    }
 
-    if (!$opts{'dry-run'}) {
-      if (run_command("perl $ENV{'ACE_ROOT'}/bin/mwc.pl $mwcargs") != 0) {
-        die "ERROR: Error from MPC, stopped";
-      }
+    if (run_command(\@cmd)) {
+      die "ERROR: Error from MPC, stopped";
     }
   }
 

--- a/docs/android.md
+++ b/docs/android.md
@@ -105,7 +105,7 @@ example, we can use `armeabi-v7a` <sup>[2](#footnote-2)</sup>.
 those sections before configuring and building OpenDDS.
 
 ```Shell
-./configure --no-tests --doc-group --target=android --macros=ANDROID_ABI=armeabi-v7a
+./configure --doc-group --target=android --macros=ANDROID_ABI=armeabi-v7a
 PATH=$PATH:$TOOLCHAIN/bin make # Pass -j/--jobs with an appropriate value or this'll take a while...
 ```
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -102,16 +102,13 @@ OpenDDS has a [CMake `FindPackage` module included](../cmake). See
 without the need to use MPC in your application.
 
 CMake is required to build Google Test for OpenDDS tests if a prebuilt Google
-Test is not found or provided. You can forgo having to have CMake by passing
-`--no-tests` to the OpenDDS configure script or building and/or installing
-Google Test separately.
+Test is not found or provided.
 
 See [`../tests/gtest_setup.txt`](../tests/gtest_setup.txt) for details.
 
 ### Google Test
 
-Google Test is required for OpenDDS tests. You can forgo this dependency by
-passing `--no-tests` to the OpenDDS configure script.
+Google Test is required for OpenDDS tests.
 
 Google Test is a git submodule that will be downloaded automatically if the
 repository was recursively cloned or submodules were initialized separately.

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -80,8 +80,7 @@ take advantage of Doxygen when writing code in OpenDDS.
   other scripting in OpenDDS codebase.
 - Google Test is required for OpenDDS tests. By default, CMake will be used to
   build a specific version of Google Test that we have as a submodule. An
-  appropriate prebuilt or system Google Test can also be used. Use `--no-tests`
-  to just build the OpenDDS libraries and the Developer's Guide examples.
+  appropriate prebuilt or system Google Test can also be used.
 
 See [dependencies.md](dependencies.md) for all dependencies and details on how
 these are used in OpenDDS.


### PR DESCRIPTION
Also added bits to make it easier to run `DevGuideExamples/DCPS/Messenger` in RTPS mode so the user can run RTPS with no tests and added an example `CMakeLists.txt`.