### PR TITLE
Fix gcc asan issue in RtpsUdpDatalink's customize_queue_element

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -922,8 +922,9 @@ RtpsUdpDataLink::customize_queue_element(TransportQueueElement* element)
   TransportQueueElement* result;
   bool deliver_after_send = false;
   if (rw != writers_.end()) {
+    writer = rw->second;
     g.release();
-    result = rw->second->customize_queue_element_helper(element, requires_inline_qos, meta_submessages, deliver_after_send);
+    result = writer->customize_queue_element_helper(element, requires_inline_qos, meta_submessages, deliver_after_send);
   } else {
     result = customize_queue_element_non_reliable_i(element, requires_inline_qos, meta_submessages, deliver_after_send);
     g.release();


### PR DESCRIPTION
There was already a stubbed writer RCH here, not sure why we weren't using it...

Grab a full RCH to RtpsWriter before releasing Datalink's lock in order to prevent deletion while we're attempting to call customize_queue_element_helper.