### PR TITLE
Improve locking around RtpsWriter's usage of SingleSendBuffer

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -78,8 +78,6 @@ public:
   void release_all();
   typedef OPENDDS_MAP(SequenceNumber, BufferType) BufferMap;
   void release_acked(SequenceNumber seq);
-  void release(BufferMap::iterator buffer_iter);
-
   size_t n_chunks() const;
 
   SingleSendBuffer(size_t capacity, size_t max_samples_per_packet);
@@ -110,7 +108,9 @@ public:
                        ACE_Message_Block* chain);
 
 private:
-  void check_capacity();
+  void check_capacity_i();
+  void release_i(BufferMap::iterator buffer_iter);
+
   RemoveResult retain_buffer(const RepoId& pub_id, BufferType& buffer);
   void insert_buffer(BufferType& buffer,
                      TransportSendStrategy::QueueType* queue,
@@ -130,6 +130,8 @@ private:
 
   typedef OPENDDS_MAP(SequenceNumber, RepoId) DestinationMap;
   DestinationMap destinations_;
+
+  ACE_Thread_Mutex mutex_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -169,6 +169,8 @@ RtpsUdpDataLink::RtpsWriter::do_remove_sample(const TransportQueueElement::Match
     return;
   }
 
+  ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
+
   if (!elems_not_acked_.empty()) {
     to_deliver.insert(to_deliver_.begin(), to_deliver_.end());
     to_deliver_.clear();
@@ -192,6 +194,7 @@ RtpsUdpDataLink::RtpsWriter::do_remove_sample(const TransportQueueElement::Match
     }
   }
 
+  g2.release();
   g.release();
 
   SnToTqeMap::iterator deliver_iter = to_deliver.begin();
@@ -456,6 +459,9 @@ RtpsUdpDataLink::RtpsWriter::pre_stop_helper(OPENDDS_VECTOR(TransportQueueElemen
       iter = to_deliver_.begin();
     }
   }
+
+  ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
+
   if (!elems_not_acked_.empty()) {
     OPENDDS_SET(SequenceNumber) sns_to_release;
     iter_t iter = elems_not_acked_.begin();
@@ -2703,6 +2709,8 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(SnToTqeMap& to_deliver)
     return;
   }
 
+  ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
+
   if (!elems_not_acked_.empty()) {
 
     //start with the max sequence number writer knows about and decrease
@@ -2910,8 +2918,12 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
     }
   }
 
-  if (!elems_not_acked_.empty()) {
-    is_final = false;
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g2, elems_not_acked_mutex_, false);
+
+    if (!elems_not_acked_.empty()) {
+      is_final = false;
+    }
   }
 
   const SequenceNumber firstSN = (durable_ || !has_data) ? 1 : send_buff_->low(),
@@ -3212,11 +3224,15 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
 RtpsUdpDataLink::RtpsWriter::~RtpsWriter()
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
   if (!to_deliver_.empty()) {
     ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: RtpsWriter::~RtpsWriter - ")
       ACE_TEXT("deleting with %d elements left to deliver\n"),
       to_deliver_.size()));
   }
+
+  ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
+
   if (!elems_not_acked_.empty()) {
     ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: RtpsWriter::~RtpsWriter - ")
       ACE_TEXT("deleting with %d elements left not fully acknowledged\n"),
@@ -3237,7 +3253,7 @@ RtpsUdpDataLink::RtpsWriter::heartbeat_high(const ReaderInfo& ri) const
 void
 RtpsUdpDataLink::RtpsWriter::add_elem_awaiting_ack(TransportQueueElement* element)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+  ACE_GUARD(ACE_Thread_Mutex, g, elems_not_acked_mutex_);
   elems_not_acked_.insert(SnToTqeMap::value_type(element->sequence(), element));
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -272,6 +272,7 @@ private:
     bool durable_;
     CORBA::Long heartbeat_count_;
     mutable ACE_Thread_Mutex mutex_;
+    mutable ACE_Thread_Mutex elems_not_acked_mutex_;
 
     void add_gap_submsg_i(RTPS::SubmessageSeq& msg,
                           const TransportQueueElement& tqe,


### PR DESCRIPTION
Issue: Discovered a deadlock scenario in the WaitForAck tests that results from a user thread sending data and the reactor thread resending data in response to a NACK within a very tight (but possible) window.

Solution: Split the locking inside RtpsWriter apart and protect elems_not_acked_ separately from the rest of RtpsWriter's members.  In addition, add thread safety mechanisms to SingleSendBuffer to protect against multithreaded access (same two sources) in order to avoid potential corruption / segfaults.