### PR TITLE
Fixing gccasan issue for invalid use after free

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -112,7 +112,7 @@ static ACE_TString config_fname(ACE_TEXT(""));
 
 static const ACE_TCHAR DEFAULT_REPO_IOR[] = ACE_TEXT("file://repo.ior");
 
-static const ACE_CString DEFAULT_PERSISTENT_DATA_DIR = "OpenDDS-durable-data-dir";
+static const char DEFAULT_PERSISTENT_DATA_DIR[] = "OpenDDS-durable-data-dir";
 
 static const ACE_TCHAR COMMON_SECTION_NAME[] = ACE_TEXT("common");
 static const ACE_TCHAR DOMAIN_SECTION_NAME[] = ACE_TEXT("domain");


### PR DESCRIPTION
Fixing gccasan issue for invalid use after free of global const ACE_CString object by changing to const char[]. The service participant object needs to have/return an ACE_CString, but there's no need for the default global variable used in initialization to be one. The issue seems to happen when ServiceParticipant instance() is re-created as part of another global/static object's shutdown process, which may be its own issue that needs to be addressed at some point.