### PR TITLE
Fix Intermittent SharedTransport Shmem Test Failures

### DIFF
--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -22,9 +22,6 @@ ReactorInterceptor::ReactorInterceptor(ACE_Reactor* reactor,
                                        ACE_thread_t owner)
   : owner_(owner)
 {
-  if (reactor == 0) {
-    ACE_DEBUG((LM_WARNING, "(%P|%t) ReactorInterceptor initialized with null reactor\n"));
-  }
   this->reactor(reactor);
 }
 

--- a/dds/DCPS/transport/shmem/ShmemDataLink.cpp
+++ b/dds/DCPS/transport/shmem/ShmemDataLink.cpp
@@ -103,6 +103,8 @@ ShmemDataLink::control_received(ReceivedDataSample& /*sample*/)
 void
 ShmemDataLink::stop_i()
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
   if (peer_alloc_) {
     peer_alloc_->release(0 /*don't close*/);
   }
@@ -114,6 +116,13 @@ ShmemTransport&
 ShmemDataLink::impl() const
 {
   return static_cast<ShmemTransport&>(DataLink::impl());
+}
+
+ShmemAllocator*
+ShmemDataLink::peer_allocator()
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, 0);
+  return peer_alloc_;
 }
 
 ShmemAllocator*

--- a/dds/DCPS/transport/shmem/ShmemDataLink.h
+++ b/dds/DCPS/transport/shmem/ShmemDataLink.h
@@ -95,7 +95,7 @@ public:
   pid_t peer_pid();
 
   ShmemAllocator* local_allocator();
-  ShmemAllocator* peer_allocator() { return peer_alloc_; }
+  ShmemAllocator* peer_allocator();
 
   void read() { recv_strategy_->read(); }
   void signal_semaphore();
@@ -112,6 +112,7 @@ protected:
 private:
   std::string peer_address_;
   ShmemAllocator* peer_alloc_;
+  ACE_Thread_Mutex mutex_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
@@ -41,7 +41,7 @@ ShmemReceiveStrategy::read()
 
   ShmemAllocator* alloc = link_->peer_allocator();
   void* mem = 0;
-  if (-1 == alloc->find(bound_name_.c_str(), mem)) {
+  if (alloc == 0 || -1 == alloc->find(bound_name_.c_str(), mem)) {
     VDBG_LVL((LM_INFO, "(%P|%t) ShmemReceiveStrategy::read link %@ "
               "peer allocator not found, receive_bytes will close link\n",
               link_), 1);
@@ -86,7 +86,7 @@ ShmemReceiveStrategy::receive_bytes(iovec iov[],
   // check that the writer's shared memory is still available
   ShmemAllocator* alloc = link_->peer_allocator();
   void* mem;
-  if (-1 == alloc->find(bound_name_.c_str(), mem)
+  if (alloc == 0 || -1 == alloc->find(bound_name_.c_str(), mem)
       || current_data_->status_ != SHMEM_DATA_IN_USE) {
     VDBG_LVL((LM_INFO, "(%P|%t) ShmemReceiveStrategy::receive_bytes closing\n"),
              1);

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.h
@@ -48,6 +48,7 @@ private:
   ShmemData* current_data_;
   size_t partial_recv_remaining_;
   const char* partial_recv_ptr_;
+  ACE_Thread_Mutex mutex_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
@@ -50,9 +50,6 @@ ShmemSendStrategy::start_i()
 
   ShmemData* data = reinterpret_cast<ShmemData*>(mem);
   const size_t limit = (extra >= sizeof(int)) ? n_elems : (n_elems - 1);
-  for (size_t i = 0; i < limit; ++i) {
-    data[i].status_ = SHMEM_DATA_FREE;
-  }
   data[limit].status_ = SHMEM_DATA_END_OF_ALLOC;
   alloc->bind(bound_name_.c_str(), mem);
 

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -268,7 +268,7 @@ ShmemTransport::ReadTask::stop()
   }
   stopped_ = true;
   ACE_OS::sema_post(&semaphore_);
-  ACE_Task_Base::wait();
+  wait();
 }
 
 void

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -67,12 +67,12 @@ ShmemTransport::connect_datalink(const RemoteTransport& remote,
   ShmemDataLinkMap::iterator iter = links_.find(key.second);
   if (iter != links_.end()) {
     ShmemDataLink_rch link = iter->second;
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-              ACE_TEXT("link found.\n")));
+    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
+              ACE_TEXT("link found.\n")), 2);
     return AcceptConnectResult(link);
   }
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-            ACE_TEXT("new link.\n")));
+  VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
+            ACE_TEXT("new link.\n")), 2);
   return AcceptConnectResult(add_datalink(key.second));
 }
 

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -67,12 +67,12 @@ ShmemTransport::connect_datalink(const RemoteTransport& remote,
   ShmemDataLinkMap::iterator iter = links_.find(key.second);
   if (iter != links_.end()) {
     ShmemDataLink_rch link = iter->second;
-    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-              ACE_TEXT("link found.\n")), 2);
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
+              ACE_TEXT("link found.\n")));
     return AcceptConnectResult(link);
   }
-    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-              ACE_TEXT("new link.\n")), 2);
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
+            ACE_TEXT("new link.\n")));
   return AcceptConnectResult(add_datalink(key.second));
 }
 
@@ -175,7 +175,10 @@ ShmemTransport::shutdown_i()
 {
   // Shutdown reserved datalinks and release configuration:
   GuardType guard(links_lock_);
-  if (read_task_) read_task_->stop();
+  if (read_task_) {
+    read_task_->stop();
+    read_task_->wait();
+  }
 
   for (ShmemDataLinkMap::iterator it(links_.begin());
        it != links_.end(); ++it) {
@@ -247,22 +250,34 @@ ShmemTransport::ReadTask::ReadTask(ShmemTransport* outer, ACE_sema_t semaphore)
 int
 ShmemTransport::ReadTask::svc()
 {
-  while (true) {
+  while (!stopped_) {
     ACE_OS::sema_wait(&semaphore_);
     if (stopped_) {
       return 0;
     }
     outer_->read_from_links();
   }
-  return 1;
+  return 0;
 }
 
 void
 ShmemTransport::ReadTask::stop()
 {
+  if (stopped_) {
+    return;
+  }
   stopped_ = true;
   ACE_OS::sema_post(&semaphore_);
-  wait();
+  ACE_Task_Base::wait();
+}
+
+void
+ShmemTransport::ReadTask::signal_semaphore()
+{
+  if (stopped_) {
+    return;
+  }
+  ACE_OS::sema_post(&semaphore_);
 }
 
 void
@@ -278,7 +293,7 @@ ShmemTransport::read_from_links()
   }
 
   typedef std::vector<ShmemDataLink_rch>::iterator dl_iter_t;
-  for (dl_iter_t dl_it = dl_copies.begin(); dl_it != dl_copies.end(); ++dl_it) {
+  for (dl_iter_t dl_it = dl_copies.begin(); !is_shut_down() && dl_it != dl_copies.end(); ++dl_it) {
     dl_it->in()->read();
   }
 }
@@ -286,7 +301,10 @@ ShmemTransport::read_from_links()
 void
 ShmemTransport::signal_semaphore()
 {
-  ACE_OS::sema_post(&read_task_->semaphore_);
+  if (is_shut_down()) {
+    return;
+  }
+  read_task_->signal_semaphore();
 }
 
 std::string

--- a/dds/DCPS/transport/shmem/ShmemTransport.h
+++ b/dds/DCPS/transport/shmem/ShmemTransport.h
@@ -82,15 +82,17 @@ private:
 
   unique_ptr<ShmemAllocator> alloc_;
 
-  struct ReadTask : ACE_Task_Base {
+  class ReadTask : public ACE_Task_Base {
+  public:
     ReadTask(ShmemTransport* outer, ACE_sema_t semaphore);
     int svc();
     void stop();
+    void signal_semaphore();
 
+  private:
     ShmemTransport* outer_;
     ACE_sema_t semaphore_;
     bool stopped_;
-
   };
   unique_ptr<ReadTask> read_task_;
 };

--- a/tests/DCPS/SharedTransport/shmem.ini
+++ b/tests/DCPS/SharedTransport/shmem.ini
@@ -3,4 +3,4 @@ DCPSGlobalTransportConfig=$file
 
 [transport/shmem1]
 transport_type=shmem
-datalink_control_size=8192
+datalink_control_size=10000


### PR DESCRIPTION
Primary Issue: We can't be sure of publisher write speed vs reader read speed and the shmem transport doesn't have backpressure, so the shared memory segment needs to be able to hold the entire 100 messages or there's always the potential that the writer will fill the segment. A better solution would be to implement real checks for backpressure, but is beyond the scope of this change.

Solution: Increase test memory segment to accommodate 100 messages.

Secondary Issue: Occasional SEGV due to reads during shutdown. Introduce locking around shutdown and allocator acquisition, and introduce additional checks in send and receive strategies after they've grabbed a pointer to the allocator. We will eventually want to migrate this to use RCH rather than straight pointers in case it gets deleted while the strategy is interacting with it, but again that's beyond the scope of this change and will probably only (rarely) cause issues during shutdown.