### PR TITLE
Resolve SetQosPartition Errors

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -372,8 +372,8 @@ private:
 
   protected:
     void gather_ack_nacks_i(MetaSubmessageVec& meta_submessages, bool finalFlag = false);
-    void generate_nack_frags(NackFragSubmessageVec& nack_frags,
-                             WriterInfo& wi, const RepoId& pub_id);
+    void generate_nack_frags_i(NackFragSubmessageVec& nack_frags,
+                               WriterInfo& wi, const RepoId& pub_id);
 
     mutable ACE_Thread_Mutex mutex_;
     WeakRcHandle<RtpsUdpDataLink> link_;

--- a/tests/DCPS/SetQosPartition/publisher.cpp
+++ b/tests/DCPS/SetQosPartition/publisher.cpp
@@ -111,7 +111,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
         OpenDDS::DCPS::unique_ptr<Writer> writer (new Writer (dw.in ()));
 
         cout << "Pub waiting for match on A partition." << std::endl;
-        if (OpenDDS::Model::WriterSync::wait_match(dw)) {
+        if (OpenDDS::Model::WriterSync::wait_match(dw, 1)) {
           cerr << "Error waiting for match on A partition" << std::endl;
           return 1;
         }
@@ -163,7 +163,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
         OpenDDS::DCPS::unique_ptr<Writer> writer (new Writer (dw.in ()));
 
         cout << "Pub waiting for match on B partition." << std::endl;
-        if (OpenDDS::Model::WriterSync::wait_match(dw)) {
+        if (OpenDDS::Model::WriterSync::wait_match(dw, 1)) {
           cerr << "Error waiting for match on B partition" << std::endl;
           return 1;
         }
@@ -196,6 +196,11 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
       {
         OpenDDS::DCPS::unique_ptr<Writer> writer (new Writer (dw.in ()));
 
+        cout << "Pub waiting for additional match on B partition." << std::endl;
+        if (OpenDDS::Model::WriterSync::wait_match(dw, 2)) {
+          cerr << "Error waiting for additional match on B partition" << std::endl;
+          return 1;
+        }
         attempts = 1;
         while (attempts != max_attempts)
         {


### PR DESCRIPTION
Discovered SEGV issues due to concurrent access of the receive strategy during send_final_acks() and shutdown. Protect interactions with RtpsUdpDataLink::receive_strategy_ by locking the strategy_lock_ (which is already locked during shutdown).