### PR TITLE
fixing topic reliability for multitopic test

### DIFF
--- a/tests/DCPS/MultiTopic/MultiTopicTest.cpp
+++ b/tests/DCPS/MultiTopic/MultiTopicTest.cpp
@@ -66,6 +66,7 @@ struct Writer {
     TopicQos topic_qos;
     other_participant->get_default_topic_qos(topic_qos);
     topic_qos.latency_budget.duration.sec = 1;
+    topic_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
     Topic_var topic2 = other_participant->create_topic(topic_name, type_name,
       topic_qos, 0, DEFAULT_STATUS_MASK);
 


### PR DESCRIPTION
Issue: MultiTopic datareaders create individual datareaders based on the default topic qos for their constituent topics. Since the topic qos was not specified, it resorted to best effort, meaning that the waits for publications matched were not guaranteed to work.

Solution, set the topic qos for the constituent topics to reliable.