### PR TITLE
Export RcObject's Symbols

### DIFF
--- a/dds/DCPS/RcObject.h
+++ b/dds/DCPS/RcObject.h
@@ -50,7 +50,7 @@ namespace DCPS {
     bool expired_;
   };
 
-  class RcObject : public PoolAllocationBase {
+  class OpenDDS_Dcps_Export RcObject : public PoolAllocationBase {
   public:
 
     virtual ~RcObject(){

--- a/dds/DCPS/RcObject.h
+++ b/dds/DCPS/RcObject.h
@@ -19,7 +19,7 @@ namespace DCPS {
 
   class RcObject;
 
-  class WeakObject : public PoolAllocationBase
+  class OpenDDS_Dcps_Export WeakObject : public PoolAllocationBase
   {
   public:
     WeakObject(RcObject* ptr)


### PR DESCRIPTION
Export RcObject symbol in order to facilitate WeakRcHandle::lock()'s dynamic_cast (needs typeinfo).