### PR TITLE
Support setting a default Configuration File

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2000,25 +2000,23 @@ Service_Participant::delete_replayer(Replayer_ptr replayer)
   return ret;
 }
 
-DDS::Topic_ptr
-Service_Participant::create_typeless_topic(
+DDS::Topic_ptr Service_Participant::create_typeless_topic(
   DDS::DomainParticipant_ptr participant,
-  const char * topic_name,
-  const char * type_name,
+  const char* topic_name,
+  const char* type_name,
   bool type_has_keys,
-  const DDS::TopicQos & qos,
+  const DDS::TopicQos& qos,
   DDS::TopicListener_ptr a_listener,
   DDS::StatusMask mask)
 {
   DomainParticipantImpl* participant_servant = dynamic_cast<DomainParticipantImpl*>(participant);
-  if (! participant_servant) {
+  if (!participant_servant) {
     return 0;
   }
   return participant_servant->create_typeless_topic(topic_name, type_name, type_has_keys, qos, a_listener, mask);
 }
 
-void
-Service_Participant::default_configuration_file(const ACE_TCHAR* path)
+void Service_Participant::default_configuration_file(const ACE_TCHAR* path)
 {
   default_configuration_file_ = path;
 }

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -198,7 +198,8 @@ Service_Participant::Service_Participant()
 #endif
     bidir_giop_(true),
     monitor_enabled_(false),
-    shut_down_(false)
+    shut_down_(false),
+    default_configuration_file_(ACE_TEXT(""))
 {
   initialize();
 }
@@ -351,7 +352,11 @@ Service_Participant::get_domain_participant_factory(int &argc,
         return DDS::DomainParticipantFactory::_nil();
       }
 
-      if (config_fname == ACE_TEXT("")) {
+      if (config_fname.is_empty() && !default_configuration_file_.is_empty()) {
+        config_fname = default_configuration_file_;
+      }
+
+      if (config_fname.is_empty()) {
         if (DCPS_debug_level) {
           ACE_DEBUG((LM_NOTICE,
                      ACE_TEXT("(%P|%t) NOTICE: not using file configuration - no configuration ")
@@ -1996,19 +2001,26 @@ Service_Participant::delete_replayer(Replayer_ptr replayer)
 }
 
 DDS::Topic_ptr
-Service_Participant::create_typeless_topic(DDS::DomainParticipant_ptr participant,
-                                     const char * topic_name,
-                                     const char * type_name,
-                                     bool type_has_keys,
-                                     const DDS::TopicQos & qos,
-                                     DDS::TopicListener_ptr a_listener,
-                                     DDS::StatusMask mask)
+Service_Participant::create_typeless_topic(
+  DDS::DomainParticipant_ptr participant,
+  const char * topic_name,
+  const char * type_name,
+  bool type_has_keys,
+  const DDS::TopicQos & qos,
+  DDS::TopicListener_ptr a_listener,
+  DDS::StatusMask mask)
 {
   DomainParticipantImpl* participant_servant = dynamic_cast<DomainParticipantImpl*>(participant);
   if (! participant_servant) {
     return 0;
   }
   return participant_servant->create_typeless_topic(topic_name, type_name, type_has_keys, qos, a_listener, mask);
+}
+
+void
+Service_Participant::default_configuration_file(const ACE_TCHAR* path)
+{
+  default_configuration_file_ = path;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -386,6 +386,13 @@ public:
   void configure_pool();
 #endif
 
+  /**
+   * Set a configuration file to use if -DCPSConfigFile wasn't passed to
+   * TheParticipantFactoryWithArgs. Must be used before
+   * TheParticipantFactory*() functions are called.
+   */
+  void default_configuration_file(const ACE_TCHAR* path);
+
 private:
 
   /// Initialize default qos.
@@ -608,13 +615,19 @@ private:
   ACE_Recursive_Thread_Mutex maps_lock_;
 
   static int zero_argc;
+
+  /**
+   * If set before TheParticipantFactoryWithArgs and -DCPSConfigFile is not
+   * passed, use this as the configuration file.
+   */
+  ACE_TString default_configuration_file_;
 };
 
-#   define TheServiceParticipant OpenDDS::DCPS::Service_Participant::instance()
+#define TheServiceParticipant OpenDDS::DCPS::Service_Participant::instance()
 
-#   define TheParticipantFactory TheServiceParticipant->get_domain_participant_factory()
+#define TheParticipantFactory TheServiceParticipant->get_domain_participant_factory()
 
-#   define TheParticipantFactoryWithArgs(argc, argv) TheServiceParticipant->get_domain_participant_factory(argc, argv)
+#define TheParticipantFactoryWithArgs(argc, argv) TheServiceParticipant->get_domain_participant_factory(argc, argv)
 
 } // namespace DCPS
 } // namespace OpenDDS


### PR DESCRIPTION
One of two changes I'm bringing over from bench.

It lets someone set a default for `DCPSConfigFile` that will be used if `-DCPSConfigFile` was not passed to `TheParticipantFactoryWithArgs` or if `TheParticipantFactory` was called. Of course this means it must be called before `TheParticipantFactory(WithArgs)`. If this is not used at all, then OpenDDS will initialize normally.

Here is an example of how I'm using it in the bench test controller application:

```C++
  TheServiceParticipant->default_configuration_file(
    ACE_TEXT_CHAR_TO_TCHAR(join_path(bench_root, "control_opendds_config.ini").c_str()));
```