### PR TITLE
Using Typedefs of Structs as Keys

### DIFF
--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -870,11 +870,7 @@ namespace {
     for (size_t i = 0; i < fields.size(); ++i) {
       string field_name = fields[i]->local_name()->get_string();
       if (field_name == key_base) {
-        AST_Type* field_type = fields[i]->field_type();
-        AST_Typedef* typedef_node = dynamic_cast<AST_Typedef*>(field_type);
-        if (typedef_node) {
-          field_type = typedef_node->primitive_base_type();
-        }
+        AST_Type* field_type = resolveActualType(fields[i]->field_type());
         if (!is_array && key_rem.empty()) {
           // The requested key field matches this one.  We do not allow
           // arrays (must be indexed specifically) or structs (must

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -871,6 +871,10 @@ namespace {
       string field_name = fields[i]->local_name()->get_string();
       if (field_name == key_base) {
         AST_Type* field_type = fields[i]->field_type();
+        AST_Typedef* typedef_node = dynamic_cast<AST_Typedef*>(field_type);
+        if (typedef_node) {
+          field_type = typedef_node->primitive_base_type();
+        }
         if (!is_array && key_rem.empty()) {
           // The requested key field matches this one.  We do not allow
           // arrays (must be indexed specifically) or structs (must
@@ -879,23 +883,14 @@ namespace {
           if (sub_struct != 0) {
             throw string("Structs not allowed as keys");
           }
-          AST_Typedef* typedef_node = dynamic_cast<AST_Typedef*>(field_type);
-          if (typedef_node != 0) {
-            AST_Array* array_node =
-              dynamic_cast<AST_Array*>(typedef_node->base_type());
-            if (array_node != 0) {
-              throw string("Arrays not allowed as keys");
-            }
+          AST_Array* array_node = dynamic_cast<AST_Array*>(field_type);
+          if (array_node != 0) {
+            throw string("Arrays not allowed as keys");
           }
           return field_type;
         } else if (is_array) {
           // must be a typedef of an array
-          AST_Typedef* typedef_node = dynamic_cast<AST_Typedef*>(field_type);
-          if (typedef_node == 0) {
-            throw string("Indexing for non-array type");
-          }
-          AST_Array* array_node =
-            dynamic_cast<AST_Array*>(typedef_node->base_type());
+          AST_Array* array_node = dynamic_cast<AST_Array*>(field_type);
           if (array_node == 0) {
             throw string("Indexing for non-array type");
           }

--- a/tests/DCPS/Compiler/annotations/topic_annotations_test_lib/topic_annotations_test.idl
+++ b/tests/DCPS/Compiler/annotations/topic_annotations_test_lib/topic_annotations_test.idl
@@ -36,7 +36,7 @@ module TopicAnnotationsTest {
   typedef SimpleKeyStruct MyStructTypedef;
   @topic
   struct TypedefStructKeyStruct {
-    long a_key_value;
+    @key long a_key_value;
     @key MyStructTypedef my_struct_typedef_key;
   };
 

--- a/tests/DCPS/Compiler/annotations/topic_annotations_test_lib/topic_annotations_test.idl
+++ b/tests/DCPS/Compiler/annotations/topic_annotations_test_lib/topic_annotations_test.idl
@@ -30,6 +30,17 @@ module TopicAnnotationsTest {
   };
 
   /*
+   * Using a Typedef of a Struct as a Key
+   * 2 Keys
+   */
+  typedef SimpleKeyStruct MyStructTypedef;
+  @topic
+  struct TypedefStructKeyStruct {
+    long a_key_value;
+    @key MyStructTypedef my_struct_typedef_key;
+  };
+
+  /*
    * Case of an Array of Primitives
    * 2 Keys
    */

--- a/tests/DCPS/Compiler/annotations/topic_annotations_test_main/main.cpp
+++ b/tests/DCPS/Compiler/annotations/topic_annotations_test_main/main.cpp
@@ -7,27 +7,27 @@
 
 using namespace TopicAnnotationsTest;
 
-template <typename T> OpenDDS::DCPS::DDSTraits<T>&
-get_traits()
+template <typename T>
+OpenDDS::DCPS::DDSTraits<T>& get_traits()
 {
   static OpenDDS::DCPS::DDSTraits<T> traits;
   return traits;
 }
 
-template <typename T> const char*
-get_type_name()
+template <typename T>
+const char* get_type_name()
 {
   return get_traits<T>().type_name();
 }
 
-template <typename T> size_t
-get_key_count()
+template <typename T>
+size_t get_key_count()
 {
   return get_traits<T>().key_count();
 }
 
-template <typename T> bool
-assert_key_count(size_t expected)
+template <typename T>
+bool assert_key_count(size_t expected)
 {
   size_t count = get_key_count<T>();
   if (count != expected) {
@@ -41,8 +41,8 @@ assert_key_count(size_t expected)
   return false;
 }
 
-template <typename T> size_t
-find_size(const T& data, size_t& padding)
+template <typename T>
+size_t find_size(const T& data, size_t& padding)
 {
   size_t size = 0;
   padding = 0;
@@ -50,8 +50,8 @@ find_size(const T& data, size_t& padding)
   return size;
 }
 
-template <typename Type> bool
-assert_key_only_size(const Type& data, size_t expected)
+template <typename Type>
+bool assert_key_only_size(const Type& data, size_t expected)
 {
   typedef OpenDDS::DCPS::KeyOnly<const Type> KeyOnlyType;
   KeyOnlyType key_only_data(data);
@@ -69,8 +69,7 @@ assert_key_only_size(const Type& data, size_t expected)
   return false;
 }
 
-int
-ACE_TMAIN(int, ACE_TCHAR**)
+int ACE_TMAIN(int, ACE_TCHAR**)
 {
   bool failed = false;
 
@@ -78,6 +77,7 @@ ACE_TMAIN(int, ACE_TCHAR**)
   failed |= assert_key_count<UnkeyedStruct>(0);
   failed |= assert_key_count<SimpleKeyStruct>(1);
   failed |= assert_key_count<NestedKeyStruct>(2);
+  failed |= assert_key_count<TypedefStructKeyStruct>(2);
   failed |= assert_key_count<LongArrayStruct>(2);
   failed |= assert_key_count<SimpleKeyArray>(2);
   failed |= assert_key_count<UnkeyedUnion>(0);

--- a/tests/DCPS/Compiler/idl_test_nested_types_lib/NestedTypesTest.idl
+++ b/tests/DCPS/Compiler/idl_test_nested_types_lib/NestedTypesTest.idl
@@ -36,4 +36,15 @@ module NestedTypesTest {
   struct KeyInNestedArray {
     ArrayOfDotSeparatedKey dots_;
   };
+
+  struct StructWithValue {
+    short value;
+  };
+  typedef StructWithValue MyStructTypedef;
+
+#pragma DCPS_DATA_TYPE "NestedTypesTest::TypedefStructKeyStruct"
+#pragma DCPS_DATA_KEY  "NestedTypesTest::TypedefStructKeyStruct my_struct_typedef_key.value"
+  struct TypedefStructKeyStruct {
+    MyStructTypedef my_struct_typedef_key;
+  };
 };


### PR DESCRIPTION
This was the other change I made in bench that I wanted to bring over. It allows typedefs of structs to be keys. The problem is that it doesn't seem to be a problem with annotations, only pragmas, but I added a annotation test anyway.