### PR TITLE
Add option for disabling builtin SEDP writers

### DIFF
--- a/dds/DCPS/RTPS/BaseMessageUtils.cpp
+++ b/dds/DCPS/RTPS/BaseMessageUtils.cpp
@@ -107,6 +107,7 @@ void locators_to_blob(const DCPS::LocatorSeq& locators,
 MessageParser::MessageParser(const ACE_Message_Block& in)
   : in_(in.duplicate())
   , ser_(in_.get(), false, DCPS::Serializer::ALIGN_CDR)
+  , header_()
   , sub_()
   , smContentStart_(0)
 {}
@@ -114,6 +115,7 @@ MessageParser::MessageParser(const ACE_Message_Block& in)
 MessageParser::MessageParser(const DDS::OctetSeq& in)
   : fromSeq_(reinterpret_cast<const char*>(in.get_buffer()), in.length())
   , ser_(&fromSeq_, false, DCPS::Serializer::ALIGN_CDR)
+  , header_()
   , sub_()
   , smContentStart_(0)
 {

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -29,6 +29,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace RTPS {
 
+const char RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS[] = "OpenDDS.RtpsDiscovery.EndpointAnnouncements";
+
 /**
  * @class RtpsDiscovery
  *

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -353,23 +353,31 @@ Sedp::init(const RepoId& guid,
   const bool besteffort = false, nondurable = false;
 #endif
 
-  publications_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  if (spdp_.available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
+    publications_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  }
   publications_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 
 #ifdef OPENDDS_SECURITY
   publications_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   publications_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  publications_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  if (spdp_.available_builtin_endpoints() & DDS::Security::SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+    publications_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  }
   publications_secure_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 #endif
 
-  subscriptions_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  if (spdp_.available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
+    subscriptions_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  }
   subscriptions_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 
 #ifdef OPENDDS_SECURITY
   subscriptions_secure_writer_.set_crypto_handles(spdp_.crypto_handle());
   subscriptions_secure_reader_->set_crypto_handles(spdp_.crypto_handle());
-  subscriptions_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  if (spdp_.available_builtin_endpoints() & DDS::Security::SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+    subscriptions_secure_writer_.enable_transport_using_config(reliable, durable, transport_cfg_);
+  }
   subscriptions_secure_reader_->enable_transport_using_config(reliable, durable, transport_cfg_);
 #endif
 
@@ -959,7 +967,8 @@ void Sedp::associate_secure_readers_to_writers(const Security::SPDPdiscoveredPar
       peer.remote_data_, dcps_participant_secure_writer_.get_repo_id(), peer.remote_id_);
     dcps_participant_secure_writer_.assoc(peer);
   }
-  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+  if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
     remote_reader_crypto_handles_[peer.remote_id_] = generate_remote_matched_reader_crypto_handle(
@@ -968,7 +977,8 @@ void Sedp::associate_secure_readers_to_writers(const Security::SPDPdiscoveredPar
       peer.remote_data_, publications_secure_writer_.get_repo_id(), peer.remote_id_);
     publications_secure_writer_.assoc(peer);
   }
-  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+  if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
     remote_reader_crypto_handles_[peer.remote_id_] = generate_remote_matched_reader_crypto_handle(
@@ -1081,12 +1091,14 @@ Sedp::send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& 
                                dcps_participant_secure_writer_.get_repo_id());
   }
 
-  if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+  if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
     send_builtin_crypto_tokens(part, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER,
                                publications_secure_writer_.get_repo_id());
   }
 
-  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+  if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
     send_builtin_crypto_tokens(part, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER,
                                subscriptions_secure_writer_.get_repo_id());
   }
@@ -1107,12 +1119,14 @@ Sedp::Task::svc_i(const ParticipantData_t* ppdata)
     pdata->participantProxy.availableBuiltinEndpoints;
 
   // See RTPS v2.1 section 8.5.5.1
-  if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
+  if (spdp_->available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER &&
+      avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
     sedp_->publications_writer_.assoc(peer);
   }
-  if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
+  if (spdp_->available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER &&
+      avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
     sedp_->subscriptions_writer_.assoc(peer);
@@ -1194,13 +1208,17 @@ Sedp::disassociate(const ParticipantData_t& pdata)
     ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
     ACE_GUARD_RETURN(ACE_Reverse_Lock< ACE_Thread_Mutex>, rg, rev_lock, false);
 
-    disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR, part,
-      ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER, publications_writer_);
+    if (spdp_.available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
+      disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR, part,
+                          ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER, publications_writer_);
+    }
     disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER, part,
       ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER, *publications_reader_);
 
-    disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR, part,
-      ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER, subscriptions_writer_);
+    if (spdp_.available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
+      disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR, part,
+                          ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER, subscriptions_writer_);
+    }
     disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER, part,
       ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER, *subscriptions_reader_);
 
@@ -1214,13 +1232,17 @@ Sedp::disassociate(const ParticipantData_t& pdata)
 #ifdef OPENDDS_SECURITY
     using namespace DDS::Security;
 
-    disassociate_helper(avail, SEDP_BUILTIN_PUBLICATIONS_SECURE_READER, part,
-      ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER, publications_secure_writer_);
+    if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+      disassociate_helper(avail, SEDP_BUILTIN_PUBLICATIONS_SECURE_READER, part,
+                          ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER, publications_secure_writer_);
+    }
     disassociate_helper(avail, SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER, part,
       ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER, *publications_secure_reader_);
 
-    disassociate_helper(avail, SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER, part,
-      ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER, subscriptions_secure_writer_);
+    if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+      disassociate_helper(avail, SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER, part,
+                          ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER, subscriptions_secure_writer_);
+    }
     disassociate_helper(avail, SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER, part,
       ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER, *subscriptions_secure_reader_);
 
@@ -1426,6 +1448,14 @@ Sedp::update_topic_qos(const RepoId& topicId, const DDS::TopicQos& qos)
 DDS::ReturnCode_t
 Sedp::remove_publication_i(const RepoId& publicationId, LocalPublication& pub)
 {
+  if (!(spdp_.available_builtin_endpoints() & (DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER
+#ifdef OPENDDS_SECURITY
+                                               | DDS::Security::SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER
+#endif
+                                               ))) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
 #ifdef OPENDDS_SECURITY
   ICE::Endpoint* endpoint = pub.publication_->get_ice_endpoint();
   if (endpoint) {
@@ -1474,6 +1504,14 @@ DDS::ReturnCode_t
 Sedp::remove_subscription_i(const RepoId& subscriptionId,
                             LocalSubscription& sub)
 {
+  if (!(spdp_.available_builtin_endpoints() & (DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER
+#ifdef OPENDDS_SECURITY
+                                               | DDS::Security::SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER
+#endif
+                                               ))) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
 #ifdef OPENDDS_SECURITY
   ICE::Endpoint* endpoint = sub.subscription_->get_ice_endpoint();
   if (endpoint) {
@@ -3350,6 +3388,14 @@ Sedp::populate_discovered_reader_msg(
 void
 Sedp::write_durable_publication_data(const RepoId& reader, bool secure)
 {
+  if (!(spdp_.available_builtin_endpoints() & (DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER
+#ifdef OPENDDS_SECURITY
+                                               | DDS::Security::SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER
+#endif
+                                               ))) {
+    return;
+  }
+
   if (secure) {
 #ifdef OPENDDS_SECURITY
     LocalPublicationIter pub, end = local_publications_.end();
@@ -3378,6 +3424,14 @@ Sedp::write_durable_publication_data(const RepoId& reader, bool secure)
 void
 Sedp::write_durable_subscription_data(const RepoId& reader, bool secure)
 {
+  if (!(spdp_.available_builtin_endpoints() & (DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER
+#ifdef OPENDDS_SECURITY
+                                               | DDS::Security::SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER
+#endif
+                                               ))) {
+    return;
+  }
+
   if (secure) {
 #ifdef OPENDDS_SECURITY
     LocalSubscriptionIter sub, end = local_subscriptions_.end();
@@ -3500,6 +3554,10 @@ Sedp::write_publication_data_unsecure(
     LocalPublication& lp,
     const RepoId& reader)
 {
+  if (!(spdp_.available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER)) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
@@ -3544,6 +3602,10 @@ Sedp::write_publication_data_secure(
     LocalPublication& lp,
     const RepoId& reader)
 {
+  if (!(spdp_.available_builtin_endpoints() & DDS::Security::SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER)) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
@@ -3635,6 +3697,10 @@ Sedp::write_subscription_data_unsecure(
     LocalSubscription& ls,
     const RepoId& reader)
 {
+  if (!(spdp_.available_builtin_endpoints() & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER)) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
@@ -3678,6 +3744,10 @@ Sedp::write_subscription_data_secure(
     LocalSubscription& ls,
     const RepoId& reader)
 {
+  if (!(spdp_.available_builtin_endpoints() & DDS::Security::SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER)) {
+    return DDS::RETCODE_PRECONDITION_NOT_MET;
+  }
+
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -141,6 +141,8 @@ public:
 
   void schedule_send(const DCPS::TimeDuration& delay);
 
+  BuiltinEndpointSet_t available_builtin_endpoints() const { return available_builtin_endpoints_; }
+
 protected:
   Sedp& endpoint_manager() { return sedp_; }
 
@@ -229,6 +231,7 @@ private:
   void remove_expired_participants();
   void get_discovered_participant_ids(DCPS::RepoIdSet& results) const;
 
+  BuiltinEndpointSet_t available_builtin_endpoints_;
   Sedp sedp_;
   // wait for acknowledgments from SpdpTransport and Sedp::Task
   // when BIT is being removed (fini_bit)

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -33,6 +33,9 @@
 #ifdef OPENDDS_SECURITY
 #include <dds/DCPS/security/framework/Properties.h>
 #include <dds/DCPS/security/framework/SecurityRegistry.h>
+#endif
+
+using namespace RtpsRelay;
 
 namespace {
   void append(DDS::PropertySeq& props, const char* name, const std::string& value, bool propagate = false)
@@ -46,13 +49,7 @@ namespace {
       ACE_ERROR((LM_ERROR, "Exception caught when appending parameter\n"));
     }
   }
-}
 
-#endif
-
-using namespace RtpsRelay;
-
-namespace {
   ACE_INET_Addr get_bind_addr(unsigned short port)
   {
     std::vector<ACE_INET_Addr> nics;
@@ -191,9 +188,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::DomainParticipantQos participant_qos;
   factory->get_default_participant_qos(participant_qos);
 
+  DDS::PropertySeq& properties = participant_qos.property.value;
+  append(properties, "OpenDDS.Rtps.Discovery.DisableWriters", "true");
+
 #ifdef OPENDDS_SECURITY
   if (secure) {
-    DDS::PropertySeq& properties = participant_qos.property.value;
     append(properties, DDS::Security::Properties::AuthIdentityCA, identity_ca_file);
     append(properties, DDS::Security::Properties::AccessPermissionsCA, permissions_ca_file);
     append(properties, DDS::Security::Properties::AuthIdentityCertificate, identity_certificate_file);

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -189,7 +189,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   factory->get_default_participant_qos(participant_qos);
 
   DDS::PropertySeq& properties = participant_qos.property.value;
-  append(properties, "OpenDDS.Rtps.Discovery.DisableWriters", "true");
+  append(properties, OpenDDS::RTPS::RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS, "false");
 
 #ifdef OPENDDS_SECURITY
   if (secure) {


### PR DESCRIPTION
This allows the application participant in the RtpsRelay to not send heartbeats and other writer messages.