### PR TITLE
Add Thrasher Test for rtps_udp transport, Fix WaitForAck & Durability Issues It Exposed

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -276,13 +276,12 @@ tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS
-# Need investigation
-# tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN !LYNXOS
-# tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN !LYNXOS
-# tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN !LYNXOS
-# tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN !LYNXOS
-# tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN !LYNXOS
-# tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -271,12 +271,16 @@ tests/DCPS/WaitForAck/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/WaitForAck/run_test.pl --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/WaitForAck/run_test.pl rtps --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl single: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl double: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS
 tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl double rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS

--- a/configure
+++ b/configure
@@ -25,7 +25,7 @@ use warnings;
 ## Version of OCI's TAO to download
 my $oci_tao_version = '2.2a';
 ## Version of DOC Group ACE/TAO to download, uses the ACE version number
-my $doc_tao_version = '6.5.6';
+my $doc_tao_version = '6.5.7';
 
 my $backup_timestamp = strftime "%Y-%m-%d-%H-%M-%S", localtime time;
 

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -78,7 +78,7 @@ DomainParticipantFactoryImpl::create_participant(
     }
   }
 
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
+  ACE_GUARD_RETURN(ACE_Thread_Mutex,
                    tao_mon,
                    participants_protector_,
                    DDS::DomainParticipant::_nil());
@@ -135,7 +135,7 @@ DomainParticipantFactoryImpl::delete_participant(
   DPSet* entry = 0;
 
   {
-    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
+    ACE_GUARD_RETURN(ACE_Thread_Mutex,
                      tao_mon,
                      participants_protector_,
                      DDS::RETCODE_ERROR);
@@ -197,7 +197,7 @@ DDS::DomainParticipant_ptr
 DomainParticipantFactoryImpl::lookup_participant(
   DDS::DomainId_t domainId)
 {
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
+  ACE_GUARD_RETURN(ACE_Thread_Mutex,
                    tao_mon,
                    participants_protector_,
                    DDS::DomainParticipant::_nil());
@@ -274,10 +274,10 @@ DomainParticipantFactoryImpl::get_qos(
   return DDS::RETCODE_OK;
 }
 
-DomainParticipantFactoryImpl::DPMap
+const DomainParticipantFactoryImpl::DPMap
 DomainParticipantFactoryImpl::participants() const
 {
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
+  ACE_GUARD_RETURN(ACE_Thread_Mutex,
                    tao_mon,
                    participants_protector_,
                    DomainParticipantFactoryImpl::DPMap());
@@ -287,7 +287,7 @@ DomainParticipantFactoryImpl::participants() const
 
 void DomainParticipantFactoryImpl::cleanup()
 {
-  ACE_GUARD(ACE_Recursive_Thread_Mutex,
+  ACE_GUARD(ACE_Thread_Mutex,
             tao_mon,
             participants_protector_);
 

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -80,7 +80,7 @@ DomainParticipantFactoryImpl::create_participant(
 
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    tao_mon,
-                   this->participants_protector_,
+                   participants_protector_,
                    DDS::DomainParticipant::_nil());
 
   participants_[domainId].insert(dp);
@@ -134,46 +134,48 @@ DomainParticipantFactoryImpl::delete_participant(
 
   DPSet* entry = 0;
 
-  if (find(participants_, domain_id, entry) == -1) {
-    GuidConverter converter(dp_id);
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: ")
-                      ACE_TEXT("DomainParticipantFactoryImpl::delete_participant: ")
-                      ACE_TEXT("%p domain_id=%d dp_id=%C.\n"),
-                      ACE_TEXT("find"),
-                      domain_id,
-                      OPENDDS_STRING(converter).c_str()), DDS::RETCODE_ERROR);
-
-  } else {
+  {
     ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                      tao_mon,
-                     this->participants_protector_,
+                     participants_protector_,
                      DDS::RETCODE_ERROR);
 
-    DDS::ReturnCode_t result
-    = the_servant->delete_contained_entities();
-
-    if (result != DDS::RETCODE_OK) {
-      return result;
-    }
-
-    if (OpenDDS::DCPS::remove(*entry, servant_rch) == -1) {
+    if (find(participants_, domain_id, entry) == -1) {
+      GuidConverter converter(dp_id);
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: ")
-                        ACE_TEXT("DomainParticipantFactoryImpl::delete_participant, ")
-                        ACE_TEXT(" %p.\n"),
-                        ACE_TEXT("remove")),
-                       DDS::RETCODE_ERROR);
-    }
+                        ACE_TEXT("DomainParticipantFactoryImpl::delete_participant: ")
+                        ACE_TEXT("%p domain_id=%d dp_id=%C.\n"),
+                        ACE_TEXT("find"),
+                        domain_id,
+                        OPENDDS_STRING(converter).c_str()), DDS::RETCODE_ERROR);
 
-    if (entry->empty()) {
-      if (unbind(participants_, domain_id) == -1) {
+    } else {
+      DDS::ReturnCode_t result
+      = the_servant->delete_contained_entities();
+
+      if (result != DDS::RETCODE_OK) {
+        return result;
+      }
+
+      if (OpenDDS::DCPS::remove(*entry, servant_rch) == -1) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("(%P|%t) ERROR: ")
                           ACE_TEXT("DomainParticipantFactoryImpl::delete_participant, ")
                           ACE_TEXT(" %p.\n"),
-                          ACE_TEXT("unbind")),
+                          ACE_TEXT("remove")),
                          DDS::RETCODE_ERROR);
+      }
+
+      if (entry->empty()) {
+        if (unbind(participants_, domain_id) == -1) {
+          ACE_ERROR_RETURN((LM_ERROR,
+                            ACE_TEXT("(%P|%t) ERROR: ")
+                            ACE_TEXT("DomainParticipantFactoryImpl::delete_participant, ")
+                            ACE_TEXT(" %p.\n"),
+                            ACE_TEXT("unbind")),
+                           DDS::RETCODE_ERROR);
+        }
       }
     }
   }
@@ -197,7 +199,7 @@ DomainParticipantFactoryImpl::lookup_participant(
 {
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    tao_mon,
-                   this->participants_protector_,
+                   participants_protector_,
                    DDS::DomainParticipant::_nil());
 
   DPSet* entry;
@@ -272,14 +274,23 @@ DomainParticipantFactoryImpl::get_qos(
   return DDS::RETCODE_OK;
 }
 
-const DomainParticipantFactoryImpl::DPMap&
+DomainParticipantFactoryImpl::DPMap
 DomainParticipantFactoryImpl::participants() const
 {
-  return this->participants_;
+  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
+                   tao_mon,
+                   participants_protector_,
+                   DomainParticipantFactoryImpl::DPMap());
+
+  return participants_;
 }
 
 void DomainParticipantFactoryImpl::cleanup()
 {
+  ACE_GUARD(ACE_Recursive_Thread_Mutex,
+            tao_mon,
+            participants_protector_);
+
   DPMap::iterator itr;
   for (itr = participants_.begin(); itr != participants_.end(); ++itr) {
     DPSet& dp_set = itr->second;

--- a/dds/DCPS/DomainParticipantFactoryImpl.h
+++ b/dds/DCPS/DomainParticipantFactoryImpl.h
@@ -75,7 +75,7 @@ public:
     DDS::DomainParticipantFactoryQos & qos);
 
   /// Expose the participants for reading.
-  const DPMap& participants() const;
+  DPMap participants() const;
 
   void cleanup();
 
@@ -92,7 +92,7 @@ private:
   /// Protect the participant collection.
   /// Use recursive mutex to allow nested acquisition and
   /// release of a mutex that occurs in the same thread.
-  ACE_Recursive_Thread_Mutex  participants_protector_;
+  mutable ACE_Recursive_Thread_Mutex  participants_protector_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DomainParticipantFactoryImpl.h
+++ b/dds/DCPS/DomainParticipantFactoryImpl.h
@@ -74,8 +74,8 @@ public:
   virtual DDS::ReturnCode_t get_qos(
     DDS::DomainParticipantFactoryQos & qos);
 
-  /// Expose the participants for reading.
-  DPMap participants() const;
+  /// Make a copy of the participants map for reading.
+  const DPMap participants() const;
 
   void cleanup();
 
@@ -84,15 +84,13 @@ private:
   DDS::DomainParticipantFactoryQos qos_;
 
   /// The default qos value of DomainParticipant.
-  DDS::DomainParticipantQos   default_participant_qos_;
+  DDS::DomainParticipantQos default_participant_qos_;
 
   /// The collection of domain participants.
-  DPMap                       participants_;
+  DPMap participants_;
 
   /// Protect the participant collection.
-  /// Use recursive mutex to allow nested acquisition and
-  /// release of a mutex that occurs in the same thread.
-  mutable ACE_Recursive_Thread_Mutex  participants_protector_;
+  mutable ACE_Thread_Mutex participants_protector_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/TopicDetails.h
+++ b/dds/DCPS/TopicDetails.h
@@ -23,6 +23,7 @@ namespace OpenDDS {
     struct TopicDetails {
 
       struct RemoteTopic {
+        RemoteTopic() : data_type_name_(), inconsistent_(false), endpoints_() {}
         OPENDDS_STRING data_type_name_;
         bool inconsistent_;
         RepoIdSet endpoints_;

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1426,6 +1426,12 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& abs_deadline, cons
   DDS::ReturnCode_t ret = DDS::RETCODE_OK;
   ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, guard, this->wfa_lock_, DDS::RETCODE_ERROR);
 
+  SequenceNumber last_acked = acked_sequences_.last_ack();
+  SequenceNumber acked = acked_sequences_.cumulative_ack();
+  if (sequence == last_acked && sequence == acked && sending_data_.size() != 0) {
+    acked_sequences_.insert(sending_data_.head()->get_header().sequence_.previous());
+  }
+
   while (MonotonicTimePoint::now() < deadline) {
 
     if (!sequence_acknowledged(sequence)) {

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -120,10 +120,6 @@ WriteDataContainer::WriteDataContainer(
 
 WriteDataContainer::~WriteDataContainer()
 {
-  ACE_GUARD(ACE_Recursive_Thread_Mutex,
-            guard,
-            lock_);
-
   if (this->unsent_data_.size() > 0) {
     ACE_DEBUG((LM_WARNING,
                ACE_TEXT("(%P|%t) WARNING: WriteDataContainer::~WriteDataContainer() - ")

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -122,7 +122,7 @@ WriteDataContainer::~WriteDataContainer()
 {
   ACE_GUARD(ACE_Recursive_Thread_Mutex,
             guard,
-            this->lock_);
+            lock_);
 
   if (this->unsent_data_.size() > 0) {
     ACE_DEBUG((LM_WARNING,
@@ -373,7 +373,7 @@ WriteDataContainer::dispose(DDS::InstanceHandle_t instance_handle,
 {
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    guard,
-                   this->lock_,
+                   lock_,
                    DDS::RETCODE_ERROR);
 
   PublicationInstance_rch instance;
@@ -427,7 +427,7 @@ WriteDataContainer::num_samples(DDS::InstanceHandle_t handle,
 {
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    guard,
-                   this->lock_,
+                   lock_,
                    DDS::RETCODE_ERROR);
   PublicationInstance_rch instance;
 
@@ -449,7 +449,7 @@ WriteDataContainer::num_all_samples()
 
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    guard,
-                   this->lock_,
+                   lock_,
                    0);
 
   for (PublicationInstanceMapType::iterator iter = instances_.begin();
@@ -542,7 +542,7 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
 
   ACE_GUARD(ACE_Recursive_Thread_Mutex,
             guard,
-            this->lock_);
+            lock_);
 
   // Delivered samples _must_ be on sending_data_ list
 
@@ -616,7 +616,7 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
 
     return;
   }
-  ACE_GUARD(ACE_SYNCH_MUTEX, wfa_guard, this->wfa_lock_);
+  ACE_GUARD(ACE_SYNCH_MUTEX, wfa_guard, wfa_lock_);
   SequenceNumber acked_seq = stale->get_header().sequence_;
   SequenceNumber prev_max = acked_sequences_.cumulative_ack();
 
@@ -718,7 +718,7 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
 
   ACE_GUARD (ACE_Recursive_Thread_Mutex,
     guard,
-    this->lock_);
+    lock_);
 
   // The dropped sample should be in the sending_data_ list.
   // Otherwise an exception will be raised.
@@ -1195,7 +1195,7 @@ WriteDataContainer::unregister_all()
     //the delete_datawriter call which does not acquire the lock in advance.
     ACE_GUARD(ACE_Recursive_Thread_Mutex,
               guard,
-              this->lock_);
+              lock_);
     // Tell transport remove all control messages currently
     // transport is processing.
     (void) this->writer_->remove_all_msgs();
@@ -1374,7 +1374,7 @@ WriteDataContainer::wait_pending()
     timeout_ptr = &timeout_at.value();
   }
 
-  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, lock_);
   const bool report = DCPS_debug_level > 0 && pending_data();
   if (report) {
     if (pending_timeout.is_zero()) {
@@ -1407,7 +1407,7 @@ WriteDataContainer::get_instance_handles(InstanceHandleVec& instance_handles)
 {
   ACE_GUARD(ACE_Recursive_Thread_Mutex,
             guard,
-            this->lock_);
+            lock_);
   PublicationInstanceMapType::iterator it = instances_.begin();
 
   while (it != instances_.end()) {
@@ -1421,8 +1421,8 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& abs_deadline, cons
 {
   const MonotonicTimePoint deadline(abs_deadline);
   DDS::ReturnCode_t ret = DDS::RETCODE_OK;
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, this->lock_, DDS::RETCODE_ERROR);
-  ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, wfa_guard, this->wfa_lock_, DDS::RETCODE_ERROR);
+  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, lock_, DDS::RETCODE_ERROR);
+  ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, wfa_guard, wfa_lock_, DDS::RETCODE_ERROR);
 
   SequenceNumber last_acked = acked_sequences_.last_ack();
   SequenceNumber acked = acked_sequences_.cumulative_ack();

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -288,7 +288,7 @@ public:
    * to remove oldest samples (forcing the transport to drop samples if necessary)
    * to make space.  If there are several threads waiting then
    * the first one in the waiting list can enqueue, others continue
-   * waiting.
+   * waiting. Note: the lock should be held before calling this method
    */
   DDS::ReturnCode_t obtain_buffer(
     DataSampleElement*& element,
@@ -357,7 +357,7 @@ private:
    * Returns if pending data exists.  This includes
    * sending, and unsent data.
    */
-  bool pending_data_i();
+  bool pending_data();
 
   void copy_and_prepend(SendStateDataSampleList& list,
                         const SendStateDataSampleList& appended,

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -249,13 +249,7 @@ public:
    * TRANSIENT_LOCAL_DURABILITY_QOS is used. The data on the list
    * returned is not put on any SendStateDataSampleList.
    */
-  SendStateDataSampleList get_resend_data() ;
-
-  /**
-   * Returns if pending data exists.  This includes
-   * sending, and unsent data.
-   */
-  bool pending_data();
+  SendStateDataSampleList get_resend_data();
 
   /**
    * Acknowledge the delivery of data.  The sample that resides in
@@ -358,6 +352,12 @@ private:
   WriteDataContainer(WriteDataContainer const &);
   WriteDataContainer & operator= (WriteDataContainer const &);
   // --------------------------
+
+  /**
+   * Returns if pending data exists.  This includes
+   * sending, and unsent data.
+   */
+  bool pending_data_i();
 
   void copy_and_prepend(SendStateDataSampleList& list,
                         const SendStateDataSampleList& appended,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1113,6 +1113,10 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
   RtpsUdpDataLink_rch link = link_.lock();
 
+  if (!link) {
+    return false;
+  }
+
   GuardType guard(link->strategy_lock_);
   if (link->receive_strategy() == 0) {
     return false;
@@ -1309,6 +1313,10 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
 
   RtpsUdpDataLink_rch link = link_.lock();
 
+  if (!link) {
+    return false;
+  }
+
   GuardType guard(link->strategy_lock_);
   if (link->receive_strategy() == 0) {
     return false;
@@ -1497,6 +1505,10 @@ RtpsUdpDataLink::RtpsReader::gather_ack_nacks_i(MetaSubmessageVec& meta_submessa
   using namespace OpenDDS::RTPS;
 
   RtpsUdpDataLink_rch link = link_.lock();
+
+  if (!link) {
+    return;
+  }
 
   GuardType guard(link->strategy_lock_);
   if (link->receive_strategy() == 0) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1382,7 +1382,6 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
     }
     if (!durable_) {
       if (wi_first < hb_first) {
-        info.recvd_.insert(SequenceRange(wi_first, hb_first.previous()));
         wi_first = hb_first;
       }
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1350,7 +1350,6 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
   SequenceNumber& wi_first = info.hb_range_.first;
   SequenceNumber& wi_last = info.hb_range_.second;
 
-  // Static Constant
   static const SequenceNumber one, zero = SequenceNumber::ZERO();
 
   bool immediate_reply = false;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -570,8 +570,8 @@ RtpsUdpReceiveStrategy::deliver_from_secure(const RTPS::Submessage& submessage)
   if (Transport_debug_level > 5) {
     ACE_HEX_DUMP((LM_DEBUG, mb.rd_ptr(), mb.length(),
                   category == DATAWRITER_SUBMESSAGE ?
-                  "RtpsUdpReceiveStrategy: decoded writer submessage" :
-                  "RtpsUdpReceiveStrategy: decoded reader submessage"));
+                  ACE_TEXT("RtpsUdpReceiveStrategy: decoded writer submessage") :
+                  ACE_TEXT("RtpsUdpReceiveStrategy: decoded reader submessage")));
   }
 
   RtpsSampleHeader rsh(mb);

--- a/tests/DCPS/Deadline/subscriber.cpp
+++ b/tests/DCPS/Deadline/subscriber.cpp
@@ -212,6 +212,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       // Since there is a whole separate test for testing set_qos, just set these right away
       dr_qos.deadline.period.sec     = DEADLINE_PERIOD.sec;
       dr_qos.deadline.period.nanosec = DEADLINE_PERIOD.nanosec;
+      dr_qos.reliability.kind        = DDS::RELIABLE_RELIABILITY_QOS;
 
       // First data reader will have a listener to test listener
       // callback on deadline expiration.

--- a/tests/DCPS/FooTest5/publisher.cpp
+++ b/tests/DCPS/FooTest5/publisher.cpp
@@ -28,7 +28,7 @@
 #include "tests/DCPS/FooType5/FooDefTypeSupportImpl.h"
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include <dds/DCPS/transport/framework/TransportExceptions.h>
-#include "model/Sync.h"
+#include "tests/Utils/StatusMatching.h"
 
 #include "ace/Arg_Shifter.h"
 #include "ace/OS_NS_unistd.h"
@@ -465,7 +465,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
       for (int i = 0; i < num_datawriters; i ++)
         {
-          OpenDDS::Model::WriterSync::wait_match(dw[i], associations_per_writer);
+          Utils::wait_match(dw[i], associations_per_writer, Utils::GTE);
           writers[i]->start ();
         }
 

--- a/tests/DCPS/LargeSample/Writer.cpp
+++ b/tests/DCPS/LargeSample/Writer.cpp
@@ -12,6 +12,8 @@
 #include <dds/DdsDcpsPublicationC.h>
 #include <dds/DCPS/WaitSet.h>
 
+#include "tests/Utils/StatusMatching.h"
+
 #include "MessengerTypeSupportC.h"
 #include "Writer.h"
 
@@ -25,44 +27,6 @@ Writer::Writer(DDS::DataWriter_ptr writer1, DDS::DataWriter_ptr writer2,
     timeout_writes_(0),
     my_pid_(my_pid)
 {
-}
-
-namespace {
-  void wait_for_match(DDS::DataWriter_ptr writer, bool match = true)
-  {
-    DDS::StatusCondition_var condition = writer->get_statuscondition();
-    condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
-
-    DDS::WaitSet_var ws = new DDS::WaitSet;
-    ws->attach_condition(condition);
-
-    DDS::Duration_t timeout =
-      { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
-
-    DDS::ConditionSeq conditions;
-    DDS::PublicationMatchedStatus matches = {0, 0, 0, 0, 0};
-
-    while (true) {
-      if (writer->get_publication_matched_status(matches) != ::DDS::RETCODE_OK) {
-        ACE_ERROR((LM_ERROR,
-                   ACE_TEXT("%N:%l: wait_for_match()")
-                   ACE_TEXT(" ERROR: get_publication_matched_status failed!\n")));
-        ACE_OS::exit(-1);
-      }
-
-      if (match ? (matches.current_count < 1) : (matches.current_count > 0)) {
-        if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
-          ACE_ERROR((LM_ERROR,
-                     ACE_TEXT("%N:%l: wait_for_match()")
-                     ACE_TEXT(" ERROR: wait failed!\n")));
-          ACE_OS::exit(-1);
-        }
-      } else {
-        break;
-      }
-    }
-    ws->detach_condition(condition);
-  }
 }
 
 void
@@ -82,8 +46,8 @@ Writer::write(bool reliable, int num_messages)
 
   try {
     // Block until Subscriber is available
-    wait_for_match(writer1_);
-    wait_for_match(writer2_);
+    Utils::wait_match(writer1_, 1, Utils::GTE);
+    Utils::wait_match(writer2_, 1, Utils::GTE);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Writers matched\n")));
 
     // Write samples
@@ -193,8 +157,8 @@ Writer::write(bool reliable, int num_messages)
     // Let readers disconnect first, once they either get the data or
     // give up and time-out.  This allows the writer to be alive while
     // processing requests for retransmission from the readers.
-    wait_for_match(writer1_, false);
-    wait_for_match(writer2_, false);
+    Utils::wait_match(writer1_, 0);
+    Utils::wait_match(writer2_, 0);
 
   } catch (const CORBA::Exception& e) {
     e._tao_print_exception("Exception caught in svc():");

--- a/tests/DCPS/ManyTopicMultiProcess/Writer.cpp
+++ b/tests/DCPS/ManyTopicMultiProcess/Writer.cpp
@@ -8,7 +8,7 @@
 #include "ace/Atomic_Op_T.h"
 
 #include "dds/DCPS/Service_Participant.h"
-#include "model/Sync.h"
+#include "tests/Utils/StatusMatching.h"
 
 #include "Foo1DefTypeSupportC.h"
 #include "Foo4DefTypeSupportC.h"
@@ -55,7 +55,7 @@ int Writer::svc()
         !ACE_OS::strcmp(topic_name, MY_TOPIC5) ||
         !ACE_OS::strcmp(topic_name, MY_TOPIC6) ||
         !ACE_OS::strcmp(topic_name, MY_TOPIC7)) {
-      OpenDDS::Model::WriterSync::wait_match(writer_);
+      Utils::wait_match(writer_, 1, Utils::GTE);
 
       ::T1::Foo1 foo;
       foo.x = -1;
@@ -88,7 +88,7 @@ int Writer::svc()
       }
 
     } else if (!ACE_OS::strcmp(topic_name, MY_TOPIC2)) {
-      OpenDDS::Model::WriterSync::wait_match(writer_, 3 /*expected readers*/);
+      Utils::wait_match(writer_, 3 /*expected readers*/, Utils::GTE);
 
       ::T4::Foo4 foo;
       foo.key = ++key;

--- a/tests/DCPS/ManyTopicTest/Writer.cpp
+++ b/tests/DCPS/ManyTopicTest/Writer.cpp
@@ -10,6 +10,7 @@
 #include "tests/DCPS/ManyTopicTypes/Foo1DefTypeSupportC.h"
 #include "tests/DCPS/ManyTopicTypes/Foo2DefTypeSupportC.h"
 #include "tests/DCPS/ManyTopicTypes/Foo3DefTypeSupportC.h"
+#include "tests/Utils/StatusMatching.h"
 
 #include "ace/OS_NS_unistd.h"
 
@@ -38,6 +39,12 @@ Writer::start()
                ACE_TEXT("activate")));
     throw TestException();
   }
+}
+
+int
+Writer::wait_match(const DDS::DataWriter_var& dw, unsigned int count)
+{
+  return Utils::wait_match(dw, count, Utils::GTE);
 }
 
 void

--- a/tests/DCPS/ManyTopicTest/Writer.h
+++ b/tests/DCPS/ManyTopicTest/Writer.h
@@ -5,7 +5,6 @@
 
 #include "dds/DdsDcpsPublicationC.h"
 #include "ace/Task.h"
-#include "model/Sync.h"
 #include "dds/DCPS/TypeSupportImpl.h"
 
 class Writer : public ACE_Task_Base
@@ -21,6 +20,7 @@ public:
   void end();
 
   bool is_finished() const;
+  int wait_match(const DDS::DataWriter_var& dw, unsigned int count);
 
 protected:
 
@@ -75,7 +75,7 @@ int TypedWriter<TSI>::svc()
       CORBA::String_var(topic->get_name()).in()));
 
     const DDS::DataWriter_var dw = DDS::DataWriter::_duplicate(writer_);
-    OpenDDS::Model::WriterSync::wait_match(dw);
+    wait_match(dw, 1);
 
     DSample foo;
     init_instance_(foo, 0);

--- a/tests/DCPS/Rejects/subscriber.cpp
+++ b/tests/DCPS/Rejects/subscriber.cpp
@@ -116,6 +116,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       dr_qos.resource_limits.max_samples_per_instance = MAX_SAMPLES_PER_INSTANCES;
       dr_qos.resource_limits.max_samples = MAX_SAMPLES;
       dr_qos.resource_limits.max_instances = MAX_INSTANCES;
+      dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
       dr_qos.history.kind = ::DDS::KEEP_ALL_HISTORY_QOS;
       dr_qos.history.depth = MAX_SAMPLES_PER_INSTANCES;

--- a/tests/DCPS/SetQosPartition/publisher.cpp
+++ b/tests/DCPS/SetQosPartition/publisher.cpp
@@ -14,9 +14,11 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include <dds/DCPS/Qos_Helper.h>
-#include <tools/modeling/codegen/model/Sync.h>
 #include "dds/DCPS/StaticIncludes.h"
 #include "dds/DCPS/unique_ptr.h"
+
+#include "tests/Utils/StatusMatching.h"
+#include "tests/Utils/ExceptionStreams.h"
 
 #ifdef ACE_AS_STATIC_LIBS
 #include <dds/DCPS/RTPS/RtpsDiscovery.h>
@@ -24,7 +26,6 @@
 #endif
 
 #include <ace/streams.h>
-#include "tests/Utils/ExceptionStreams.h"
 #include "ace/Get_Opt.h"
 #include "ace/OS_NS_unistd.h"
 
@@ -111,7 +112,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
         OpenDDS::DCPS::unique_ptr<Writer> writer (new Writer (dw.in ()));
 
         cout << "Pub waiting for match on A partition." << std::endl;
-        if (OpenDDS::Model::WriterSync::wait_match(dw, 1)) {
+        if (Utils::wait_match(dw, 1, Utils::GTE)) {
           cerr << "Error waiting for match on A partition" << std::endl;
           return 1;
         }
@@ -163,7 +164,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
         OpenDDS::DCPS::unique_ptr<Writer> writer (new Writer (dw.in ()));
 
         cout << "Pub waiting for match on B partition." << std::endl;
-        if (OpenDDS::Model::WriterSync::wait_match(dw, 1)) {
+        if (wait_match(dw, 1, Utils::GTE)) {
           cerr << "Error waiting for match on B partition" << std::endl;
           return 1;
         }
@@ -197,7 +198,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
         OpenDDS::DCPS::unique_ptr<Writer> writer (new Writer (dw.in ()));
 
         cout << "Pub waiting for additional match on B partition." << std::endl;
-        if (OpenDDS::Model::WriterSync::wait_match(dw, 2)) {
+        if (wait_match(dw, 2, Utils::GTE)) {
           cerr << "Error waiting for additional match on B partition" << std::endl;
           return 1;
         }

--- a/tests/DCPS/SetQosPartition/subscriber.cpp
+++ b/tests/DCPS/SetQosPartition/subscriber.cpp
@@ -203,7 +203,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       if (listener_servant1->num_reads() > expected
         || listener_servant2->num_reads() > expected)
       {
-        cerr << "ERROR: received more than expected messages" << endl;
+        cerr << "ERROR: received more (" << listener_servant1->num_reads() << " + " << listener_servant2->num_reads() << ") than expected messages: (" << expected << " + " << expected << ")" << endl;
         exit (1);
       }
 

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -15,7 +15,7 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include <dds/DCPS/Service_Participant.h>
-#include "model/Sync.h"
+#include "tests/Utils/StatusMatching.h"
 
 #include "dds/DCPS/StaticIncludes.h"
 #ifdef ACE_AS_STATIC_LIBS
@@ -199,7 +199,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                          -1);
       }
       // Block until Subscriber is available
-      OpenDDS::Model::WriterSync::wait_match(dw, 1);
+      Utils::wait_match(dw, 1, Utils::GTE);
 
       // Start writing threads
       std::cout << "Creating Writer" << std::endl;

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -6,7 +6,9 @@
 
 DataReaderListenerImpl::DataReaderListenerImpl(std::size_t& received_samples,
                                                const ProgressIndicator& progress)
-  : received_samples_(received_samples),
+  : mutex_(),
+    condition_(mutex_),
+    received_samples_(received_samples),
     progress_(progress)
 {}
 
@@ -37,8 +39,11 @@ DataReaderListenerImpl::on_data_available(
   {
     if (si.valid_data)
     {
+      ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
       ++received_samples_;
       ++progress_;
+      x_and_y_map[(size_t) foo.x].insert((size_t) foo.y);
+      condition_.broadcast();
     }
   }
 }
@@ -78,3 +83,14 @@ DataReaderListenerImpl::on_sample_lost(
     DDS::DataReader_ptr,
     const DDS::SampleLostStatus&)
 {}
+
+bool
+DataReaderListenerImpl::wait_received(const OpenDDS::DCPS::TimeDuration& duration, size_t target)
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
+  const OpenDDS::DCPS::MonotonicTimePoint deadline(OpenDDS::DCPS::MonotonicTimePoint::now() + duration);
+  while (received_samples_ < target && OpenDDS::DCPS::MonotonicTimePoint::now() < deadline) {
+    condition_.wait(&deadline.value());
+  }
+  return received_samples_ >= target;
+}

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -42,7 +42,7 @@ DataReaderListenerImpl::on_data_available(
       ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
       ++received_samples_;
       ++progress_;
-      x_and_y_map[(size_t) foo.x].insert((size_t) foo.y);
+      task_sample_set_map[(size_t) foo.x].insert((size_t) foo.y);
       condition_.broadcast();
     }
   }

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.h
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.h
@@ -6,6 +6,8 @@
 
 #include <dds/DdsDcpsSubscriptionC.h>
 #include <dds/DCPS/LocalObject.h>
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/TimeDuration.h>
 
 #include "ProgressIndicator.h"
 
@@ -15,7 +17,7 @@ class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener>
 {
 public:
-  DataReaderListenerImpl(std::size_t& received_samples,
+  DataReaderListenerImpl(size_t& received_samples,
                          const ProgressIndicator& progress);
 
   virtual ~DataReaderListenerImpl();
@@ -47,10 +49,17 @@ public:
       DDS::DataReader_ptr reader,
       const DDS::SampleLostStatus& status);
 
+  bool
+  wait_received(const OpenDDS::DCPS::TimeDuration& duration, size_t target);
+
+  OPENDDS_MAP(size_t, OPENDDS_SET(size_t)) x_and_y_map;
+
 private:
 
-  std::size_t& received_samples_;
+  mutable ACE_Thread_Mutex mutex_;
+  ACE_Condition<ACE_Thread_Mutex> condition_;
 
+  size_t& received_samples_;
   ProgressIndicator progress_;
 };
 

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.h
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.h
@@ -52,7 +52,7 @@ public:
   bool
   wait_received(const OpenDDS::DCPS::TimeDuration& duration, size_t target);
 
-  OPENDDS_MAP(size_t, OPENDDS_SET(size_t)) x_and_y_map;
+  OPENDDS_MAP(size_t, OPENDDS_SET(size_t)) task_sample_set_map;
 
 private:
 

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -87,8 +87,11 @@ ParticipantTask::svc()
     //DDS::StatusCondition_var cond;
     //DDS::WaitSet_var ws = new DDS::WaitSet;
 
+    int this_thread_index = 0;
     { // Scope for guard to serialize creating Entities.
       GuardType guard(lock_);
+
+      this_thread_index = thread_index_++;
 
       // Create Participant
       participant =
@@ -102,9 +105,8 @@ ParticipantTask::svc()
       OpenDDS::RTPS::RtpsDiscovery_rch rd = OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(disc);
       if (!rd.is_nil()) {
         char config_name[64], inst_name[64];
-        ACE_OS::snprintf(config_name, 64, "cfg_%d", thread_index_);
-        ACE_OS::snprintf(inst_name, 64, "rtps_%d", thread_index_);
-        ++thread_index_;
+        ACE_OS::snprintf(config_name, 64, "cfg_%d", this_thread_index);
+        ACE_OS::snprintf(inst_name, 64, "rtps_%d", this_thread_index);
 
         ACE_DEBUG((LM_INFO,
           "(%P|%t)    -> PARTICIPANT creating transport config %C\n",
@@ -208,6 +210,8 @@ ParticipantTask::svc()
     {
       Foo foo;
       foo.key = 3;
+      foo.x = (float) this_thread_index;
+      foo.y = (float) i;
       DDS::InstanceHandle_t handle = writer_i->register_instance(foo);
 
       if (writer_i->write(foo, handle) != DDS::RETCODE_OK) {

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -104,10 +104,11 @@ ParticipantTask::svc()
       OpenDDS::DCPS::Discovery_rch disc = TheServiceParticipant->get_discovery(42);
       OpenDDS::RTPS::RtpsDiscovery_rch rd = OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(disc);
       if (!rd.is_nil()) {
-        char config_name[64], inst_name[64], nak_depth[8];
+        char config_name[64], inst_name[64];
+        ACE_TCHAR nak_depth[8];
         ACE_OS::snprintf(config_name, 64, "cfg_%d", this_thread_index);
         ACE_OS::snprintf(inst_name, 64, "rtps_%d", this_thread_index);
-        ACE_OS::snprintf(nak_depth, 8, "%lu", samples_per_thread_);
+        ACE_OS::snprintf(nak_depth, 8, ACE_TEXT("%lu"), samples_per_thread_);
 
         ACE_DEBUG((LM_INFO,
           "(%P|%t)    -> PARTICIPANT creating transport config %C\n",

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -84,8 +84,6 @@ ParticipantTask::svc()
     DDS::Publisher_var publisher;
     DDS::DataWriter_var writer;
     FooDataWriter_var writer_i;
-    //DDS::StatusCondition_var cond;
-    //DDS::WaitSet_var ws = new DDS::WaitSet;
 
     int this_thread_index = 0;
     { // Scope for guard to serialize creating Entities.

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -104,9 +104,10 @@ ParticipantTask::svc()
       OpenDDS::DCPS::Discovery_rch disc = TheServiceParticipant->get_discovery(42);
       OpenDDS::RTPS::RtpsDiscovery_rch rd = OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(disc);
       if (!rd.is_nil()) {
-        char config_name[64], inst_name[64];
+        char config_name[64], inst_name[64], nak_depth[8];
         ACE_OS::snprintf(config_name, 64, "cfg_%d", this_thread_index);
         ACE_OS::snprintf(inst_name, 64, "rtps_%d", this_thread_index);
+        ACE_OS::snprintf(nak_depth, 8, "%d", samples_per_thread_);
 
         ACE_DEBUG((LM_INFO,
           "(%P|%t)    -> PARTICIPANT creating transport config %C\n",
@@ -120,7 +121,7 @@ ParticipantTask::svc()
         ach.open();
         ach.open_section(ach.root_section(), ACE_TEXT("not_root"), 1, sect_key);
         ach.set_string_value(sect_key, ACE_TEXT("use_multicast"), ACE_TEXT("0"));
-        ach.set_string_value(sect_key, ACE_TEXT("nak_depth"), ACE_TEXT("512"));
+        ach.set_string_value(sect_key, ACE_TEXT("nak_depth"), nak_depth);
         ach.set_string_value(sect_key, ACE_TEXT("heartbeat_period"), ACE_TEXT("200"));
         ach.set_string_value(sect_key, ACE_TEXT("heartbeat_response_delay"), ACE_TEXT("100"));
         inst->load(ach, sect_key);

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -17,20 +17,60 @@
 #include <dds/DCPS/transport/framework/TransportConfig.h>
 #include <dds/DCPS/transport/framework/TransportInst.h>
 
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+
 #include "ParticipantTask.h"
 #include "ProgressIndicator.h"
 #include "FooTypeTypeSupportImpl.h"
 
 ParticipantTask::ParticipantTask(const std::size_t& samples_per_thread)
   : samples_per_thread_(samples_per_thread)
-#ifdef OPENDDS_SAFETY_PROFILE
   , thread_index_(0)
-#endif
 {
 }
 
 ParticipantTask::~ParticipantTask()
 {}
+
+namespace {
+
+int
+wait_match(const DDS::DataWriter_var& writer,
+           unsigned int num_readers)
+{
+  DDS::StatusCondition_var condition = writer->get_statuscondition();
+  condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
+  DDS::WaitSet_var ws = new DDS::WaitSet;
+  ws->attach_condition(condition);
+  DDS::ConditionSeq conditions;
+  DDS::PublicationMatchedStatus ms = { 0, 0, 0, 0, 0 };
+  DDS::Duration_t timeout = { 3, 0 };
+  DDS::ReturnCode_t stat;
+  do {
+    stat = writer->get_publication_matched_status(ms);
+    if (stat != DDS::RETCODE_OK) {
+      ACE_ERROR_RETURN((
+                  LM_ERROR,
+                  ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() -")
+                  ACE_TEXT(" get_publication_matched_status failed!\n")),
+                 -1);
+    } else if (ms.current_count == (CORBA::Long)num_readers) {
+      break;  // matched
+    }
+    // wait for a change
+    stat = ws->wait(conditions, timeout);
+    if ((stat != DDS::RETCODE_OK) && (stat != DDS::RETCODE_TIMEOUT)) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() -")
+                        ACE_TEXT(" wait failed!\n")),
+                       -1);
+    }
+  } while (true);
+  ws->detach_condition(condition);
+  return 0;
+}
+
+} // end anonymous namespace
 
 int
 ParticipantTask::svc()
@@ -44,8 +84,8 @@ ParticipantTask::svc()
     DDS::Publisher_var publisher;
     DDS::DataWriter_var writer;
     FooDataWriter_var writer_i;
-    DDS::StatusCondition_var cond;
-    DDS::WaitSet_var ws = new DDS::WaitSet;
+    //DDS::StatusCondition_var cond;
+    //DDS::WaitSet_var ws = new DDS::WaitSet;
 
     { // Scope for guard to serialize creating Entities.
       GuardType guard(lock_);
@@ -57,147 +97,133 @@ ParticipantTask::svc()
                                 DDS::DomainParticipantListener::_nil(),
                                 ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-#ifdef OPENDDS_SAFETY_PROFILE
       // RTPS cannot be shared
-      char config_name[64], inst_name[64];
-      ACE_OS::snprintf(config_name, 64, "cfg_%d", thread_index_);
-      ACE_OS::snprintf(inst_name, 64, "rtps_%d", thread_index_);
-      ++thread_index_;
+      OpenDDS::DCPS::Discovery_rch disc = TheServiceParticipant->get_discovery(42);
+      OpenDDS::RTPS::RtpsDiscovery_rch rd = OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(disc);
+      if (!rd.is_nil()) {
+        char config_name[64], inst_name[64];
+        ACE_OS::snprintf(config_name, 64, "cfg_%d", thread_index_);
+        ACE_OS::snprintf(inst_name, 64, "rtps_%d", thread_index_);
+        ++thread_index_;
 
-      ACE_DEBUG((LM_INFO,
-        "(%P|%t)    -> PARTICIPANT creating transport config %C\n",
-        config_name));
-      OpenDDS::DCPS::TransportConfig_rch config =
-        TheTransportRegistry->create_config(config_name);
-      OpenDDS::DCPS::TransportInst_rch inst =
-        TheTransportRegistry->create_inst(inst_name, "rtps_udp");
-      config->instances_.push_back(inst);
-      TheTransportRegistry->bind_config(config_name, participant);
-#endif
-
+        ACE_DEBUG((LM_INFO,
+          "(%P|%t)    -> PARTICIPANT creating transport config %C\n",
+          config_name));
+        OpenDDS::DCPS::TransportConfig_rch config =
+          TheTransportRegistry->create_config(config_name);
+        OpenDDS::DCPS::TransportInst_rch inst =
+          TheTransportRegistry->create_inst(inst_name, "rtps_udp");
+        ACE_Configuration_Heap ach;
+        ACE_Configuration_Section_Key sect_key;
+        ach.open();
+        ach.open_section(ach.root_section(), "not_root", 1, sect_key);
+        ach.set_string_value(sect_key, "use_multicast", "0");
+        ach.set_string_value(sect_key, "nak_depth", "512");
+        ach.set_string_value(sect_key, "heartbeat_period", "200");
+        ach.set_string_value(sect_key, "heartbeat_response_delay", "100");
+        inst->load(ach, sect_key);
+        config->instances_.push_back(inst);
+        TheTransportRegistry->bind_config(config_name, participant);
+      }
     } // End of lock scope.
 
-    if (CORBA::is_nil(participant.in()))
+    if (CORBA::is_nil(participant.in())) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l: svc()")
                         ACE_TEXT(" create_participant failed!\n")), 1);
+    }
 
-    {
-      // Create Publisher
-      publisher =
-        participant->create_publisher(PUBLISHER_QOS_DEFAULT,
-                                      DDS::PublisherListener::_nil(),
-                                      ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    // Create Publisher
+    publisher =
+      participant->create_publisher(PUBLISHER_QOS_DEFAULT,
+                                    DDS::PublisherListener::_nil(),
+                                    ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      if (CORBA::is_nil(publisher.in()))
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: svc()")
-                          ACE_TEXT(" create_publisher failed!\n")), 1);
+    if (CORBA::is_nil(publisher.in())) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("%N:%l: svc()")
+                        ACE_TEXT(" create_publisher failed!\n")), 1);
+    }
 
 
-      // Register Type (FooType)
-      FooTypeSupport_var ts = new FooTypeSupportImpl;
-      if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK)
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: svc()")
-                          ACE_TEXT(" register_type failed!\n")), 1);
+    // Register Type (FooType)
+    FooTypeSupport_var ts = new FooTypeSupportImpl;
+    if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK)
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("%N:%l: svc()")
+                        ACE_TEXT(" register_type failed!\n")), 1);
 
-      // Create Topic (FooTopic)
-      DDS::Topic_var topic =
-        participant->create_topic("FooTopic",
-                                  CORBA::String_var(ts->get_type_name()),
-                                  TOPIC_QOS_DEFAULT,
-                                  DDS::TopicListener::_nil(),
-                                  ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    // Create Topic (FooTopic)
+    DDS::Topic_var topic =
+      participant->create_topic("FooTopic",
+                                CORBA::String_var(ts->get_type_name()),
+                                TOPIC_QOS_DEFAULT,
+                                DDS::TopicListener::_nil(),
+                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      if (CORBA::is_nil(topic.in()))
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: svc()")
-                          ACE_TEXT(" create_topic failed!\n")), 1);
+    if (CORBA::is_nil(topic.in())) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("%N:%l: svc()")
+                        ACE_TEXT(" create_topic failed!\n")), 1);
+    }
 
-      // Create DataWriter
-      DDS::DataWriterQos writer_qos;
-      publisher->get_default_datawriter_qos(writer_qos);
-      writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
-      writer_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    // Create DataWriter
+    DDS::DataWriterQos writer_qos;
+    publisher->get_default_datawriter_qos(writer_qos);
+    writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    writer_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
-      writer_qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_);
+    writer_qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_);
 #endif
 
-      writer =
-        publisher->create_datawriter(topic.in(),
-                                     writer_qos,
-                                     DDS::DataWriterListener::_nil(),
-                                     ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    writer =
+      publisher->create_datawriter(topic.in(),
+                                   writer_qos,
+                                   DDS::DataWriterListener::_nil(),
+                                   ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      if (CORBA::is_nil(writer.in()))
+    if (CORBA::is_nil(writer.in())) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("%N:%l: svc()")
+                        ACE_TEXT(" create_datawriter failed!\n")), 1);
+    }
+
+    wait_match(writer, 1);
+
+    writer_i = FooDataWriter::_narrow(writer);
+    if (CORBA::is_nil(writer_i)) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("%N:%l: svc()")
+                        ACE_TEXT(" _narrow failed!\n")), 1);
+    }
+
+    // The following is intentionally inefficient to stress various
+    // pathways related to publication; we should be especially dull
+    // and write only one sample at a time per writer.
+
+    ProgressIndicator progress("(%P|%t)       PARTICIPANT %d%% (%d samples sent)\n",
+                               samples_per_thread_);
+
+    for (std::size_t i = 0; i < samples_per_thread_; ++i)
+    {
+      Foo foo;
+      foo.key = 3;
+      DDS::InstanceHandle_t handle = writer_i->register_instance(foo);
+
+      if (writer_i->write(foo, handle) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%N:%l: svc()")
-                          ACE_TEXT(" create_datawriter failed!\n")), 1);
-
-      writer_i = FooDataWriter::_narrow(writer);
-      if (CORBA::is_nil(writer_i))
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: svc()")
-                          ACE_TEXT(" _narrow failed!\n")), 1);
-
-      // Block until Subscriber is available
-      cond = writer->get_statuscondition();
-      cond->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
-
-      ws->attach_condition(cond);
-
-      DDS::Duration_t timeout =
-        { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
-
-      DDS::ConditionSeq conditions;
-      DDS::PublicationMatchedStatus matches = {0, 0, 0, 0, 0};
-      do
-      {
-        if (ws->wait(conditions, timeout) != DDS::RETCODE_OK)
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("%N:%l: svc()")
-                            ACE_TEXT(" wait failed!\n")), 1);
-
-        if (writer->get_publication_matched_status(matches) != ::DDS::RETCODE_OK)
-        {
-          ACE_ERROR ((LM_ERROR,
-            "(%P|%t) ERROR: failed to get publication matched status\n"));
-          ACE_OS::exit (1);
-        }
+                          ACE_TEXT(" write failed!\n")), 1);
       }
-      while (matches.current_count < 1);
+      ++progress;
+    }
 
-      ws->detach_condition(cond);
-
-      // The following is intentionally inefficient to stress various
-      // pathways related to publication; we should be especially dull
-      // and write only one sample at a time per writer.
-
-      ProgressIndicator progress("(%P|%t)       PARTICIPANT %d%% (%d samples sent)\n",
-                                 samples_per_thread_);
-
-      for (std::size_t i = 0; i < samples_per_thread_; ++i)
-      {
-        Foo foo;
-        foo.key = 3;
-        DDS::InstanceHandle_t handle = writer_i->register_instance(foo);
-
-        if (writer_i->write(foo, handle) != DDS::RETCODE_OK) {
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("%N:%l: svc()")
-                            ACE_TEXT(" write failed!\n")), 1);
-        }
-        ++progress;
-      }
-
-      DDS::Duration_t interval = { 30, 0};
-      if( DDS::RETCODE_OK != writer->wait_for_acknowledgments( interval)) {
-        ACE_ERROR_RETURN((LM_ERROR,
-          ACE_TEXT("(%P:%t) ERROR: svc() - ")
-          ACE_TEXT("timed out waiting for acks!\n")
-        ), 1);
-      }
+    DDS::Duration_t interval = { 30, 0 };
+    if (DDS::RETCODE_OK != writer->wait_for_acknowledgments(interval)) {
+      ACE_ERROR_RETURN((LM_ERROR,
+        ACE_TEXT("(%P:%t) ERROR: svc() - ")
+        ACE_TEXT("timed out waiting for acks!\n")
+      ), 1);
     }
 
     // Clean-up!

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -116,11 +116,11 @@ ParticipantTask::svc()
         ACE_Configuration_Heap ach;
         ACE_Configuration_Section_Key sect_key;
         ach.open();
-        ach.open_section(ach.root_section(), "not_root", 1, sect_key);
-        ach.set_string_value(sect_key, "use_multicast", "0");
-        ach.set_string_value(sect_key, "nak_depth", "512");
-        ach.set_string_value(sect_key, "heartbeat_period", "200");
-        ach.set_string_value(sect_key, "heartbeat_response_delay", "100");
+        ach.open_section(ach.root_section(), ACE_TEXT("not_root"), 1, sect_key);
+        ach.set_string_value(sect_key, ACE_TEXT("use_multicast"), "0");
+        ach.set_string_value(sect_key, ACE_TEXT("nak_depth"), "512");
+        ach.set_string_value(sect_key, ACE_TEXT("heartbeat_period"), "200");
+        ach.set_string_value(sect_key, ACE_TEXT("heartbeat_response_delay"), "100");
         inst->load(ach, sect_key);
         config->instances_.push_back(inst);
         TheTransportRegistry->bind_config(config_name, participant);

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -107,7 +107,7 @@ ParticipantTask::svc()
         char config_name[64], inst_name[64], nak_depth[8];
         ACE_OS::snprintf(config_name, 64, "cfg_%d", this_thread_index);
         ACE_OS::snprintf(inst_name, 64, "rtps_%d", this_thread_index);
-        ACE_OS::snprintf(nak_depth, 8, "%d", samples_per_thread_);
+        ACE_OS::snprintf(nak_depth, 8, "%lu", samples_per_thread_);
 
         ACE_DEBUG((LM_INFO,
           "(%P|%t)    -> PARTICIPANT creating transport config %C\n",

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -109,8 +109,8 @@ ParticipantTask::svc()
         ACE_OS::snprintf(nak_depth, 8, ACE_TEXT("%lu"), samples_per_thread_);
 
         ACE_DEBUG((LM_INFO,
-          "(%P|%t)    -> PARTICIPANT creating transport config %C\n",
-          config_name));
+          "(%P|%t)    -> PARTICIPANT %d creating transport config %C\n",
+          this_thread_index, config_name));
         OpenDDS::DCPS::TransportConfig_rch config =
           TheTransportRegistry->create_config(config_name);
         OpenDDS::DCPS::TransportInst_rch inst =
@@ -190,7 +190,11 @@ ParticipantTask::svc()
                         ACE_TEXT(" create_datawriter failed!\n")), 1);
     }
 
+    ACE_DEBUG((LM_INFO, "(%P|%t)    -> PARTICIPANT %d waiting for match\n", this_thread_index));
+
     wait_match(writer, 1);
+
+    ACE_DEBUG((LM_INFO, "(%P|%t)    -> PARTICIPANT %d match found!\n", this_thread_index));
 
     writer_i = FooDataWriter::_narrow(writer);
     if (CORBA::is_nil(writer_i)) {

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -119,10 +119,10 @@ ParticipantTask::svc()
         ACE_Configuration_Section_Key sect_key;
         ach.open();
         ach.open_section(ach.root_section(), ACE_TEXT("not_root"), 1, sect_key);
-        ach.set_string_value(sect_key, ACE_TEXT("use_multicast"), "0");
-        ach.set_string_value(sect_key, ACE_TEXT("nak_depth"), "512");
-        ach.set_string_value(sect_key, ACE_TEXT("heartbeat_period"), "200");
-        ach.set_string_value(sect_key, ACE_TEXT("heartbeat_response_delay"), "100");
+        ach.set_string_value(sect_key, ACE_TEXT("use_multicast"), ACE_TEXT("0"));
+        ach.set_string_value(sect_key, ACE_TEXT("nak_depth"), ACE_TEXT("512"));
+        ach.set_string_value(sect_key, ACE_TEXT("heartbeat_period"), ACE_TEXT("200"));
+        ach.set_string_value(sect_key, ACE_TEXT("heartbeat_response_delay"), ACE_TEXT("100"));
         inst->load(ach, sect_key);
         config->instances_.push_back(inst);
         TheTransportRegistry->bind_config(config_name, participant);

--- a/tests/DCPS/Thrasher/ParticipantTask.h
+++ b/tests/DCPS/Thrasher/ParticipantTask.h
@@ -25,9 +25,7 @@ private:
 
   LockType lock_;
   const std::size_t& samples_per_thread_;
-#ifdef OPENDDS_SAFETY_PROFILE
   int thread_index_;
-#endif
 };
 
 #endif /* DCPS_THRASHER_PARTICIPANTTASK_H */

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -25,7 +25,7 @@ namespace
 {
   std::size_t expected_samples = 1024;
   std::size_t received_samples = 0;
-  int n_publishers = 1;
+  size_t n_publishers = 1;
 
   void
   parse_args(int& argc, ACE_TCHAR** argv)
@@ -43,7 +43,7 @@ namespace
       }
       else if ((arg = shifter.get_the_parameter(ACE_TEXT("-t"))))
       {
-        n_publishers = ACE_OS::atoi(arg);
+        n_publishers = static_cast<size_t>(ACE_OS::atoi(arg));
         shifter.consume_arg();
       }
       else

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -179,8 +179,8 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
       wait_match(reader, 0, true);
 
       for (size_t x = 0; x < n_publishers; ++x) {
-        OPENDDS_MAP(size_t, OPENDDS_SET(size_t))::const_iterator xit = listener_p->x_and_y_map.find(x);
-        if (xit == listener_p->x_and_y_map.end()) {
+        OPENDDS_MAP(size_t, OPENDDS_SET(size_t))::const_iterator xit = listener_p->task_sample_set_map.find(x);
+        if (xit == listener_p->task_sample_set_map.end()) {
           ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) <- ERROR: MISSING ALL SAMPLES FROM PUBLISHER %d\n"), x));
           break;
         }

--- a/tests/DCPS/Thrasher/run_test.pl
+++ b/tests/DCPS/Thrasher/run_test.pl
@@ -36,9 +36,21 @@ if ($arg eq 'low') {
   $pub_opts .= "-t 64 -s 16";
   $sub_opts .= "-t 64 -n 1024";
 
+} elsif ($arg eq 'double') {
+  $pub_opts .= "-t 2 -s 1";
+  $sub_opts .= "-t 2 -n 2";
+
 } elsif ($arg eq 'single') {
   $pub_opts .= "-t 1 -s 1";
   $sub_opts .= "-t 1 -n 1";
+
+} elsif ($arg eq 'superlow') {
+  $pub_opts .= "-t 4 -s 256";
+  $sub_opts .= "-t 4 -n 1024";
+
+} elsif ($arg eq 'megalow') {
+  $pub_opts .= "-t 2 -s 512";
+  $sub_opts .= "-t 2 -n 1024";
 
 } else { # default (i.e. lazy)
   $pub_opts .= "-t 1 -s 1024";
@@ -61,7 +73,9 @@ $pub_opts .= " -DCPSConfigFile $ini_file";
 $sub_opts .= " -DCPSConfigFile $ini_file";
 
 my $test = new PerlDDS::TestFramework();
-$test->setup_discovery();
+if ("thrasher.ini" eq $ini_file) {
+  $test->setup_discovery();
+}
 $test->enable_console_logging();
 
 $test->process('sub', 'subscriber', $sub_opts);

--- a/tests/DCPS/Thrasher/run_test.pl
+++ b/tests/DCPS/Thrasher/run_test.pl
@@ -36,6 +36,10 @@ if ($arg eq 'low') {
   $pub_opts .= "-t 64 -s 16";
   $sub_opts .= "-t 64 -n 1024";
 
+} elsif ($arg eq 'triangle') {
+  $pub_opts .= "-t 3 -s 3";
+  $sub_opts .= "-t 3 -n 9";
+
 } elsif ($arg eq 'double') {
   $pub_opts .= "-t 2 -s 1";
   $sub_opts .= "-t 2 -n 2";

--- a/tests/DCPS/Thrasher/thrasher_rtps.ini
+++ b/tests/DCPS/Thrasher/thrasher_rtps.ini
@@ -12,4 +12,6 @@ ResendPeriod=2
 [transport/the_rtps_transport]
 transport_type=rtps_udp
 use_multicast=0
-nak_depth=64
+nak_depth=512
+heartbeat_period=200
+heartbeat_response_delay=100

--- a/tests/Utils/StatusMatching.h
+++ b/tests/Utils/StatusMatching.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#ifndef TESTUTILS_STATUS_MATCHING_H
+#define TESTUTILS_STATUS_MATCHING_H
+
+#include "dds/DdsDcpsPublicationC.h"
+#include "dds/DdsDcpsSubscriptionC.h"
+#include "dds/DCPS/WaitSet.h"
+
+namespace Utils {
+
+enum CmpOp {
+  LT,
+  LTE,
+  EQ,
+  GTE,
+  GT
+};
+
+template <typename Entity>
+int wait_match(const Entity& entity, unsigned int count, CmpOp cmp = EQ)
+{
+  return 0;
+}
+
+template <>
+int wait_match<DDS::DataWriter_var>(const DDS::DataWriter_var& writer, unsigned int num_readers, CmpOp cmp)
+{
+  DDS::StatusCondition_var condition = writer->get_statuscondition();
+  condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
+
+  DDS::WaitSet_var ws(new DDS::WaitSet);
+  ws->attach_condition(condition);
+
+  DDS::ReturnCode_t stat;
+
+  DDS::ConditionSeq conditions;
+  DDS::PublicationMatchedStatus ms = { 0, 0, 0, 0, 0 };
+
+  const DDS::Duration_t wake_interval = { 3, 0 };
+
+  bool stop = false;
+  while (!stop) {
+    stat = writer->get_publication_matched_status(ms);
+    if (stat != DDS::RETCODE_OK) {
+      ACE_ERROR_RETURN((
+                  LM_ERROR,
+                  ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() -")
+                  ACE_TEXT(" get_publication_matched_status failed!\n")),
+                 -1);
+    } else {
+      if (cmp == LT && ms.current_count < static_cast<CORBA::Long>(num_readers)) {
+        stop = true;
+      } else if (cmp == LTE && ms.current_count <= static_cast<CORBA::Long>(num_readers)) {
+        stop = true;
+      } else if (cmp == EQ && ms.current_count == static_cast<CORBA::Long>(num_readers)) {
+        stop = true;
+      } else if (cmp == GTE && ms.current_count >= static_cast<CORBA::Long>(num_readers)) {
+        stop = true;
+      } else if (cmp == GT && ms.current_count > static_cast<CORBA::Long>(num_readers)) {
+        stop = true;
+      } else {
+        // wait for a change
+        stat = ws->wait(conditions, wake_interval);
+        if ((stat != DDS::RETCODE_OK) && (stat != DDS::RETCODE_TIMEOUT)) {
+          ACE_ERROR_RETURN((LM_ERROR,
+                            ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() -")
+                            ACE_TEXT(" wait failed!\n")),
+                           -1);
+        }
+      }
+    }
+  }
+
+  ws->detach_condition(condition);
+  return 0;
+}
+
+template <>
+int wait_match<DDS::DataReader_var>(const DDS::DataReader_var& reader, unsigned int num_writers, CmpOp cmp)
+{
+  DDS::StatusCondition_var condition = reader->get_statuscondition();
+  condition->set_enabled_statuses(DDS::SUBSCRIPTION_MATCHED_STATUS);
+
+  DDS::WaitSet_var ws(new DDS::WaitSet);
+  ws->attach_condition(condition);
+
+  DDS::ReturnCode_t stat;
+
+  DDS::ConditionSeq conditions;
+  DDS::SubscriptionMatchedStatus ms = { 0, 0, 0, 0, 0 };
+
+  const DDS::Duration_t wake_interval = { 3, 0 };
+
+  bool stop = false;
+  while (!stop) {
+    stat = reader->get_subscription_matched_status(ms);
+    if (stat != DDS::RETCODE_OK) {
+      ACE_ERROR_RETURN((
+                  LM_ERROR,
+                  ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() -")
+                  ACE_TEXT(" get_subscription_matched_status failed!\n")),
+                 -1);
+    } else {
+      if (cmp == LT && ms.current_count < static_cast<CORBA::Long>(num_writers)) {
+        stop = true;
+      } else if (cmp == LTE && ms.current_count <= static_cast<CORBA::Long>(num_writers)) {
+        stop = true;
+      } else if (cmp == EQ && ms.current_count == static_cast<CORBA::Long>(num_writers)) {
+        stop = true;
+      } else if (cmp == GTE && ms.current_count >= static_cast<CORBA::Long>(num_writers)) {
+        stop = true;
+      } else if (cmp == GT && ms.current_count > static_cast<CORBA::Long>(num_writers)) {
+        stop = true;
+      } else {
+        // wait for a change
+        stat = ws->wait(conditions, wake_interval);
+        if ((stat != DDS::RETCODE_OK) && (stat != DDS::RETCODE_TIMEOUT)) {
+          ACE_ERROR_RETURN((LM_ERROR,
+                            ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() -")
+                            ACE_TEXT(" wait failed!\n")),
+                           -1);
+        }
+      }
+    }
+  }
+
+  ws->detach_condition(condition);
+  return 0;
+}
+
+}
+
+#endif
+


### PR DESCRIPTION
On the DDS Build Scoreboard I noticed a stack trace pointing to a corrupted free in DomainParticipantFactoryImpl::delete_participant's use of Util::remove() and it looks like we're not correctly using the participants_protector_ mutex in this instance. Fixed this, added locking / copying around another accessor of the same data structure (internals are RcHandles), and migrated to a non-recursive mutex because it didn't look like we needed one.