### PR TITLE
SPDP improvements for the RtpsRelay

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1586,10 +1586,10 @@ namespace OpenDDS {
 
 #ifdef OPENDDS_SECURITY
         bool has_last_stateless_msg_;
-        MonotonicTimePoint last_stateless_msg_time_;
+        MonotonicTimePoint stateless_msg_deadline_;
         DDS::Security::ParticipantStatelessMessage last_stateless_msg_;
 
-        MonotonicTimePoint auth_started_time_;
+        MonotonicTimePoint auth_deadline_;
         AuthState auth_state_;
 
         DDS::Security::IdentityToken identity_token_;

--- a/dds/DCPS/JobQueue.h
+++ b/dds/DCPS/JobQueue.h
@@ -1,0 +1,69 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_JOB_QUEUE_H
+#define OPENDDS_DCPS_JOB_QUEUE_H
+
+#include "RcEventHandler.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+class JobQueue : public RcEventHandler {
+public:
+  class Job : public RcObject {
+  public:
+    virtual ~Job() { }
+    virtual void execute() = 0;
+  };
+  typedef RcHandle<Job> JobPtr;
+
+  explicit JobQueue(ACE_Reactor* reactor)
+  {
+    this->reactor(reactor);
+  }
+
+  void enqueue(JobPtr job)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
+    const bool empty = job_queue_.empty();
+    job_queue_.push(job);
+    if (empty) {
+      reactor()->notify(this);
+    }
+  }
+
+private:
+  RcHandle<ReactorInterceptor> interceptor_;
+  ACE_Thread_Mutex mutex_;
+  OPENDDS_QUEUE(JobPtr) job_queue_;
+
+  int handle_exception(ACE_HANDLE /*fd*/)
+  {
+    ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, -1);
+    size_t count = job_queue_.size();
+    while (count--) {
+      JobPtr job = job_queue_.front();
+      job_queue_.pop();
+      {
+        ACE_GUARD_RETURN(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock, -1);
+        job->execute();
+      }
+    }
+    return 0;
+  }
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_JOB_QUEUE_H  */

--- a/dds/DCPS/JobQueue.h
+++ b/dds/DCPS/JobQueue.h
@@ -57,6 +57,11 @@ private:
         job->execute();
       }
     }
+
+    if (!job_queue_.empty()) {
+      reactor()->notify(this);
+    }
+
     return 0;
   }
 };

--- a/dds/DCPS/PeriodicTask.h
+++ b/dds/DCPS/PeriodicTask.h
@@ -1,0 +1,140 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_PERIODIC_TASK_H
+#define OPENDDS_DCPS_PERIODIC_TASK_H
+
+#include "RcEventHandler.h"
+#include "ReactorInterceptor.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+class PeriodicTask : public RcEventHandler {
+public:
+  explicit PeriodicTask(RcHandle<ReactorInterceptor> interceptor)
+    : interceptor_(interceptor)
+    , enabled_(false)
+  {
+    reactor(interceptor->reactor());
+  }
+
+  virtual ~PeriodicTask() {}
+
+  void enable(bool reenable, const TimeDuration& period)
+  {
+    interceptor_->execute_or_enqueue(new ScheduleEnableCommand(this, reenable, period));
+  }
+
+  void disable()
+  {
+    interceptor_->execute_or_enqueue(new ScheduleDisableCommand(this));
+  }
+
+  void disable_and_wait()
+  {
+    ReactorInterceptor::CommandPtr command = interceptor_->execute_or_enqueue(new ScheduleDisableCommand(this));
+    command->wait();
+  }
+
+  virtual void execute(const MonotonicTimePoint& now) = 0;
+
+private:
+  RcHandle<ReactorInterceptor> interceptor_;
+  bool enabled_;
+
+  struct ScheduleEnableCommand : public ReactorInterceptor::Command {
+    ScheduleEnableCommand(PeriodicTask* hb, bool reenable, const TimeDuration& period)
+      : periodic_task_(hb), reenable_(reenable), period_(period)
+    { }
+
+    virtual void execute()
+    {
+      periodic_task_->enable_i(reenable_, period_);
+    }
+
+    PeriodicTask* const periodic_task_;
+    const bool reenable_;
+    const TimeDuration period_;
+  };
+
+  struct ScheduleDisableCommand : public ReactorInterceptor::Command {
+    ScheduleDisableCommand(PeriodicTask* hb)
+      : periodic_task_(hb)
+    { }
+
+    virtual void execute()
+    {
+      periodic_task_->disable_i();
+    }
+
+    PeriodicTask* const periodic_task_;
+  };
+
+  int handle_timeout(const ACE_Time_Value& tv, const void*)
+  {
+    const MonotonicTimePoint now(tv);
+    execute(now);
+    return 0;
+  }
+
+  void enable_i(bool reenable, const TimeDuration& per)
+  {
+    if (!enabled_) {
+      const long timer =
+        reactor()->schedule_timer(this, 0, ACE_Time_Value::zero, per.value());
+
+      if (timer == -1) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) PeriodicTask::enable"
+                   " failed to schedule timer %p\n", ACE_TEXT("")));
+      } else {
+        enabled_ = true;
+      }
+    } else if (reenable) {
+      disable_i();
+      enable_i(false, per);
+    }
+  }
+
+  void
+  disable_i()
+  {
+    if (enabled_) {
+      reactor()->cancel_timer(this);
+      enabled_ = false;
+    }
+  }
+};
+
+template <typename Outer>
+class PmfPeriodicTask : public PeriodicTask {
+public:
+  typedef void (Outer::*PMF)(const MonotonicTimePoint&);
+
+  PmfPeriodicTask(RcHandle<ReactorInterceptor> interceptor, Outer* outer, PMF function)
+    : PeriodicTask(interceptor)
+    , outer_(outer)
+    , function_(function) {}
+
+private:
+  Outer* outer_;
+  PMF function_;
+
+  void execute(const MonotonicTimePoint& now)
+  {
+    (outer_->*function_)(now);
+  }
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_PERIODIC_TASK_H  */

--- a/dds/DCPS/PeriodicTask.h
+++ b/dds/DCPS/PeriodicTask.h
@@ -65,7 +65,7 @@ private:
   };
 
   struct ScheduleDisableCommand : public ReactorInterceptor::Command {
-    ScheduleDisableCommand(PeriodicTask* hb)
+    explicit ScheduleDisableCommand(PeriodicTask* hb)
       : periodic_task_(hb)
     { }
 

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -72,6 +72,11 @@ public:
     resend_period_ = period;
   }
 
+  DCPS::TimeDuration lease_duration() const { return lease_duration_; }
+  void lease_duration(const DCPS::TimeDuration& period) {
+    lease_duration_ = period;
+  }
+
   u_short pb() const { return pb_; }
   void pb(u_short port_base) {
     pb_ = port_base;
@@ -146,9 +151,24 @@ public:
     spdp_rtps_relay_address_ = address;
   }
 
+  const DCPS::TimeDuration& spdp_rtps_relay_beacon_period() const { return spdp_rtps_relay_beacon_period_; }
+  void spdp_rtps_relay_beacon_period(const DCPS::TimeDuration& period) {
+    spdp_rtps_relay_beacon_period_ = period;
+  }
+
+  const DCPS::TimeDuration& spdp_rtps_relay_send_period() const { return spdp_rtps_relay_send_period_; }
+  void spdp_rtps_relay_send_period(const DCPS::TimeDuration& period) {
+    spdp_rtps_relay_send_period_ = period;
+  }
+
   const ACE_INET_Addr& sedp_rtps_relay_address() const { return sedp_rtps_relay_address_; }
   void sedp_rtps_relay_address(const ACE_INET_Addr& address) {
     sedp_rtps_relay_address_ = address;
+  }
+
+  const DCPS::TimeDuration& sedp_rtps_relay_beacon_period() const { return sedp_rtps_relay_beacon_period_; }
+  void sedp_rtps_relay_beacon_period(const DCPS::TimeDuration& period) {
+    sedp_rtps_relay_beacon_period_ = period;
   }
 
   bool rtps_relay_only() const { return rtps_relay_only_; }
@@ -163,9 +183,6 @@ public:
   void use_ice(bool ui) {
     use_ice_ = ui;
   }
-
-  const DCPS::TimeDuration& max_spdp_timer_period() const { return max_spdp_timer_period_; }
-  void max_spdp_timer_period(const DCPS::TimeDuration& x) { max_spdp_timer_period_ = x; }
 
   const DCPS::TimeDuration& max_auth_time() const { return max_auth_time_; }
   void max_auth_time(const DCPS::TimeDuration& x) { max_auth_time_ = x; }
@@ -188,12 +205,10 @@ public:
                         const DCPS::RepoId& local_participant) const;
   u_short get_sedp_port(DDS::DomainId_t domain,
                         const DCPS::RepoId& local_participant) const;
-  void schedule_send(DDS::DomainId_t domain,
-                     const DCPS::RepoId& local_participant,
-                     const DCPS::TimeDuration& delay) const;
 
 private:
   DCPS::TimeDuration resend_period_;
+  DCPS::TimeDuration lease_duration_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
   unsigned char ttl_;
   bool sedp_multicast_;
@@ -202,11 +217,13 @@ private:
   OPENDDS_STRING guid_interface_;
   AddrVec spdp_send_addrs_;
   ACE_INET_Addr spdp_rtps_relay_address_;
+  DCPS::TimeDuration spdp_rtps_relay_beacon_period_;
+  DCPS::TimeDuration spdp_rtps_relay_send_period_;
   ACE_INET_Addr sedp_rtps_relay_address_;
+  DCPS::TimeDuration sedp_rtps_relay_beacon_period_;
   bool rtps_relay_only_;
   ACE_INET_Addr sedp_stun_server_address_;
   bool use_ice_;
-  DCPS::TimeDuration max_spdp_timer_period_;
   DCPS::TimeDuration max_auth_time_;
   DCPS::TimeDuration auth_resend_period_;
   u_short max_spdp_sequence_msg_reset_check_;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -332,19 +332,19 @@ Sedp::init(const RepoId& guid,
   }
 
   {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_inst->rtps_relay_address_lock_, -1);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_inst->rtps_relay_config_lock_, -1);
     rtps_inst->rtps_relay_address_ = disco.sedp_rtps_relay_address();
   }
 
   {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_inst->rtps_relay_address_lock_, -1);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_inst->rtps_relay_config_lock_, -1);
     rtps_inst->rtps_relay_beacon_period_ = disco.sedp_rtps_relay_beacon_period();
   }
 
   rtps_inst->rtps_relay_only_ = disco.rtps_relay_only();
 
   {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_inst->stun_server_address_lock_, -1);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_inst->stun_server_config_lock_, -1);
     rtps_inst->stun_server_address_ = disco.sedp_stun_server_address();
   }
   rtps_inst->use_ice_ = disco.use_ice();

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -27,7 +27,7 @@
 #include "dds/DCPS/DataSampleHeader.h"
 #include "dds/DCPS/PoolAllocationBase.h"
 #include "dds/DCPS/DiscoveryBase.h"
-#include "dds/DCPS/ReactorInterceptor.h"
+#include "dds/DCPS/JobQueue.h"
 
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include "dds/DCPS/transport/framework/TransportSendListener.h"
@@ -76,9 +76,6 @@ public:
   DDS::ReturnCode_t init(const DCPS::RepoId& guid,
                          const RtpsDiscovery& disco,
                          DDS::DomainId_t domainId);
-
-  void rtps_relay_address(const ACE_INET_Addr& address);
-  void rtps_relay_only(bool flag);
 
 #ifdef OPENDDS_SECURITY
   DDS::ReturnCode_t init_security(DDS::Security::IdentityHandle id_handle,
@@ -161,7 +158,7 @@ public:
 
 private:
 
-  class AssociationComplete : public DCPS::ReactorInterceptor::Command {
+  class AssociationComplete : public DCPS::JobQueue::Job {
   public:
     AssociationComplete(Sedp* sedp, const DCPS::RepoId& local, const DCPS::RepoId& remote) : sedp_(sedp), local_(local), remote_(remote) {}
     void execute();

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1537,7 +1537,8 @@ Spdp::SpdpTransport::open()
 #endif
 
   relay_sender_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::send_relay);
-  if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
+  if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr() ||
+      outer_->disco_->use_rtps_relay()) {
     relay_sender_->enable(false, outer_->disco_->spdp_rtps_relay_send_period());
   }
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1507,20 +1507,20 @@ Spdp::SpdpTransport::open()
 
   job_queue_ = DCPS::make_rch<DCPS::JobQueue>(reactor);
 
-  local_sender_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), this, &SpdpTransport::send_local);
+  local_sender_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::send_local);
   local_sender_->enable(false, outer_->disco_->resend_period());
 
 #ifdef OPENDDS_SECURITY
-  auth_deadline_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), this, &SpdpTransport::process_auth_deadlines);
-  auth_resend_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), this, &SpdpTransport::process_auth_resends);
+  auth_deadline_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::process_auth_deadlines);
+  auth_resend_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::process_auth_resends);
 #endif
 
-  relay_sender_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), this, &SpdpTransport::send_relay);
+  relay_sender_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::send_relay);
   if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
     relay_sender_->enable(false, outer_->disco_->spdp_rtps_relay_send_period());
   }
 
-  relay_beacon_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), this, &SpdpTransport::send_relay_beacon);
+  relay_beacon_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::send_relay_beacon);
   if (outer_->disco_->spdp_rtps_relay_address() != ACE_INET_Addr()) {
     relay_beacon_->enable(false, outer_->disco_->spdp_rtps_relay_beacon_period());
   }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -17,6 +17,9 @@
 #include "dds/DCPS/Definitions.h"
 #include "dds/DCPS/RcEventHandler.h"
 #include "dds/DCPS/ReactorTask.h"
+#include "dds/DCPS/PeriodicTask.h"
+#include "dds/DCPS/SporadicTask.h"
+#include "dds/DCPS/JobQueue.h"
 
 #include "RtpsCoreC.h"
 #include "Sedp.h"
@@ -29,7 +32,6 @@
 
 #include "dds/DCPS/PoolAllocator.h"
 #include "dds/DCPS/PoolAllocationBase.h"
-#include "dds/DCPS/ReactorInterceptor.h"
 
 #include "dds/DCPS/security/framework/SecurityConfig_rch.h"
 #ifdef OPENDDS_SECURITY
@@ -99,12 +101,17 @@ public:
   void handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
 #endif
 
-  void handle_participant_data(DCPS::MessageId id, const ParticipantData_t& pdata, const DCPS::SequenceNumber& seq);
+  void handle_participant_data(DCPS::MessageId id,
+                               const ParticipantData_t& pdata,
+                               const DCPS::SequenceNumber& seq,
+                               const ACE_INET_Addr& from);
 
   static bool validateSequenceNumber(const DCPS::SequenceNumber& seq, DiscoveredParticipantIter& iter);
 
 #ifdef OPENDDS_SECURITY
-  void check_auth_states(const DCPS::MonotonicTimePoint& tv);
+  void process_auth_deadlines(const DCPS::MonotonicTimePoint& tv);
+  void process_auth_resends(const DCPS::MonotonicTimePoint& tv);
+
   /**
    * Write Secured Updated DP QOS
    *
@@ -133,13 +140,11 @@ public:
   void remove_sedp_unicast(const ACE_INET_Addr& addr);
   void add_sedp_unicast(const ACE_INET_Addr& addr);
 
-  DCPS::ReactorInterceptor& interceptor() { return interceptor_; }
+  DCPS::RcHandle<DCPS::JobQueue> job_queue() const { return tport_->job_queue_; }
 
   u_short get_spdp_port() const { return tport_ ? tport_->uni_port_ : 0; }
 
   u_short get_sedp_port() const { return sedp_.local_address().get_port_number(); }
-
-  void schedule_send(const DCPS::TimeDuration& delay);
 
 protected:
   Sedp& endpoint_manager() { return sedp_; }
@@ -160,22 +165,13 @@ private:
             RtpsDiscovery* disco);
 
   RtpsDiscovery* disco_;
-  DCPS::ReactorTask reactor_task_;
-
-  class Interceptor : public DCPS::ReactorInterceptor {
-  public:
-    Interceptor(DCPS::ReactorTask* task, ACE_Reactor* reactor, ACE_thread_t owner) : ReactorInterceptor(reactor, owner), task_(task) {}
-    bool reactor_is_shut_down() const;
-  private:
-    DCPS::ReactorTask* task_;
-  } interceptor_;
 
   // Participant:
   const DDS::DomainId_t domain_;
   DCPS::RepoId guid_;
   DCPS::LocatorSeq sedp_unicast_, sedp_multicast_;
 
-  void data_received(const DataSubmessage& data, const ParameterList& plist);
+  void data_received(const DataSubmessage& data, const ParameterList& plist, const ACE_INET_Addr& from);
 
   void match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
 
@@ -192,13 +188,14 @@ private:
     SpdpTransport(Spdp* outer, bool securityGuids);
     ~SpdpTransport();
 
-    virtual int handle_timeout(const ACE_Time_Value&, const void*);
     virtual int handle_input(ACE_HANDLE h);
     virtual int handle_exception(ACE_HANDLE fd = ACE_INVALID_HANDLE);
 
     void open();
-    void write();
-    void write_i();
+    void write(bool include_local, bool include_relay);
+    void write_i(bool include_local, bool include_relay);
+    void write_i(const DCPS::RepoId& guid, bool include_local, bool include_relay);
+    void send(bool include_local, bool include_relay);
     void close();
     void dispose_unregister();
     bool open_unicast_socket(u_short port_common, u_short participant_id);
@@ -217,8 +214,22 @@ private:
     ACE_SOCK_Dgram_Mcast multicast_socket_;
     OPENDDS_SET(ACE_INET_Addr) send_addrs_;
     ACE_Message_Block buff_, wbuff_;
-    DCPS::TimeDuration disco_resend_period_;
-    DCPS::MonotonicTimePoint last_disco_resend_;
+    DCPS::ReactorTask reactor_task_;
+    DCPS::RcHandle<DCPS::JobQueue> job_queue_;
+    typedef DCPS::PmfPeriodicTask<SpdpTransport> SpdpPeriodic;
+    typedef DCPS::PmfSporadicTask<SpdpTransport> SpdpSporadic;
+    void send_local(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpPeriodic> local_sender_;
+#ifdef OPENDDS_SECURITY
+    void process_auth_deadlines(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpSporadic> auth_deadline_processor_;
+    void process_auth_resends(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpSporadic> auth_resend_processor_;
+#endif
+    void send_relay(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpPeriodic> relay_sender_;
+    void send_relay_beacon(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpPeriodic> relay_beacon_;
   } *tport_;
 
   ACE_Event_Handler_var eh_; // manages our refcount on tport_
@@ -248,10 +259,17 @@ private:
   DDS::Security::PermissionsCredentialToken permissions_credential_token_;
 
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
+
+  typedef std::multimap<DCPS::MonotonicTimePoint, DCPS::RepoId> TimeQueue;
+  TimeQueue auth_deadlines_;
+  TimeQueue auth_resends_;
 #endif
 
   void start_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail, const ICE::AgentInfo& agent_info);
   void stop_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail);
+
+  void purge_auth_deadlines(DiscoveredParticipantIter iter);
+  void purge_auth_resends(DiscoveredParticipantIter iter);
 
   friend class ::DDS_TEST;
 };

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -95,12 +95,6 @@ public:
     return command;
   }
 
-  CommandPtr enqueue(Command* c)
-  {
-    OPENDDS_ASSERT(c);
-    return enqueue_i(c, false);
-  }
-
   virtual bool reactor_is_shut_down() const = 0;
 
 protected:

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -130,6 +130,7 @@ OpenDDS::DCPS::ReactorTask::svc()
   reactor_owner_ = ACE_Thread_Manager::instance()->thr_self();
   wait_for_startup();
 
+  interceptor_ = make_rch<Interceptor>(this);
 
   {
     // Obtain the lock.  This should only happen once the open() has hit

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -11,6 +11,7 @@
 #include "dds/DCPS/dcps_export.h"
 #include "dds/DCPS/RcObject.h"
 #include "dds/DCPS/TimeTypes.h"
+#include "dds/DCPS/ReactorInterceptor.h"
 #include "ace/Task.h"
 #include "ace/Barrier.h"
 #include "ace/Synch_Traits.h"
@@ -54,6 +55,8 @@ public:
 
   bool is_shut_down() const { return state_ == STATE_NOT_RUNNING; }
 
+  RcHandle<ReactorInterceptor> interceptor() const { return interceptor_; }
+
   OPENDDS_POOL_ALLOCATION_FWD
 
 private:
@@ -67,6 +70,18 @@ private:
 
   enum State { STATE_NOT_RUNNING, STATE_OPENING, STATE_RUNNING };
 
+  class Interceptor : public DCPS::ReactorInterceptor {
+  public:
+    Interceptor(DCPS::ReactorTask* task) : ReactorInterceptor(task->get_reactor(), task->get_reactor_owner()), task_(task) {}
+    bool reactor_is_shut_down() const
+    {
+      return task_->is_shut_down();
+    }
+
+  private:
+    DCPS::ReactorTask* task_;
+  };
+
   ACE_Barrier   barrier_;
   LockType      lock_;
   State         state_;
@@ -76,6 +91,9 @@ private:
   ACE_Proactor* proactor_;
   bool          use_async_send_;
   TimerQueueType* timer_queue_;
+
+  RcHandle<Interceptor> interceptor_;
+
 };
 
 } // namespace DCPS

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -72,7 +72,10 @@ private:
 
   class Interceptor : public DCPS::ReactorInterceptor {
   public:
-    Interceptor(DCPS::ReactorTask* task) : ReactorInterceptor(task->get_reactor(), task->get_reactor_owner()), task_(task) {}
+    explicit Interceptor(DCPS::ReactorTask* task)
+     : ReactorInterceptor(task->get_reactor(), task->get_reactor_owner())
+     , task_(task)
+     {}
     bool reactor_is_shut_down() const
     {
       return task_->is_shut_down();

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -82,7 +82,7 @@ private:
     }
 
   private:
-    DCPS::ReactorTask* task_;
+    DCPS::ReactorTask* const task_;
   };
 
   ACE_Barrier   barrier_;

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -1,0 +1,137 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_SPORADIC_TASK_H
+#define OPENDDS_DCPS_SPORADIC_TASK_H
+
+#include "RcEventHandler.h"
+#include "ReactorInterceptor.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+class SporadicTask : public RcEventHandler {
+public:
+  explicit SporadicTask(RcHandle<ReactorInterceptor> interceptor)
+    : interceptor_(interceptor)
+    , scheduled_(false)
+  {
+    reactor(interceptor->reactor());
+  }
+
+  virtual ~SporadicTask() {}
+
+  void schedule(const TimeDuration& delay)
+  {
+    interceptor_->execute_or_enqueue(new ScheduleCommand(this, delay));
+  }
+
+  void cancel()
+  {
+    interceptor_->execute_or_enqueue(new CancelCommand(this));
+  }
+
+  void cancel_and_wait()
+  {
+    ReactorInterceptor::CommandPtr command = interceptor_->execute_or_enqueue(new CancelCommand(this));
+    command->wait();
+  }
+
+  virtual void execute(const MonotonicTimePoint& now) = 0;
+
+private:
+  RcHandle<ReactorInterceptor> interceptor_;
+  bool scheduled_;
+
+  struct ScheduleCommand : public ReactorInterceptor::Command {
+    ScheduleCommand(SporadicTask* hb, const TimeDuration& delay)
+      : sporadic_task_(hb), delay_(delay)
+    { }
+
+    virtual void execute()
+    {
+      sporadic_task_->schedule_i(delay_);
+    }
+
+    SporadicTask* const sporadic_task_;
+    const TimeDuration delay_;
+  };
+
+  struct CancelCommand : public ReactorInterceptor::Command {
+    CancelCommand(SporadicTask* hb)
+      : sporadic_task_(hb)
+    { }
+
+    virtual void execute()
+    {
+      sporadic_task_->cancel_i();
+    }
+
+    SporadicTask* const sporadic_task_;
+  };
+
+  int handle_timeout(const ACE_Time_Value& tv, const void*)
+  {
+    const MonotonicTimePoint now(tv);
+    scheduled_ = false;
+    execute(now);
+    return 0;
+  }
+
+  void schedule_i(const TimeDuration& delay)
+  {
+    if (!scheduled_) {
+      const long timer = reactor()->schedule_timer(this, 0, delay.value());
+
+      if (timer == -1) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::enable"
+                   " failed to schedule timer %p\n", ACE_TEXT("")));
+      } else {
+        scheduled_ = true;
+      }
+    }
+  }
+
+  void
+  cancel_i()
+  {
+    if (scheduled_) {
+      reactor()->cancel_timer(this);
+      scheduled_ = false;
+    }
+  }
+};
+
+template <typename Outer>
+class PmfSporadicTask : public SporadicTask {
+public:
+  typedef void (Outer::*PMF)(const MonotonicTimePoint&);
+
+  PmfSporadicTask(RcHandle<ReactorInterceptor> interceptor, Outer* outer, PMF function)
+    : SporadicTask(interceptor)
+    , outer_(outer)
+    , function_(function)
+  {}
+
+private:
+  Outer* outer_;
+  PMF function_;
+
+  void execute(const MonotonicTimePoint& now)
+  {
+    (outer_->*function_)(now);
+  }
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_SPORADIC_TASK_H  */

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -95,9 +95,9 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
                 config.nak_response_delay_)
   , heartbeat_reply_(this, &RtpsUdpDataLink::send_heartbeat_replies,
                      config.heartbeat_response_delay_)
-  , heartbeat_(reactor_task->interceptor(), this, &RtpsUdpDataLink::send_heartbeats)
-  , heartbeatchecker_(reactor_task->interceptor(), this, &RtpsUdpDataLink::check_heartbeats)
-  , relay_beacon_(reactor_task->interceptor(), this, &RtpsUdpDataLink::send_relay_beacon)
+  , heartbeat_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_heartbeats)
+  , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
+  , relay_beacon_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_relay_beacon)
   , held_data_delivery_handler_(this)
   , max_bundle_size_(config.max_bundle_size_)
   , quick_reply_delay_(config.heartbeat_response_delay_ * QUICK_REPLY_DELAY_RATIO)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -110,7 +110,7 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
     ACE_INET_Addr addr(rtps_relay_address_s.c_str());
     rtps_relay_address(addr);
   }
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("DataRtpsRelayBeaconPeriod"),
+  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("RtpsRelayBeaconPeriod"),
                         rtps_relay_beacon_period_);
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("RtpsRelayOnly"), rtps_relay_only_, bool);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -42,6 +42,7 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , handshake_timeout_(30) // default syn_timeout in OpenDDS_Multicast
   , durable_data_timeout_(60)
   , opendds_discovery_guid_(GUID_UNKNOWN)
+  , rtps_relay_beacon_period_(30)
   , rtps_relay_only_(false)
   , use_ice_(false)
 {
@@ -109,6 +110,8 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
     ACE_INET_Addr addr(rtps_relay_address_s.c_str());
     rtps_relay_address(addr);
   }
+  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("DataRtpsRelayBeaconPeriod"),
+                        rtps_relay_beacon_period_);
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("RtpsRelayOnly"), rtps_relay_only_, bool);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -100,49 +100,49 @@ private:
   ACE_INET_Addr local_address_;
   OPENDDS_STRING local_address_config_str_;
   ACE_INET_Addr rtps_relay_address_;
-  mutable ACE_SYNCH_MUTEX rtps_relay_address_lock_;
+  mutable ACE_SYNCH_MUTEX rtps_relay_config_lock_;
   TimeDuration rtps_relay_beacon_period_;
   bool rtps_relay_only_;
   bool use_ice_;
   ACE_INET_Addr stun_server_address_;
-  mutable ACE_SYNCH_MUTEX stun_server_address_lock_;
+  mutable ACE_SYNCH_MUTEX stun_server_config_lock_;
 
   ICE::AddressListType host_addresses() const;
 };
 
 inline void RtpsUdpInst::rtps_relay_address(const ACE_INET_Addr& address)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_address_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_config_lock_);
   rtps_relay_address_ = address;
 }
 
 inline ACE_INET_Addr RtpsUdpInst::rtps_relay_address() const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_address_lock_, ACE_INET_Addr());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_config_lock_, ACE_INET_Addr());
   return rtps_relay_address_;
 }
 
 inline void RtpsUdpInst::rtps_relay_beacon_period(const TimeDuration& period)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_address_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_config_lock_);
   rtps_relay_beacon_period_ = period;
 }
 
 inline TimeDuration RtpsUdpInst::rtps_relay_beacon_period() const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_address_lock_, TimeDuration());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_config_lock_, TimeDuration());
   return rtps_relay_beacon_period_;
 }
 
 inline void RtpsUdpInst::stun_server_address(const ACE_INET_Addr& address)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, stun_server_address_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, g, stun_server_config_lock_);
   stun_server_address_ = address;
 }
 
 inline ACE_INET_Addr RtpsUdpInst::stun_server_address() const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, stun_server_address_lock_, ACE_INET_Addr());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, stun_server_config_lock_, ACE_INET_Addr());
   return stun_server_address_;
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -76,6 +76,8 @@ public:
   ///{
   void rtps_relay_address(const ACE_INET_Addr& address);
   ACE_INET_Addr rtps_relay_address() const;
+  void rtps_relay_beacon_period(const TimeDuration& period);
+  TimeDuration rtps_relay_beacon_period() const;
   void rtps_relay_only(bool flag) { rtps_relay_only_ = flag; }
   bool rtps_relay_only() const { return rtps_relay_only_; }
   void stun_server_address(const ACE_INET_Addr& address);
@@ -98,6 +100,8 @@ private:
   ACE_INET_Addr local_address_;
   OPENDDS_STRING local_address_config_str_;
   ACE_INET_Addr rtps_relay_address_;
+  mutable ACE_SYNCH_MUTEX rtps_relay_address_lock_;
+  TimeDuration rtps_relay_beacon_period_;
   bool rtps_relay_only_;
   bool use_ice_;
   ACE_INET_Addr stun_server_address_;
@@ -108,14 +112,26 @@ private:
 
 inline void RtpsUdpInst::rtps_relay_address(const ACE_INET_Addr& address)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_address_lock_);
   rtps_relay_address_ = address;
 }
 
 inline ACE_INET_Addr RtpsUdpInst::rtps_relay_address() const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_address_lock_, ACE_INET_Addr());
   return rtps_relay_address_;
+}
+
+inline void RtpsUdpInst::rtps_relay_beacon_period(const TimeDuration& period)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_address_lock_);
+  rtps_relay_beacon_period_ = period;
+}
+
+inline TimeDuration RtpsUdpInst::rtps_relay_beacon_period() const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_address_lock_, TimeDuration());
+  return rtps_relay_beacon_period_;
 }
 
 inline void RtpsUdpInst::stun_server_address(const ACE_INET_Addr& address)

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -172,7 +172,6 @@ public:
 private:
   const ACE_INET_Addr application_participant_addr_;
   const std::string application_participant_addr_str_;
-  OpenDDS::DCPS::Message_Block_Shared_Ptr spdp_message_;
   typedef std::map<OpenDDS::DCPS::RepoId, OpenDDS::DCPS::Message_Block_Shared_Ptr, OpenDDS::DCPS::GUID_tKeyLessThan> SpdpMessages;
   SpdpMessages spdp_messages_;
   ACE_Thread_Mutex spdp_messages_mutex_;

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -460,8 +460,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
                                  &data_vertical_handler, &data_horizontal_handler);
   statistics_h.open();
 
-  rtps_discovery->schedule_send(application_domain, application_participant_id, OpenDDS::DCPS::TimeDuration(1));
-
   reactor->run_reactor_event_loop();
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
* Add INFO_DST to SPDP messages that are sent in response to
  discovered a new participant.  This allows the RtpsRelay to only
  forward the SPDP message to the intended destination.
* Both SPDP and RTPS transports send a beacon to the RtpsRelay.  The
  period of the beacon is configurable.  The beacon is sent
  unconditionally.
* Polling was converted to events in SPDP to handle authentication
  timeouts and resends.
* Three helper classes:
  * JobQueue - allows a thread to post a job on a Reactor.
  * PeriodicTask - a wrapper for periodic tasks.
  * SporadicTask - a wrapper for sporadic (one-shot) tasks.
* ReactorTask has an implicit ReactorInterceptor.

As an aside, the JobQueue was motivated by a deadlock where a
ReactorInterceptor command acquired a lock so that a subsequenct
execute_or_enqueue was not safe because the same lock was already
held.  This suggests that there are probably other situations where
ReactorInterceptor commands are acquiring locks which may result in
the same problem.  I recommend the following:
  1. Don't use the ReactorInterceptor as a general-purpose job queue.
     Use JobQueue.
  2. Limit ReactorInterceptor commands to dealing with the reactor and
     perhaps a small number of control variables.  Furthermore, all state
     updates should be performed by ReactorInterceptor commands.  This
     implicitly provides atomicity.  PeriodicTask and
     SporadicTask are examples of this.
  3. Avoid waiting for ReactorInterceptor commands.  Specifically, it
     is common to wait for a timer id so that it can be cancelled
     later.  An alternative approach would be to writer a helper and
     use multiple instances so the timer id is not necessary.
     Alternatively, the helper can maintain a list of timer ids.  In
     either case, writing a helper is good because it separates out
     the complexity of deadling with the reactor.