### PR TITLE
Cmake macro keyword signature fix

### DIFF
--- a/cmake/api_macros.cmake
+++ b/cmake/api_macros.cmake
@@ -24,7 +24,7 @@ macro(OPENDDS_GET_SOURCES_AND_OPTIONS
   set(_options_n
     PUBLIC PRIVATE INTERFACE
     TAO_IDL_OPTIONS OPENDDS_IDL_OPTIONS
-    TARGET_LINK_KEYWORD)
+    DEPENDENCY_LINK_KEYWORD)
 
   cmake_parse_arguments(_arg "" "" "${_options_n}" ${ARGN})
 
@@ -49,11 +49,10 @@ macro(OPENDDS_GET_SOURCES_AND_OPTIONS
   set(${tao_options} ${_arg_TAO_IDL_OPTIONS})
   set(${opendds_options} ${_arg_OPENDDS_IDL_OPTIONS})
 
-  string(TOUPPER "${_arg_TARGET_LINK_KEYWORD}" keyword)  
+  string(TOUPPER "${_arg_DEPENDENCY_LINK_KEYWORD}" keyword)
   if("${keyword}" MATCHES "\\_LINK$")
-    string(REPLACE "_LINK" "" ${link_keyword_option} ${keyword}) 
+    string(REPLACE "_LINK" "" ${link_keyword_option} ${keyword})
   endif()
-  
 
   foreach(arg ${_arg_UNPARSED_ARGUMENTS})
     get_filename_component(arg ${arg} ABSOLUTE)
@@ -162,9 +161,11 @@ macro(OPENDDS_TARGET_SOURCES target)
         ${OPENDDS_DCPS_COMPILE_DEFS})
   endif()
 
-  if(_link_signature_option)
-    message("OPENDDS_TARGET_SOURCES Linking against libraries with scope: '${_link_signature_option}'")
-  endif() 
+  if(OPENDDS_CMAKE_VERBOSE)
+    if(_link_signature_option)
+      message(STATUS "OPENDDS_TARGET_SOURCES Linking against dependencies with scope: '${_link_signature_option}'")
+    endif()
+  endif()
 
   if (OPENDDS_DCPS_LINK_DEPS)
     target_link_libraries(${target} ${_link_signature_option} ${OPENDDS_DCPS_LINK_DEPS})

--- a/cmake/api_macros.cmake
+++ b/cmake/api_macros.cmake
@@ -157,7 +157,7 @@ macro(OPENDDS_TARGET_SOURCES target)
     target_link_libraries(${target} ${OPENDDS_DCPS_LINK_DEPS})
   endif()
 
-  target_link_libraries(${target} Threads::Threads)
+  target_link_libraries(${target} PUBLIC Threads::Threads)
 
   foreach(scope PUBLIC PRIVATE INTERFACE)
     if(_idl_sources_${scope})

--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -85,3 +85,5 @@ if (NOT DEFINED TAO_ROOT)
 else()
   _OPENDDS_RETURN_ERR("TAO_ROOT has already been set")
 endif()
+
+set(OPENDDS_DEPENDENCY_LINK_KEYWORD "PUBLIC" CACHE "The scope to use when linking a target against dependencies in the OPENDDS_TARGET_SOURCES macro. Set to empty when plain signature is desirable." STRING)

--- a/tests/cmake_integration/Messenger/Messenger_1/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/Messenger_1/CMakeLists.txt
@@ -44,7 +44,7 @@ OPENDDS_TARGET_SOURCES(subscriber
 )
 
 foreach(t ${all_targets})
-  target_link_libraries(${t} OpenDDS::OpenDDS)
+  target_link_libraries(${t} PUBLIC OpenDDS::OpenDDS)
 endforeach()
 
 # Copy configs/scripts into build-output directory

--- a/tests/cmake_integration/Messenger/Messenger_2/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/Messenger_2/CMakeLists.txt
@@ -42,10 +42,10 @@ add_executable(subscriber
 )
 
 foreach(t ${all_targets})
-  target_link_libraries(${t} OpenDDS::OpenDDS)
+  target_link_libraries(${t} PUBLIC OpenDDS::OpenDDS)
 
   if (NOT "${t}" STREQUAL "messenger")
-    target_link_libraries(${t} messenger)
+    target_link_libraries(${t} PUBLIC messenger)
   endif()
 endforeach()
 


### PR DESCRIPTION
Attempts to address #1336 in a general way that allows a user to specify scope for linking in  'OPENDDS_TARGET_SOURCES', with an optional argument 'TARGET_LINK_KEYWORD' if the intention is to link the target against libraries using scope, ie making use of keyword signature for `target_link_libraries`. 
If 'TARGET_LINK_KEYWORD' is not supplied, the plain signature of `target_link_libraries` will be used for the linking that happens in the body of the 'OPENDDS_TARGET_SOURCES' cmake macro.

'TARGET_LINK_KEYWORD' can be specified as follows: PUBLIC_LINK | PRIVATE_LINK | INTERFACE_LINK. The keyword is made up of the scope, appended with _LINK, to distinguish the scope that is used in linking from the scope that may be specified for the sources. 