### PR TITLE
RtpsRelay:  Relay addresses not updated when client changes servers

### DIFF
--- a/tests/DCPS/RtpsRelay/Unit/main.cpp
+++ b/tests/DCPS/RtpsRelay/Unit/main.cpp
@@ -35,11 +35,11 @@ void test_invalid(int& status, const std::string& s)
   }
 }
 
-#define ASSERT_MATCHED(x) do {                                          \
-  GuidSet expected_local_guids;                                       \
-  expected_local_guids.insert(x->participant_guid());                 \
-  if (relay_addresses_map[RelayAddresses()] != expected_local_guids) { \
-    std::cout << "ERROR: " <<  __func__ << " failed: local guids do not match" << std::endl; \
+#define ASSERT_MATCHED(x) do {                                  \
+  GuidSet expected_guids;                                       \
+  expected_guids.insert(x->participant_guid());                 \
+  if (guids != expected_guids) { \
+    std::cout << "ERROR: " <<  __func__ << " failed: guids do not match" << std::endl; \
     status = EXIT_FAILURE;                                              \
   } \
   ReaderSet actual_readers, expected_readers;                           \
@@ -59,8 +59,8 @@ void test_invalid(int& status, const std::string& s)
 } while(0);
 
 #define ASSERT_NOT_MATCHED do { \
-  if (!relay_addresses_map.empty()) {                    \
-    std::cout << "ERROR: " <<  __func__ << " failed: local guids should be empty" << std::endl; \
+  if (!guids.empty()) {                    \
+    std::cout << "ERROR: " <<  __func__ << " failed: guids should be empty" << std::endl; \
     status = EXIT_FAILURE;                                              \
   } \
   ReaderSet actual_readers, expected_readers;                   \
@@ -87,7 +87,7 @@ void writer_then_matched_reader(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -96,12 +96,12 @@ void writer_then_matched_reader(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bjec[!s] *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 }
@@ -116,7 +116,7 @@ void reader_then_matched_writer(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -125,12 +125,12 @@ void reader_then_matched_writer(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(reader, relay_addresses_map);
-  index.insert(writer, relay_addresses_map);
+  GuidSet guids;
+  index.insert(reader, guids);
+  index.insert(writer, guids);
 
   ASSERT_MATCHED(reader);
 }
@@ -146,7 +146,7 @@ void matched_then_writer_changes_reliability(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -156,19 +156,19 @@ void matched_then_writer_changes_reliability(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   writer_entry.data_writer_qos().reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
 
-  relay_addresses_map.clear();
-  index.reinsert(writer, writer_entry, true, relay_addresses_map);
+  guids.clear();
+  index.reinsert(writer, writer_entry, guids);
   ASSERT_NOT_MATCHED;
 }
 
@@ -183,7 +183,7 @@ void matched_then_reader_changes_reliability(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -193,19 +193,19 @@ void matched_then_reader_changes_reliability(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   reader_entry.data_reader_qos().reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
 
-  relay_addresses_map.clear();
-  index.reinsert(reader, reader_entry, true, relay_addresses_map);
+  guids.clear();
+  index.reinsert(reader, reader_entry, guids);
 
   ASSERT_NOT_MATCHED;
 }
@@ -220,7 +220,7 @@ void matched_then_writer_changes_partition(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -229,19 +229,19 @@ void matched_then_writer_changes_partition(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   writer_entry.publisher_qos().partition.name[0] = "Object";
 
-  relay_addresses_map.clear();
-  index.reinsert(writer, writer_entry, true, relay_addresses_map);
+  guids.clear();
+  index.reinsert(writer, writer_entry, guids);
 
   ASSERT_NOT_MATCHED;
 }
@@ -256,7 +256,7 @@ void matched_then_reader_changes_partition(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -265,19 +265,19 @@ void matched_then_reader_changes_partition(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   reader_entry.subscriber_qos().partition.name[0] = "Object";
 
-  relay_addresses_map.clear();
-  index.reinsert(reader, reader_entry, true, relay_addresses_map);
+  guids.clear();
+  index.reinsert(reader, reader_entry, guids);
 
   ASSERT_NOT_MATCHED;
 }
@@ -292,7 +292,7 @@ void matched_then_writer_changes_topic(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -301,19 +301,19 @@ void matched_then_writer_changes_topic(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   writer_entry.topic_name("a new topic");
 
-  relay_addresses_map.clear();
-  index.reinsert(writer, writer_entry, true, relay_addresses_map);
+  guids.clear();
+  index.reinsert(writer, writer_entry, guids);
 
   ASSERT_NOT_MATCHED;
 }
@@ -328,7 +328,7 @@ void matched_then_reader_changes_topic(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -337,19 +337,19 @@ void matched_then_reader_changes_topic(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   reader_entry.topic_name("a new topic");
 
-  relay_addresses_map.clear();
-  index.reinsert(reader, reader_entry, true, relay_addresses_map);
+  guids.clear();
+  index.reinsert(reader, reader_entry, guids);
 
   ASSERT_NOT_MATCHED;
 }
@@ -365,7 +365,7 @@ void unmatched_then_writer_changes_reliability(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -375,18 +375,18 @@ void unmatched_then_writer_changes_reliability(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_NOT_MATCHED;
 
   writer_entry.data_writer_qos().reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
 
-  index.reinsert(writer, writer_entry, true, relay_addresses_map);
+  index.reinsert(writer, writer_entry, guids);
 
   ASSERT_MATCHED(reader);
 }
@@ -402,7 +402,7 @@ void unmatched_then_reader_changes_reliability(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -412,18 +412,18 @@ void unmatched_then_reader_changes_reliability(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "?bject *, [Ii]nc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_NOT_MATCHED;
 
   reader_entry.data_reader_qos().reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
 
-  index.reinsert(reader, reader_entry, true, relay_addresses_map);
+  index.reinsert(reader, reader_entry, guids);
 
   ASSERT_MATCHED(writer);
 }
@@ -438,7 +438,7 @@ void unmatched_then_writer_changes_partition(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -447,18 +447,18 @@ void unmatched_then_writer_changes_partition(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "OCI";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_NOT_MATCHED;
 
   writer_entry.publisher_qos().partition.name[0] = "OCI";
 
-  index.reinsert(writer, writer_entry, true, relay_addresses_map);
+  index.reinsert(writer, writer_entry, guids);
 
   ASSERT_MATCHED(reader);
 }
@@ -473,7 +473,7 @@ void unmatched_then_reader_changes_partition(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -482,18 +482,18 @@ void unmatched_then_reader_changes_partition(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "OCI";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_NOT_MATCHED;
 
   reader_entry.subscriber_qos().partition.name[0] = "Object Computing, Inc.";
 
-  index.reinsert(reader, reader_entry, true, relay_addresses_map);
+  index.reinsert(reader, reader_entry, guids);
 
   ASSERT_MATCHED(writer);
 }
@@ -508,7 +508,7 @@ void unmatched_then_writer_changes_topic(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "O*C*I*";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -517,18 +517,18 @@ void unmatched_then_writer_changes_topic(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "Object Computing, Inc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_NOT_MATCHED;
 
   writer_entry.topic_name("the topic");
 
-  index.reinsert(writer, writer_entry, true, relay_addresses_map);
+  index.reinsert(writer, writer_entry, guids);
 
   ASSERT_MATCHED(reader);
 }
@@ -541,7 +541,7 @@ void unmatched_then_reader_changes_topic(int& status)
   writer_entry.type_name("the type");
   writer_entry.data_writer_qos(TheServiceParticipant->initial_DataWriterQos());
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("wrong topic");
@@ -550,18 +550,18 @@ void unmatched_then_reader_changes_topic(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_NOT_MATCHED;
 
   reader_entry.topic_name("the topic");
 
-  index.reinsert(reader, reader_entry, true, relay_addresses_map);
+  index.reinsert(reader, reader_entry, guids);
 
   ASSERT_MATCHED(writer);
 }
@@ -576,7 +576,7 @@ void matched_then_writer_disappears(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "Object Computing, Inc.";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -585,18 +585,18 @@ void matched_then_writer_disappears(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "O*C*I*";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
 
   ASSERT_MATCHED(writer);
 
   index.erase(writer);
 
-  relay_addresses_map.clear();
+  guids.clear();
 
   ASSERT_NOT_MATCHED;
 }
@@ -611,7 +611,7 @@ void matched_then_reader_disappears(int& status)
   writer_entry.publisher_qos(TheServiceParticipant->initial_PublisherQos());
   writer_entry.publisher_qos().partition.name.length(1);
   writer_entry.publisher_qos().partition.name[0] = "O*C*I*";
-  WriterPtr writer(new Writer(writer_entry, true));
+  WriterPtr writer(new Writer(writer_entry));
 
   ReaderEntry reader_entry;
   reader_entry.topic_name("the topic");
@@ -620,17 +620,17 @@ void matched_then_reader_disappears(int& status)
   reader_entry.subscriber_qos(TheServiceParticipant->initial_SubscriberQos());
   reader_entry.subscriber_qos().partition.name.length(1);
   reader_entry.subscriber_qos().partition.name[0] = "Object Computing, Inc.";
-  ReaderPtr reader(new Reader(reader_entry, true));
+  ReaderPtr reader(new Reader(reader_entry));
 
   Index index;
-  RelayAddressesMap relay_addresses_map;
-  index.insert(writer, relay_addresses_map);
-  index.insert(reader, relay_addresses_map);
+  GuidSet guids;
+  index.insert(writer, guids);
+  index.insert(reader, guids);
   ASSERT_MATCHED(writer);
 
   index.erase(reader);
 
-  relay_addresses_map.clear();
+  guids.clear();
 
   ASSERT_NOT_MATCHED;
 }

--- a/tools/rtpsrelay/AssociationTable.h
+++ b/tools/rtpsrelay/AssociationTable.h
@@ -11,23 +11,17 @@ namespace RtpsRelay {
 
 class AssociationTable {
 public:
-  explicit AssociationTable(const RelayAddresses& relay_addresses) :
-    relay_addresses_(relay_addresses)
-  {}
   void insert(const WriterEntry& entry,
-              RelayAddressesMap& relay_addresses_map);
+              GuidSet& guids);
   void remove(const WriterEntry& entry);
   void insert(const ReaderEntry& entry,
-              RelayAddressesMap& relay_addresses_map);
+              GuidSet& guids);
   void remove(const ReaderEntry& entry);
 
-  void populate_relay_addresses_map(RelayAddressesMap& relay_addresses_map,
-                                    const OpenDDS::DCPS::RepoId& from,
-                                    const GuidSet& to) const;
+  void lookup_destinations(GuidSet& to,
+                           const OpenDDS::DCPS::RepoId& from) const;
 
 private:
-  const RelayAddresses& relay_addresses_;
-
   typedef std::map<OpenDDS::DCPS::RepoId, WriterPtr, OpenDDS::DCPS::GUID_tKeyLessThan> WritersMap;
   WritersMap writers_;
   typedef std::map<OpenDDS::DCPS::RepoId, ReaderPtr, OpenDDS::DCPS::GUID_tKeyLessThan> ReadersMap;

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -5,11 +5,9 @@
 namespace RtpsRelay {
 
 PublicationListener::PublicationListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
-                                         WriterEntryDataWriter_ptr writer,
-                                         const RelayAddresses& relay_addresses)
+                                         WriterEntryDataWriter_ptr writer)
   : participant_(participant)
   , writer_(writer)
-  , relay_addresses_(relay_addresses)
 {}
 
 void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
@@ -83,8 +81,6 @@ void PublicationListener::write_sample(const DDS::PublicationBuiltinTopicData& d
     data.type_name.in(),
     data_writer_qos,
     publisher_qos,
-
-    relay_addresses_
   };
 
   DDS::ReturnCode_t ret = writer_->write(entry, DDS::HANDLE_NIL);

--- a/tools/rtpsrelay/PublicationListener.h
+++ b/tools/rtpsrelay/PublicationListener.h
@@ -11,8 +11,7 @@ namespace RtpsRelay {
 class PublicationListener : public ListenerBase {
 public:
   PublicationListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
-                      WriterEntryDataWriter_ptr writer,
-                      const RelayAddresses& relay_addresses);
+                      WriterEntryDataWriter_ptr writer);
 private:
   void on_data_available(DDS::DataReader_ptr reader) override;
   void write_sample(const DDS::PublicationBuiltinTopicData& data,
@@ -21,7 +20,6 @@ private:
 
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   WriterEntryDataWriter_ptr writer_;
-  const RelayAddresses& relay_addresses_;
 };
 
 }

--- a/tools/rtpsrelay/ReaderListener.cpp
+++ b/tools/rtpsrelay/ReaderListener.cpp
@@ -33,9 +33,10 @@ void ReaderListener::on_data_available(DDS::DataReader_ptr reader)
     switch (infos[idx].instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       {
-        RelayAddressesMap relay_addresses_map;
-        association_table_.insert(data[idx], relay_addresses_map);
-        spdp_handler_.replay(guid_to_repoid(data[idx].guid()), relay_addresses_map);
+        const auto from = guid_to_repoid(data[idx].guid());
+        GuidSet to;
+        association_table_.insert(data[idx], to);
+        spdp_handler_.replay(from, to);
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -112,8 +112,7 @@ protected:
                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg) override;
   void send(const GuidSet& to,
             const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg);
-  void populate_relay_addresses_map(RelayAddressesMap& relay_addresses_map,
-                                    const GuidSet& to);
+  RelayAddressesMap populate_relay_addresses_map(const GuidSet& to);
 
   GuidRelayAddressesDataWriter_ptr responsible_relay_writer_;
   GuidRelayAddressesDataReader_ptr responsible_relay_reader_;

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -80,6 +80,8 @@ public:
   VerticalHandler(ACE_Reactor* reactor,
                   const RelayAddresses& relay_addresses,
                   const AssociationTable& association_table,
+                  GuidRelayAddressesDataWriter_ptr responsible_relay_writer,
+                  GuidRelayAddressesDataReader_ptr responsible_relay_reader,
                   const OpenDDS::DCPS::TimeDuration& lifespan,
                   const OpenDDS::RTPS::RtpsDiscovery_rch& rtps_discovery,
                   DDS::DomainId_t application_domain,
@@ -108,9 +110,13 @@ protected:
   void process_message(const ACE_INET_Addr& remote,
                        const OpenDDS::DCPS::MonotonicTimePoint& now,
                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg) override;
-  void send(const RelayAddressesMap& relay_addresses_map,
+  void send(const GuidSet& to,
             const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg);
+  void populate_relay_addresses_map(RelayAddressesMap& relay_addresses_map,
+                                    const GuidSet& to);
 
+  GuidRelayAddressesDataWriter_ptr responsible_relay_writer_;
+  GuidRelayAddressesDataReader_ptr responsible_relay_reader_;
   const RelayAddresses& relay_addresses_;
   HorizontalHandler* horizontal_handler_;
   GuidAddrMap guid_addr_map_;
@@ -128,6 +134,10 @@ private:
                      GuidSet& to,
                      bool& is_pad_only,
                      bool check_submessages);
+  RelayAddresses read_relay_addresses(const OpenDDS::DCPS::RepoId& guid) const;
+  void write_relay_addresses(const OpenDDS::DCPS::RepoId& guid,
+                             const RelayAddresses& relay_addresses);
+  void unregister_relay_addresses(const OpenDDS::DCPS::RepoId& guid);
 
   OpenDDS::RTPS::RtpsDiscovery_rch rtps_discovery_;
   const DDS::DomainId_t application_domain_;
@@ -159,6 +169,8 @@ public:
   SpdpHandler(ACE_Reactor* reactor,
               const RelayAddresses& relay_addresses,
               const AssociationTable& association_table,
+              GuidRelayAddressesDataWriter_ptr responsible_relay_writer,
+              GuidRelayAddressesDataReader_ptr responsible_relay_reader,
               const OpenDDS::DCPS::TimeDuration& lifespan,
               const OpenDDS::RTPS::RtpsDiscovery_rch& rtps_discovery,
               DDS::DomainId_t application_domain,
@@ -166,8 +178,8 @@ public:
               const CRYPTO_TYPE& crypto,
               const ACE_INET_Addr& application_participant_addr);
 
-  void replay(const OpenDDS::DCPS::RepoId& guid,
-              const RelayAddressesMap& relay_addresses_map);
+  void replay(const OpenDDS::DCPS::RepoId& from,
+              const GuidSet& to);
 
 private:
   const ACE_INET_Addr application_participant_addr_;
@@ -191,6 +203,8 @@ public:
   SedpHandler(ACE_Reactor* reactor,
               const RelayAddresses& relay_addresses,
               const AssociationTable& association_table,
+              GuidRelayAddressesDataWriter_ptr responsible_relay_writer,
+              GuidRelayAddressesDataReader_ptr responsible_relay_reader,
               const OpenDDS::DCPS::TimeDuration& lifespan,
               const OpenDDS::RTPS::RtpsDiscovery_rch& rtps_discovery,
               DDS::DomainId_t application_domain,
@@ -215,6 +229,8 @@ public:
   DataHandler(ACE_Reactor* reactor,
               const RelayAddresses& relay_addresses,
               const AssociationTable& association_table,
+              GuidRelayAddressesDataWriter_ptr responsible_relay_writer,
+              GuidRelayAddressesDataReader_ptr responsible_relay_reader,
               const OpenDDS::DCPS::TimeDuration& lifespan,
               const OpenDDS::RTPS::RtpsDiscovery_rch& rtps_discovery,
               DDS::DomainId_t application_domain,

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -245,7 +245,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     addr_to_string(data_horizontal_addr)
   };
 
-  AssociationTable association_table(relay_addresses);
+  AssociationTable association_table;
 
   HorizontalHandler spdp_horizontal_handler(reactor, association_table);
   HorizontalHandler sedp_horizontal_handler(reactor, association_table);
@@ -266,9 +266,120 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   const int crypto = 0;
 #endif
 
-  SpdpHandler spdp_vertical_handler(reactor, relay_addresses, association_table, lifespan, rtps_discovery, application_domain, application_participant_id, crypto, spdp);
-  SedpHandler sedp_vertical_handler(reactor, relay_addresses, association_table, lifespan, rtps_discovery, application_domain, application_participant_id, crypto, sedp);
-  DataHandler data_vertical_handler(reactor, relay_addresses, association_table, lifespan, rtps_discovery, application_domain, application_participant_id, crypto);
+  DDS::Subscriber_var bit_subscriber = application_participant->get_builtin_subscriber();
+
+  GuidRelayAddressesTypeSupportImpl::_var_type guid_relay_addresses_ts =
+    new GuidRelayAddressesTypeSupportImpl;
+  if (guid_relay_addresses_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to register GuidRelayAddresses type\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::Topic_var responsible_relay_topic =
+    relay_participant->create_topic("Responsible Relay",
+                                    guid_relay_addresses_ts->get_type_name(),
+                                    TOPIC_QOS_DEFAULT, nullptr,
+                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!responsible_relay_topic) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Responsible Relay topic\n"));
+    return EXIT_FAILURE;
+  }
+
+  ReaderEntryTypeSupportImpl::_var_type reader_entry_ts =
+    new ReaderEntryTypeSupportImpl;
+  if (reader_entry_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to register ReaderEntry type\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::Topic_var readers_topic = relay_participant->create_topic("Readers", reader_entry_ts->get_type_name(),
+                                                                 TOPIC_QOS_DEFAULT, nullptr,
+                                                                 OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!readers_topic) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Readers topic\n"));
+    return EXIT_FAILURE;
+  }
+
+  WriterEntryTypeSupportImpl::_var_type writer_entry_ts =
+    new WriterEntryTypeSupportImpl;
+  if (writer_entry_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to register WriterEntry type\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::Topic_var writers_topic = relay_participant->create_topic("Writers", writer_entry_ts->get_type_name(),
+                                                                 TOPIC_QOS_DEFAULT, nullptr,
+                                                                 OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!writers_topic) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writers topic\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::Publisher_var relay_publisher = relay_participant->create_publisher(PUBLISHER_QOS_DEFAULT, nullptr,
+                                                                           OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_publisher) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Relay publisher\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::Subscriber_var relay_subscriber = relay_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr,
+                                                                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_subscriber) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Relay subscriber\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::DataWriterQos writer_qos;
+  relay_publisher->get_default_datawriter_qos(writer_qos);
+
+  writer_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
+  DDS::DataReaderQos reader_qos;
+  relay_subscriber->get_default_datareader_qos(reader_qos);
+
+  reader_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
+  DDS::DataWriter_var responsible_relay_writer_var =
+    relay_publisher->create_datawriter(responsible_relay_topic, writer_qos, nullptr,
+                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!responsible_relay_writer_var) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Responsible Relay data writer\n"));
+    return EXIT_FAILURE;
+  }
+
+  GuidRelayAddressesDataWriter_ptr responsible_relay_writer = GuidRelayAddressesDataWriter::_narrow(responsible_relay_writer_var);
+
+  if (!responsible_relay_writer) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to narrow Responsible Relay data writer\n"));
+    return EXIT_FAILURE;
+  }
+
+  DDS::DataReader_var responsible_relay_reader_var =
+    relay_subscriber->create_datareader(responsible_relay_topic, reader_qos, nullptr,
+                                        DDS::DATA_AVAILABLE_STATUS);
+  if (!responsible_relay_reader_var) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reponsible Relay data reader\n"));
+    return EXIT_FAILURE;
+  }
+
+  GuidRelayAddressesDataReader_ptr responsible_relay_reader = GuidRelayAddressesDataReader::_narrow(responsible_relay_reader_var);
+
+  if (!responsible_relay_reader) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to narrow Responsible Relay data reader\n"));
+    return EXIT_FAILURE;
+  }
+
+  SpdpHandler spdp_vertical_handler(reactor, relay_addresses, association_table, responsible_relay_writer, responsible_relay_reader, lifespan, rtps_discovery, application_domain, application_participant_id, crypto, spdp);
+  SedpHandler sedp_vertical_handler(reactor, relay_addresses, association_table, responsible_relay_writer, responsible_relay_reader, lifespan, rtps_discovery, application_domain, application_participant_id, crypto, sedp);
+  DataHandler data_vertical_handler(reactor, relay_addresses, association_table, responsible_relay_writer, responsible_relay_reader, lifespan, rtps_discovery, application_domain, application_participant_id, crypto);
 
   spdp_horizontal_handler.vertical_handler(&spdp_vertical_handler);
   sedp_horizontal_handler.vertical_handler(&sedp_vertical_handler);
@@ -293,166 +404,69 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     << "SEDP Vertical listening on " << sedp_vertical_handler.relay_address() << '\n'
     << "Data Vertical listening on " << data_vertical_handler.relay_address() << std::endl;
 
-  DDS::Subscriber_var bit_subscriber = application_participant->get_builtin_subscriber();
-  {
-    ReaderEntryTypeSupportImpl::_var_type reader_entry_ts =
-      new ReaderEntryTypeSupportImpl;
-    if (reader_entry_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to register ReaderEntry type\n"));
-      return EXIT_FAILURE;
-    }
+  DDS::DataWriter_var reader_writer_var = relay_publisher->create_datawriter(readers_topic, writer_qos, nullptr,
+                                                                             OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    CORBA::String_var type_name = reader_entry_ts->get_type_name();
-    DDS::Topic_var topic = relay_participant->create_topic("Readers", type_name,
-                                                           TOPIC_QOS_DEFAULT, nullptr,
-                                                           OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (!topic) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Readers topic\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::Publisher_var publisher = relay_participant->create_publisher(PUBLISHER_QOS_DEFAULT, nullptr,
-                                                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (!publisher) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reader publisher\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::Subscriber_var subscriber = relay_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr,
-                                                                          OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (!subscriber) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reader subscriber\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::DataWriterQos writer_qos;
-    publisher->get_default_datawriter_qos(writer_qos);
-
-    writer_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-    writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
-
-    DDS::DataWriter_var writer = publisher->create_datawriter(topic, writer_qos, nullptr,
-                                                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (!writer) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reader data writer\n"));
-      return EXIT_FAILURE;
-    }
-
-    ReaderEntryDataWriter_ptr reader_writer = ReaderEntryDataWriter::_narrow(writer);
-
-    if (!reader_writer) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to narrow Reader data writer\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::DataReaderQos reader_qos;
-    subscriber->get_default_datareader_qos(reader_qos);
-
-    reader_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-    reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
-
-    DDS::DataReader_var reader = subscriber->create_datareader(topic, reader_qos,
-                                                               new ReaderListener(association_table, spdp_vertical_handler),
-                                                               DDS::DATA_AVAILABLE_STATUS);
-
-    if (!reader) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reader data reader\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::DataReader_var dr = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_SUBSCRIPTION_TOPIC);
-    DDS::DataReaderListener_var subscription_listener(new SubscriptionListener(application_participant_impl,
-                                                                               reader_writer,
-                                                                               relay_addresses));
-    DDS::ReturnCode_t ret = dr->set_listener(subscription_listener, DDS::DATA_AVAILABLE_STATUS);
-    if (ret != DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to set listener on SubscriptionBuiltinTopicDataDataReader\n"));
-      return EXIT_FAILURE;
-    }
+  if (!reader_writer_var) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reader data writer\n"));
+    return EXIT_FAILURE;
   }
 
-  {
-    WriterEntryTypeSupportImpl::_var_type writer_entry_ts =
-      new WriterEntryTypeSupportImpl;
-    if (writer_entry_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to register WriterEntry type\n"));
-      return EXIT_FAILURE;
-    }
+  ReaderEntryDataWriter_ptr reader_writer = ReaderEntryDataWriter::_narrow(reader_writer_var);
 
-    CORBA::String_var type_name = writer_entry_ts->get_type_name();
-    DDS::Topic_var topic = relay_participant->create_topic("Writers", type_name,
-                                                           TOPIC_QOS_DEFAULT, nullptr,
-                                                           OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  if (!reader_writer) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to narrow Reader data writer\n"));
+    return EXIT_FAILURE;
+  }
 
-    if (!topic) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writers topic\n"));
-      return EXIT_FAILURE;
-    }
+  DDS::DataReader_var reader_reader_var = relay_subscriber->create_datareader(readers_topic, reader_qos,
+                                                                              new ReaderListener(association_table, spdp_vertical_handler),
+                                                                              DDS::DATA_AVAILABLE_STATUS);
 
-    DDS::Publisher_var publisher = relay_participant->create_publisher(PUBLISHER_QOS_DEFAULT, nullptr,
-                                                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  if (!reader_reader_var) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Reader data reader\n"));
+    return EXIT_FAILURE;
+  }
 
-    if (!publisher) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writer publisher\n"));
-      return EXIT_FAILURE;
-    }
+  DDS::DataReader_var subscription_reader = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_SUBSCRIPTION_TOPIC);
+  DDS::DataReaderListener_var subscription_listener(new SubscriptionListener(application_participant_impl,
+                                                                             reader_writer));
+  DDS::ReturnCode_t ret = subscription_reader->set_listener(subscription_listener, DDS::DATA_AVAILABLE_STATUS);
+  if (ret != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to set listener on SubscriptionBuiltinTopicDataDataReader\n"));
+    return EXIT_FAILURE;
+  }
 
-    DDS::Subscriber_var subscriber = relay_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr,
-                                                                          OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  DDS::DataWriter_var writer_writer_var = relay_publisher->create_datawriter(writers_topic, writer_qos, nullptr,
+                                                                             OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-    if (!subscriber) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writer subscriber\n"));
-      return EXIT_FAILURE;
-    }
+  if (!writer_writer_var) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writer data writer\n"));
+    return EXIT_FAILURE;
+  }
 
-    DDS::DataWriterQos writer_qos;
-    publisher->get_default_datawriter_qos(writer_qos);
+  WriterEntryDataWriter_ptr writer_writer = WriterEntryDataWriter::_narrow(writer_writer_var);
 
-    writer_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-    writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+  if (!writer_writer) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to narrow Writer data writer\n"));
+    return EXIT_FAILURE;
+  }
 
-    DDS::DataWriter_var writer = publisher->create_datawriter(topic, writer_qos, nullptr,
-                                                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  DDS::DataReader_var writer_reader = relay_subscriber->create_datareader(writers_topic, reader_qos,
+                                                                          new WriterListener(association_table, spdp_vertical_handler),
+                                                                          DDS::DATA_AVAILABLE_STATUS);
+  if (!writer_reader) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writer data reader\n"));
+    return EXIT_FAILURE;
+  }
 
-    if (!writer) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writer data writer\n"));
-      return EXIT_FAILURE;
-    }
-
-    WriterEntryDataWriter_ptr writer_writer = WriterEntryDataWriter::_narrow(writer);
-
-    if (!writer_writer) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to narrow Writer data writer\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::DataReaderQos reader_qos;
-    subscriber->get_default_datareader_qos(reader_qos);
-
-    reader_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-    reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
-
-    DDS::DataReader_var reader = subscriber->create_datareader(topic, reader_qos,
-                                                               new WriterListener(association_table, spdp_vertical_handler),
-                                                               DDS::DATA_AVAILABLE_STATUS);
-    if (!reader) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: failed to create Writer data reader\n"));
-      return EXIT_FAILURE;
-    }
-
-    DDS::DataReader_var dr = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PUBLICATION_TOPIC);
-    DDS::DataReaderListener_var publication_listener(new PublicationListener(application_participant_impl,
-                                                                             writer_writer,
-                                                                             relay_addresses));
-    DDS::ReturnCode_t ret = dr->set_listener(publication_listener, DDS::DATA_AVAILABLE_STATUS);
-    if (ret != DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to set listener on PublicationBuiltinTopicDataDataReader\n"));
-      return EXIT_FAILURE;
-    }
+  DDS::DataReader_var publication_reader = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PUBLICATION_TOPIC);
+  DDS::DataReaderListener_var publication_listener(new PublicationListener(application_participant_impl,
+                                                                           writer_writer));
+  ret = publication_reader->set_listener(publication_listener, DDS::DATA_AVAILABLE_STATUS);
+  if (ret != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) %N:%l ERROR: Failed to set listener on PublicationBuiltinTopicDataDataReader\n"));
+    return EXIT_FAILURE;
   }
 
   StatisticsHandler statistics_h(reactor,

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -5,11 +5,9 @@
 namespace RtpsRelay {
 
 SubscriptionListener::SubscriptionListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
-                                           ReaderEntryDataWriter_ptr writer,
-                                           const RelayAddresses& relay_addresses)
+                                           ReaderEntryDataWriter_ptr writer)
   : participant_(participant)
   , writer_(writer)
-  , relay_addresses_(relay_addresses)
 {}
 
 void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
@@ -80,8 +78,6 @@ void SubscriptionListener::write_sample(const DDS::SubscriptionBuiltinTopicData&
     data.type_name.in(),
     data_reader_qos,
     subscriber_qos,
-
-    relay_addresses_
   };
 
   DDS::ReturnCode_t ret = writer_->write(entry, DDS::HANDLE_NIL);

--- a/tools/rtpsrelay/SubscriptionListener.h
+++ b/tools/rtpsrelay/SubscriptionListener.h
@@ -11,8 +11,7 @@ namespace RtpsRelay {
 class SubscriptionListener : public ListenerBase {
 public:
   SubscriptionListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
-                       ReaderEntryDataWriter_ptr writer,
-                       const RelayAddresses& relay_addresses);
+                       ReaderEntryDataWriter_ptr writer);
 private:
   void on_data_available(DDS::DataReader_ptr /*reader*/) override;
   void write_sample(const DDS::SubscriptionBuiltinTopicData& data,
@@ -21,7 +20,6 @@ private:
 
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   ReaderEntryDataWriter_ptr writer_;
-  const RelayAddresses& relay_addresses_;
 };
 
 }

--- a/tools/rtpsrelay/WriterListener.cpp
+++ b/tools/rtpsrelay/WriterListener.cpp
@@ -33,9 +33,10 @@ void WriterListener::on_data_available(DDS::DataReader_ptr reader)
     switch (infos[idx].instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       {
-        RelayAddressesMap relay_addresses_map;
-        association_table_.insert(data[idx], relay_addresses_map);
-        spdp_handler_.replay(guid_to_repoid(data[idx].guid()), relay_addresses_map);
+        const auto from = guid_to_repoid(data[idx].guid());
+        GuidSet to;
+        association_table_.insert(data[idx], to);
+        spdp_handler_.replay(from, to);
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:

--- a/tools/rtpsrelay/lib/Relay.idl
+++ b/tools/rtpsrelay/lib/Relay.idl
@@ -27,12 +27,6 @@ module RtpsRelay {
     @key EntityId_t entityId;
   };
 
-  struct RelayAddresses {
-    string spdp_relay_address;
-    string sedp_relay_address;
-    string data_relay_address;
-  };
-
   @topic
   struct WriterEntry {
     @key GUID_t guid;
@@ -41,8 +35,6 @@ module RtpsRelay {
     string type_name;
     DDS::DataWriterQos data_writer_qos;
     DDS::PublisherQos publisher_qos;
-
-    RelayAddresses relay_addresses;
   };
 
   @topic
@@ -53,11 +45,21 @@ module RtpsRelay {
     string type_name;
     DDS::DataReaderQos data_reader_qos;
     DDS::SubscriberQos subscriber_qos;
+  };
 
+  struct RelayAddresses {
+    string spdp_relay_address;
+    string sedp_relay_address;
+    string data_relay_address;
+  };
+
+  @topic
+  struct GuidRelayAddresses {
+    @key GUID_t guid;
     RelayAddresses relay_addresses;
   };
 
-typedef sequence<GUID_t> GuidSequence;
+  typedef sequence<GUID_t> GuidSequence;
 
   struct RelayHeader {
     GuidSequence to;


### PR DESCRIPTION
Previously, the relay addresses were bundled with the reader and
writer entries.  Suppose there are two relays A and B and a client
connects to A, switches to B, and then switches back to A before the
participant lease duration.  This causes A to write entries for the
participant and then B will write entries for the participant.
However, the client is associated with A but the topic says it should
be associated with B.

To solve this problem, remove the relay addresses from the reader and
writer entries and create a new topic for participant to relay
pairings (Responsible Relay).  The relays maintain the Responsible
Relay topic based on the traffic that they are observing.  The Reader
and Writer entries are just for matching.

For this change, we had to remove the local/remote distinction in the
QosIndex.  This means that every relay must maintain a complete
association table.