### PR TITLE
Spdp uses destructed lock on shutdown

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -31,6 +31,346 @@ namespace RTPS {
 
 const char RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS[] = "OpenDDS.RtpsDiscovery.EndpointAnnouncements";
 
+class OpenDDS_Rtps_Export RtpsDiscoveryConfig : public OpenDDS::DCPS::RcObject {
+public:
+  typedef OPENDDS_VECTOR(OPENDDS_STRING) AddrVec;
+
+  RtpsDiscoveryConfig();
+
+  DCPS::TimeDuration resend_period() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return resend_period_;
+  }
+  void resend_period(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    resend_period_ = period;
+  }
+
+  DCPS::TimeDuration lease_duration() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return lease_duration_;
+  }
+  void lease_duration(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    lease_duration_ = period;
+  }
+
+  u_short pb() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return pb_;
+  }
+  void pb(u_short port_base)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    pb_ = port_base;
+  }
+
+  u_short dg() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return dg_;
+  }
+  void dg(u_short domain_gain)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    dg_ = domain_gain;
+  }
+
+  u_short pg() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return pg_;
+  }
+  void pg(u_short participant_gain)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    pg_ = participant_gain;
+  }
+
+  u_short d0() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return d0_;
+  }
+  void d0(u_short offset_zero)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    d0_ = offset_zero;
+  }
+
+  u_short d1() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return d1_;
+  }
+  void d1(u_short offset_one)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    d1_ = offset_one;
+  }
+
+  u_short dx() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return dx_;
+  }
+  void dx(u_short offset_two)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    dx_ = offset_two;
+  }
+
+  unsigned char ttl() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, 0);
+    return ttl_;
+  }
+  void ttl(unsigned char time_to_live)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    ttl_ = time_to_live;
+  }
+
+  OPENDDS_STRING sedp_local_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, OPENDDS_STRING());
+    return sedp_local_address_;
+  }
+  void sedp_local_address(const OPENDDS_STRING& mi)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_local_address_ = mi;
+  }
+
+  OPENDDS_STRING spdp_local_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, OPENDDS_STRING());
+    return spdp_local_address_;
+  }
+  void spdp_local_address(const OPENDDS_STRING& mi)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_local_address_ = mi;
+  }
+
+  bool sedp_multicast() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, bool());
+    return sedp_multicast_;
+  }
+  void sedp_multicast(bool sm)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_multicast_ = sm;
+  }
+
+  OPENDDS_STRING multicast_interface() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, OPENDDS_STRING());
+    return multicast_interface_;
+  }
+  void multicast_interface(const OPENDDS_STRING& mi)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    multicast_interface_ = mi;
+  }
+
+  OPENDDS_STRING default_multicast_group() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, OPENDDS_STRING());
+    return default_multicast_group_;
+  }
+  void default_multicast_group(const OPENDDS_STRING& group)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    default_multicast_group_ = group;
+  }
+
+  AddrVec spdp_send_addrs() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, AddrVec());
+    return spdp_send_addrs_;
+  }
+  void spdp_send_addrs(const AddrVec& addrs)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_send_addrs_ = addrs;
+  }
+
+  OPENDDS_STRING guid_interface() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, OPENDDS_STRING());
+    return guid_interface_;
+  }
+  void guid_interface(const OPENDDS_STRING& gi)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    guid_interface_ = gi;
+  }
+
+  DCPS::TimeDuration max_auth_time() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return max_auth_time_;
+  }
+  void max_auth_time(const DCPS::TimeDuration& x)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    max_auth_time_ = x;
+  }
+
+  DCPS::TimeDuration auth_resend_period() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return auth_resend_period_;
+  }
+  void auth_resend_period(const DCPS::TimeDuration& x)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    auth_resend_period_ = x;
+  }
+
+  u_short max_spdp_sequence_msg_reset_check() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
+    return max_spdp_sequence_msg_reset_check_;
+  }
+  void max_spdp_sequence_msg_reset_check(u_short reset_value)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    max_spdp_sequence_msg_reset_check_ = reset_value;
+  }
+
+  ACE_INET_Addr spdp_rtps_relay_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+    return spdp_rtps_relay_address_;
+  }
+  void spdp_rtps_relay_address(const ACE_INET_Addr& address)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_rtps_relay_address_ = address;
+  }
+
+  DCPS::TimeDuration spdp_rtps_relay_beacon_period() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return spdp_rtps_relay_beacon_period_;
+  }
+  void spdp_rtps_relay_beacon_period(const DCPS::TimeDuration& period) {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_rtps_relay_beacon_period_ = period;
+  }
+
+  DCPS::TimeDuration spdp_rtps_relay_send_period() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return spdp_rtps_relay_send_period_;
+  }
+  void spdp_rtps_relay_send_period(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_rtps_relay_send_period_ = period;
+  }
+
+  ACE_INET_Addr sedp_rtps_relay_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+    return sedp_rtps_relay_address_;
+  }
+  void sedp_rtps_relay_address(const ACE_INET_Addr& address)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_rtps_relay_address_ = address;
+  }
+
+  DCPS::TimeDuration sedp_rtps_relay_beacon_period() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return sedp_rtps_relay_beacon_period_;
+  }
+  void sedp_rtps_relay_beacon_period(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_rtps_relay_beacon_period_ = period;
+  }
+
+  bool use_rtps_relay() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, bool());
+    return use_rtps_relay_;
+  }
+  void use_rtps_relay(bool f)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    use_rtps_relay_ = f;
+  }
+
+  bool rtps_relay_only() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, bool());
+    return rtps_relay_only_;
+  }
+  void rtps_relay_only(bool f)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    rtps_relay_only_ = f;
+  }
+
+  ACE_INET_Addr sedp_stun_server_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+    return sedp_stun_server_address_;
+  }
+  void sedp_stun_server_address(const ACE_INET_Addr& address)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_stun_server_address_ = address;
+  }
+
+  bool use_ice() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, bool());
+    return use_ice_;
+  }
+  void use_ice(bool ui)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    use_ice_ = ui;
+  }
+
+private:
+  mutable ACE_SYNCH_MUTEX lock_;
+  DCPS::TimeDuration resend_period_;
+  DCPS::TimeDuration lease_duration_;
+  u_short pb_, dg_, pg_, d0_, d1_, dx_;
+  unsigned char ttl_;
+  bool sedp_multicast_;
+  OPENDDS_STRING multicast_interface_, sedp_local_address_, spdp_local_address_;
+  OPENDDS_STRING default_multicast_group_;  /// FUTURE: handle > 1 group.
+  OPENDDS_STRING guid_interface_;
+  AddrVec spdp_send_addrs_;
+  DCPS::TimeDuration max_auth_time_;
+  DCPS::TimeDuration auth_resend_period_;
+  u_short max_spdp_sequence_msg_reset_check_;
+  ACE_INET_Addr spdp_rtps_relay_address_;
+  DCPS::TimeDuration spdp_rtps_relay_beacon_period_;
+  DCPS::TimeDuration spdp_rtps_relay_send_period_;
+  ACE_INET_Addr sedp_rtps_relay_address_;
+  DCPS::TimeDuration sedp_rtps_relay_beacon_period_;
+  bool use_rtps_relay_;
+  bool rtps_relay_only_;
+  ACE_INET_Addr sedp_stun_server_address_;
+  bool use_ice_;
+};
+
+typedef OpenDDS::DCPS::RcHandle<RtpsDiscoveryConfig> RtpsDiscoveryConfig_rch;
+
 /**
  * @class RtpsDiscovery
  *
@@ -42,6 +382,8 @@ const char RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS[] = "OpenDDS.RtpsDiscovery.Endp
  */
 class OpenDDS_Rtps_Export RtpsDiscovery : public OpenDDS::DCPS::PeerDiscovery<Spdp> {
 public:
+  typedef RtpsDiscoveryConfig::AddrVec AddrVec;
+
   explicit RtpsDiscovery(const RepoKey& key);
   ~RtpsDiscovery();
 
@@ -69,144 +411,64 @@ public:
 
   // configuration parameters:
 
-  DCPS::TimeDuration resend_period() const { return resend_period_; }
-  void resend_period(const DCPS::TimeDuration& period) {
-    resend_period_ = period;
-  }
+  DCPS::TimeDuration resend_period() const { return config_->resend_period(); }
+  void resend_period(const DCPS::TimeDuration& period) { config_->resend_period(period); }
 
-  DCPS::TimeDuration lease_duration() const { return lease_duration_; }
-  void lease_duration(const DCPS::TimeDuration& period) {
-    lease_duration_ = period;
-  }
+  DCPS::TimeDuration lease_duration() const { return config_->lease_duration(); }
+  void lease_duration(const DCPS::TimeDuration& period) { config_->lease_duration(period); }
 
-  u_short pb() const { return pb_; }
-  void pb(u_short port_base) {
-    pb_ = port_base;
-  }
+  u_short pb() const { return config_->pb(); }
+  void pb(u_short port_base) { config_->pb(port_base); }
 
-  u_short dg() const { return dg_; }
-  void dg(u_short domain_gain) {
-    dg_ = domain_gain;
-  }
+  u_short dg() const { return config_->dg(); }
+  void dg(u_short domain_gain) { config_->dg(domain_gain); }
 
-  u_short pg() const { return pg_; }
-  void pg(u_short participant_gain) {
-    pg_ = participant_gain;
-  }
+  u_short pg() const { return config_->pg(); }
+  void pg(u_short participant_gain) { config_->pg(participant_gain); }
 
-  u_short d0() const { return d0_; }
-  void d0(u_short offset_zero) {
-    d0_ = offset_zero;
-  }
+  u_short d0() const { return config_->d0(); }
+  void d0(u_short offset_zero) { config_->d0(offset_zero); }
 
-  u_short d1() const { return d1_; }
-  void d1(u_short offset_one) {
-    d1_ = offset_one;
-  }
+  u_short d1() const { return config_->d1(); }
+  void d1(u_short offset_one) { config_->d1(offset_one); }
 
-  u_short dx() const { return dx_; }
-  void dx(u_short offset_two) {
-    dx_ = offset_two;
-  }
+  u_short dx() const { return config_->dx(); }
+  void dx(u_short offset_two) { config_->dx(offset_two); }
 
-  unsigned char ttl() const { return ttl_; }
-  void ttl(unsigned char time_to_live) {
-    ttl_ = time_to_live;
-  }
+  unsigned char ttl() const { return config_->ttl(); }
+  void ttl(unsigned char time_to_live) { config_->ttl(time_to_live); }
 
-  OPENDDS_STRING sedp_local_address() const { return sedp_local_address_; }
-  void sedp_local_address(const OPENDDS_STRING& mi) {
-    sedp_local_address_ = mi;
-  }
+  OPENDDS_STRING sedp_local_address() const { return config_->sedp_local_address(); }
+  void sedp_local_address(const OPENDDS_STRING& mi) { config_->sedp_local_address(mi); }
 
-  OPENDDS_STRING spdp_local_address() const { return spdp_local_address_; }
-  void spdp_local_address(const OPENDDS_STRING& mi) {
-    spdp_local_address_ = mi;
-  }
+  OPENDDS_STRING spdp_local_address() const { return config_->spdp_local_address(); }
+  void spdp_local_address(const OPENDDS_STRING& mi) { config_->spdp_local_address(mi); }
 
-  bool sedp_multicast() const { return sedp_multicast_; }
-  void sedp_multicast(bool sm) {
-    sedp_multicast_ = sm;
-  }
+  bool sedp_multicast() const { return config_->sedp_multicast(); }
+  void sedp_multicast(bool sm) { config_->sedp_multicast(sm); }
 
-  OPENDDS_STRING multicast_interface() const { return multicast_interface_; }
-  void multicast_interface(const OPENDDS_STRING& mi) {
-    multicast_interface_ = mi;
-  }
+  OPENDDS_STRING multicast_interface() const { return config_->multicast_interface(); }
+  void multicast_interface(const OPENDDS_STRING& mi) { config_->multicast_interface(mi); }
 
-  OPENDDS_STRING default_multicast_group() const { return default_multicast_group_; }
-  void default_multicast_group(const OPENDDS_STRING& group) {
-    default_multicast_group_ = group;
-  }
+  OPENDDS_STRING default_multicast_group() const { return config_->default_multicast_group(); }
+  void default_multicast_group(const OPENDDS_STRING& group) { config_->default_multicast_group(group); }
 
-  typedef OPENDDS_VECTOR(OPENDDS_STRING) AddrVec;
-  const AddrVec& spdp_send_addrs() const { return spdp_send_addrs_; }
-  AddrVec& spdp_send_addrs() { return spdp_send_addrs_; }
+  AddrVec spdp_send_addrs() const { return config_->spdp_send_addrs(); }
+  void spdp_send_addrs(const AddrVec& addrs) { return config_->spdp_send_addrs(addrs); }
 
-  OPENDDS_STRING guid_interface() const { return guid_interface_; }
-  void guid_interface(const OPENDDS_STRING& gi) {
-    guid_interface_ = gi;
-  }
+  OPENDDS_STRING guid_interface() const { return config_->guid_interface(); }
+  void guid_interface(const OPENDDS_STRING& gi) { config_->guid_interface(gi); }
 
-  const ACE_INET_Addr& spdp_rtps_relay_address() const
-  {
-    static const ACE_INET_Addr dummy;
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_config_lock_, dummy);
-    return spdp_rtps_relay_address_;
-  }
-  void spdp_rtps_relay_address(const ACE_INET_Addr& address)
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_config_lock_);
-    spdp_rtps_relay_address_ = address;
-  }
+  DCPS::TimeDuration max_auth_time() const { return config_->max_auth_time(); }
+  void max_auth_time(const DCPS::TimeDuration& x) { config_->max_auth_time(x); }
 
-  const DCPS::TimeDuration& spdp_rtps_relay_beacon_period() const { return spdp_rtps_relay_beacon_period_; }
-  void spdp_rtps_relay_beacon_period(const DCPS::TimeDuration& period) {
-    spdp_rtps_relay_beacon_period_ = period;
-  }
+  DCPS::TimeDuration auth_resend_period() const { return config_->auth_resend_period(); }
+  void auth_resend_period(const DCPS::TimeDuration& x) { config_->auth_resend_period(x); }
 
-  const DCPS::TimeDuration& spdp_rtps_relay_send_period() const { return spdp_rtps_relay_send_period_; }
-  void spdp_rtps_relay_send_period(const DCPS::TimeDuration& period) {
-    spdp_rtps_relay_send_period_ = period;
-  }
+  u_short max_spdp_sequence_msg_reset_check() const { return config_->max_spdp_sequence_msg_reset_check(); }
+  void max_spdp_sequence_msg_reset_check(u_short reset_value) { config_->max_spdp_sequence_msg_reset_check(reset_value); }
 
-  const ACE_INET_Addr& sedp_rtps_relay_address() const
-  {
-    static const ACE_INET_Addr dummy;
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_config_lock_, dummy);
-    return sedp_rtps_relay_address_;
-  }
-  void sedp_rtps_relay_address(const ACE_INET_Addr& address);
-
-  const DCPS::TimeDuration& sedp_rtps_relay_beacon_period() const { return sedp_rtps_relay_beacon_period_; }
-  void sedp_rtps_relay_beacon_period(const DCPS::TimeDuration& period) {
-    sedp_rtps_relay_beacon_period_ = period;
-  }
-
-  bool use_rtps_relay() const { return use_rtps_relay_; }
-  void use_rtps_relay(bool f) { use_rtps_relay_ = f; }
-
-  bool rtps_relay_only() const { return rtps_relay_only_; }
-  void rtps_relay_only(bool f) { rtps_relay_only_ = f; }
-
-  const ACE_INET_Addr& sedp_stun_server_address() const
-  {
-    static const ACE_INET_Addr dummy;
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, stun_config_lock_, dummy);
-    return sedp_stun_server_address_;
-  }
-  void sedp_stun_server_address(const ACE_INET_Addr& address);
-
-  bool use_ice() const { return use_ice_; }
-  void use_ice(bool ui) {
-    use_ice_ = ui;
-  }
-
-  const DCPS::TimeDuration& max_auth_time() const { return max_auth_time_; }
-  void max_auth_time(const DCPS::TimeDuration& x) { max_auth_time_ = x; }
-
-  const DCPS::TimeDuration& auth_resend_period() const { return auth_resend_period_; }
-  void auth_resend_period(const DCPS::TimeDuration& x) { auth_resend_period_ = x; }
+  RtpsDiscoveryConfig_rch config() const { return config_; }
 
 #ifdef OPENDDS_SECURITY
   DDS::Security::ParticipantCryptoHandle get_crypto_handle(DDS::DomainId_t domain,
@@ -214,41 +476,16 @@ public:
                                                            const DCPS::RepoId& remote_participant = GUID_UNKNOWN) const;
 #endif
 
-  u_short max_spdp_sequence_msg_reset_check() const { return max_spdp_sequence_msg_reset_check_; }
-  void max_spdp_sequence_msg_reset_check(u_short reset_value) {
-    max_spdp_sequence_msg_reset_check_ = reset_value;
-  }
-
   u_short get_spdp_port(DDS::DomainId_t domain,
                         const DCPS::RepoId& local_participant) const;
   u_short get_sedp_port(DDS::DomainId_t domain,
                         const DCPS::RepoId& local_participant) const;
 
-private:
-  DCPS::TimeDuration resend_period_;
-  DCPS::TimeDuration lease_duration_;
-  u_short pb_, dg_, pg_, d0_, d1_, dx_;
-  unsigned char ttl_;
-  bool sedp_multicast_;
-  OPENDDS_STRING multicast_interface_, sedp_local_address_, spdp_local_address_;
-  OPENDDS_STRING default_multicast_group_;  /// FUTURE: handle > 1 group.
-  OPENDDS_STRING guid_interface_;
-  AddrVec spdp_send_addrs_;
-  ACE_INET_Addr spdp_rtps_relay_address_;
-  DCPS::TimeDuration spdp_rtps_relay_beacon_period_;
-  DCPS::TimeDuration spdp_rtps_relay_send_period_;
-  ACE_INET_Addr sedp_rtps_relay_address_;
-  DCPS::TimeDuration sedp_rtps_relay_beacon_period_;
-  bool use_rtps_relay_;
-  bool rtps_relay_only_;
-  mutable ACE_SYNCH_MUTEX rtps_relay_config_lock_;
-  ACE_INET_Addr sedp_stun_server_address_;
-  bool use_ice_;
-  mutable ACE_SYNCH_MUTEX stun_config_lock_;
-  DCPS::TimeDuration max_auth_time_;
-  DCPS::TimeDuration auth_resend_period_;
-  u_short max_spdp_sequence_msg_reset_check_;
+  void sedp_rtps_relay_address(const ACE_INET_Addr& address);
+  void sedp_stun_server_address(const ACE_INET_Addr& address);
 
+private:
+  RtpsDiscoveryConfig_rch config_;
 
   /// Guids will be unique within this RTPS configuration
   GuidGenerator guid_gen_;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -331,13 +331,13 @@ Sedp::init(const RepoId& guid,
     rtps_inst->local_address_.set(sedp_addr.c_str());
   }
 
-  rtps_relay_address(disco.sedp_rtps_relay_address());
-  rtps_inst->rtps_relay_beacon_period_ = disco.sedp_rtps_relay_beacon_period();
-  rtps_inst->use_rtps_relay_ = disco.use_rtps_relay();
-  rtps_inst->rtps_relay_only_ = disco.rtps_relay_only();
+  rtps_relay_address(disco.config()->sedp_rtps_relay_address());
+  rtps_inst->rtps_relay_beacon_period_ = disco.config()->sedp_rtps_relay_beacon_period();
+  rtps_inst->use_rtps_relay_ = disco.config()->use_rtps_relay();
+  rtps_inst->rtps_relay_only_ = disco.config()->rtps_relay_only();
 
-  stun_server_address(disco.sedp_stun_server_address());
-  rtps_inst->use_ice_ = disco.use_ice();
+  stun_server_address(disco.config()->sedp_stun_server_address());
+  rtps_inst->use_ice_ = disco.config()->use_ice();
 
   // Create a config
   OPENDDS_STRING config_name = DCPS::TransportRegistry::DEFAULT_INST_PREFIX +

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -47,6 +47,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace RTPS {
 
+class RtpsDiscoveryConfig;
 class RtpsDiscovery;
 
 /// Each instance of class Spdp represents the implementation of the RTPS
@@ -171,6 +172,7 @@ private:
             RtpsDiscovery* disco);
 
   RtpsDiscovery* disco_;
+  DCPS::RcHandle<RtpsDiscoveryConfig> config_;
 
   // Participant:
   const DDS::DomainId_t domain_;


### PR DESCRIPTION
The SPDP transports sends unregister/dispose messages as part of
shutdown.  If it is using the RtpsRelay, then it must acquire the lock
for the address.  However, the lock has already been destroyed.

The solution was to move all of the configuration for RtpsDiscovery to
a separate configuration object that will not be destroyed until the
Spdp object is destroyed.