### PR TITLE
ICE Agent Info exchanged in the clear when security is enabled

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2904,25 +2904,30 @@ Sedp::Writer::write_dcps_participant_secure(const Security::SPDPdiscoveredPartic
 {
   using DCPS::Serializer;
 
-  DDS::ReturnCode_t result = DDS::RETCODE_OK;
-
   ParameterList plist;
 
-  bool err = ParameterListConverter::to_param_list(msg, plist);
-
-  if (err) {
+  if (!ParameterListConverter::to_param_list(msg, plist)) {
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: Sedp::write_dcps_participant_secure - ")
                ACE_TEXT("Failed to convert SPDPdiscoveredParticipantData ")
                ACE_TEXT("to ParameterList\n")));
 
-    result = DDS::RETCODE_ERROR;
-
-  } else {
-    result = write_parameter_list(plist, reader, sequence);
+    return DDS::RETCODE_ERROR;
   }
 
-  return result;
+  ICE::Endpoint* endpoint = get_ice_endpoint();
+  if (endpoint) {
+    const ICE::AgentInfo& agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+    if (ParameterListConverter::to_param_list(agent_info, plist) < 0) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+                 ACE_TEXT("Sedp::write_dcps_participant_secure() - ")
+                 ACE_TEXT("failed to convert from ICE::AgentInfo ")
+                 ACE_TEXT("to ParameterList\n")));
+      return DDS::RETCODE_ERROR;
+    }
+  }
+
+  return write_parameter_list(plist, reader, sequence);
 }
 #endif
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1257,10 +1257,8 @@ Spdp::attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp
 
 void Spdp::update_agent_info(const DCPS::RepoId&, const ICE::AgentInfo&)
 {
-#ifdef OPENDDS_SECURITY
   if (is_security_enabled())
     write_secure_updates();
-#endif
 }
 #endif
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -175,9 +175,11 @@ void Spdp::init(DDS::DomainId_t /*domain*/,
 
 #ifdef OPENDDS_SECURITY
   ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
-  RepoId l = guid_;
-  l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
-  ICE::Agent::instance()->add_local_agent_info_listener(endpoint, l, this);
+  if (endpoint) {
+    RepoId l = guid_;
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    ICE::Agent::instance()->add_local_agent_info_listener(endpoint, l, this);
+  }
 #endif
 }
 
@@ -345,9 +347,11 @@ Spdp::~Spdp()
 
 #ifdef OPENDDS_SECURITY
   ICE::Endpoint* endpoint = sedp_.get_ice_endpoint();
-  RepoId l = guid_;
-  l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
-  ICE::Agent::instance()->remove_local_agent_info_listener(endpoint, l);
+  if (endpoint) {
+    RepoId l = guid_;
+    l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
+    ICE::Agent::instance()->remove_local_agent_info_listener(endpoint, l);
+  }
 #endif
 
   // ensure sedp's task queue is drained before data members are being

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -52,7 +52,7 @@ class RtpsDiscovery;
 
 /// Each instance of class Spdp represents the implementation of the RTPS
 /// Simple Participant Discovery Protocol for a single local DomainParticipant.
-class OpenDDS_Rtps_Export Spdp : public DCPS::LocalParticipant<Sedp> {
+class OpenDDS_Rtps_Export Spdp : public DCPS::LocalParticipant<Sedp>, public ICE::AgentInfoListener {
 public:
 
   Spdp(DDS::DomainId_t domain,
@@ -186,6 +186,7 @@ private:
 #ifdef OPENDDS_SECURITY
   bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
+  void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);
 #endif
 
 #ifndef DDS_HAS_MINIMUM_BIT

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -52,7 +52,11 @@ class RtpsDiscovery;
 
 /// Each instance of class Spdp represents the implementation of the RTPS
 /// Simple Participant Discovery Protocol for a single local DomainParticipant.
-class OpenDDS_Rtps_Export Spdp : public DCPS::LocalParticipant<Sedp>, public ICE::AgentInfoListener {
+class OpenDDS_Rtps_Export Spdp : public DCPS::LocalParticipant<Sedp>
+#ifdef OPENDDS_SECURITY
+                               , public ICE::AgentInfoListener
+#endif
+{
 public:
 
   Spdp(DDS::DomainId_t domain,


### PR DESCRIPTION
When security is enabled for a participant, only include the ICE agent
info in the secure SPDP messages.