### PR TITLE
Normalize Enum-like Values to String Functions

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2093,7 +2093,7 @@ DataReaderImpl::writer_became_alive(WriterInfo& info,
         ACE_TEXT("reader %C from writer %C previous state %C.\n"),
         OPENDDS_STRING(reader_converter).c_str(),
         OPENDDS_STRING(writer_converter).c_str(),
-        info.get_state_str().c_str()));
+        info.get_state_str()));
   }
 
   // caller should already have the samples_lock_ !!!
@@ -2165,10 +2165,9 @@ DataReaderImpl::writer_became_dead(WriterInfo& info,
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::writer_became_dead: ")
         ACE_TEXT("reader %C from writer %C previous state %C.\n"),
-
         OPENDDS_STRING(reader_converter).c_str(),
         OPENDDS_STRING(writer_converter).c_str(),
-        info.get_state_str().c_str()));
+        info.get_state_str()));
   }
 
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1281,10 +1281,9 @@ DDS::ReturnCode_t read_instance_i(MessageSequenceType& received_data,
     }
     if ((state_obj->instance_state() & instance_states) == 0) {
       if (!msg.empty()) msg += " and ";
-      msg += "instance state is "
-        + state_obj->instance_state_string()
-        + " while the validity mask is "
-        + InstanceState::instance_state_mask_string(instance_states);
+      msg += "instance state is ";
+      msg += state_obj->instance_state_string();
+      msg += " while the validity mask is " + InstanceState::instance_state_mask_string(instance_states);
     }
     const GuidConverter conv(get_subscription_id());
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl_T::read_instance_i: ")

--- a/dds/DCPS/DataSampleHeader.cpp
+++ b/dds/DCPS/DataSampleHeader.cpp
@@ -476,8 +476,7 @@ DataSampleHeader::join(const DataSampleHeader& first,
   return true;
 }
 
-const char *
-to_string(const MessageId value)
+const char* to_string(MessageId value)
 {
   switch (value) {
   case SAMPLE_DATA:
@@ -505,12 +504,14 @@ to_string(const MessageId value)
   case END_HISTORIC_SAMPLES:
     return "END_HISTORIC_SAMPLES";
   default:
-    return "Unknown";
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: to_string(MessageId): ")
+      ACE_TEXT("%d is either invalid or not recognized.\n"),
+      value));
+    return "Invalid MessageId";
   }
 }
 
-const char *
-to_string(const SubMessageId value)
+const char* to_string(SubMessageId value)
 {
   switch (value) {
   case SUBMESSAGE_NONE:
@@ -524,7 +525,10 @@ to_string(const SubMessageId value)
   case MULTICAST_NAKACK:
     return "MULTICAST_NAKACK";
   default:
-    return "Unknown";
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: to_string(SubMessageId): ")
+      ACE_TEXT("%d is either invalid or not recognized.\n"),
+      value));
+    return "Invalid SubMessageId";
   }
 }
 
@@ -607,55 +611,17 @@ OPENDDS_STRING to_string(const DataSampleHeader& value)
 
 #ifndef OPENDDS_SAFETY_PROFILE
 /// Message Id enumeration insertion onto an ostream.
-std::ostream& operator<<(std::ostream& str, const MessageId value)
+std::ostream& operator<<(std::ostream& os, const MessageId value)
 {
-  switch (value) {
-  case SAMPLE_DATA:
-    return str << "SAMPLE_DATA";
-  case DATAWRITER_LIVELINESS:
-    return str << "DATAWRITER_LIVELINESS";
-  case INSTANCE_REGISTRATION:
-    return str << "INSTANCE_REGISTRATION";
-  case UNREGISTER_INSTANCE:
-    return str << "UNREGISTER_INSTANCE";
-  case DISPOSE_INSTANCE:
-    return str << "DISPOSE_INSTANCE";
-  case GRACEFUL_DISCONNECT:
-    return str << "GRACEFUL_DISCONNECT";
-  case REQUEST_ACK:
-    return str << "REQUEST_ACK";
-  case SAMPLE_ACK:
-    return str << "SAMPLE_ACK";
-  case END_COHERENT_CHANGES:
-    return str << "END_COHERENT_CHANGES";
-  case TRANSPORT_CONTROL:
-    return str << "TRANSPORT_CONTROL";
-  case DISPOSE_UNREGISTER_INSTANCE:
-    return str << "DISPOSE_UNREGISTER_INSTANCE";
-  case END_HISTORIC_SAMPLES:
-    return str << "END_HISTORIC_SAMPLES";
-  default:
-    return str << "Unknown";
-  }
+  os << to_string(value);
+  return os;
 }
 
 /// Sub-Message Id enumeration insertion onto an ostream.
-std::ostream& operator<<(std::ostream& os, const SubMessageId rhs)
+std::ostream& operator<<(std::ostream& os, const SubMessageId value)
 {
-  switch (rhs) {
-  case SUBMESSAGE_NONE:
-    return os << "SUBMESSAGE_NONE";
-  case MULTICAST_SYN:
-    return os << "MULTICAST_SYN";
-  case MULTICAST_SYNACK:
-    return os << "MULTICAST_SYNACK";
-  case MULTICAST_NAK:
-    return os << "MULTICAST_NAK";
-  case MULTICAST_NAKACK:
-    return os << "MULTICAST_NAKACK";
-  default:
-    return os << "Unknown";
-  }
+  os << to_string(value);
+  return os;
 }
 
 /// Message header insertion onto an ostream.

--- a/dds/DCPS/DataSampleHeader.h
+++ b/dds/DCPS/DataSampleHeader.h
@@ -252,8 +252,8 @@ private:
   size_t marshaled_size_;
 };
 
-const char* to_string(const MessageId value);
-const char* to_string(const SubMessageId value);
+const char* to_string(MessageId value);
+const char* to_string(SubMessageId value);
 OPENDDS_STRING to_string(const DataSampleHeader& value);
 
 /// Marshal/Insertion into a buffer.
@@ -263,11 +263,11 @@ bool operator<<(ACE_Message_Block&, const DataSampleHeader& value);
 #ifndef OPENDDS_SAFETY_PROFILE
 /// Message Id enumeration insertion onto an ostream.
 OpenDDS_Dcps_Export
-std::ostream& operator<<(std::ostream& str, const MessageId value);
+std::ostream& operator<<(std::ostream& os, MessageId value);
 
 /// Sub-Message Id enumeration insertion onto an ostream.
 OpenDDS_Dcps_Export
-std::ostream& operator<<(std::ostream& os, const SubMessageId rhs);
+std::ostream& operator<<(std::ostream& os, SubMessageId value);
 
 /// Message header insertion onto an ostream.
 OpenDDS_Dcps_Export

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -270,7 +270,7 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
     const GuidConverter conv(remote_id);
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
-               ACE_TEXT(" writer %C succeeded in associating with reader %C\n"),
+               ACE_TEXT("writer %C succeeded in associating with reader %C\n"),
                OPENDDS_STRING(writer_conv).c_str(),
                OPENDDS_STRING(conv).c_str()));
   }
@@ -890,7 +890,7 @@ DataWriterImpl::set_qos(const DDS::DataWriterQos & qos)
         if (!status) {
           ACE_ERROR_RETURN((LM_ERROR,
                             ACE_TEXT("(%P|%t) DataWriterImpl::set_qos, ")
-                            ACE_TEXT("qos not updated. \n")),
+                            ACE_TEXT("qos not updated.\n")),
                            DDS::RETCODE_ERROR);
         }
       }
@@ -974,7 +974,7 @@ DataWriterImpl::create_ack_token(DDS::Duration_t max_wait) const
   if (DCPS_debug_level > 0) {
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::create_ack_token() - ")
-               ACE_TEXT("for sequence %q \n"),
+               ACE_TEXT("for sequence %q\n"),
                this->sequence_number_.getValue()));
   }
   return AckToken(max_wait, this->sequence_number_);
@@ -1196,7 +1196,7 @@ DataWriterImpl::get_matched_subscriptions(
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::get_matched_subscriptions: ")
-                      ACE_TEXT(" Entity is not enabled. \n")),
+                      ACE_TEXT(" Entity is not enabled.\n")),
                      DDS::RETCODE_NOT_ENABLED);
   }
 
@@ -1230,7 +1230,7 @@ DataWriterImpl::get_matched_subscription_data(
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::")
                       ACE_TEXT("get_matched_subscription_data: ")
-                      ACE_TEXT("Entity is not enabled. \n")),
+                      ACE_TEXT("Entity is not enabled.\n")),
                      DDS::RETCODE_NOT_ENABLED);
   }
   RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
@@ -1443,7 +1443,7 @@ DataWriterImpl::enable()
   if (!publisher || this->publication_id_ == GUID_UNKNOWN) {
     ACE_DEBUG((LM_WARNING,
                ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::enable, ")
-               ACE_TEXT("add_publication returned invalid id. \n")));
+               ACE_TEXT("add_publication returned invalid id.\n")));
     data_container_->shutdown_ = true;
     return DDS::RETCODE_ERROR;
   }
@@ -1509,18 +1509,16 @@ DataWriterImpl::register_instance_i(DDS::InstanceHandle_t& handle,
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::register_instance_i: ")
-                      ACE_TEXT(" Entity is not enabled. \n")),
+                      ACE_TEXT("Entity is not enabled.\n")),
                      DDS::RETCODE_NOT_ENABLED);
   }
 
-  DDS::ReturnCode_t ret =
-    this->data_container_->register_instance(handle, data);
-
+  DDS::ReturnCode_t ret = data_container_->register_instance(handle, data);
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::register_instance_i: ")
                       ACE_TEXT("register instance with container failed, returned <%C>.\n"),
-                      retcode_to_string(ret).c_str()),
+                      retcode_to_string(ret)),
                      ret);
   }
 
@@ -1530,13 +1528,12 @@ DataWriterImpl::register_instance_i(DDS::InstanceHandle_t& handle,
 
   DataSampleElement* element = 0;
   ret = this->data_container_->obtain_buffer_for_control(element);
-
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::register_instance_i: ")
-                      ACE_TEXT("obtain_buffer_for_control returned %d.\n"),
-                      ret),
+                      ACE_TEXT("obtain_buffer_for_control failed, returned <%C>.\n"),
+                      retcode_to_string(ret)),
                      ret);
   }
 
@@ -1551,12 +1548,12 @@ DataWriterImpl::register_instance_i(DDS::InstanceHandle_t& handle,
   element->set_sample(move(sample));
 
   ret = this->data_container_->enqueue_control(element);
-
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::register_instance_i: ")
-                      ACE_TEXT("enqueue_control failed.\n")),
+                      ACE_TEXT("enqueue_control failed, returned <%C>\n"),
+                      retcode_to_string(ret)),
                      ret);
   }
 
@@ -1581,7 +1578,7 @@ DataWriterImpl::register_instance_from_durable_data(
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::register_instance_from_durable_data: ")
                       ACE_TEXT("register instance with container failed, returned <%C>.\n"),
-                      retcode_to_string(ret).c_str()),
+                      retcode_to_string(ret)),
                      ret);
   }
 
@@ -1599,7 +1596,7 @@ DataWriterImpl::unregister_instance_i(DDS::InstanceHandle_t handle,
   if (enabled_ == false) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::unregister_instance_i: ")
-                      ACE_TEXT(" Entity is not enabled.\n")),
+                      ACE_TEXT("Entity is not enabled.\n")),
                      DDS::RETCODE_NOT_ENABLED);
   }
 
@@ -1618,7 +1615,7 @@ DataWriterImpl::unregister_instance_i(DDS::InstanceHandle_t handle,
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::unregister_instance_i: ")
-                      ACE_TEXT(" unregister with container failed. \n")),
+                      ACE_TEXT("unregister with container failed.\n")),
                      ret);
   }
 
@@ -1669,7 +1666,7 @@ DataWriterImpl::dispose_and_unregister(DDS::InstanceHandle_t handle,
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::dispose_and_unregister: ")
-                      ACE_TEXT("dispose on container failed. \n")),
+                      ACE_TEXT("dispose on container failed.\n")),
                      ret);
   }
 
@@ -1679,7 +1676,7 @@ DataWriterImpl::dispose_and_unregister(DDS::InstanceHandle_t handle,
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::dispose_and_unregister: ")
-                      ACE_TEXT("unregister with container failed. \n")),
+                      ACE_TEXT("unregister with container failed.\n")),
                      ret);
   }
 
@@ -1754,7 +1751,7 @@ DataWriterImpl::write(Message_Block_Ptr data,
   if (enabled_ == false) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::write: ")
-                      ACE_TEXT(" Entity is not enabled. \n")),
+                      ACE_TEXT("Entity is not enabled.\n")),
                      DDS::RETCODE_NOT_ENABLED);
   }
 
@@ -1891,7 +1888,7 @@ DataWriterImpl::dispose(DDS::InstanceHandle_t handle,
   if (enabled_ == false) {
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::dispose: ")
-                      ACE_TEXT(" Entity is not enabled. \n")),
+                      ACE_TEXT("Entity is not enabled.\n")),
                      DDS::RETCODE_NOT_ENABLED);
   }
 
@@ -2163,7 +2160,7 @@ DataWriterImpl::data_delivered(const DataSampleElement* sample)
     GuidConverter writer_converter(publication_id_);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::data_delivered: ")
-               ACE_TEXT(" The publication id %C from delivered element ")
+               ACE_TEXT("The publication id %C from delivered element ")
                ACE_TEXT("does not match the datawriter's id %C\n"),
                OPENDDS_STRING(sample_converter).c_str(),
                OPENDDS_STRING(writer_converter).c_str()));
@@ -2437,7 +2434,7 @@ DataWriterImpl::send_liveliness(const MonotonicTimePoint& now)
     if (this->send_control(header, move(liveliness_msg)) == SEND_CONTROL_ERROR) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::send_liveliness: ")
-                        ACE_TEXT(" send_control failed. \n")),
+                        ACE_TEXT("send_control failed.\n")),
                        false);
     }
   }

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -12,119 +12,107 @@
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
-  namespace DCPS {
+namespace DCPS {
 
-/** Servant for DataWriter interface of the Traits::MessageType data type.
+/**
+ * Servant for DataWriter interface of the Traits::MessageType data type.
  *
  * See the DDS specification, OMG formal/04-12-02, for a description of
  * this interface.
  */
-  template <typename MessageType>
-  class
+template <typename MessageType>
+class
 #if ( __GNUC__ == 4 && __GNUC_MINOR__ == 1)
-    OpenDDS_Dcps_Export
+  OpenDDS_Dcps_Export
 #endif
-    DataWriterImpl_T
-    : public virtual OpenDDS::DCPS::LocalObject<typename DDSTraits<MessageType>::DataWriterType>,
-      public virtual OpenDDS::DCPS::DataWriterImpl
+DataWriterImpl_T
+: public virtual OpenDDS::DCPS::LocalObject<typename DDSTraits<MessageType>::DataWriterType>,
+  public virtual OpenDDS::DCPS::DataWriterImpl
+{
+public:
+  typedef DDSTraits<MessageType> TraitsType;
+  typedef MarshalTraits<MessageType> MarshalTraitsType;
+
+  typedef OPENDDS_MAP_CMP_T(MessageType, DDS::InstanceHandle_t,
+                            typename TraitsType::LessThanType) InstanceMap;
+  typedef ::OpenDDS::DCPS::Dynamic_Cached_Allocator_With_Overflow<ACE_Thread_Mutex> DataAllocator;
+
+  enum {
+    cdr_header_size = 4
+  };
+
+  DataWriterImpl_T()
+    : marshaled_size_(0)
+    , key_marshaled_size_(0)
   {
-  public:
-    typedef DDSTraits<MessageType> TraitsType;
-    typedef MarshalTraits<MessageType> MarshalTraitsType;
-
-    typedef OPENDDS_MAP_CMP_T(MessageType, DDS::InstanceHandle_t,
-                              typename TraitsType::LessThanType) InstanceMap;
-    typedef ::OpenDDS::DCPS::Dynamic_Cached_Allocator_With_Overflow<ACE_Thread_Mutex>  DataAllocator;
-
-    enum {
-      cdr_header_size = 4
-    };
-
-    DataWriterImpl_T (void)
-      : marshaled_size_ (0)
-      , key_marshaled_size_ (0)
-    {
-      MessageType data;
-      if (MarshalTraitsType::gen_is_bounded_size()) {
-        marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(data, true);
-        // worst case: CDR encapsulation (4 bytes) + Padding for alignment (4 bytes)
-      } else {
-        marshaled_size_ = 0; // should use gen_find_size when marshaling
-      }
-      if (MarshalTraitsType::gen_is_bounded_key_size()) {
-        OpenDDS::DCPS::KeyOnly<const MessageType> ko(data);
-        key_marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(ko, true);
-        // worst case: CDR Encapsulation (4 bytes) + Padding for alignment (4 bytes)
-      } else {
-        key_marshaled_size_ = 0; // should use gen_find_size when marshaling
-      }
+    MessageType data;
+    if (MarshalTraitsType::gen_is_bounded_size()) {
+      marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(data, true);
+      // worst case: CDR encapsulation (4 bytes) + Padding for alignment (4 bytes)
+    } else {
+      marshaled_size_ = 0; // should use gen_find_size when marshaling
     }
-
-    virtual ~DataWriterImpl_T (void)
-    {
+    if (MarshalTraitsType::gen_is_bounded_key_size()) {
+      OpenDDS::DCPS::KeyOnly<const MessageType> ko(data);
+      key_marshaled_size_ = 8 + TraitsType::gen_max_marshaled_size(ko, true);
+      // worst case: CDR Encapsulation (4 bytes) + Padding for alignment (4 bytes)
+    } else {
+      key_marshaled_size_ = 0; // should use gen_find_size when marshaling
     }
+  }
 
-  virtual DDS::InstanceHandle_t
-  register_instance(const MessageType& instance)
+  virtual ~DataWriterImpl_T()
+  {
+  }
+
+  virtual DDS::InstanceHandle_t register_instance(const MessageType& instance)
   {
     return register_instance_w_timestamp(instance, SystemTimePoint::now().to_dds_time());
   }
 
-  virtual DDS::InstanceHandle_t register_instance_w_timestamp (
-      const MessageType & instance,
-      const DDS::Time_t & timestamp)
-    {
-      DDS::InstanceHandle_t registered_handle = DDS::HANDLE_NIL;
+  virtual DDS::InstanceHandle_t register_instance_w_timestamp(
+    const MessageType& instance, const DDS::Time_t& timestamp)
+  {
+    DDS::InstanceHandle_t registered_handle = DDS::HANDLE_NIL;
 
-      DDS::ReturnCode_t const ret
-          = this->get_or_create_instance_handle(registered_handle,
-                                                instance,
-                                                timestamp);
-      if (ret != DDS::RETCODE_OK)
-        {
-          ACE_ERROR ((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ")
-                      ACE_TEXT("%CDataWriterImpl::")
-                      ACE_TEXT("register_instance_w_timestamp, ")
-                      ACE_TEXT("register failed: %C.\n"),
-                      TraitsType::type_name(),
-                      retcode_to_string(ret).c_str()));
-        }
-
-      return registered_handle;
+    const DDS::ReturnCode_t ret = get_or_create_instance_handle(registered_handle, instance, timestamp);
+    if (ret != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::register_instance_w_timestamp: ")
+        ACE_TEXT("register failed: %C\n"),
+        TraitsType::type_name(),
+        retcode_to_string(ret)));
     }
 
-  virtual DDS::ReturnCode_t
-  unregister_instance(const MessageType& instance, DDS::InstanceHandle_t handle)
+    return registered_handle;
+  }
+
+  virtual DDS::ReturnCode_t unregister_instance(const MessageType& instance, DDS::InstanceHandle_t handle)
   {
     return unregister_instance_w_timestamp(instance, handle, SystemTimePoint::now().to_dds_time());
   }
 
-  virtual DDS::ReturnCode_t unregister_instance_w_timestamp (
-      const MessageType & instance_data,
-      DDS::InstanceHandle_t instance_handle,
-      const DDS::Time_t & timestamp)
-    {
-      if (instance_handle == DDS::HANDLE_NIL)
-        {
-          instance_handle = this->lookup_instance(instance_data);
-          if (instance_handle == DDS::HANDLE_NIL)
-            {
-              ACE_ERROR_RETURN ((LM_ERROR,
-                                 ACE_TEXT("(%P|%t) ")
-                                 ACE_TEXT("%CDataWriterImpl::unregister_instance_w_timestamp, ")
-                                 ACE_TEXT("The instance sample is not registered.\n"),
-                                 TraitsType::type_name()),
-                                DDS::RETCODE_ERROR);
-            }
-        }
-
-      // DataWriterImpl::unregister_instance_i will call back to inform the
-      // DataWriter.
-      // That the instance handle is removed from there and hence
-      // DataWriter can remove the instance here.
-      return OpenDDS::DCPS::DataWriterImpl::unregister_instance_i(instance_handle, timestamp);
+  virtual DDS::ReturnCode_t unregister_instance_w_timestamp(
+    const MessageType& instance_data,
+    DDS::InstanceHandle_t instance_handle,
+    const DDS::Time_t& timestamp)
+  {
+    if (instance_handle == DDS::HANDLE_NIL) {
+      instance_handle = this->lookup_instance(instance_data);
+      if (instance_handle == DDS::HANDLE_NIL) {
+        ACE_ERROR_RETURN((
+            LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::unregister_instance_w_timestamp: ")
+            ACE_TEXT("The instance sample is not registered.\n"),
+            TraitsType::type_name()),
+          DDS::RETCODE_ERROR);
+      }
     }
+
+    // DataWriterImpl::unregister_instance_i will call back to inform the
+    // DataWriter.
+    // That the instance handle is removed from there and hence
+    // DataWriter can remove the instance here.
+    return OpenDDS::DCPS::DataWriterImpl::unregister_instance_i(instance_handle, timestamp);
+  }
 
   //WARNING: If the handle is non-nil and the instance is not registered
   //         then this operation may cause an access violation.
@@ -138,60 +126,55 @@ namespace OpenDDS {
   //WARNING: If the handle is non-nil and the instance is not registered
   //         then this operation may cause an access violation.
   //         This lack of safety helps performance.
-  virtual DDS::ReturnCode_t write_w_timestamp (
-      const MessageType & instance_data,
-      DDS::InstanceHandle_t handle,
-      const DDS::Time_t & source_timestamp)
-    {
-      //  This operation assumes the provided handle is valid. The handle
-      //  provided will not be verified.
+  virtual DDS::ReturnCode_t write_w_timestamp(
+    const MessageType& instance_data,
+    DDS::InstanceHandle_t handle,
+    const DDS::Time_t& source_timestamp)
+  {
+    //  This operation assumes the provided handle is valid. The handle
+    //  provided will not be verified.
 
-      if (handle == DDS::HANDLE_NIL) {
-        DDS::InstanceHandle_t registered_handle = DDS::HANDLE_NIL;
-        DDS::ReturnCode_t ret
-            = this->get_or_create_instance_handle(registered_handle,
-                                                  instance_data,
-                                                  source_timestamp);
-        if (ret != DDS::RETCODE_OK) {
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) ")
-                            ACE_TEXT("%CDataWriterImpl::write_w_timestamp, ")
-                            ACE_TEXT("register failed: %C.\n"),
-                            TraitsType::type_name(),
-                            retcode_to_string(ret).c_str()),
-                           ret);
-        }
-
-        handle = registered_handle;
+    if (handle == DDS::HANDLE_NIL) {
+      DDS::InstanceHandle_t registered_handle = DDS::HANDLE_NIL;
+      const DDS::ReturnCode_t ret =
+        this->get_or_create_instance_handle(registered_handle, instance_data, source_timestamp);
+      if (ret != DDS::RETCODE_OK) {
+        ACE_ERROR_RETURN((
+            LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::write_w_timestamp: ")
+            ACE_TEXT("register failed: %C.\n"),
+            TraitsType::type_name(),
+            retcode_to_string(ret)),
+          ret);
       }
 
-      // list of reader RepoIds that should not get data
-      OpenDDS::DCPS::GUIDSeq_var filter_out;
+      handle = registered_handle;
+    }
+
+    // list of reader RepoIds that should not get data
+    OpenDDS::DCPS::GUIDSeq_var filter_out;
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
-      if (TheServiceParticipant->publisher_content_filter()) {
-        ACE_GUARD_RETURN(ACE_Thread_Mutex, reader_info_guard, this->reader_info_lock_, DDS::RETCODE_ERROR);
-        for (RepoIdToReaderInfoMap::iterator iter = reader_info_.begin(),
-               end = reader_info_.end(); iter != end; ++iter) {
-          const ReaderInfo& ri = iter->second;
-          if (!ri.eval_.is_nil()) {
-            if (!filter_out.ptr()) {
-              filter_out = new OpenDDS::DCPS::GUIDSeq;
-            }
-            if (!ri.eval_->eval(instance_data, ri.expression_params_)) {
-              push_back(filter_out.inout(), iter->first);
-            }
+    if (TheServiceParticipant->publisher_content_filter()) {
+      ACE_GUARD_RETURN(ACE_Thread_Mutex, reader_info_guard, this->reader_info_lock_, DDS::RETCODE_ERROR);
+      for (RepoIdToReaderInfoMap::iterator iter = reader_info_.begin(),
+           end = reader_info_.end(); iter != end; ++iter) {
+        const ReaderInfo& ri = iter->second;
+        if (!ri.eval_.is_nil()) {
+          if (!filter_out.ptr()) {
+            filter_out = new OpenDDS::DCPS::GUIDSeq;
+          }
+          if (!ri.eval_->eval(instance_data, ri.expression_params_)) {
+            push_back(filter_out.inout(), iter->first);
           }
         }
       }
+    }
 #endif
 
-      Message_Block_Ptr marshalled(
-        dds_marshal (instance_data, OpenDDS::DCPS::FULL_MARSHALING));
-
-      return OpenDDS::DCPS::DataWriterImpl::write(move(marshalled), handle,
-                                                  source_timestamp,
-                                                  filter_out._retn());
-    }
+    Message_Block_Ptr marshalled(
+      dds_marshal(instance_data, OpenDDS::DCPS::FULL_MARSHALING));
+    return OpenDDS::DCPS::DataWriterImpl::write(
+      move(marshalled), handle, source_timestamp, filter_out._retn());
+  }
 
   virtual DDS::ReturnCode_t
   dispose(const MessageType& instance_data, DDS::InstanceHandle_t instance_handle)
@@ -199,134 +182,104 @@ namespace OpenDDS {
     return dispose_w_timestamp(instance_data, instance_handle, SystemTimePoint::now().to_dds_time());
   }
 
-  virtual DDS::ReturnCode_t dispose_w_timestamp (
-      const MessageType & instance_data,
-      DDS::InstanceHandle_t instance_handle,
-      const DDS::Time_t & source_timestamp)
-    {
-      if (instance_handle == DDS::HANDLE_NIL)
-        {
-          instance_handle = this->lookup_instance(instance_data);
-          if (instance_handle == DDS::HANDLE_NIL)
-            {
-              ACE_ERROR_RETURN ((LM_ERROR,
-                                 ACE_TEXT("(%P|%t) ")
-                                 ACE_TEXT("%CDataWriterImpl::dispose_w_timestamp, ")
-                                 ACE_TEXT("The instance sample is not registered.\n"),
-                                 TraitsType::type_name()),
-                                DDS::RETCODE_ERROR);
-            }
-        }
-
-      return OpenDDS::DCPS::DataWriterImpl::dispose(instance_handle,
-                                                    source_timestamp);
+  virtual DDS::ReturnCode_t dispose_w_timestamp(
+    const MessageType& instance_data,
+    DDS::InstanceHandle_t instance_handle,
+    const DDS::Time_t& source_timestamp)
+  {
+    if (instance_handle == DDS::HANDLE_NIL) {
+      instance_handle = this->lookup_instance(instance_data);
+      if (instance_handle == DDS::HANDLE_NIL) {
+        ACE_ERROR_RETURN((
+            LM_ERROR,
+            ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::dispose_w_timestamp, ")
+            ACE_TEXT("The instance sample is not registered.\n"),
+            TraitsType::type_name()),
+          DDS::RETCODE_ERROR);
+      }
     }
 
-  virtual DDS::ReturnCode_t get_key_value (
-      MessageType & key_holder,
-      DDS::InstanceHandle_t handle)
-    {
-      ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex,
-                        guard,
-                        get_lock (),
-                        DDS::RETCODE_ERROR);
+    return OpenDDS::DCPS::DataWriterImpl::dispose(instance_handle, source_timestamp);
+  }
 
-      typename InstanceMap::iterator const the_end = instance_map_.end ();
-      for (typename InstanceMap::iterator it = instance_map_.begin ();
-           it != the_end;
-           ++it)
-        {
-          if (it->second == handle)
-            {
-              key_holder = it->first;
-              return DDS::RETCODE_OK;
-            }
-        }
+  virtual DDS::ReturnCode_t get_key_value(
+    MessageType& key_holder,
+    DDS::InstanceHandle_t handle)
+  {
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
 
-      return DDS::RETCODE_BAD_PARAMETER;
+    typename InstanceMap::iterator const the_end = instance_map_.end();
+    for (typename InstanceMap::iterator it = instance_map_.begin(); it != the_end; ++it) {
+      if (it->second == handle) {
+        key_holder = it->first;
+        return DDS::RETCODE_OK;
+      }
     }
 
-  virtual DDS::InstanceHandle_t lookup_instance (
-      const MessageType & instance_data)
-    {
-      ACE_GUARD_RETURN (ACE_Recursive_Thread_Mutex,
-                        guard,
-                        get_lock (),
-                        DDS::RETCODE_ERROR);
+    return DDS::RETCODE_BAD_PARAMETER;
+  }
 
-      typename InstanceMap::const_iterator const it = instance_map_.find(instance_data);
+  virtual DDS::InstanceHandle_t lookup_instance(
+    const MessageType& instance_data)
+  {
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
 
-      if (it == instance_map_.end())
-        {
-          return DDS::HANDLE_NIL;
-        }
-      else
-        {
-          return it->second;
-        }
+    typename InstanceMap::const_iterator const it = instance_map_.find(instance_data);
+    if (it == instance_map_.end()) {
+      return DDS::HANDLE_NIL;
+    } else {
+      return it->second;
     }
-
+  }
 
   /**
    * Do parts of enable specific to the datatype.
    * Called by DataWriterImpl::enable().
    */
-    virtual DDS::ReturnCode_t enable_specific ()
-    {
-      if (MarshalTraitsType::gen_is_bounded_size ())
-        {
-          data_allocator_.reset(new DataAllocator (n_chunks_, marshaled_size_));
-          if (::OpenDDS::DCPS::DCPS_debug_level >= 2)
-            ACE_DEBUG((LM_DEBUG,
-                       ACE_TEXT("(%P|%t) %CDataWriterImpl::")
-                       ACE_TEXT("enable_specific-data")
-                       ACE_TEXT(" Dynamic_Cached_Allocator_With_Overflow %x ")
-                       ACE_TEXT("with %d chunks\n"),
-                       TraitsType::type_name(),
-                       data_allocator_.get(),
-                       n_chunks_));
-        }
-      else
-        {
-          if (::OpenDDS::DCPS::DCPS_debug_level >= 2)
-            ACE_DEBUG((LM_DEBUG,
-                       ACE_TEXT("(%P|%t) %CDataWriterImpl::enable_specific")
-                       ACE_TEXT(" is unbounded data - allocate from heap\n"), TraitsType::type_name()));
-        }
-
-      mb_allocator_.reset(
-        new ::OpenDDS::DCPS::MessageBlockAllocator (
-                                                    n_chunks_ * association_chunk_multiplier_));
-      db_allocator_.reset(new ::OpenDDS::DCPS::DataBlockAllocator (n_chunks_));
-
-      if (::OpenDDS::DCPS::DCPS_debug_level >= 2)
-        {
-          ACE_DEBUG((LM_DEBUG,
-                     ACE_TEXT("(%P|%t) %CDataWriterImpl::")
-                     ACE_TEXT("enable_specific-mb ")
-                     ACE_TEXT("Cached_Allocator_With_Overflow ")
-                     ACE_TEXT("%x with %d chunks\n"),
-                     TraitsType::type_name(),
-                     mb_allocator_.get(),
-                     n_chunks_ * association_chunk_multiplier_));
-          ACE_DEBUG((LM_DEBUG,
-                     ACE_TEXT("(%P|%t) %CDataWriterImpl::")
-                     ACE_TEXT("enable_specific-db ")
-                     ACE_TEXT("Cached_Allocator_With_Overflow ")
-                     ACE_TEXT("%x with %d chunks\n"),
-                     TraitsType::type_name(),
-                     db_allocator_.get(),
-                     n_chunks_));
-        }
-
-      return DDS::RETCODE_OK;
+  virtual DDS::ReturnCode_t enable_specific()
+  {
+    if(MarshalTraitsType::gen_is_bounded_size()) {
+      data_allocator_.reset(new DataAllocator(n_chunks_, marshaled_size_));
+      if (::OpenDDS::DCPS::DCPS_debug_level >= 2) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %CDataWriterImpl::")
+                   ACE_TEXT("enable_specific-data Dynamic_Cached_Allocator_With_Overflow %x ")
+                   ACE_TEXT("with %d chunks\n"),
+                   TraitsType::type_name(),
+                   data_allocator_.get(),
+                   n_chunks_));
+      }
+    } else if (::OpenDDS::DCPS::DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %CDataWriterImpl::enable_specific")
+                 ACE_TEXT(" is unbounded data - allocate from heap\n"), TraitsType::type_name()));
     }
+
+    mb_allocator_.reset(new ::OpenDDS::DCPS::MessageBlockAllocator(n_chunks_ * association_chunk_multiplier_));
+    db_allocator_.reset(new ::OpenDDS::DCPS::DataBlockAllocator(n_chunks_));
+
+    if (::OpenDDS::DCPS::DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %CDataWriterImpl::enable_specific-mb ")
+                 ACE_TEXT("Cached_Allocator_With_Overflow ")
+                 ACE_TEXT("%x with %d chunks\n"),
+                 TraitsType::type_name(),
+                 mb_allocator_.get(),
+                 n_chunks_ * association_chunk_multiplier_));
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %CDataWriterImpl::enable_specific-db ")
+                 ACE_TEXT("Cached_Allocator_With_Overflow ")
+                 ACE_TEXT("%x with %d chunks\n"),
+                 TraitsType::type_name(),
+                 db_allocator_.get(),
+                 n_chunks_));
+    }
+
+    return DDS::RETCODE_OK;
+  }
 
   /**
    * Accessor to the marshalled data sample allocator.
    */
   ACE_INLINE
-  DataAllocator* data_allocator () const  {
+  DataAllocator* data_allocator() const
+  {
     return data_allocator_.get();
   };
 
@@ -340,213 +293,200 @@ private:
    *        just the keys or the entire message.
    * @return returns the serialized data.
    */
-    ACE_Message_Block* dds_marshal(
-                                   const MessageType& instance_data,
-                                   OpenDDS::DCPS::MarshalingType marshaling_type)
-    {
-      const bool cdr = this->cdr_encapsulation(), swap = this->swap_bytes();
+  ACE_Message_Block* dds_marshal(const MessageType& instance_data,
+                                 OpenDDS::DCPS::MarshalingType marshaling_type)
+  {
+    const bool cdr = this->cdr_encapsulation(), swap = this->swap_bytes();
 
-      Message_Block_Ptr mb;
-      ACE_Message_Block* tmp_mb;
+    Message_Block_Ptr mb;
+    ACE_Message_Block* tmp_mb;
 
-      if (marshaling_type == OpenDDS::DCPS::KEY_ONLY_MARSHALING) {
-        // Don't use the cached allocator for the registered sample message
-        // block.
+    if (marshaling_type == OpenDDS::DCPS::KEY_ONLY_MARSHALING) {
+      // Don't use the cached allocator for the registered sample message
+      // block.
 
-        OpenDDS::DCPS::KeyOnly<const MessageType > ko_instance_data(instance_data);
-        size_t effective_size = 0, padding = 0;
-        if (key_marshaled_size_) {
-          effective_size = key_marshaled_size_;
-        } else {
-          if (cdr && !Serializer::use_rti_serialization()) {
-            effective_size = cdr_header_size; // CDR encapsulation
-          }
-          TraitsType::gen_find_size(ko_instance_data, effective_size, padding);
-          if (cdr && Serializer::use_rti_serialization()) {
-            effective_size += (cdr_header_size);
-          }
+      OpenDDS::DCPS::KeyOnly<const MessageType > ko_instance_data(instance_data);
+      size_t effective_size = 0, padding = 0;
+      if (key_marshaled_size_) {
+        effective_size = key_marshaled_size_;
+      } else {
+        if (cdr && !Serializer::use_rti_serialization()) {
+          effective_size = cdr_header_size; // CDR encapsulation
         }
-        if (cdr) {
-          effective_size += padding;
-        }
-
-        ACE_NEW_RETURN(tmp_mb,
-          ACE_Message_Block(
-            effective_size,
-            ACE_Message_Block::MB_DATA,
-            0, // cont
-            0, // data
-            0, // alloc_strategy
-            get_db_lock()),
-          0);
-        mb.reset(tmp_mb);
-        OpenDDS::DCPS::Serializer serializer(mb.get(), swap, cdr
-                                             ? OpenDDS::DCPS::Serializer::ALIGN_CDR
-                                             : OpenDDS::DCPS::Serializer::ALIGN_NONE);
-        if (cdr) {
-          serializer << ACE_OutputCDR::from_octet(0);
-          serializer << ACE_OutputCDR::from_octet(swap ? !ACE_CDR_BYTE_ORDER : ACE_CDR_BYTE_ORDER);
-          serializer << ACE_CDR::UShort(0);
-        }
-        // If this is RTI serialization, start counting byte offset AFTER
-        // the header
+        TraitsType::gen_find_size(ko_instance_data, effective_size, padding);
         if (cdr && Serializer::use_rti_serialization()) {
-          // Start counting byte-offset AFTER header
-          serializer.reset_alignment();
-        }
-        serializer << ko_instance_data;
-      } else { // OpenDDS::DCPS::FULL_MARSHALING
-        size_t effective_size = 0, padding = 0;
-        if (marshaled_size_) {
-          effective_size = marshaled_size_;
-        } else {
-          if (cdr && !Serializer::use_rti_serialization()) {
-            effective_size = cdr_header_size; // CDR encapsulation
-          }
-          TraitsType::gen_find_size(instance_data, effective_size, padding);
-          if (cdr && Serializer::use_rti_serialization()) {
-            effective_size += (cdr_header_size);
-          }
-        }
-        if (cdr) {
-          effective_size += padding;
-        }
-
-        ACE_NEW_MALLOC_RETURN(tmp_mb,
-          static_cast<ACE_Message_Block*>(
-            mb_allocator_->malloc(sizeof(ACE_Message_Block))),
-          ACE_Message_Block(
-            effective_size,
-            ACE_Message_Block::MB_DATA,
-            0, // cont
-            0, // data
-            data_allocator_.get(), // allocator_strategy
-            get_db_lock(), // data block locking_strategy
-            ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY,
-            ACE_Time_Value::zero,
-            ACE_Time_Value::max_time,
-            db_allocator_.get(),
-            mb_allocator_.get()),
-          0);
-        mb.reset(tmp_mb);
-        OpenDDS::DCPS::Serializer serializer(mb.get(), swap, cdr
-                                             ? OpenDDS::DCPS::Serializer::ALIGN_CDR
-                                             : OpenDDS::DCPS::Serializer::ALIGN_NONE);
-        if (cdr) {
-          serializer << ACE_OutputCDR::from_octet(0);
-          serializer << ACE_OutputCDR::from_octet(swap ? !ACE_CDR_BYTE_ORDER : ACE_CDR_BYTE_ORDER);
-          serializer << ACE_CDR::UShort(0);
-        }
-        // If this is RTI serialization, start counting byte offset AFTER
-        // the header
-        if (cdr && Serializer::use_rti_serialization()) {
-          // Start counting byte-offset AFTER header
-          serializer.reset_alignment();
-        }
-
-        if (!(serializer << instance_data)) {
-          ACE_ERROR_RETURN((LM_ERROR,
-            ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::dds_marshal(): ")
-            ACE_TEXT("instance_data serialization error.\n"),
-            TraitsType::type_name()),
-            0);
+          effective_size += cdr_header_size;
         }
       }
+      if (cdr) {
+        effective_size += padding;
+      }
 
-      return mb.release();
+      ACE_NEW_RETURN(tmp_mb,
+        ACE_Message_Block(
+          effective_size,
+          ACE_Message_Block::MB_DATA,
+          0, // cont
+          0, // data
+          0, // alloc_strategy
+          get_db_lock()),
+        0);
+      mb.reset(tmp_mb);
+      OpenDDS::DCPS::Serializer serializer(mb.get(), swap, cdr
+                                           ? OpenDDS::DCPS::Serializer::ALIGN_CDR
+                                           : OpenDDS::DCPS::Serializer::ALIGN_NONE);
+      if (cdr) {
+        serializer << ACE_OutputCDR::from_octet(0);
+        serializer << ACE_OutputCDR::from_octet(swap ? !ACE_CDR_BYTE_ORDER : ACE_CDR_BYTE_ORDER);
+        serializer << ACE_CDR::UShort(0);
+      }
+      // If this is RTI serialization, start counting byte offset AFTER
+      // the header
+      if (cdr && Serializer::use_rti_serialization()) {
+        // Start counting byte-offset AFTER header
+        serializer.reset_alignment();
+      }
+      serializer << ko_instance_data;
+    } else { // OpenDDS::DCPS::FULL_MARSHALING
+      size_t effective_size = 0, padding = 0;
+      if (marshaled_size_) {
+        effective_size = marshaled_size_;
+      } else {
+        if (cdr && !Serializer::use_rti_serialization()) {
+          effective_size = cdr_header_size; // CDR encapsulation
+        }
+        TraitsType::gen_find_size(instance_data, effective_size, padding);
+        if (cdr && Serializer::use_rti_serialization()) {
+          effective_size += cdr_header_size;
+        }
+      }
+      if (cdr) {
+        effective_size += padding;
+      }
+
+      ACE_NEW_MALLOC_RETURN(tmp_mb,
+        static_cast<ACE_Message_Block*>(
+          mb_allocator_->malloc(sizeof(ACE_Message_Block))),
+        ACE_Message_Block(
+          effective_size,
+          ACE_Message_Block::MB_DATA,
+          0, // cont
+          0, // data
+          data_allocator_.get(), // allocator_strategy
+          get_db_lock(), // data block locking_strategy
+          ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY,
+          ACE_Time_Value::zero,
+          ACE_Time_Value::max_time,
+          db_allocator_.get(),
+          mb_allocator_.get()),
+        0);
+      mb.reset(tmp_mb);
+      OpenDDS::DCPS::Serializer serializer(mb.get(), swap, cdr
+                                           ? OpenDDS::DCPS::Serializer::ALIGN_CDR
+                                           : OpenDDS::DCPS::Serializer::ALIGN_NONE);
+      if (cdr) {
+        serializer << ACE_OutputCDR::from_octet(0);
+        serializer << ACE_OutputCDR::from_octet(swap ? !ACE_CDR_BYTE_ORDER : ACE_CDR_BYTE_ORDER);
+        serializer << ACE_CDR::UShort(0);
+      }
+
+      // If this is RTI serialization, start counting byte offset AFTER
+      // the header
+      if (cdr && Serializer::use_rti_serialization()) {
+        // Start counting byte-offset AFTER header
+        serializer.reset_alignment();
+      }
+
+      if (!(serializer << instance_data)) {
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::dds_marshal(): ")
+          ACE_TEXT("instance_data serialization error.\n"),
+          TraitsType::type_name()),
+          0);
+      }
     }
 
-  /**
-   * Find the instance handle for the given instance_data using
-   * the data type's key(s).  If the instance does not already exist
-   * create a new instance handle for it.
-   */
+    return mb.release();
+  }
+
+/**
+ * Find the instance handle for the given instance_data using
+ * the data type's key(s).  If the instance does not already exist
+ * create a new instance handle for it.
+ */
   DDS::ReturnCode_t get_or_create_instance_handle(
     DDS::InstanceHandle_t& handle,
     const MessageType& instance_data,
     const DDS::Time_t & source_timestamp)
-    {
-      ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                       guard,
-                       get_lock(),
-                       DDS::RETCODE_ERROR);
+  {
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
 
-      handle = DDS::HANDLE_NIL;
-      typename InstanceMap::const_iterator it = instance_map_.find(instance_data);
+    handle = DDS::HANDLE_NIL;
+    typename InstanceMap::const_iterator it = instance_map_.find(instance_data);
 
-      bool needs_creation = true;
-      bool needs_registration = true;
+    bool needs_creation = true;
+    bool needs_registration = true;
 
-      if (it != instance_map_.end())
-        {
-          needs_creation = false;
+    if (it != instance_map_.end()) {
+      needs_creation = false;
 
-          handle = it->second;
-          OpenDDS::DCPS::PublicationInstance_rch instance = get_handle_instance(handle);
+      handle = it->second;
+      OpenDDS::DCPS::PublicationInstance_rch instance = get_handle_instance(handle);
 
-          if (instance->unregistered_ == false)
-            {
-              needs_registration = false;
-            }
-          // else: The instance is unregistered and now register again.
-        }
-
-      if (needs_registration)
-        {
-          // don't use fast allocator for registration.
-          Message_Block_Ptr marshalled(
-            this->dds_marshal(instance_data,
-                              OpenDDS::DCPS::KEY_ONLY_MARSHALING));
-
-          // tell DataWriterLocal and Publisher about the instance.
-          DDS::ReturnCode_t ret = register_instance_i(handle, move(marshalled), source_timestamp);
-          // note: the WriteDataContainer/PublicationInstance maintains ownership
-          // of the marshalled sample.
-
-          if (ret != DDS::RETCODE_OK)
-            {
-              handle = DDS::HANDLE_NIL;
-              return ret;
-            }
-
-          if (needs_creation)
-            {
-              std::pair<typename InstanceMap::iterator, bool> pair =
-                instance_map_.insert(typename InstanceMap::value_type(instance_data, handle));
-
-              if (pair.second == false)
-                {
-                  handle = DDS::HANDLE_NIL;
-                  ACE_ERROR_RETURN ((LM_ERROR,
-                                     ACE_TEXT("(%P|%t) ")
-                                     ACE_TEXT("%CDataWriterImpl::")
-                                     ACE_TEXT("get_or_create_instance_handle, ")
-                                     ACE_TEXT("insert %C failed.\n"),
-                                     TraitsType::type_name(), TraitsType::type_name()),
-                                    DDS::RETCODE_ERROR);
-                }
-            } // end of if (needs_creation)
-
-          send_all_to_flush_control(guard);
-
-        } // end of if (needs_registration)
-
-      return DDS::RETCODE_OK;
+      if (instance->unregistered_ == false) {
+        needs_registration = false;
+      }
+      // else: The instance is unregistered and now register again.
     }
 
-    InstanceMap instance_map_;
-    size_t marshaled_size_;
-    size_t key_marshaled_size_;
-    unique_ptr<DataAllocator> data_allocator_;
-    unique_ptr<MessageBlockAllocator> mb_allocator_;
-    unique_ptr<DataBlockAllocator> db_allocator_;
+    if (needs_registration) {
+      // don't use fast allocator for registration.
+      Message_Block_Ptr marshalled(
+        this->dds_marshal(instance_data,
+                          OpenDDS::DCPS::KEY_ONLY_MARSHALING));
 
-    // A class, normally provided by an unit test, that needs access to
-    // private methods/members.
-    friend class ::DDS_TEST;
-  };
+      // tell DataWriterLocal and Publisher about the instance.
+      DDS::ReturnCode_t ret = register_instance_i(handle, move(marshalled), source_timestamp);
+      // note: the WriteDataContainer/PublicationInstance maintains ownership
+      // of the marshalled sample.
 
+      if (ret != DDS::RETCODE_OK) {
+        handle = DDS::HANDLE_NIL;
+        return ret;
+      }
+
+      if (needs_creation) {
+        std::pair<typename InstanceMap::iterator, bool> pair =
+          instance_map_.insert(typename InstanceMap::value_type(instance_data, handle));
+
+        if (pair.second == false) {
+          handle = DDS::HANDLE_NIL;
+          ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::get_or_create_instance_handle ")
+                            ACE_TEXT("insert %C failed.\n"),
+                            TraitsType::type_name(), TraitsType::type_name()),
+                           DDS::RETCODE_ERROR);
+        }
+      } // end of if (needs_creation)
+
+      send_all_to_flush_control(guard);
+
+    } // end of if (needs_registration)
+
+    return DDS::RETCODE_OK;
   }
+
+  InstanceMap instance_map_;
+  size_t marshaled_size_;
+  size_t key_marshaled_size_;
+  unique_ptr<DataAllocator> data_allocator_;
+  unique_ptr<MessageBlockAllocator> mb_allocator_;
+  unique_ptr<DataBlockAllocator> db_allocator_;
+
+  // A class, normally provided by an unit test, that needs access to
+  // private methods/members.
+  friend class ::DDS_TEST;
+};
+
+}
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -340,7 +340,7 @@ void InstanceState::ScheduleCommand::execute()
   }
 }
 
-OPENDDS_STRING InstanceState::instance_state_string(DDS::InstanceStateKind value)
+const char* InstanceState::instance_state_string(DDS::InstanceStateKind value)
 {
   switch (value) {
   case DDS::ALIVE_INSTANCE_STATE:
@@ -354,13 +354,11 @@ OPENDDS_STRING InstanceState::instance_state_string(DDS::InstanceStateKind value
   case DDS::ANY_INSTANCE_STATE:
     return "ANY_INSTANCE_STATE";
   default:
-    ACE_ERROR((LM_ERROR,
-      ACE_TEXT("(%P|%t) ERROR: OpenDDS::DCPS::InstanceState::instance_state_string(): ")
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: InstanceState::instance_state_string: ")
       ACE_TEXT("%d is either invalid or not recognized.\n"),
-      value
-    ));
+      value));
 
-    return "(Unknown Instance State: " + to_dds_string(value) + ")";
+    return "Invalid instance state";
   }
 }
 

--- a/dds/DCPS/InstanceState.h
+++ b/dds/DCPS/InstanceState.h
@@ -139,13 +139,10 @@ public:
   DDS::InstanceHandle_t instance_handle() const { return handle_; }
 
   /// Return string of the name of the current instance state
-  OPENDDS_STRING instance_state_string() const
-  {
-    return instance_state_string(instance_state_);
-  }
+  const char* instance_state_string() const;
 
   /// Return string of the name of the instance state kind passed
-  static OPENDDS_STRING instance_state_string(DDS::InstanceStateKind value);
+  static const char* instance_state_string(DDS::InstanceStateKind value);
 
   /// Return string representation of the instance state mask passed
   static OPENDDS_STRING instance_state_mask_string(DDS::InstanceStateMask mask);

--- a/dds/DCPS/InstanceState.inl
+++ b/dds/DCPS/InstanceState.inl
@@ -161,4 +161,10 @@ OpenDDS::DCPS::InstanceState::no_writer () const
   return writers_.empty();
 }
 
+ACE_INLINE
+const char* OpenDDS::DCPS::InstanceState::instance_state_string() const
+{
+  return instance_state_string(instance_state_);
+}
+
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3933,8 +3933,9 @@ Sedp::Task::svc()
 {
   for (Msg* msg = 0; getq(msg) != -1; /*no increment*/) {
     if (DCPS::DCPS_debug_level > 5) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::Task::svc "
-        "got message from queue type %C\n", msg->msgTypeToString().c_str()));
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Sedp::Task::svc ")
+        ACE_TEXT("got message from queue type %C\n"),
+        msg->msgTypeToString()));
     }
 
     DCPS::unique_ptr<Msg> delete_the_msg(msg);
@@ -4744,7 +4745,7 @@ WaitForAcks::reset()
   // cause wait_for_acks() to exit it's loop
 }
 
-OPENDDS_STRING Sedp::Msg::msgTypeToString(const MsgType type) {
+const char* Sedp::Msg::msgTypeToString(MsgType type) {
   switch (type) {
   case MSG_PARTICIPANT:
     return "MSG_PARTICIPANT";
@@ -4779,13 +4780,14 @@ OPENDDS_STRING Sedp::Msg::msgTypeToString(const MsgType type) {
 #endif
 
   default:
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) Sedp::Msg::msgTypeToString() : ERROR: ")
-      ACE_TEXT("%u is not a valid queue type\n"), static_cast<unsigned>(type)));
-    return OpenDDS::DCPS::to_dds_string(static_cast<unsigned>(type));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Sedp::Msg::msgTypeToString: ")
+      ACE_TEXT("%d is either invalid or not recognized.\n"),
+      type));
+    return "Invalid message queue type";
   }
 }
 
-OPENDDS_STRING Sedp::Msg::msgTypeToString() const {
+const char* Sedp::Msg::msgTypeToString() const {
   return msgTypeToString(type_);
 }
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -253,8 +253,8 @@ private:
       : type_(mt), id_(id), pgmdata_(data) {}
 #endif
 
-    static OPENDDS_STRING msgTypeToString(MsgType type);
-    OPENDDS_STRING msgTypeToString() const;
+    static const char* msgTypeToString(MsgType type);
+    const char* msgTypeToString() const;
   };
 
 

--- a/dds/DCPS/SafetyProfileStreams.cpp
+++ b/dds/DCPS/SafetyProfileStreams.cpp
@@ -106,21 +106,20 @@ to_dds_string(unsigned long to_convert, bool as_hex)
   return OPENDDS_STRING(buf);
 }
 
-OPENDDS_STRING
-to_hex_dds_string(const unsigned char* data, const size_t size, const char delim, const size_t delim_every)
+OPENDDS_STRING to_hex_dds_string(
+  const unsigned char* data, const size_t size, const char delim, const size_t delim_every)
 {
   return to_hex_dds_string(reinterpret_cast<const char*>(data), size, delim, delim_every);
 }
 
-static inline
-char nibble_to_hex_char(char nibble)
+static inline char nibble_to_hex_char(char nibble)
 {
   nibble &= 0x0F;
   return ((nibble < 0xA) ? '0' : ('a' - 0xA)) + nibble;
 }
 
-OPENDDS_STRING
-to_hex_dds_string(const char* data, size_t size, const char delim, const size_t delim_every)
+OPENDDS_STRING to_hex_dds_string(
+  const char* data, size_t size, const char delim, const size_t delim_every)
 {
   const bool valid_delim = delim && delim_every;
   size_t l = size * 2;
@@ -143,8 +142,7 @@ to_hex_dds_string(const char* data, size_t size, const char delim, const size_t 
   return rv;
 }
 
-OPENDDS_STRING
-retcode_to_string(DDS::ReturnCode_t value)
+const char* retcode_to_string(DDS::ReturnCode_t value)
 {
   switch (value) {
   case DDS::RETCODE_OK:
@@ -178,11 +176,10 @@ retcode_to_string(DDS::ReturnCode_t value)
     return "Not allowed by security";
 #endif
   default:
-    ACE_ERROR((LM_ERROR,
-      ACE_TEXT("(%P|%t) ERROR: OpenDDS::DCPS::retcode_to_string: ")
-      ACE_TEXT("%d is either completely invalid or unknown to this function.\n"),
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: retcode_to_string: ")
+      ACE_TEXT("%d is either invalid or not recognized.\n"),
       value));
-    return OPENDDS_STRING("(Unknown Return Code: ") + to_dds_string(value) + ")";
+    return "Invalid return code";
   }
 }
 

--- a/dds/DCPS/SafetyProfileStreams.h
+++ b/dds/DCPS/SafetyProfileStreams.h
@@ -28,7 +28,7 @@ OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(long long to_convert);
 OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(unsigned long long to_convert, bool as_hex = false);
 OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(unsigned long to_convert, bool as_hex = false);
 
-OpenDDS_Dcps_Export OPENDDS_STRING retcode_to_string(DDS::ReturnCode_t value);
+OpenDDS_Dcps_Export const char* retcode_to_string(DDS::ReturnCode_t value);
 
 //@{
 /**

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -272,7 +272,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
         GuidConverter converter(dr_servant->get_subscription_id());
         ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader(%C): ")
           ACE_TEXT("will return \"%C\" because datareader %s\n"),
-          OPENDDS_STRING(converter).c_str(), retcode_to_string(rc).c_str(),
+          OPENDDS_STRING(converter).c_str(), retcode_to_string(rc),
           reason));
       }
       return rc;

--- a/dds/DCPS/WriterInfo.cpp
+++ b/dds/DCPS/WriterInfo.cpp
@@ -53,8 +53,8 @@ WriterInfoListener::writer_removed(WriterInfo&)
 {
 }
 
-WriterInfo::WriterInfo(WriterInfoListener*         reader,
-                       const PublicationId&        writer_id,
+WriterInfo::WriterInfo(WriterInfoListener* reader,
+                       const PublicationId& writer_id,
                        const ::DDS::DataWriterQos& writer_qos)
   : last_liveliness_activity_time_(MonotonicTimePoint::now()),
   historic_samples_timer_(NO_TIMER),
@@ -84,26 +84,21 @@ WriterInfo::WriterInfo(WriterInfoListener*         reader,
   }
 }
 
-OPENDDS_STRING
-WriterInfo::get_state_str() const
+const char* WriterInfo::get_state_str() const
 {
-  OPENDDS_STRING ret;
-  switch (this->state_) {
-  case WriterInfo::NOT_SET:
-    ret += "NOT_SET";
-    break;
-  case WriterInfo::ALIVE:
-    ret += "ALIVE";
-    break;
-  case WriterInfo::DEAD:
-    ret += "DEAD";
-    break;
+  switch (state_) {
+  case NOT_SET:
+    return "NOT_SET";
+  case ALIVE:
+    return "ALIVE";
+  case DEAD:
+    return "DEAD";
   default:
-    ret += "UNSPECIFIED(";
-    ret += to_dds_string(int(this->state_));
-    ret += ")";
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: WriterInfo::get_state_str: ")
+      ACE_TEXT("%d is either invalid or not recognized.\n"),
+      state_));
+    return "Invalid state";
   }
-  return ret.c_str();
 }
 
 void

--- a/dds/DCPS/WriterInfo.h
+++ b/dds/DCPS/WriterInfo.h
@@ -78,8 +78,8 @@ public:
   enum WriterState { NOT_SET, ALIVE, DEAD };
   enum HistoricSamplesState { NO_TIMER = -1 };
 
-  WriterInfo(WriterInfoListener*         reader,
-             const PublicationId&        writer_id,
+  WriterInfo(WriterInfoListener* reader,
+             const PublicationId& writer_id,
              const DDS::DataWriterQos& writer_qos);
 
   /// check to see if this writer is alive (called by handle_timeout).
@@ -90,14 +90,14 @@ public:
   MonotonicTimePoint check_activity(const MonotonicTimePoint& now);
 
   /// called when a sample or other activity is received from this writer.
-  void received_activity(const MonotonicTimePoint & when);
+  void received_activity(const MonotonicTimePoint& when);
 
   /// returns 1 if the DataWriter is lively; 2 if dead; otherwise returns 0.
   WriterState get_state() {
     return state_;
   };
 
-  OPENDDS_STRING get_state_str() const;
+  const char* get_state_str() const;
 
   /// update liveliness when remove_association is called.
   void removed();

--- a/dds/DCPS/security/CommonUtilities.cpp
+++ b/dds/DCPS/security/CommonUtilities.cpp
@@ -83,7 +83,7 @@ bool set_security_error(DDS::Security::SecurityException& ex,
   return set_security_error(ex, code, minor_code, full.c_str());
 }
 
-OPENDDS_STRING ctk_to_dds_string(const CryptoTransformKind& keyKind)
+const char* ctk_to_dds_string(const CryptoTransformKind& keyKind)
 {
   if (!keyKind[0] && !keyKind[1] && !keyKind[2]) {
     switch (keyKind[3]) {
@@ -99,8 +99,10 @@ OPENDDS_STRING ctk_to_dds_string(const CryptoTransformKind& keyKind)
       return "CRYPTO_TRANSFORMATION_KIND_AES256_GCM";
     }
   }
-  return OPENDDS_STRING("Unknown CryptoTransformKind ") +
-    to_hex_dds_string(keyKind, sizeof(keyKind), ' ');
+  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Security::CommonUtilities::ctk_to_dds_string: ")
+    ACE_TEXT("%C is either invalid or not recognized.\n"),
+    to_hex_dds_string(keyKind, sizeof(keyKind), ' ').c_str()));
+  return "Invalid CryptoTransformKind";
 }
 
 OPENDDS_STRING ctki_to_dds_string(const CryptoTransformKeyId& keyId)

--- a/dds/DCPS/security/CommonUtilities.h
+++ b/dds/DCPS/security/CommonUtilities.h
@@ -53,7 +53,7 @@ bool set_security_error(DDS::Security::SecurityException& ex,
                         const unsigned char (&a1)[4],
                         const unsigned char (&a2)[4]);
 
-OPENDDS_STRING ctk_to_dds_string(const CryptoTransformKind& keyKind);
+const char* ctk_to_dds_string(const CryptoTransformKind& keyKind);
 OPENDDS_STRING ctki_to_dds_string(const CryptoTransformKeyId& keyId);
 OPENDDS_STRING to_dds_string(const KeyOctetSeq& keyData);
 OPENDDS_STRING to_dds_string(const KeyMaterial_AES_GCM_GMAC& km);

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -1450,7 +1450,7 @@ bool CryptoBuiltInImpl::preprocess_secure_submsg(
         if (security_debug.chlookup) {
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {chlookup} CryptoBuiltInImpl::preprocess_secure_submsg: ")
             ACE_TEXT("    Key: %C\n"),
-            (ctk_to_dds_string(keyseq[i].transformation_kind) + ", " +
+            (OPENDDS_STRING(ctk_to_dds_string(keyseq[i].transformation_kind)) + ", " +
               ctki_to_dds_string(keyseq[i].sender_key_id)).c_str()));
         }
         if (matches(keyseq[i], ch)) {

--- a/dds/DCPS/transport/tcp/TcpConnection.cpp
+++ b/dds/DCPS/transport/tcp/TcpConnection.cpp
@@ -284,7 +284,7 @@ OpenDDS::DCPS::TcpConnection::handle_setup_input(ACE_HANDLE /*h*/)
             "%@ %C:%d->%C:%d, priority==%d, reconnect_state = %C\n", this,
             remote_address_.get_host_addr(), remote_address_.get_port_number(),
             local_address_.get_host_addr(), local_address_.get_port_number(),
-            transport_priority_, reconnect_state_string().c_str()));
+            transport_priority_, reconnect_state_string()));
 
       // remove from reactor, normal recv strategy setup will add us back
       if (reactor()->remove_handler(this, READ_MASK | DONT_CALL) == -1) {
@@ -692,15 +692,15 @@ OpenDDS::DCPS::TcpConnection::active_reconnect_i()
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "active_reconnect_i(%C:%d->%C:%d) reconnect_state = %C\n",
-        this->remote_address_.get_host_addr(), this->remote_address_.get_port_number(),
-        this->local_address_.get_host_addr(), this->local_address_.get_port_number(),
-        this->reconnect_state_string().c_str()));
+        remote_address_.get_host_addr(), remote_address_.get_port_number(),
+        local_address_.get_host_addr(), local_address_.get_port_number(),
+        reconnect_state_string()));
   if (DCPS_debug_level >= 1) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) DBG:   TcpConnection::"
           "active_reconnect_i(%C:%d->%C:%d) reconnect_state = %C\n",
-          this->remote_address_.get_host_addr(), this->remote_address_.get_port_number(),
-          this->local_address_.get_host_addr(), this->local_address_.get_port_number(),
-          this->reconnect_state_string().c_str()));
+          remote_address_.get_host_addr(), remote_address_.get_port_number(),
+          local_address_.get_host_addr(), local_address_.get_port_number(),
+          reconnect_state_string()));
   }
   // We need reset the state to INIT_STATE if we are previously reconnected.
   // This would allow re-establishing connection after the re-established
@@ -1061,8 +1061,7 @@ OpenDDS::DCPS::TcpConnection::spawn_reconnect_thread()
   }
 }
 
-OPENDDS_STRING
-OpenDDS::DCPS::TcpConnection::reconnect_state_string() const
+const char* OpenDDS::DCPS::TcpConnection::reconnect_state_string() const
 {
   switch (reconnect_state_) {
   case INIT_STATE:
@@ -1076,13 +1075,10 @@ OpenDDS::DCPS::TcpConnection::reconnect_state_string() const
   case PASSIVE_TIMEOUT_CALLED_STATE:
     return "PASSIVE_TIMEOUT_CALLED_STATE";
   default:
-    ACE_ERROR((LM_ERROR,
-      ACE_TEXT("TcpConnection::reconnect_state_string(): ")
-      ACE_TEXT("%d is either completely invalid or at least not defined in this function.\n"),
-      reconnect_state_
-    ));
-    return OPENDDS_STRING("(Unknown Reconnect State: ")
-      + to_dds_string(reconnect_state_) + ")";
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: TcpConnection::reconnect_state_string: ")
+      ACE_TEXT("%d is either invalid or not recognized.\n"),
+      reconnect_state_));
+    return "Invalid reconnect state";
   }
 }
 

--- a/dds/DCPS/transport/tcp/TcpConnection.h
+++ b/dds/DCPS/transport/tcp/TcpConnection.h
@@ -263,7 +263,7 @@ private:
   RcHandle<TcpReconnectTask> reconnect_task_;
 
   /// Get name of the current reconnect state as a string.
-  OPENDDS_STRING reconnect_state_string() const;
+  const char* reconnect_state_string() const;
 };
 
 } // namespace DCPS

--- a/tests/DCPS/GroupPresentation/DataReaderListener.cpp
+++ b/tests/DCPS/GroupPresentation/DataReaderListener.cpp
@@ -81,7 +81,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("%N:%l: on_data_available()")
                  ACE_TEXT(" ERROR: take_next_sample unexpected status: %C\n"),
-                 retcode_to_string(status).c_str()));
+                 retcode_to_string(status)));
       this->verify_result_ = false;
     }
 

--- a/tests/DCPS/Presentation/main.cpp
+++ b/tests/DCPS/Presentation/main.cpp
@@ -79,7 +79,7 @@ public:
     if (take_result != DDS::RETCODE_OK) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l on_data_available() ERROR: ")
                  ACE_TEXT("take failed: %C\n"),
-                 retcode_to_string(take_result).c_str()));
+                 retcode_to_string(take_result)));
       error = true;
       done = true;
       return;
@@ -150,7 +150,7 @@ public:
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
                         ACE_TEXT("get_default_subscriber_qos failed: %C\n"),
-                        retcode_to_string(rc).c_str()), false);
+                        retcode_to_string(rc)), false);
     }
 
     // TODO Currently only TOPIC access_scope is supported.
@@ -172,7 +172,7 @@ public:
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
                         ACE_TEXT("get_default_publisher_qos failed: %C\n"),
-                        retcode_to_string(rc).c_str()), false);
+                        retcode_to_string(rc)), false);
     }
 
     // TODO Currently only TOPIC access_scope is supported.
@@ -242,14 +242,14 @@ public:
         if (rc != DDS::RETCODE_OK) {
           ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
                             ACE_TEXT("wait failed: %C\n"),
-                            retcode_to_string(rc).c_str()), false);
+                            retcode_to_string(rc)), false);
         }
 
         rc = writer_->get_publication_matched_status(matches);
         if (rc != ::DDS::RETCODE_OK) {
           ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
                             ACE_TEXT("Failed to get publication match status: %C\n"),
-                            retcode_to_string(rc).c_str()), false);
+                            retcode_to_string(rc)), false);
         }
       } while (matches.total_count < (coherent ? 2 : 1));
       ws->detach_condition(cond);
@@ -267,7 +267,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete reader1 failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -276,7 +276,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete reader2 failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -285,7 +285,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete writer failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -294,7 +294,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete subscriber failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -303,7 +303,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete publisher failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
   }
@@ -349,7 +349,7 @@ coherent_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l coherent_test() ERROR: ")
           ACE_TEXT("Unable to write sample %u: %C\n"),
-          retcode_to_string(rc).c_str(), i), false);
+          retcode_to_string(rc), i), false);
     }
   }
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("Waiting...\n")));
@@ -369,7 +369,7 @@ coherent_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     } else if (rc != DDS::RETCODE_NO_DATA) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l coherent_test() ERROR: ")
         ACE_TEXT("Expected RETCODE_NO_DATA, but error is: %C\n"),
-        retcode_to_string(rc).c_str()), false);
+        retcode_to_string(rc)), false);
     }
   }
 
@@ -388,7 +388,7 @@ coherent_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l coherent_test() ERROR: ")
                         ACE_TEXT("wait failed: %C\n"),
-                        retcode_to_string(rc).c_str()), false);
+                        retcode_to_string(rc)), false);
     }
   }
 
@@ -402,7 +402,7 @@ coherent_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l coherent_test() ERROR: ")
         ACE_TEXT("take error: %C\n"),
-        retcode_to_string(rc).c_str()), false);
+        retcode_to_string(rc)), false);
     }
     if (foo.length() != SAMPLES_PER_TEST) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l coherent_test() ERROR: ")
@@ -467,7 +467,7 @@ ordered_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l ordered_test() ERROR: ")
           ACE_TEXT("Unable to write sample %u: %C\n"),
-          retcode_to_string(rc).c_str(), i * 2), false);
+          i * 2, retcode_to_string(rc)), false);
     }
 
     // Write second instance
@@ -476,7 +476,7 @@ ordered_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l ordered_test() ERROR: ")
           ACE_TEXT("Unable to write sample %u: %C\n"),
-          retcode_to_string(rc).c_str(), i * 2 + 1), false);
+          i * 2 + 1, retcode_to_string(rc)), false);
     }
   }
 
@@ -493,7 +493,7 @@ ordered_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l ordered_test() ERROR: ")
                         ACE_TEXT("wait failed: %C\n"),
-                        retcode_to_string(rc).c_str()), false);
+                        retcode_to_string(rc)), false);
     }
   }
 
@@ -511,7 +511,7 @@ ordered_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l ordered_test() ERROR: ")
                         ACE_TEXT("Unable to take samples: %C\n"),
-                        retcode_to_string(rc).c_str()), false);
+                        retcode_to_string(rc)), false);
     }
 
     DDS::Time_t last_timestamp = {0, 0};
@@ -556,7 +556,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l main() ERROR: ")
                         ACE_TEXT("register_type failed: %C\n"),
-                        retcode_to_string(rc).c_str()), 1);
+                        retcode_to_string(rc)), 1);
     }
 
     // Create Topic (FooTopic)

--- a/tests/DCPS/UnionTopic/UnionTopic.cpp
+++ b/tests/DCPS/UnionTopic/UnionTopic.cpp
@@ -88,7 +88,7 @@ public:
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
         ACE_TEXT("get_default_datawriter_qos failed: %C\n"),
-        retcode_to_string(rc).c_str()), false);
+        retcode_to_string(rc)), false);
     }
     writer_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
     writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
@@ -113,14 +113,14 @@ public:
         if (rc != DDS::RETCODE_OK) {
           ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
             ACE_TEXT("wait failed: %C\n"),
-            retcode_to_string(rc).c_str()), false);
+            retcode_to_string(rc)), false);
         }
 
         rc = writer_->get_publication_matched_status(matches);
         if (rc != ::DDS::RETCODE_OK) {
           ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l setup_test() ERROR: ")
             ACE_TEXT("Failed to get publication match status: %C\n"),
-            retcode_to_string(rc).c_str()), false);
+            retcode_to_string(rc)), false);
         }
       } while (matches.total_count < 1);
       ws->detach_condition(cond);
@@ -138,7 +138,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete reader failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -147,7 +147,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete writer failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -156,7 +156,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete subscriber failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
 
@@ -165,7 +165,7 @@ public:
       if (rc != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l ~Test() ERROR: ")
           ACE_TEXT("delete publisher failed: %C\n"),
-          retcode_to_string(rc).c_str()));
+          retcode_to_string(rc)));
       }
     }
   }
@@ -185,7 +185,7 @@ bool wait_for_dispose(ElectionNews_tDataReader_var& reader_i) {
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l wait_for_dispose() ERROR: ")
       ACE_TEXT("wait failed: %C\n"),
-      retcode_to_string(rc).c_str()), false);
+      retcode_to_string(rc)), false);
   }
   return true;
 }
@@ -254,14 +254,14 @@ basic_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
         ACE_TEXT("Unable to write sample %C: %C\n"),
-        i->first.c_str(), retcode_to_string(rc).c_str()), false);
+        i->first.c_str(), retcode_to_string(rc)), false);
     }
   }
   rc = writer_i->dispose(news, DDS::HANDLE_NIL);
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
       ACE_TEXT("Unable to dispose: %C\n"),
-      retcode_to_string(rc).c_str()), false);
+      retcode_to_string(rc)), false);
   }
 
   // Wait for the Dispose and Read Them
@@ -283,7 +283,7 @@ basic_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
       ACE_TEXT("Unable to read: %C\n"),
-      retcode_to_string(rc).c_str()), false);
+      retcode_to_string(rc)), false);
   }
   size_t count = 0;
   bool got_dispose = false;
@@ -324,13 +324,13 @@ basic_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
       ACE_TEXT("Unable to write result sample: %C\n"),
-      retcode_to_string(rc).c_str()), false);
+      retcode_to_string(rc)), false);
   }
   rc = writer_i->dispose(news, DDS::HANDLE_NIL);
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
       ACE_TEXT("Unable to dispose: %C\n"),
-      retcode_to_string(rc).c_str()), false);
+      retcode_to_string(rc)), false);
   }
 
   // Wait for the Dispose and Read
@@ -347,7 +347,7 @@ basic_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
       ACE_TEXT("Unable to read: %C\n"),
-      retcode_to_string(rc).c_str()), false);
+      retcode_to_string(rc)), false);
   }
   if (newsSeq.length() != 2) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
@@ -412,7 +412,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l main() ERROR: ")
         ACE_TEXT("register_type failed: %C\n"),
-        retcode_to_string(rc).c_str()), 1);
+        retcode_to_string(rc)), 1);
     }
 
     // Create Topic
@@ -439,14 +439,14 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l: main() ERROR: ")
         ACE_TEXT("delete_contained_entities failed: %C\n"),
-        retcode_to_string(rc).c_str()));
+        retcode_to_string(rc)));
       status = 1;
     }
     rc = dpf->delete_participant(participant.in());
     if (rc != DDS::RETCODE_OK) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l: main() ERROR: ")
         ACE_TEXT("delete_participant failed: %C\n"),
-        retcode_to_string(rc).c_str()));
+        retcode_to_string(rc)));
       status = 1;
     }
     TheServiceParticipant->shutdown();

--- a/tests/DCPS/ViewState/main.cpp
+++ b/tests/DCPS/ViewState/main.cpp
@@ -550,7 +550,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             ACE_ERROR ((LM_ERROR,
               ACE_TEXT("(%P|%t) ERROR: expected an invalid data sample (dispose notification), instance state is %C.\n"),
               OpenDDS::DCPS::InstanceState::instance_state_string(
-                info4[2].instance_state).c_str()));
+                info4[2].instance_state)));
             test_failed = 1;
           }
 

--- a/tests/DCPS/ZeroCopyRead/main.cpp
+++ b/tests/DCPS/ZeroCopyRead/main.cpp
@@ -1616,7 +1616,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         if (status != ::DDS::RETCODE_PRECONDITION_NOT_MET) {
           ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) t10 ERROR: ")
             ACE_TEXT("expected PRECONDITION_NOT_MET from delete_datareader, ")
-            ACE_TEXT("but it returned: %C\n"), retcode_to_string(status).c_str()));
+            ACE_TEXT("but it returned: %C\n"), retcode_to_string(status)));
           test_failed = 1;
         }
 
@@ -1636,7 +1636,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         if (status != ::DDS::RETCODE_OK) {
           ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) t10 ERROR: ")
             ACE_TEXT("delete_datareader returned: %C\n"),
-            retcode_to_string(status).c_str()));
+            retcode_to_string(status)));
           test_failed = 1;
         }
       }


### PR DESCRIPTION
- Normalize these enum-like value to string functions, by making them return `const char *` instead of `OPENDDS_STRING` (Fix for https://github.com/objectcomputing/OpenDDS/issues/1188) and having them behave the same when an invalid value is passed:
  - `DataSampleHeader.cpp`:
    - `to_string(MessageId)`
    - `to_string(SubMessageId)`
  - `InstanceState.cpp`:
    - `InstanceState::instance_state_string(DDS::InstanceStateKind)`
    - `InstanceState::instance_state_string()`
  - `Sedp.cpp`:
    - `Sedp::Msg::msgTypeToString(MsgType)`
    - `Sedp::Msg::msgTypeToString()`
  - `SafetyProfileStreams.cpp`:
    - `retcode_to_string(DDS::ReturnCode_t)`
  - `WriterInfo.cpp`:
    - `WriterInfo::get_state_str()`
  - `security/CommonUtilities.cpp`:
    - `ctk_to_dds_string(const CryptoTransformKind&)`
  - `transport/tcp/TcpConnection.cpp`:
    - `TcpConnection::reconnect_state_string()`
- Remove logging single spaces before newlines in `DataWriterImpl.cpp`
- Try to fix style in `DataWriterImpl_T.h`