### PR TITLE
RtpsUdpDataLink: avoid local classes since they can't be template arguments

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -299,44 +299,16 @@ void
 RtpsUdpDataLink::add_address(const DCPS::NetworkInterface& nic,
                              const ACE_INET_Addr&)
 {
-  struct JoinMulticastGroup : public JobQueue::Job {
-    JoinMulticastGroup(DCPS::RcHandle<RtpsUdpDataLink> tport,
-                       const DCPS::NetworkInterface& nic)
-      : tport_(tport)
-      , nic_(nic)
-    {}
-
-    void execute()
-    {
-      tport_->join_multicast_group(nic_);
-    }
-
-    DCPS::RcHandle<RtpsUdpDataLink> tport_;
-    DCPS::NetworkInterface nic_;
-  };
-  job_queue_->enqueue(DCPS::make_rch<JoinMulticastGroup>(rchandle_from(this), nic));
+  job_queue_->enqueue(make_rch<ChangeMulticastGroup>(rchandle_from(this), nic,
+                                                     ChangeMulticastGroup::CMG_JOIN));
 }
 
 void
 RtpsUdpDataLink::remove_address(const DCPS::NetworkInterface& nic,
                                 const ACE_INET_Addr&)
 {
-  struct LeaveMulticastGroup : public DCPS::JobQueue::Job {
-    LeaveMulticastGroup(DCPS::RcHandle<RtpsUdpDataLink> tport,
-                        const DCPS::NetworkInterface& nic)
-      : tport_(tport)
-      , nic_(nic)
-    {}
-
-    void execute()
-    {
-      tport_->leave_multicast_group(nic_);
-    }
-
-    DCPS::RcHandle<RtpsUdpDataLink> tport_;
-    DCPS::NetworkInterface nic_;
-  };
-  job_queue_->enqueue(DCPS::make_rch<LeaveMulticastGroup>(rchandle_from(this), nic));
+  job_queue_->enqueue(make_rch<ChangeMulticastGroup>(rchandle_from(this), nic,
+                                                     ChangeMulticastGroup::CMG_LEAVE));
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -60,7 +60,7 @@ class ReceivedDataSample;
 typedef RcHandle<RtpsUdpInst> RtpsUdpInst_rch;
 typedef RcHandle<RtpsUdpTransport> RtpsUdpTransport_rch;
 
-  class OpenDDS_Rtps_Udp_Export RtpsUdpDataLink : public DataLink, public virtual NetworkConfigListener {
+class OpenDDS_Rtps_Udp_Export RtpsUdpDataLink : public DataLink, public virtual NetworkConfigListener {
 public:
 
   RtpsUdpDataLink(RtpsUdpTransport& transport,
@@ -645,6 +645,30 @@ private:
 #endif
 
   void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses) const;
+
+  struct ChangeMulticastGroup : public JobQueue::Job {
+    enum CmgAction {CMG_JOIN, CMG_LEAVE};
+
+    ChangeMulticastGroup(RcHandle<RtpsUdpDataLink> link,
+                         const NetworkInterface& nic, CmgAction action)
+      : link_(link)
+      , nic_(nic)
+      , action_(action)
+    {}
+
+    void execute()
+    {
+      if (action_ == CMG_JOIN) {
+        link_->join_multicast_group(nic_);
+      } else {
+        link_->leave_multicast_group(nic_);
+      }
+    }
+
+    RcHandle<RtpsUdpDataLink> link_;
+    NetworkInterface nic_;
+    CmgAction action_;
+  };
 };
 
 } // namespace DCPS


### PR DESCRIPTION
Same idea as #1382 but this time in the transport lib