### PR TITLE
Enable LinuxNetworkConfigMonitor on Android

### DIFF
--- a/dds/DCPS/LinuxNetworkConfigMonitor.cpp
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.cpp
@@ -9,9 +9,9 @@
 
 #include "ace/config.h"
 
-#ifdef ACE_LINUX
-
 #include "LinuxNetworkConfigMonitor.h"
+
+#ifdef OPENDDS_LINUX_NETWORK_CONFIG_MONITOR
 
 #include <ace/Netlink_Addr.h>
 
@@ -236,4 +236,4 @@ void LinuxNetworkConfigMonitor::process_message(const nlmsghdr* header)
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#endif // ACE_LINUX
+#endif // OPENDDS_LINUX_NETWORK_CONFIG_MONITOR

--- a/dds/DCPS/LinuxNetworkConfigMonitor.h
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.h
@@ -10,7 +10,9 @@
 
 #include "ace/config.h"
 
-#ifdef ACE_LINUX
+#if defined(ACE_LINUX) || defined(ACE_ANDROID)
+
+#define OPENDDS_LINUX_NETWORK_CONFIG_MONTIOR
 
 #include "NetworkConfigMonitor.h"
 #include "RcEventHandler.h"
@@ -44,6 +46,6 @@ private:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#endif // ACE_LINUX
+#endif // ACE_LINUX || ACE_ANDROID
 
 #endif // OPENDDS_DCPS_LINUXNETWORKCONFIGPUBLISHER_H

--- a/dds/DCPS/LinuxNetworkConfigMonitor.h
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.h
@@ -10,7 +10,7 @@
 
 #include "ace/config.h"
 
-#if defined(ACE_LINUX) || defined(ACE_ANDROID)
+#if (defined(ACE_LINUX) || defined(ACE_ANDROID)) && !defined(OPENDDS_SAFETY_PROFILE)
 
 #define OPENDDS_LINUX_NETWORK_CONFIG_MONTIOR
 

--- a/dds/DCPS/RTPS/GuidGenerator.cpp
+++ b/dds/DCPS/RTPS/GuidGenerator.cpp
@@ -127,7 +127,7 @@ GuidGenerator::interfaceName(const char* iface)
 
   alloc->free(addrs);
   return found ? 0 : -1;
-#elif defined ACE_LINUX || defined __ANDROID_API__
+#elif defined ACE_LINUX || defined ACE_ANDROID
   ifreq ifr;
   // Guarantee that iface will fit in ifr.ifr_name and still be null terminated
   // ifr.ifr_name is sized to IFNAMSIZ

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2041,7 +2041,7 @@ NetworkConfigMonitor_rch Service_Participant::network_config_monitor()
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, network_config_monitor_lock_, NetworkConfigMonitor_rch());
 
   if (!network_config_monitor_) {
-#if defined OPENDDS_LINUX_NETWORK_CONFIG_MONITOR && !defined OPENDDS_SAFETY_PROFILE
+#ifdef OPENDDS_LINUX_NETWORK_CONFIG_MONITOR
     network_config_monitor_ = make_rch<LinuxNetworkConfigMonitor>(reactor_task_.interceptor());
 #endif
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -17,9 +17,7 @@
 #include "ConfigUtils.h"
 #include "RecorderImpl.h"
 #include "ReplayerImpl.h"
-#ifdef ACE_LINUX
 #include "LinuxNetworkConfigMonitor.h"
-#endif
 #include "StaticDiscovery.h"
 #if defined(OPENDDS_SECURITY)
 #include "security/framework/SecurityRegistry.h"
@@ -2043,7 +2041,7 @@ NetworkConfigMonitor_rch Service_Participant::network_config_monitor()
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, network_config_monitor_lock_, NetworkConfigMonitor_rch());
 
   if (!network_config_monitor_) {
-#if defined ACE_LINUX && !defined OPENDDS_SAFETY_PROFILE
+#if defined OPENDDS_LINUX_NETWORK_CONFIG_MONITOR && !defined OPENDDS_SAFETY_PROFILE
     network_config_monitor_ = make_rch<LinuxNetworkConfigMonitor>(reactor_task_.interceptor());
 #endif
 


### PR DESCRIPTION
Enable using `LinuxNetworkConfigMonitor` from #1365 on Android. Should have thought of this before, but it slipped my mind that `ACE_LINUX` doesn't get defined on Android.

Being built on OpenDDS-Android here: https://travis-ci.org/iguessthislldo/OpenDDS-Android/builds/615397160