### PR TITLE
Add Master CMakeLists.txt for CMake Tests

### DIFF
--- a/tests/cmake_integration/CMakeLists.txt
+++ b/tests/cmake_integration/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.3)
+
+project(opendds_cmake_tests_root_project)
+
+# Must Specify binary_dir Option to Avoid Conflicts
+add_subdirectory(idl_include_path idl_include_path_build)
+add_subdirectory(Messenger Messenger_build)

--- a/tests/cmake_integration/CMakeLists.txt
+++ b/tests/cmake_integration/CMakeLists.txt
@@ -2,6 +2,4 @@ cmake_minimum_required(VERSION 3.3)
 
 project(opendds_cmake_tests_root_project)
 
-# Must Specify binary_dir Option to Avoid Conflicts
-add_subdirectory(idl_include_path idl_include_path_build)
-add_subdirectory(Messenger Messenger_build)
+add_subdirectory(Messenger)

--- a/tests/cmake_integration/Messenger/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/CMakeLists.txt
@@ -2,6 +2,5 @@ cmake_minimum_required(VERSION 3.3)
 
 project(opendds_cmake_messenger_tests)
 
-# Must Specify binary_dir Option to Avoid Conflicts
-add_subdirectory(Messenger_1 Messenger_1_build)
-add_subdirectory(Messenger_2 Messenger_2_build)
+add_subdirectory(Messenger_1)
+add_subdirectory(Messenger_2)

--- a/tests/cmake_integration/Messenger/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.3)
+
+project(opendds_cmake_messenger_tests)
+
+# Must Specify binary_dir Option to Avoid Conflicts
+add_subdirectory(Messenger_1 Messenger_1_build)
+add_subdirectory(Messenger_2 Messenger_2_build)

--- a/tests/cmake_integration/Messenger/Messenger_1/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/Messenger_1/CMakeLists.txt
@@ -13,9 +13,13 @@ if (NOT OPENDDS_OWNERSHIP_PROFILE)
   message(FATAL_ERROR "These tests require OpenDDS to be built with Ownership Profile enabled")
 endif()
 
+set(target_prefix "opendds_cmake_messenger_1_")
+set(publisher "${target_prefix}publisher")
+set(subscriber "${target_prefix}subscriber")
+
 set(src "${CMAKE_CURRENT_SOURCE_DIR}/../../../DCPS/Messenger")
 set(dst ${CMAKE_CURRENT_BINARY_DIR})
-set(all_targets publisher subscriber)
+set(all_targets ${publisher} ${subscriber})
 
 foreach(file
   Messenger.idl subscriber.cpp publisher.cpp Writer.cpp Writer.h Args.h
@@ -24,20 +28,26 @@ foreach(file
 endforeach()
 
 # Publisher
-add_executable(publisher
+add_executable(${publisher}
     ${dst}/publisher.cpp
 )
-OPENDDS_TARGET_SOURCES(publisher
+set_target_properties(${publisher}
+  PROPERTIES OUTPUT_NAME publisher
+)
+OPENDDS_TARGET_SOURCES(${publisher}
     ${dst}/Writer.cpp
     ${dst}/Writer.h
     ${dst}/Messenger.idl
 )
 
 # Subscriber
-add_executable(subscriber
+add_executable(${subscriber}
     ${dst}/subscriber.cpp
 )
-OPENDDS_TARGET_SOURCES(subscriber
+set_target_properties(${subscriber}
+  PROPERTIES OUTPUT_NAME subscriber
+)
+OPENDDS_TARGET_SOURCES(${subscriber}
     ${dst}/DataReaderListener.cpp
     ${dst}/DataReaderListener.h
     ${dst}/Messenger.idl
@@ -56,11 +66,11 @@ file(GLOB pl "${src}/*.pl")
 file(GLOB xml "${src}/*.xml")
 file(GLOB p7s "${src}/*.p7s")
 
-add_custom_target(Copy_ini_and_scripts
+add_custom_target("${target_prefix}Copy_ini_and_scripts"
   ALL
   COMMAND_EXPAND_LISTS
   VERBATIM
   COMMENT "Copying configs/scripts into build-output directory"
   COMMAND ${CMAKE_COMMAND} -E copy ${ini} ${pl} ${xml} ${p7s} ${dst}/$<CONFIG>
 )
-add_dependencies(Copy_ini_and_scripts ${all_targets})
+add_dependencies("${target_prefix}Copy_ini_and_scripts" ${all_targets})

--- a/tests/cmake_integration/Messenger/Messenger_2/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/Messenger_2/CMakeLists.txt
@@ -13,9 +13,14 @@ if (NOT OPENDDS_OWNERSHIP_PROFILE)
   message(FATAL_ERROR "These tests require OpenDDS to be built with Ownership Profile enabled")
 endif()
 
+set(target_prefix "opendds_cmake_messenger_2_")
+set(publisher "${target_prefix}publisher")
+set(subscriber "${target_prefix}subscriber")
+set(messenger "${target_prefix}messenger")
+
 set(src "${CMAKE_CURRENT_SOURCE_DIR}/../../../DCPS/Messenger")
 set(dst ${CMAKE_CURRENT_BINARY_DIR})
-set(all_targets publisher subscriber messenger)
+set(all_targets ${publisher} ${subscriber} ${messenger})
 
 foreach(file
   Messenger.idl subscriber.cpp publisher.cpp Writer.cpp Writer.h Args.h
@@ -24,28 +29,37 @@ foreach(file
 endforeach()
 
 # Messenger library
-add_library(messenger)
-OPENDDS_TARGET_SOURCES(messenger ${dst}/Messenger.idl)
+add_library(${messenger})
+set_target_properties(${messenger}
+  PROPERTIES OUTPUT_NAME messenger
+)
+OPENDDS_TARGET_SOURCES(${messenger} ${dst}/Messenger.idl)
 
 # Publisher
-add_executable(publisher
+add_executable(${publisher}
     ${dst}/publisher.cpp
     ${dst}/Writer.cpp
     ${dst}/Writer.h
 )
+set_target_properties(${publisher}
+  PROPERTIES OUTPUT_NAME publisher
+)
 
 # Subscriber
-add_executable(subscriber
+add_executable(${subscriber}
     ${dst}/subscriber.cpp
     ${dst}/DataReaderListener.cpp
     ${dst}/DataReaderListener.h
+)
+set_target_properties(${subscriber}
+  PROPERTIES OUTPUT_NAME subscriber
 )
 
 foreach(t ${all_targets})
   target_link_libraries(${t} OpenDDS::OpenDDS)
 
-  if (NOT "${t}" STREQUAL "messenger")
-    target_link_libraries(${t} messenger)
+  if (NOT "${t}" STREQUAL "${messenger}")
+    target_link_libraries(${t} ${messenger})
   endif()
 endforeach()
 
@@ -55,12 +69,11 @@ file(GLOB pl "${src}/*.pl")
 file(GLOB xml "${src}/*.xml")
 file(GLOB p7s "${src}/*.p7s")
 
-add_custom_target(Copy_ini_and_scripts
+add_custom_target("${target_prefix}Copy_ini_and_scripts"
   ALL
   COMMAND_EXPAND_LISTS
   VERBATIM
   COMMENT "Copying configs/scripts into build-output directory"
   COMMAND ${CMAKE_COMMAND} -E copy ${ini} ${pl} ${xml} ${p7s} ${dst}/$<CONFIG>
 )
-
-add_dependencies(Copy_ini_and_scripts ${all_targets})
+add_dependencies("${target_prefix}Copy_ini_and_scripts" ${all_targets})


### PR DESCRIPTION
This will make it much easier to change the cmake tests because right now they are hardcoded on the scoreboard for each build. The downside to is it requires unique target names in each project, but that's not different from MPC. The alternative method I also explored was using [`ExternalProject_Add`](https://cmake.org/cmake/help/latest/module/ExternalProject.html), which I started [here](https://github.com/objectcomputing/OpenDDS/compare/master...iguessthislldo:igtd/cmake_tests_external_project). I would like to go with this one though because it seems like dealing with `ExternalProject_Add` is probably a bigger pain than making sure the target names are unique.