### PR TITLE
Improvements for Topic Type Annotations

### DIFF
--- a/MPC/config/dcps_ts_defaults.mpb
+++ b/MPC/config/dcps_ts_defaults.mpb
@@ -32,9 +32,6 @@ project : dds_macros, taobaseidldefaults {
   // any OpenDDS annotations, all other unknown annotations will be caught by
   // opendds_idl.
   idlflags += --idl-version 4 --unknown-annotations ignore
-  
-  // Topic types must be declared using topic anotations
-  dcps_ts_flags += --default-nested
 }
 
 feature(!no_opendds_safety_profile): taobaseidldefaults {

--- a/MPC/modules/IDLBase.pm
+++ b/MPC/modules/IDLBase.pm
@@ -107,13 +107,12 @@ my $tsreg  = 'TypeSupport\.idl';
 # ************************************************************
 
 sub do_cached_parse {
-  my($self, $file, $flags, $called_from_base) = @_;
+  my($self, $file, $flags) = @_;
 
-  ## If we are being called from the base type (i.e., IDLBase::get_output)
-  ## we need to set the default_nested to true.  Otherwise, in certain
-  ## environments, we can get extra output files being added to the project
-  ## that are never going to exist.
-  $self->{'default_nested'} = $called_from_base;
+  # By default opendds_idl considers all types not to be topic types (aka
+  # "nested") unless --no-default-nested was passed or annotations say
+  # otherwise.
+  $self->{'default_nested'} = 1;
 
   ## Set up the macros and include paths supplied in the command flags
   my %macros = ('__OPENDDS_IDL' => 1);
@@ -127,8 +126,8 @@ sub do_cached_parse {
       elsif ($arg =~ /^\-I(.+)/) {
         push(@include, $1);
       }
-      elsif ($arg eq '--no-default-nested') {
-        $self->{'default_nested'} = 0;
+      elsif ($arg =~ /^--(no-)?default-nested$/) {
+        $self->{'default_nested'} = !$1;
       }
     }
   }
@@ -159,10 +158,8 @@ sub get_output {
   my @filenames;
   my %seen;
 
-  ## Parse the IDL file and get back the types and names.  We pass the
-  ## file, flags and a boolean that indicates that the method is being
-  ## called from the base project (and not from the TYPESUPPORTHelper).
-  my($data, $fwd) = $self->do_cached_parse($file, $flags, 1);
+  ## Parse the IDL file and get back the types and names.
+  my($data, $fwd) = $self->do_cached_parse($file, $flags);
 
   ## Get the file names based on the type and name of each entry
   my @tmp;
@@ -366,16 +363,13 @@ sub parse {
     elsif ($str =~ s/^L'(.|\\.|\\[0-7]{1,3}|\\x[a-f\d]{1,2}|\\u[a-f\d]{1,4})'//i) {
       ## Wchar literal
     }
-    elsif ($str =~ s/^@([a-z_]+)(?:\s*\((TRUE|FALSE)\))?//) {
-      my $nkey = $1;
-      my $val  = (defined $2 && $2 eq 'FALSE' ? 0 : 1);
-      if ($nkey eq 'default_nested' || $nkey eq 'nested') {
-        $cnested = $val;
-      }
-    }
-    elsif ($str =~ s/^@([a-z_]+)//) {
-      my $nkey = $1;
-      if ($nkey eq 'topic') {
+    elsif ($str =~ s/^@([a-z_]+)(?:\s*\((.*)\))?//) {
+      # Topic Type Annotations
+      my $name = $1;
+      if ($name eq 'default_nested' || $name eq 'nested') {
+        $cnested = (defined $2 && $2 eq 'FALSE') ? 0 : 1;
+      } elsif ($name eq 'topic') {
+        # @topic can have parameters, but we can ignore them here
         $cnested = 0;
       }
     }

--- a/MPC/modules/IDLBase.pm
+++ b/MPC/modules/IDLBase.pm
@@ -127,8 +127,8 @@ sub do_cached_parse {
       elsif ($arg =~ /^\-I(.+)/) {
         push(@include, $1);
       }
-      elsif ($arg eq '--default-nested') {
-        $self->{'default_nested'} = 1;
+      elsif ($arg eq '--no-default-nested') {
+        $self->{'default_nested'} = 0;
       }
     }
   }
@@ -372,8 +372,11 @@ sub parse {
       if ($nkey eq 'default_nested' || $nkey eq 'nested') {
         $cnested = $val;
       }
-      elsif ($nkey eq 'topic') {
-        $cnested = !$val;
+    }
+    elsif ($str =~ s/^@([a-z_]+)//) {
+      my $nkey = $1;
+      if ($nkey eq 'topic') {
+        $cnested = 0;
       }
     }
     elsif ($str =~ s/^([a-z_][\w]*)//i) {

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@ Released %TIMESTAMP%
     favor of the `@topic` and `@key` IDL annotations.
   - See section 2.1.1 of the OpenDDS 3.14 Developer's Guide for more
     information on both of these features.
-  - See `docs/migrating_to_topic_annotations.md` for a guide on how to migrate
-    existing IDL to use topic annotations.
+  - See `docs/migrating_to_topic_type_annotations.md` for a guide on how to
+    migrate existing IDL to use topic type annotations.
 - Monitor and the ishapes demo now use Qt5
 - Expanded Android Documentation in `docs/android.md`
 - Updated dissector to work with Wireshark 3.0

--- a/dds/idl/annotations.h
+++ b/dds/idl/annotations.h
@@ -1,3 +1,6 @@
+#ifndef OPENDDS_IDL_ANNOTATIONS_HEADER
+#define OPENDDS_IDL_ANNOTATIONS_HEADER
+
 #include <string>
 #include <map>
 
@@ -121,3 +124,5 @@ public:
   virtual std::string definition() const;
   virtual std::string name() const;
 };
+
+#endif

--- a/dds/idl/be_global.cpp
+++ b/dds/idl/be_global.cpp
@@ -5,6 +5,11 @@
  * See: http://www.opendds.org/license.html
  */
 
+#include "be_global.h"
+
+#include "be_util.h"
+#include "be_extern.h"
+
 #include <ast_generator.h>
 #include <global_extern.h>
 #include <idl_defines.h>
@@ -30,10 +35,6 @@
 #include <vector>
 #include <set>
 
-#include "be_global.h"
-#include "be_util.h"
-#include "be_extern.h"
-
 using namespace std;
 
 BE_GlobalData* be_global = 0;
@@ -50,7 +51,7 @@ BE_GlobalData::BE_GlobalData()
   , face_ts_(false)
   , seq_("Seq")
   , language_mapping_(LANGMAP_NONE)
-  , root_default_nested_(false)
+  , root_default_nested_(true)
   , warn_about_dcps_data_type_(true)
 {
 }
@@ -644,7 +645,7 @@ bool BE_GlobalData::is_default_nested(UTL_Scope* scope)
     return is_default_nested(module->defined_in());
   }
 
-  return root_default_nested_; // True if --default-nested was passed
+  return root_default_nested_;
 }
 
 bool BE_GlobalData::check_key(AST_Field* node, bool& value)

--- a/dds/idl/be_global.h
+++ b/dds/idl/be_global.h
@@ -8,8 +8,13 @@
 #ifndef OPENDDS_IDL_BE_GLOBAL_H
 #define OPENDDS_IDL_BE_GLOBAL_H
 
-#include <idl_defines.h>
+#include "annotations.h"
+
 #include <utl_scoped_name.h>
+#include <idl_defines.h>
+#ifndef TAO_IDL_HAS_ANNOTATIONS
+#  error "Annotation support in tao_idl is required, please use a newer version of TAO"
+#endif
 
 #include <ace/SString.h>
 
@@ -20,11 +25,6 @@
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#ifndef TAO_IDL_HAS_ANNOTATIONS
-#  error "Annotation support in tao_idl is required, please use a newer version of TAO"
-#endif
-#include "annotations.h"
 
 class AST_Generator;
 class AST_Decl;
@@ -168,8 +168,8 @@ public:
 
   /**
    * Nested property of the root module. Assuming there are no annotations, all
-   * potential topic types inherit this value. True when --default-nested is
-   * passed, otherwise false.
+   * potential topic types inherit this value. True by default unless
+   * --no-default-nested was passed.
    */
   bool root_default_nested() const;
 

--- a/dds/idl/be_util.cpp
+++ b/dds/idl/be_util.cpp
@@ -13,11 +13,12 @@
 //=============================================================================
 
 #include "be_util.h"
+
 #include "be_extern.h"
 
-#include "ast_generator.h"
+#include <ast_generator.h>
 
-#include "ace/OS_NS_strings.h"
+#include <ace/OS_NS_strings.h>
 
 // Prepare an argument for a BE
 void
@@ -98,7 +99,6 @@ void
 be_util::usage()
 {
   ACE_DEBUG((LM_DEBUG,
-    ACE_TEXT(" --[no-]default-nested\ttreat unannotated types as if they were nested\n")
     ACE_TEXT(" -o <dir>\t\tsets output directory for all files\n")
     ACE_TEXT(" -Lface\t\t\tgenerate FACE IDL to C++ mapping\n")
     ACE_TEXT(" -Lspcpp\t\tgenerate Safety Profile IDL to C++ mapping\n")
@@ -114,6 +114,7 @@ be_util::usage()
     ACE_TEXT("\t\t\t\t-Wb,v8 is an alternative form for this option\n")
     ACE_TEXT(" -Grapidjson\t\tgenerate TypeSupport for converting data samples ")
     ACE_TEXT("to RapidJSON JavaScript objects\n")
+    ACE_TEXT(" --[no-]default-nested\tTopic types must be declared. True by default.\n")
     ACE_TEXT(" --no-dcps-data-type-warnings\t\tdon't warn about #pragma DCPS_DATA_TYPE\n")
     ACE_TEXT(" -Wb,export_macro=<macro name>\t\tsets export macro ")
     ACE_TEXT("for all files\n")

--- a/dds/idl/dds_visitor.cpp
+++ b/dds/idl/dds_visitor.cpp
@@ -244,8 +244,8 @@ dds_visitor::visit_structure(AST_Structure* node)
     if (be_global->warn_about_dcps_data_type()) {
       idl_global->err()->misc_warning("\n"
         "  DCPS_DATA_TYPE and DCPS_DATA_KEY pragma statements are deprecated; please use\n"
-        "  topic annotations instead.\n"
-        "  See docs/migrating_to_topic_annotations.md in the OpenDDS source code for\n"
+        "  topic type annotations instead.\n"
+        "  See docs/migrating_to_topic_type_annotations.md in the OpenDDS source code for\n"
         "  more information.", node);
     }
   }

--- a/dds/idl/dds_visitor.cpp
+++ b/dds/idl/dds_visitor.cpp
@@ -5,34 +5,8 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "ast_argument.h"
-#include "ast_attribute.h"
-#include "ast_component_fwd.h"
-#include "ast_enum.h"
-#include "ast_enum_val.h"
-#include "ast_eventtype.h"
-#include "ast_eventtype_fwd.h"
-#include "ast_exception.h"
-#include "ast_factory.h"
-#include "ast_home.h"
-#include "ast_interface.h"
-#include "ast_module.h"
-#include "ast_native.h"
-#include "ast_operation.h"
-#include "ast_predefined_type.h"
-#include "ast_root.h"
-#include "ast_sequence.h"
-#include "ast_structure.h"
-#include "ast_union.h"
-#include "ast_valuetype.h"
-#include "ast_valuetype_fwd.h"
-#include "utl_identifier.h"
-#include "utl_string.h"
-#include "utl_exceptlist.h"
-#include "utl_err.h"
-#include "nr_extern.h"
-
 #include "dds_visitor.h"
+
 #include "metaclass_generator.h"
 #include "ts_generator.h"
 #include "marshal_generator.h"
@@ -43,9 +17,38 @@
 #include "langmap_generator.h"
 #include "topic_keys.h"
 
+#include <ast_argument.h>
+#include <ast_attribute.h>
+#include <ast_component_fwd.h>
+#include <ast_enum.h>
+#include <ast_enum_val.h>
+#include <ast_eventtype.h>
+#include <ast_eventtype_fwd.h>
+#include <ast_exception.h>
+#include <ast_factory.h>
+#include <ast_home.h>
+#include <ast_interface.h>
+#include <ast_module.h>
+#include <ast_native.h>
+#include <ast_operation.h>
+#include <ast_predefined_type.h>
+#include <ast_root.h>
+#include <ast_sequence.h>
+#include <ast_structure.h>
+#include <ast_union.h>
+#include <ast_valuetype.h>
+#include <ast_valuetype_fwd.h>
+#include <utl_identifier.h>
+#include <utl_string.h>
+#include <utl_exceptlist.h>
+#include <utl_err.h>
+#include <nr_extern.h>
+
 #include <iostream>
 #include <vector>
 #include <fstream>
+#include <string>
+#include <set>
 
 using namespace std;
 
@@ -233,20 +236,78 @@ dds_visitor::visit_structure(AST_Structure* node)
   ACE_UNUSED_ARG(g);
 
   // Check That Sample Keys Are Valid
+  TopicKeys topic_keys(node);
   try {
-    TopicKeys(node).count();
+    topic_keys.count();
   } catch (TopicKeys::Error& error) {
     idl_global->err()->misc_error(error.what(), error.node());
     return -1;
   }
 
-  if (idl_global->is_dcps_type(node->name())) {
+  IDL_GlobalData::DCPS_Data_Type_Info* info = idl_global->is_dcps_type(node->name());
+  if (info) {
     if (be_global->warn_about_dcps_data_type()) {
       idl_global->err()->misc_warning("\n"
         "  DCPS_DATA_TYPE and DCPS_DATA_KEY pragma statements are deprecated; please use\n"
         "  topic type annotations instead.\n"
         "  See docs/migrating_to_topic_type_annotations.md in the OpenDDS source code for\n"
         "  more information.", node);
+    }
+
+    /*
+     * If the struct is declared a topic type using both the older and newer
+     * styles, warn if the keys are inconsistent.
+     */
+    if (be_global->is_topic_type(node)) {
+      set<string> topic_type_keys, dcps_data_type_keys;
+
+      TopicKeys::Iterator finished = topic_keys.end();
+      for (TopicKeys::Iterator i = topic_keys.begin(); i != finished; ++i) {
+        topic_type_keys.insert(i.path());
+      }
+
+      IDL_GlobalData::DCPS_Data_Type_Info_Iter iter(info->key_list_);
+      for (ACE_TString* kp = 0; iter.next(kp) != 0; iter.advance()) {
+        dcps_data_type_keys.insert(ACE_TEXT_ALWAYS_CHAR(kp->c_str()));
+      }
+
+      if (topic_type_keys != dcps_data_type_keys) {
+        string message = "\n"
+          "  The keys are inconsistent on this struct declared to be a topic type using\n"
+          "  both a DCPS_DATA_TYPE pragma and the annotation-based system.";
+
+        bool header = false;
+        for (set<string>::iterator i = topic_type_keys.begin();
+            i != topic_type_keys.end(); ++i) {
+          if (dcps_data_type_keys.find(*i) == dcps_data_type_keys.end()) {
+            if (!header) {
+              message += "\n\n"
+                "  The following keys were declared using @key, but not DCPS_DATA_KEY:";
+              header = true;
+            }
+            message += string("\n    ") + *i;
+          }
+        }
+
+        header = false;
+        for (set<string>::iterator i = dcps_data_type_keys.begin();
+            i != dcps_data_type_keys.end(); ++i) {
+          if (topic_type_keys.find(*i) == topic_type_keys.end()) {
+            if (!header) {
+              message += "\n\n"
+                "  The following keys were declared using DCPS_DATA_KEY, but not @key:";
+              header = true;
+            }
+            message += string("\n    ") + *i;
+          }
+        }
+
+        message += "\n\n"
+          "  DCPS_DATA_TYPE and DCPS_DATA_KEY are deprecated, so the annotation-based keys\n"
+          "  will be used.";
+
+        idl_global->err()->misc_warning(message.c_str(), node);
+      }
     }
   }
 

--- a/dds/idl/dds_visitor.cpp
+++ b/dds/idl/dds_visitor.cpp
@@ -285,7 +285,7 @@ dds_visitor::visit_structure(AST_Structure* node)
                 "  The following keys were declared using @key, but not DCPS_DATA_KEY:";
               header = true;
             }
-            message += string("\n    ") + *i;
+            message += "\n    " + *i;
           }
         }
 
@@ -298,7 +298,7 @@ dds_visitor::visit_structure(AST_Structure* node)
                 "  The following keys were declared using DCPS_DATA_KEY, but not @key:";
               header = true;
             }
-            message += string("\n    ") + *i;
+            message += "\n    " + *i;
           }
         }
 

--- a/dds/idl/dds_visitor.h
+++ b/dds/idl/dds_visitor.h
@@ -8,15 +8,13 @@
 #ifndef dds_visitor_H
 #define dds_visitor_H
 
-#include "ast_visitor.h"
 #include "be_extern.h"
 #include "dds_generator.h"
 
-#include "tao/Basic_Types.h"
-#include "tao/Version.h"
+#include <ast_visitor.h>
 
-#include <set>
-#include <string>
+#include <tao/Basic_Types.h>
+#include <tao/Version.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once

--- a/docs/migrating_to_topic_type_annotations.md
+++ b/docs/migrating_to_topic_type_annotations.md
@@ -1,11 +1,11 @@
-# Migrating to Topic Annotations
+# Migrating to Topic Type Annotations
 
 In OpenDDS 3.14, we have deprecated the `#pragma DCPS_DATA_TYPE` and `#pragma
 DCPS_DATA_KEY` preprocessor statements in favor of IDL 4 annotations. This
-document will just give advice on how to migrate existing IDL to use topic
+document will just give advice on how to migrate existing IDL to use topic type
 annotations. It is recommended to also read the "Defining the Data Types"
-section in the OpenDDS Developer's Guide, where topic annotations are covered
-in more detail.
+section in the OpenDDS Developer's Guide, where topic type annotations are
+covered in more detail.
 
 **Table of Contents:**
 

--- a/tests/DCPS/Compiler/is_topic_type/.gitignore
+++ b/tests/DCPS/Compiler/is_topic_type/.gitignore
@@ -1,4 +1,4 @@
 !/dn/is_topic_type_dn.mpc
 /dn/*
-!/wo_dn/is_topic_type_dn.mpc
-/wo_dn/*
+!/no_dn/is_topic_type_dn.mpc
+/no_dn/*

--- a/tests/DCPS/Compiler/is_topic_type/README.md
+++ b/tests/DCPS/Compiler/is_topic_type/README.md
@@ -2,6 +2,7 @@
 
 Test of the `@topic`/`@nested`/`@default_nested` logic handled by
 `is_topic_type`, located in `dds/idl/be_global.cpp`. Has two subtests, one
-where `--default-nested` was passed to `opendds_idl` (`dn`) and one where it
-wasn't (`wo_dn`). `-Gitl` is passed in both cases and the ITL files are used by
-`run_test.pl` to assert what types should and shouldn't be topic types.
+where `--default-nested` was passed to `opendds_idl` (`dn`) and one where
+`--no-default-nested` (`no_dn`) was. `-Gitl` is passed in both cases and the
+ITL files are used by `run_test.pl` to assert what types should and shouldn't
+be topic types.

--- a/tests/DCPS/Compiler/is_topic_type/no_dn/is_topic_type_no_dn.mpc
+++ b/tests/DCPS/Compiler/is_topic_type/no_dn/is_topic_type_no_dn.mpc
@@ -1,5 +1,4 @@
 project: dcps_test_idl_only_lib, msvc_bigobj {
-  dcps_ts_flags -= --default-nested
   dcps_ts_flags += -Gitl --no-default-nested
   idlflags += -I..
 

--- a/tests/DCPS/Compiler/is_topic_type/run_test.pl
+++ b/tests/DCPS/Compiler/is_topic_type/run_test.pl
@@ -11,33 +11,34 @@ if ($@) {
 }
 
 # The expected results of is_topic_type()
-# dn and wo_dn refers to running opendds_idl with and without --default-nested
+# dn and no_dn refers to running opendds_idl with --default-nested and
+# --no-default-nested respectively
 my %expected = (
-  "NonAnnotatedStruct"                             => {not_found => 1, dn => 0, wo_dn => 1},
-  "TopicStruct"                                    => {not_found => 1, dn => 1, wo_dn => 1},
-  "NestedStruct"                                   => {not_found => 1, dn => 0, wo_dn => 0},
-  "NestedTrueStruct"                               => {not_found => 1, dn => 0, wo_dn => 0},
-  "NestedFalseStruct"                              => {not_found => 1, dn => 1, wo_dn => 1},
-  "NonAnnotatedModule/NonAnnotatedStruct"          => {not_found => 1, dn => 0, wo_dn => 1},
-  "NonAnnotatedModule/TopicStruct"                 => {not_found => 1, dn => 1, wo_dn => 1},
-  "NonAnnotatedModule/NestedStruct"                => {not_found => 1, dn => 0, wo_dn => 0},
-  "NonAnnotatedModule/NestedTrueStruct"            => {not_found => 1, dn => 0, wo_dn => 0},
-  "NonAnnotatedModule/NestedFalseStruct"           => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedModule/NonAnnotatedStruct"         => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedModule/TopicStruct"                => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedModule/NestedStruct"               => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedModule/NestedTrueStruct"           => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedModule/NestedFalseStruct"          => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedTrueModule/NonAnnotatedStruct"     => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedTrueModule/TopicStruct"            => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedTrueModule/NestedStruct"           => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedTrueModule/NestedTrueStruct"       => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedTrueModule/NestedFalseStruct"      => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedFalseModule/NonAnnotatedStruct"    => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedFalseModule/TopicStruct"           => {not_found => 1, dn => 1, wo_dn => 1},
-  "DefaultNestedFalseModule/NestedStruct"          => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedFalseModule/NestedTrueStruct"      => {not_found => 1, dn => 0, wo_dn => 0},
-  "DefaultNestedFalseModule/NestedFalseStruct"     => {not_found => 1, dn => 1, wo_dn => 1},
+  "NonAnnotatedStruct"                             => {not_found => 1, dn => 0, no_dn => 1},
+  "TopicStruct"                                    => {not_found => 1, dn => 1, no_dn => 1},
+  "NestedStruct"                                   => {not_found => 1, dn => 0, no_dn => 0},
+  "NestedTrueStruct"                               => {not_found => 1, dn => 0, no_dn => 0},
+  "NestedFalseStruct"                              => {not_found => 1, dn => 1, no_dn => 1},
+  "NonAnnotatedModule/NonAnnotatedStruct"          => {not_found => 1, dn => 0, no_dn => 1},
+  "NonAnnotatedModule/TopicStruct"                 => {not_found => 1, dn => 1, no_dn => 1},
+  "NonAnnotatedModule/NestedStruct"                => {not_found => 1, dn => 0, no_dn => 0},
+  "NonAnnotatedModule/NestedTrueStruct"            => {not_found => 1, dn => 0, no_dn => 0},
+  "NonAnnotatedModule/NestedFalseStruct"           => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedModule/NonAnnotatedStruct"         => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedModule/TopicStruct"                => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedModule/NestedStruct"               => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedModule/NestedTrueStruct"           => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedModule/NestedFalseStruct"          => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedTrueModule/NonAnnotatedStruct"     => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedTrueModule/TopicStruct"            => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedTrueModule/NestedStruct"           => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedTrueModule/NestedTrueStruct"       => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedTrueModule/NestedFalseStruct"      => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedFalseModule/NonAnnotatedStruct"    => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedFalseModule/TopicStruct"           => {not_found => 1, dn => 1, no_dn => 1},
+  "DefaultNestedFalseModule/NestedStruct"          => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedFalseModule/NestedTrueStruct"      => {not_found => 1, dn => 0, no_dn => 0},
+  "DefaultNestedFalseModule/NestedFalseStruct"     => {not_found => 1, dn => 1, no_dn => 1},
 );
 
 sub subtest {
@@ -84,6 +85,6 @@ sub subtest {
 
 my $status = 0;
 $status |= subtest('dn');
-$status |= subtest('wo_dn');
+$status |= subtest('no_dn');
 
 exit $status;

--- a/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/mpc.xsl
+++ b/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/mpc.xsl
@@ -46,6 +46,12 @@
   <xsl:text>
   includes += $(DDS_ROOT)/tools/modeling/codegen
 
+  <!--
+    Suppress DCPS_DATA_TYPE warnings for now. The proper thing to do would be
+    to modify idl.xsl to use topic type annotations.
+  -->
+  dcps_ts_flags += --no-dcps-data-type-warnings
+
   idlflags      += -Wb,export_macro=</xsl:text>
   <xsl:value-of select="$normalized-modelname"/>
   <xsl:text>_Export -Wb,export_include=</xsl:text>


### PR DESCRIPTION
- Made root default nested behavior like the traditional behavior or `--default-nested` is now the default.
- Use the term "topic type annotations" instead of "topic annotations" to try to avoid giving the impression that only the `@topic` annotation is the only thing being talked about or it's the only annotation that should be used.
- Warn when structs that are declared to be topic types using both `DCPS_DATA_TYPE` and the new topic type system have inconsistent keys between the two systems.
- Suppress DCPS_DATA_TYPE warnings in generated modeling IDL.