### PR TITLE
OpenDDS crashes when UseIce=1 but DCPSSecurity=0

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -327,6 +327,9 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                               value.c_str(), rtps_name.c_str()), -1);
           }
           config->use_ice(bool(smInt));
+          if (smInt && !TheServiceParticipant->get_security()) {
+            ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Security must be enabled (-DCPSSecurity 1) when using ICE (UseIce)\n")), -1);
+          }
         } else if (name == "IceTa") {
           // In milliseconds.
           const OPENDDS_STRING& string_value = it->second;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -128,6 +128,9 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
   }
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("UseIce"), use_ice_, bool);
+  if (use_ice_ && !TheServiceParticipant->get_security()) {
+    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Security must be enabled (-DCPSSecurity 1) when using ICE (UseIce)\n")), -1);
+  }
 
   return 0;
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -127,10 +127,12 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
     stun_server_address(addr);
   }
 
+#ifdef OPENDDS_SECURITY
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("UseIce"), use_ice_, bool);
   if (use_ice_ && !TheServiceParticipant->get_security()) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Security must be enabled (-DCPSSecurity 1) when using ICE (UseIce)\n")), -1);
   }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Solution: Check for DCPSSecurity whenever UseIce is active.