### PR TITLE
Make install with DESTDIR (for Java bindings)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,14 +299,10 @@ jobs:
           not(contains(variables['ConfigOpts'], '--no-ownership-profile')))
   - script: |
       set -e
-      set -x
       # Make sure install using DESTDIR is also working
       export DESTDIR=$(realpath install_temp)
       export INSTALL_PREFIX=$(realpath install_prefix)
       make install
-      ls -al
-      ls -al install_temp || true
-      ls -al $DESTDIR/$INSTALL_PREFIX || true
       cp -r $DESTDIR/$INSTALL_PREFIX .
       cat << EOF > install_setenv.sh
       export opendds_prefix=$INSTALL_PREFIX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,10 +299,14 @@ jobs:
           not(contains(variables['ConfigOpts'], '--no-ownership-profile')))
   - script: |
       set -e
+      set -x
       # Make sure install using DESTDIR is also working
       export DESTDIR=$(realpath install_temp)
       export INSTALL_PREFIX=$(realpath install_prefix)
       make install
+      ls -al
+      ls -al install_temp || true
+      ls -al $DESTDIR/$INSTALL_PREFIX || true
       cp -r $DESTDIR/$INSTALL_PREFIX .
       cat << EOF > install_setenv.sh
       export opendds_prefix=$INSTALL_PREFIX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,7 @@ jobs:
         ConfigOpts: --no-inline --java=/usr/lib/jvm/zulu-12-azure-amd64
       Release:
         ConfigOpts: --no-debug --optimize --java=/usr/lib/jvm/zulu-12-azure-amd64
-        Install: true
+        DoMakeInstall: true
       Safety:
         ConfigOpts: --safety-profile
       SafetyBaseNoBuiltinTopics:
@@ -314,7 +314,7 @@ jobs:
       export MPC_ROOT=$(realpath ACE_TAO/ACE/MPC)
       EOF
     displayName: Install OpenDDS
-    condition: and(succeeded(), ne(variables['Install'], ''))
+    condition: and(succeeded(), ne(variables['DoMakeInstall'], ''))
   - script: |
       set -e
       source install_setenv.sh
@@ -323,7 +323,7 @@ jobs:
       $ACE_ROOT/bin/mwc.pl -type gnuace .
       make
     displayName: Build Messenger Using Installed OpenDDS and MPC
-    condition: and(succeeded(), ne(variables['Install'], ''))
+    condition: and(succeeded(), ne(variables['DoMakeInstall'], ''))
   - script: |
       set -e
       source install_setenv.sh
@@ -334,7 +334,7 @@ jobs:
       cmake -DCMAKE_PREFIX_PATH=$opendds_prefix ..
       cmake --build .
     displayName: Build Messenger Using Installed OpenDDS and CMake
-    condition: and(succeeded(), ne(variables['Install'], ''))
+    condition: and(succeeded(), ne(variables['DoMakeInstall'], ''))
 
 - job: macOS
   timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,7 @@ jobs:
         ConfigOpts: --no-inline --java=/usr/lib/jvm/zulu-12-azure-amd64
       Release:
         ConfigOpts: --no-debug --optimize --java=/usr/lib/jvm/zulu-12-azure-amd64
-        InstallPrefix: 'install'
+        Install: true
       Safety:
         ConfigOpts: --safety-profile
       SafetyBaseNoBuiltinTopics:
@@ -233,7 +233,10 @@ jobs:
         ConfigOpts: --security --features=versioned_namespace=1
         PackageDeps: libxerces-c-dev libssl-dev cmake
       SecurityWithoutFeatures:
-        ConfigOpts: --no-inline --no-debug --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --security
+        ConfigOpts: >
+          --security --no-inline --no-debug
+          --no-built-in-topics --no-content-subscription --no-ownership-profile
+          --no-object-model-profile --no-persistence-profile
         PackageDeps: libxerces-c-dev libssl-dev cmake
       WChar:
         ConfigOpts: --features=uses_wchar=1 --no-inline
@@ -267,54 +270,62 @@ jobs:
         PackageDeps: g++-9
   steps:
   - script: |
+      set -e
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
       sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ $(Repo) main"
     displayName: Add repository ($(Repo))
     condition: and(succeeded(), ne(variables['Repo'], ''))
   - script: |
+      set -e
       sudo apt-get --yes update
-      sudo apt-get --yes install libxerces-c-dev libssl-dev $(PackageDeps)
+      sudo apt-get --yes install $(PackageDeps)
     displayName: Install system packages
     condition: and(succeeded(), ne(variables['PackageDeps'], ''))
   - script: |
+      set -e
       ./configure -v --mpcopts="-workers 4" --ace-github-latest --tests $(ConfigOpts)
       tools/scripts/show_build_config.pl
     displayName: Run configure script
   - script: make -sj6
     displayName: Compile
   - script: |
-      source $(Build.SourcesDirectory)/setenv.sh && $DDS_ROOT/tests/cmake_integration/run_ci_tests.pl
+      set -e
+      source $(Build.SourcesDirectory)/setenv.sh
+      $DDS_ROOT/tests/cmake_integration/run_ci_tests.pl
     displayName: Compile and run CMake tests
     condition: >
       and(succeeded(),
           not(contains(variables['ConfigOpts'], '--safety-profile')),
           not(contains(variables['ConfigOpts'], '--no-ownership-profile')))
   - script: |
+      set -e
       # Make sure install using DESTDIR is also working
-      export DESTDIR=$(realpath $(InstallPrefix)_temp)
-      export INSTALL_PREFIX=$(realpath $(InstallPrefix))
+      export DESTDIR=$(realpath install_temp)
+      export INSTALL_PREFIX=$(realpath install_prefix)
       make install
       cp -r $DESTDIR/$INSTALL_PREFIX .
       cat << EOF > install_setenv.sh
       export opendds_prefix=$INSTALL_PREFIX
-      source $INSTALL_PREFIX/share/ace/ace-devel.sh
-      source $INSTALL_PREFIX/share/tao/tao-devel.sh
-      source $INSTALL_PREFIX/share/dds/dds-devel.sh
-      export PATH="$INSTALL_PREFIX/bin:$PATH"
-      export LD_LIBRARY_PATH="$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+      source \$opendds_prefix/share/ace/ace-devel.sh
+      source \$opendds_prefix/share/tao/tao-devel.sh
+      source \$opendds_prefix/share/dds/dds-devel.sh
+      export PATH="\$opendds_prefix/bin:\$PATH"
+      export LD_LIBRARY_PATH="\$opendds_prefix/lib:\$LD_LIBRARY_PATH"
       export MPC_ROOT=$(realpath ACE_TAO/ACE/MPC)
       EOF
     displayName: Install OpenDDS
-    condition: and(succeeded(), ne(variables['InstallPrefix'], ''))
+    condition: and(succeeded(), ne(variables['Install'], ''))
   - script: |
+      set -e
       source install_setenv.sh
       cd tests/DCPS/Messenger
       git clean -dfx .
       $ACE_ROOT/bin/mwc.pl -type gnuace .
       make
     displayName: Build Messenger Using Installed OpenDDS and MPC
-    condition: and(succeeded(), ne(variables['InstallPrefix'], ''))
+    condition: and(succeeded(), ne(variables['Install'], ''))
   - script: |
+      set -e
       source install_setenv.sh
       cd tests/cmake_integration/Messenger/Messenger_1
       rm -fr build
@@ -323,7 +334,7 @@ jobs:
       cmake -DCMAKE_PREFIX_PATH=$opendds_prefix ..
       cmake --build .
     displayName: Build Messenger Using Installed OpenDDS and CMake
-    condition: and(succeeded(), ne(variables['InstallPrefix'], ''))
+    condition: and(succeeded(), ne(variables['Install'], ''))
 
 - job: macOS
   timeoutInMinutes: 90

--- a/dds/InfoRepo/DCPSInfoRepo.mpc
+++ b/dds/InfoRepo/DCPSInfoRepo.mpc
@@ -156,9 +156,4 @@ project(*Main): dcpsexe, iortable, bidir_giop, DCPSInfoRepo_bits, imr_client, sv
 
   TypeSupport_Files {
   }
-
-  verbatim(gnuace, postinstall) {
-"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
-"	ln -sf $(INSTALL_PREFIX)/bin/DCPSInfoRepo $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
-  }
 }

--- a/dds/InfoRepo/DCPSInfoRepo.mpc
+++ b/dds/InfoRepo/DCPSInfoRepo.mpc
@@ -156,4 +156,9 @@ project(*Main): dcpsexe, iortable, bidir_giop, DCPSInfoRepo_bits, imr_client, sv
 
   TypeSupport_Files {
   }
+
+  verbatim(gnuace, postinstall) {
+"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
+"	ln -sf $(INSTALL_PREFIX)/bin/DCPSInfoRepo $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
+  }
 }

--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -109,7 +109,7 @@ project: idl2jni, javah, dcpslib, optional_jni_check, dcps_java_optional, dcps_t
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/idl2jni.mpb"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/dcps_java.mpb"
 "	rm $(DESTDIR)$(INSTALL_PREFIX)/dds/*.idl && rmdir $(DESTDIR)$(INSTALL_PREFIX)/dds"

--- a/java/idl2jni/codegen/idl2jni_codegen.mpc
+++ b/java/idl2jni/codegen/idl2jni_codegen.mpc
@@ -22,7 +22,7 @@ project: aceexe, crosscompile, dds_macros, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	@$(MKDIR) $(INSTALL_PREFIX)/share/dds/bin"
-"	ln -sf $(INSTALL_PREFIX)/bin/idl2jni $(INSTALL_PREFIX)/share/dds/bin"
+"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
+"	ln -sf $(INSTALL_PREFIX)/bin/idl2jni $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
   }
 }

--- a/java/idl2jni/corba/idl2jni_corba.mpc
+++ b/java/idl2jni/corba/idl2jni_corba.mpc
@@ -13,6 +13,6 @@ project: java, dds_macros, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/i2jrt_corba.jar $(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/i2jrt_corba.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
   }
 }

--- a/java/idl2jni/runtime/idl2jni_runtime.mpc
+++ b/java/idl2jni/runtime/idl2jni_runtime.mpc
@@ -24,9 +24,9 @@ project: taolib, java, javah, optional_jni_check, dds_macros, i2jrt_optional, in
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/i2jrt.jar $(INSTALL_PREFIX)/lib"
-"	@$(MKDIR) $(INSTALL_PREFIX)/share/dds/java/build_scripts"
-"	cp ../../build_scripts/java?_wrapper.pl $(INSTALL_PREFIX)/share/dds/java/build_scripts"
-"	cp *.h $(INSTALL_PREFIX)/share/dds/java"
+"	cp $(DDS_ROOT)/lib/i2jrt.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
+"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java/build_scripts"
+"	cp ../../build_scripts/java?_wrapper.pl $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java/build_scripts"
+"	cp *.h $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java"
   }
 }

--- a/java/tao/tao_java.mpc
+++ b/java/tao/tao_java.mpc
@@ -34,6 +34,6 @@ project: taolib, idl2jni, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/tao_java.jar $(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/tao_java.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
   }
 }


### PR DESCRIPTION
The last build of #1429 was actually a failure for the Linux Release build, but I have no idea why. I'm also adding `set -e` to the scripts in the Linux builds to make them fail on non-zero exit statuses.