### PR TITLE
docker option to pick ACE source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
     libxerces-c-dev \
     libssl-dev \
     perl-base \
-    perl-modules
+    perl-modules \
+    git
 
 WORKDIR /usr/src/gtest
 RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
@@ -20,11 +21,13 @@ RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
 
 ADD . /opt/OpenDDS
 
+ARG ACE_CONFIG_OPTION="--doc-group"
+ARG MPC_ROOT="/opt/OpenDDS/ACE_wrappers/MPC"
 RUN cd /opt/OpenDDS && \
-    ./configure --prefix=/usr/local --security --doc-group --std=c++11 && \
+    ./configure --prefix=/usr/local --security --std=c++11 ${ACE_CONFIG_OPTION} && \
     make && \
     make install && \
-    cp -a /opt/OpenDDS/ACE_wrappers/MPC /usr/local/share/ace/MPC
+    cp -a ${MPC_ROOT} /usr/local/share/ace/MPC
 
 ENV ACE_ROOT=/usr/local/share/ace \
     TAO_ROOT=/usr/local/share/tao \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,7 +224,7 @@ jobs:
         ConfigOpts: --no-inline --java=/usr/lib/jvm/zulu-12-azure-amd64
       Release:
         ConfigOpts: --no-debug --optimize --java=/usr/lib/jvm/zulu-12-azure-amd64
-        InstallPrefix: 'install'
+        DoMakeInstall: true
       Safety:
         ConfigOpts: --safety-profile
       SafetyBaseNoBuiltinTopics:
@@ -233,7 +233,10 @@ jobs:
         ConfigOpts: --security --features=versioned_namespace=1
         PackageDeps: libxerces-c-dev libssl-dev cmake
       SecurityWithoutFeatures:
-        ConfigOpts: --no-inline --no-debug --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --security
+        ConfigOpts: >
+          --security --no-inline --no-debug
+          --no-built-in-topics --no-content-subscription --no-ownership-profile
+          --no-object-model-profile --no-persistence-profile
         PackageDeps: libxerces-c-dev libssl-dev cmake
       WChar:
         ConfigOpts: --features=uses_wchar=1 --no-inline
@@ -270,54 +273,62 @@ jobs:
         PackageDeps: g++-9
   steps:
   - script: |
+      set -e
       wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
       sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ $(Repo) main"
     displayName: Add repository ($(Repo))
     condition: and(succeeded(), ne(variables['Repo'], ''))
   - script: |
+      set -e
       sudo apt-get --yes update
-      sudo apt-get --yes install libxerces-c-dev libssl-dev $(PackageDeps)
+      sudo apt-get --yes install $(PackageDeps)
     displayName: Install system packages
     condition: and(succeeded(), ne(variables['PackageDeps'], ''))
   - script: |
+      set -e
       ./configure -v --mpcopts="-workers 4" --ace-github-latest --tests $(ConfigOpts)
       tools/scripts/show_build_config.pl
     displayName: Run configure script
   - script: make -sj6
     displayName: Compile
   - script: |
-      source $(Build.SourcesDirectory)/setenv.sh && $DDS_ROOT/tests/cmake_integration/run_ci_tests.pl
+      set -e
+      source $(Build.SourcesDirectory)/setenv.sh
+      $DDS_ROOT/tests/cmake_integration/run_ci_tests.pl
     displayName: Compile and run CMake tests
     condition: >
       and(succeeded(),
           not(contains(variables['ConfigOpts'], '--safety-profile')),
           not(contains(variables['ConfigOpts'], '--no-ownership-profile')))
   - script: |
+      set -e
       # Make sure install using DESTDIR is also working
-      export DESTDIR=$(realpath $(InstallPrefix)_temp)
-      export INSTALL_PREFIX=$(realpath $(InstallPrefix))
+      export DESTDIR=$(realpath install_temp)
+      export INSTALL_PREFIX=$(realpath install_prefix)
       make install
       cp -r $DESTDIR/$INSTALL_PREFIX .
       cat << EOF > install_setenv.sh
       export opendds_prefix=$INSTALL_PREFIX
-      source $INSTALL_PREFIX/share/ace/ace-devel.sh
-      source $INSTALL_PREFIX/share/tao/tao-devel.sh
-      source $INSTALL_PREFIX/share/dds/dds-devel.sh
-      export PATH="$INSTALL_PREFIX/bin:$PATH"
-      export LD_LIBRARY_PATH="$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
+      source \$opendds_prefix/share/ace/ace-devel.sh
+      source \$opendds_prefix/share/tao/tao-devel.sh
+      source \$opendds_prefix/share/dds/dds-devel.sh
+      export PATH="\$opendds_prefix/bin:\$PATH"
+      export LD_LIBRARY_PATH="\$opendds_prefix/lib:\$LD_LIBRARY_PATH"
       export MPC_ROOT=$(realpath ACE_TAO/ACE/MPC)
       EOF
     displayName: Install OpenDDS
-    condition: and(succeeded(), ne(variables['InstallPrefix'], ''))
+    condition: and(succeeded(), ne(variables['DoMakeInstall'], ''))
   - script: |
+      set -e
       source install_setenv.sh
       cd tests/DCPS/Messenger
       git clean -dfx .
       $ACE_ROOT/bin/mwc.pl -type gnuace .
       make
     displayName: Build Messenger Using Installed OpenDDS and MPC
-    condition: and(succeeded(), ne(variables['InstallPrefix'], ''))
+    condition: and(succeeded(), ne(variables['DoMakeInstall'], ''))
   - script: |
+      set -e
       source install_setenv.sh
       cd tests/cmake_integration/Messenger/Messenger_1
       rm -fr build
@@ -326,7 +337,7 @@ jobs:
       cmake -DCMAKE_PREFIX_PATH=$opendds_prefix ..
       cmake --build .
     displayName: Build Messenger Using Installed OpenDDS and CMake
-    condition: and(succeeded(), ne(variables['InstallPrefix'], ''))
+    condition: and(succeeded(), ne(variables['DoMakeInstall'], ''))
 
 - job: macOS
   timeoutInMinutes: 90

--- a/dds/DCPS/Definitions.h
+++ b/dds/DCPS/Definitions.h
@@ -77,9 +77,6 @@ typedef Cached_Allocator_With_Overflow<ACE_Data_Block, ACE_Thread_Mutex> DataBlo
 struct DataSampleHeader;
 typedef Cached_Allocator_With_Overflow<DataSampleHeader, ACE_Null_Mutex> DataSampleHeaderAllocator;
 
-#define DUP true
-#define NO_DUP false
-
 /// This struct holds both object reference and the corresponding servant.
 template <typename T_impl, typename T, typename T_ptr, typename T_var>
 struct Objref_Servant_Pair {

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -151,7 +151,7 @@ DomainParticipantImpl::create_publisher(
   DDS::Publisher_ptr pub_obj(pub);
 
   // this object will also act as the guard for leaking Publisher Impl
-  Publisher_Pair pair(pub, pub_obj, NO_DUP);
+  Publisher_Pair pair(pub, pub_obj, false);
 
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    tao_mon,
@@ -199,7 +199,7 @@ DomainParticipantImpl::delete_publisher(
                    this->publishers_protector_,
                    DDS::RETCODE_ERROR);
 
-  Publisher_Pair pair(the_servant, p, DUP);
+  Publisher_Pair pair(the_servant, p, true);
 
   if (OpenDDS::DCPS::remove(publishers_, pair) == -1) {
     ACE_ERROR((LM_ERROR,
@@ -240,7 +240,7 @@ DomainParticipantImpl::create_subscriber(
 
   DDS::Subscriber_ptr sub_obj(sub);
 
-  Subscriber_Pair pair(sub, sub_obj, NO_DUP);
+  Subscriber_Pair pair(sub, sub_obj, false);
 
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    tao_mon,
@@ -299,7 +299,7 @@ DomainParticipantImpl::delete_subscriber(
                    this->subscribers_protector_,
                    DDS::RETCODE_ERROR);
 
-  Subscriber_Pair pair(the_servant, s, DUP);
+  Subscriber_Pair pair(the_servant, s, true);
 
   if (OpenDDS::DCPS::remove(subscribers_, pair) == -1) {
     ACE_ERROR((LM_ERROR,
@@ -1910,7 +1910,7 @@ DomainParticipantImpl::create_new_topic(
   DDS::Topic_ptr obj(topic_servant);
 
   // this object will also act as a guard against leaking the new TopicImpl
-  RefCounted_Topic refCounted_topic(Topic_Pair(topic_servant, obj, NO_DUP));
+  RefCounted_Topic refCounted_topic(Topic_Pair(topic_servant, obj, false));
 
   if (OpenDDS::DCPS::bind(topics_, topic_name, refCounted_topic) == -1) {
     ACE_ERROR((LM_ERROR,

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2891,7 +2891,10 @@ Sedp::Writer::transport_assoc_done(int flags, const RepoId& remote) {
                DCPS::LogGuid(remote).c_str()));
     return;
   }
-  sedp_.spdp_.job_queue()->enqueue(make_rch<AssociationComplete>(&sedp_, repo_id_, remote));
+  DCPS::RcHandle<DCPS::JobQueue> job_queue = sedp_.spdp_.job_queue();
+  if (job_queue) {
+    job_queue->enqueue(make_rch<AssociationComplete>(&sedp_, repo_id_, remote));
+  }
 }
 
 void

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ -z "${BASIS}" ]]; then
-    docker build -t $IMAGE_NAME .
+    docker build --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION --build-arg MPC_ROOT=$MPC_ROOT -t $IMAGE_NAME .
 else
-    docker build --build-arg BASIS=$BASIS -t $IMAGE_NAME .
+    docker build --build-arg BASIS=$BASIS --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION --build-arg MPC_ROOT=$MPC_ROOT -t $IMAGE_NAME .
 fi

--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -109,7 +109,7 @@ project: idl2jni, javah, dcpslib, optional_jni_check, dcps_java_optional, dcps_t
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/idl2jni.mpb"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/dcps_java.mpb"
 "	rm $(DESTDIR)$(INSTALL_PREFIX)/dds/*.idl && rmdir $(DESTDIR)$(INSTALL_PREFIX)/dds"

--- a/java/idl2jni/codegen/idl2jni_codegen.mpc
+++ b/java/idl2jni/codegen/idl2jni_codegen.mpc
@@ -22,7 +22,7 @@ project: aceexe, crosscompile, dds_macros, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	@$(MKDIR) $(INSTALL_PREFIX)/share/dds/bin"
-"	ln -sf $(INSTALL_PREFIX)/bin/idl2jni $(INSTALL_PREFIX)/share/dds/bin"
+"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
+"	ln -sf $(INSTALL_PREFIX)/bin/idl2jni $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
   }
 }

--- a/java/idl2jni/corba/idl2jni_corba.mpc
+++ b/java/idl2jni/corba/idl2jni_corba.mpc
@@ -13,6 +13,6 @@ project: java, dds_macros, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/i2jrt_corba.jar $(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/i2jrt_corba.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
   }
 }

--- a/java/idl2jni/runtime/idl2jni_runtime.mpc
+++ b/java/idl2jni/runtime/idl2jni_runtime.mpc
@@ -24,9 +24,9 @@ project: taolib, java, javah, optional_jni_check, dds_macros, i2jrt_optional, in
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/i2jrt.jar $(INSTALL_PREFIX)/lib"
-"	@$(MKDIR) $(INSTALL_PREFIX)/share/dds/java/build_scripts"
-"	cp ../../build_scripts/java?_wrapper.pl $(INSTALL_PREFIX)/share/dds/java/build_scripts"
-"	cp *.h $(INSTALL_PREFIX)/share/dds/java"
+"	cp $(DDS_ROOT)/lib/i2jrt.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
+"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java/build_scripts"
+"	cp ../../build_scripts/java?_wrapper.pl $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java/build_scripts"
+"	cp *.h $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java"
   }
 }

--- a/java/tao/tao_java.mpc
+++ b/java/tao/tao_java.mpc
@@ -34,6 +34,6 @@ project: taolib, idl2jni, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/tao_java.jar $(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/tao_java.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
   }
 }


### PR DESCRIPTION
Use `ACE_CONFIG_OPTION` and `ACE_SOURCE_DIR` options to pick difference ACE source. 

`ACE_CONFIG_OPTION` can be used to select `--ace-github-latest` instead of the default `--doc-group`.

`ACE_SOURCE_DIR` copies the correct files based on the ACE source to `/usr/local/share/ace/MPC`. Defaults to `/opt/OpenDDS/ACE_wrappers/MPC`. Use `/opt/OpenDDS/ACE_TAO/ACE/MPC` when using `--ace-github-latest` in `ACE_CONFIG_OPTION`.