### PR TITLE
Sedp::Writer::write_dcps_participant_secure has inverted condition

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3098,7 +3098,7 @@ Sedp::Writer::write_dcps_participant_secure(const Security::SPDPdiscoveredPartic
 
   ParameterList plist;
 
-  if (!ParameterListConverter::to_param_list(msg, plist)) {
+  if (ParameterListConverter::to_param_list(msg, plist)) {
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: Sedp::write_dcps_participant_secure - ")
                ACE_TEXT("Failed to convert SPDPdiscoveredParticipantData ")
@@ -3116,7 +3116,7 @@ Sedp::Writer::write_dcps_participant_secure(const Security::SPDPdiscoveredPartic
   if (spdp_endpoint) {
     ai_map["SPDP"] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
   }
-  if (ParameterListConverter::to_param_list(ai_map, plist) < 0) {
+  if (ParameterListConverter::to_param_list(ai_map, plist)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
                ACE_TEXT("Sedp::write_dcps_participant_secure() - ")
                ACE_TEXT("failed to convert from ICE::AgentInfo ")

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -888,7 +888,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
 
     ParameterList plist;
     set_participant_guid(guid_, plist);
-    if (ParameterListConverter::to_param_list(pbtds.base, plist) < 0) {
+    if (ParameterListConverter::to_param_list(pbtds.base, plist)) {
       ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Spdp::handle_handshake_message() - ")
         ACE_TEXT("Failed to convert from ParticipantBuiltinTopicData to ParameterList\n")));
       return;
@@ -1325,7 +1325,7 @@ Spdp::attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp
 
     ParameterList plist;
     set_participant_guid(guid_, plist);
-    if (ParameterListConverter::to_param_list(pbtds.base, plist) < 0) {
+    if (ParameterListConverter::to_param_list(pbtds.base, plist)) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::attempt_authentication() - ")
         ACE_TEXT("Failed to convert from ParticipantBuiltinTopicData to ParameterList\n")));
       return;
@@ -1821,7 +1821,7 @@ Spdp::SpdpTransport::write_i(WriteFlags flags)
   ++seq_;
 
   ParameterList plist;
-  if (ParameterListConverter::to_param_list(pdata, plist) < 0) {
+  if (ParameterListConverter::to_param_list(pdata, plist)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
       ACE_TEXT("Spdp::SpdpTransport::write() - ")
       ACE_TEXT("failed to convert from SPDPdiscoveredParticipantData ")
@@ -1840,7 +1840,7 @@ Spdp::SpdpTransport::write_i(WriteFlags flags)
     if (spdp_endpoint) {
       ai_map["SPDP"] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
     }
-    if (ParameterListConverter::to_param_list(ai_map, plist) < 0) {
+    if (ParameterListConverter::to_param_list(ai_map, plist)) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
                  ACE_TEXT("Spdp::SpdpTransport::write() - ")
                  ACE_TEXT("failed to convert from ICE::AgentInfo ")
@@ -1879,7 +1879,7 @@ Spdp::SpdpTransport::write_i(const DCPS::RepoId& guid, WriteFlags flags)
   ++seq_;
 
   ParameterList plist;
-  if (ParameterListConverter::to_param_list(pdata, plist) < 0) {
+  if (ParameterListConverter::to_param_list(pdata, plist)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
       ACE_TEXT("Spdp::SpdpTransport::write() - ")
       ACE_TEXT("failed to convert from SPDPdiscoveredParticipantData ")
@@ -1898,7 +1898,7 @@ Spdp::SpdpTransport::write_i(const DCPS::RepoId& guid, WriteFlags flags)
     if (spdp_endpoint) {
       ai_map["SPDP"] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
     }
-    if (ParameterListConverter::to_param_list(ai_map, plist) < 0) {
+    if (ParameterListConverter::to_param_list(ai_map, plist)) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
                  ACE_TEXT("Spdp::SpdpTransport::write() - ")
                  ACE_TEXT("failed to convert from ICE::AgentInfo ")


### PR DESCRIPTION
Solution: Use the correct check for to_param_list.  Also, make style
of to_param_list consistent.