### PR TITLE
Docker build: optional ACE source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ RUN cd /opt/OpenDDS && \
 ENV ACE_ROOT=/usr/local/share/ace \
     TAO_ROOT=/usr/local/share/tao \
     DDS_ROOT=/usr/local/share/dds \
+    MPC_ROOT=/usr/local/share/MPC \
     PATH=".:/usr/local/share/ace/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 WORKDIR /opt/OpenDDS/tests/DCPS/Messenger
-RUN . /opt/OpenDDS/setenv.sh && mwc.pl -type gnuace && make
+RUN mwc.pl -type gnuace && make
 
 WORKDIR /opt/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cd /opt/OpenDDS && \
     ./configure --prefix=/usr/local --security --std=c++11 ${ACE_CONFIG_OPTION} && \
     make && \
     make install && \
-    cp -a ${MPC_ROOT} /usr/local/share/ace/MPC
+    cp -a ${MPC_ROOT} /usr/local/share/MPC
 
 ENV ACE_ROOT=/usr/local/share/ace \
     TAO_ROOT=/usr/local/share/tao \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,11 @@ RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
 ADD . /opt/OpenDDS
 
 ARG ACE_CONFIG_OPTION="--doc-group"
-ARG MPC_ROOT="/opt/OpenDDS/ACE_wrappers/MPC"
 RUN cd /opt/OpenDDS && \
     ./configure --prefix=/usr/local --security --std=c++11 ${ACE_CONFIG_OPTION} && \
     make && \
     make install && \
+    . /opt/OpenDDS/setenv.sh && \
     cp -a ${MPC_ROOT} /usr/local/share/MPC
 
 ENV ACE_ROOT=/usr/local/share/ace \
@@ -35,6 +35,6 @@ ENV ACE_ROOT=/usr/local/share/ace \
     PATH=".:/usr/local/share/ace/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 WORKDIR /opt/OpenDDS/tests/DCPS/Messenger
-RUN mwc.pl -type gnuace && make
+RUN . /opt/OpenDDS/setenv.sh && mwc.pl -type gnuace && make
 
 WORKDIR /opt/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
     libxerces-c-dev \
     libssl-dev \
     perl-base \
-    perl-modules
+    perl-modules \
+    git
 
 WORKDIR /usr/src/gtest
 RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
@@ -20,11 +21,13 @@ RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
 
 ADD . /opt/OpenDDS
 
+ARG ACE_CONFIG_OPTION="--doc-group"
+ARG MPC_ROOT="/opt/OpenDDS/ACE_wrappers/MPC"
 RUN cd /opt/OpenDDS && \
-    ./configure --prefix=/usr/local --security --doc-group --std=c++11 && \
+    ./configure --prefix=/usr/local --security --std=c++11 ${ACE_CONFIG_OPTION} && \
     make && \
     make install && \
-    cp -a /opt/OpenDDS/ACE_wrappers/MPC /usr/local/share/ace/MPC
+    cp -a ${MPC_ROOT} /usr/local/share/ace/MPC
 
 ENV ACE_ROOT=/usr/local/share/ace \
     TAO_ROOT=/usr/local/share/tao \

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ -z "${BASIS}" ]]; then
-    docker build --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION --build-arg MPC_ROOT=$MPC_ROOT -t $IMAGE_NAME .
+    docker build --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION -t $IMAGE_NAME .
 else
-    docker build --build-arg BASIS=$BASIS --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION --build-arg MPC_ROOT=$MPC_ROOT -t $IMAGE_NAME .
+    docker build --build-arg BASIS=$BASIS --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION -t $IMAGE_NAME .
 fi

--- a/hooks/build
+++ b/hooks/build
@@ -1,10 +1,10 @@
 #!/bin/bash
 BASIS_ARG=""
 ACE_ARG=""
-if [[ ! -z "${BASIS}" ]]; then
+if [[ -n "${BASIS}" ]]; then
     BASIS_ARG="--build-arg BASIS=$BASIS"
 fi
-if [[ ! -z "${ACE_CONFIG_OPTION}" ]]; then
+if [[ -n "${ACE_CONFIG_OPTION}" ]]; then
     ACE_ARG="--build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION"
 fi
 

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,11 @@
 #!/bin/bash
-if [[ -z "${BASIS}" ]]; then
-    docker build --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION -t $IMAGE_NAME .
-else
-    docker build --build-arg BASIS=$BASIS --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION -t $IMAGE_NAME .
+BASIS_ARG=""
+ACE_ARG=""
+if [[ ! -z "${BASIS}" ]]; then
+    BASIS_ARG="--build-arg BASIS=$BASIS"
 fi
+if [[ ! -z "${ACE_CONFIG_OPTION}" ]]; then
+    ACE_ARG="--build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION"
+fi
+
+docker build $BASIS_ARG $ACE_ARG -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ -z "${BASIS}" ]]; then
-    docker build -t $IMAGE_NAME .
+    docker build --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION --build-arg MPC_ROOT=$MPC_ROOT -t $IMAGE_NAME .
 else
-    docker build --build-arg BASIS=$BASIS -t $IMAGE_NAME .
+    docker build --build-arg BASIS=$BASIS --build-arg ACE_CONFIG_OPTION=$ACE_CONFIG_OPTION --build-arg MPC_ROOT=$MPC_ROOT -t $IMAGE_NAME .
 fi


### PR DESCRIPTION
Use `ACE_CONFIG_OPTION` and `ACE_SOURCE_DIR` options to pick difference ACE source.

`ACE_CONFIG_OPTION` can be used to select `--ace-github-latest` instead of the default `--doc-group`.

`ACE_SOURCE_DIR` copies the correct files based on the ACE source to `/usr/local/share/ace/MPC`. Defaults to `/opt/OpenDDS/ACE_wrappers/MPC`. Use `/opt/OpenDDS/ACE_TAO/ACE/MPC` when using `--ace-github-latest` in `ACE_CONFIG_OPTION`.

