### PR TITLE
Fix deadlock causes by packet removal during reliable resend

### DIFF
--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -156,7 +156,7 @@ public:
   virtual RemoveResult remove_sample(const DataSampleElement* sample);
 
   // ciju: Called by LinkSet with locks held
-  void remove_all_msgs(RepoId pub_id);
+  virtual void remove_all_msgs(const RepoId& pub_id);
 
   /// This is called by our TransportReceiveStrategy object when it
   /// has received a complete data sample.  This method will cause

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -208,7 +208,7 @@ DataLink::remove_sample(const DataSampleElement* sample)
 }
 
 ACE_INLINE void
-DataLink::remove_all_msgs(RepoId pub_id)
+DataLink::remove_all_msgs(const RepoId& pub_id)
 {
   DBG_ENTRY_LVL("DataLink","remove_all_msgs",6);
 

--- a/dds/DCPS/transport/framework/DataLinkSet.h
+++ b/dds/DCPS/transport/framework/DataLinkSet.h
@@ -57,7 +57,7 @@ public:
 
   bool remove_sample(const DataSampleElement* sample);
 
-  bool remove_all_msgs(RepoId pub_id);
+  bool remove_all_msgs(const RepoId& pub_id);
 
   /// Calls send_start() on the links in link_set and also adds
   /// the links from link_set to *this.

--- a/dds/DCPS/transport/framework/DataLinkSet.inl
+++ b/dds/DCPS/transport/framework/DataLinkSet.inl
@@ -167,7 +167,7 @@ OpenDDS::DCPS::DataLinkSet::remove_sample(const DataSampleElement* sample)
 }
 
 ACE_INLINE bool
-OpenDDS::DCPS::DataLinkSet::remove_all_msgs(RepoId pub_id)
+OpenDDS::DCPS::DataLinkSet::remove_all_msgs(const RepoId& pub_id)
 {
   DBG_ENTRY_LVL("DataLinkSet", "remove_all_msgs", 6);
   GuardType guard(this->lock_);

--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -34,6 +34,11 @@ TransportSendBuffer::~TransportSendBuffer()
 }
 
 void
+TransportSendBuffer::retain_all(const RepoId&)
+{
+}
+
+void
 TransportSendBuffer::resend_one(const BufferType& buffer)
 {
   int bp = 0;

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -40,7 +40,7 @@ public:
   size_t capacity() const;
   void bind(TransportSendStrategy* strategy);
 
-  virtual void retain_all(const RepoId& pub_id) = 0;
+  virtual void retain_all(const RepoId& pub_id);
   virtual void insert(SequenceNumber sequence,
                       TransportSendStrategy::QueueType* queue,
                       ACE_Message_Block* chain) = 0;

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -1261,7 +1261,7 @@ TransportSendStrategy::send_stop(RepoId /*repoId*/)
 }
 
 void
-TransportSendStrategy::remove_all_msgs(RepoId pub_id)
+TransportSendStrategy::remove_all_msgs(const RepoId& pub_id)
 {
   DBG_ENTRY_LVL("TransportSendStrategy","remove_all_msgs",6);
 

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -80,7 +80,7 @@ public:
   /// (basically, an "unsend" attempt) from this strategy object.
   RemoveResult remove_sample(const DataSampleElement* sample);
 
-  void remove_all_msgs(RepoId pub_id);
+  void remove_all_msgs(const RepoId& pub_id);
 
   /// Called by our ThreadSynch object when we should be able to
   /// start sending any partial packet bytes and/or compose a new

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -207,12 +207,13 @@ RtpsUdpDataLink::RtpsWriter::remove_sample(const DataSampleElement* sample)
 
   if (!elems_not_acked_.empty()) {
     typedef SnToTqeMap::iterator iter_t;
-    for (iter_t it = elems_not_acked_.begin(); !found && it != elems_not_acked_.end(); ++it) {
+    for (iter_t it = elems_not_acked_.begin(); it != elems_not_acked_.end(); ++it) {
       if (modp.matches(*it->second)) {
         found = true;
         to_release = it->first;
         tqe = it->second;
         elems_not_acked_.erase(it);
+        break;
       }
     }
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -227,7 +227,6 @@ private:
       , outer_(outer)
     {}
 
-    void retain_all(const RepoId&) {}
     void insert(SequenceNumber sequence,
                 TransportSendStrategy::QueueType* queue,
                 ACE_Message_Block* chain);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -70,8 +70,8 @@ public:
 
   bool add_delayed_notification(TransportQueueElement* element);
 
-  void do_remove_sample(const RepoId& pub_id,
-                        const TransportQueueElement::MatchCriteria& criteria);
+  RemoveResult remove_sample(const DataSampleElement* sample) override;
+  void remove_all_msgs(const RepoId& pub_id) override;
 
   RtpsUdpInst& config() const;
 
@@ -227,7 +227,7 @@ private:
       , outer_(outer)
     {}
 
-    void retain_all(const RepoId& pub_id);
+    void retain_all(const RepoId&) {}
     void insert(SequenceNumber sequence,
                 TransportSendStrategy::QueueType* queue,
                 ACE_Message_Block* chain);
@@ -307,7 +307,10 @@ private:
     ~RtpsWriter();
     SequenceNumber heartbeat_high(const ReaderInfo&) const;
     void add_elem_awaiting_ack(TransportQueueElement* element);
-    void do_remove_sample(const TransportQueueElement::MatchCriteria& criteria);
+
+    void send_delayed_notifications(const TransportQueueElement::MatchCriteria& criteria);
+    RemoveResult remove_sample(const DataSampleElement* sample);
+    void remove_all_msgs();
 
     bool add_reader(const RepoId& id, const ReaderInfo& info);
     bool has_reader(const RepoId& id) const;
@@ -316,8 +319,7 @@ private:
     CORBA::Long get_heartbeat_count() const { return heartbeat_count_; }
 
     bool is_reader_handshake_done(const RepoId& id) const;
-    void pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_deliver,
-                         OPENDDS_VECTOR(TransportQueueElement*)& to_drop);
+    void pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop);
     TransportQueueElement* customize_queue_element_helper(TransportQueueElement* element,
                                                           bool requires_inline_qos,
                                                           MetaSubmessageVec& meta_submessages,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -70,8 +70,8 @@ public:
 
   bool add_delayed_notification(TransportQueueElement* element);
 
-  RemoveResult remove_sample(const DataSampleElement* sample) override;
-  void remove_all_msgs(const RepoId& pub_id) override;
+  RemoveResult remove_sample(const DataSampleElement* sample);
+  void remove_all_msgs(const RepoId& pub_id);
 
   RtpsUdpInst& config() const;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -274,14 +274,6 @@ RtpsUdpSendStrategy::add_delayed_notification(TransportQueueElement* element)
   }
 }
 
-RemoveResult
-RtpsUdpSendStrategy::do_remove_sample(const RepoId& pub_id,
-  const TransportQueueElement::MatchCriteria& criteria)
-{
-  link_->do_remove_sample(pub_id, criteria);
-  return TransportSendStrategy::do_remove_sample(pub_id, criteria);
-}
-
 #ifdef OPENDDS_SECURITY
 namespace {
   DDS::OctetSeq toSeq(const ACE_Message_Block* mb)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
@@ -68,8 +68,6 @@ protected:
   }
 
   virtual void add_delayed_notification(TransportQueueElement* element);
-  virtual RemoveResult do_remove_sample(const RepoId& pub_id,
-    const TransportQueueElement::MatchCriteria& criteria);
 
 private:
   bool marshal_transport_header(ACE_Message_Block* mb);


### PR DESCRIPTION
Primary issue was that packet removal was violating the datalink (e.g. writer) / send-strategy locking order requirement. Secondary issue included the fact that the code path for removal bounced back and forth between the strategy and datalink (including send buffer) several times.

This solution overrides datalink framework methods so they can be implemented in rtps writer directly while the lock is held, and manually handles retaining items in the send buffer to avoid the back & forth. Should also be slightly more efficient in terms of comparing match criteria / building TQE & SeqNum sets.