### PR TITLE
Handling multiple transport instances

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -303,11 +303,10 @@ TransportClient::associate(const AssociationData& data, bool active)
             if (res.link_.is_nil()) {
                 // In this case, it may be waiting for the TCP connection to be established.  Just wait without trying other transports.
                 pending_assoc_timer_->schedule_timer(this, iter->second);
+            } else {
+              use_datalink_i(data.remote_id_, res.link_, guard);
+              return true;
             }
-            else {
-                use_datalink_i(data.remote_id_, res.link_, guard);
-            }
-            return true;
           }
         }
       }
@@ -429,7 +428,6 @@ TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
                               "between %C and remote %C unsuccessful\n",
                               OPENDDS_STRING(tmp_local).c_str(),
                               OPENDDS_STRING(tmp_remote).c_str()), 0);
-          break;
         }
 
         if (res.success_) {


### PR DESCRIPTION
Removed break from active processing side to allow continuance of loop to process candidate links when the first connection link fails to succeed. The loop was kicking out too early. 

On the passive side of association, for loops that have multiple impls to look at for candidate association was kicking out after the first indication of a successful impl existence, but when the link was null, it did not proceed to the next one in the list to check further, but was simply returning out of the associate method.

(cherry picked from commit d6a38fca10a435bb8638d0c6e044a1a6b77f6ae5)