### PR TITLE
CMake: fix public idl cpp sources

### DIFF
--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -44,7 +44,8 @@ function(opendds_target_generated_dependencies target idl_file scope)
 
   add_dependencies(${target} ${bridge_target})
 
-  target_sources(${target} ${scope} ${cpp_files} ${all_idl_files} ${hdr_files})
+  target_sources(${target} ${scope} ${all_idl_files} ${hdr_files})
+  target_sources(${target} PRIVATE ${cpp_files})
 
   foreach(file ${hdr_files})
     get_target_property(target_includes ${target} INCLUDE_DIRECTORIES)


### PR DESCRIPTION
Fix the issue when an IDL is added as a PUBLIC or INTERFACES sources of a target, the generated cpp files also listed as PUBLIC or INTERFACE files for the target.