### PR TITLE
[3.13] Adding TCP connection timeout for active tcp connection attempts

### DIFF
--- a/dds/DCPS/transport/tcp/TcpConnection.cpp
+++ b/dds/DCPS/transport/tcp/TcpConnection.cpp
@@ -820,6 +820,25 @@ OpenDDS::DCPS::TcpConnection::handle_timeout(const ACE_Time_Value &,
                this->remote_address_.get_port_number()));
     break;
 
+  case INIT_STATE: {
+    // couldn't initialize connection successfully.
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpConnection::handle_timeout, failed connection initialization due to timeout.: %C to %C:%d.\n",
+               this->config_name().c_str(),
+               this->remote_address_.get_host_addr(),
+               this->remote_address_.get_port_number()));
+
+    // build key and remove from service
+    TcpTransport& transport = static_cast<TcpTransport&>(link_->impl());
+
+    const bool is_loop(local_address_ == remote_address_);
+    const PriorityKey key(transport_priority_, remote_address_,
+                          is_loop, true /* active */);
+
+    transport.async_connect_failed(key);
+    }
+
+    break;
+
   default :
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: TcpConnection::handle_timeout, ")

--- a/dds/DCPS/transport/tcp/TcpInst.cpp
+++ b/dds/DCPS/transport/tcp/TcpInst.cpp
@@ -65,6 +65,9 @@ OpenDDS::DCPS::TcpInst::load(ACE_Configuration_Heap& cf,
   GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("max_output_pause_period"),
                    this->max_output_pause_period_, int)
 
+  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("active_conn_timeout_period"),
+                   this->active_conn_timeout_period_, int)
+
   return 0;
 }
 
@@ -82,6 +85,7 @@ OpenDDS::DCPS::TcpInst::dump_to_str() const
   os << formatNameForDump("conn_retry_attempts")           << this->conn_retry_attempts_ << std::endl;
   os << formatNameForDump("passive_reconnect_duration")    << this->passive_reconnect_duration_ << std::endl;
   os << formatNameForDump("max_output_pause_period")       << this->max_output_pause_period_ << std::endl;
+  os << formatNameForDump("active_conn_timeout_period")    << this->active_conn_timeout_period_ << std::endl;
   return OPENDDS_STRING(os.str());
 }
 

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -78,6 +78,14 @@ public:
   /// The default is 2 seconds (2000 millseconds).
   int passive_reconnect_duration_;
 
+  /// The time period in milliseconds for the acceptor side
+  /// of a connection to wait for the connection to be established.
+  /// If not connected within this period then this link is removed
+  /// from pending and any other links are attempted.
+  /// The default is 5 seconds (5000 millseconds).
+  int active_conn_timeout_period_;
+
+
   bool is_reliable() const { return true; }
 
   /// The public address is our publicly advertised address.

--- a/dds/DCPS/transport/tcp/TcpInst.inl
+++ b/dds/DCPS/transport/tcp/TcpInst.inl
@@ -17,7 +17,8 @@ OpenDDS::DCPS::TcpInst::TcpInst(const OPENDDS_STRING& name)
     conn_retry_backoff_multiplier_(2.0),
     conn_retry_attempts_(3),
     max_output_pause_period_(-1),
-    passive_reconnect_duration_(2000)
+    passive_reconnect_duration_(2000),
+    active_conn_timeout_period_(5000)
 {
   DBG_ENTRY_LVL("TcpInst", "TcpInst", 6);
 }

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -118,8 +118,11 @@ TcpTransport::connect_datalink(const RemoteTransport& remote,
   key.address().addr_to_string(str,sizeof(str)/sizeof(str[0]));
 
   // Can't make this call while holding onto TransportClient::lock_
+  ACE_Time_Value conn_timeout;
+  conn_timeout.msec(this->config().active_conn_timeout_period_);
+
   const int ret =
-    connector_.connect(pConn, key.address(), ACE_Synch_Options::asynch);
+    connector_.connect(pConn, key.address(), ACE_Synch_Options(ACE_Synch_Options::USE_REACTOR|ACE_Synch_Options::USE_TIMEOUT, conn_timeout));
 
   if (ret == -1 && errno != EWOULDBLOCK) {
 


### PR DESCRIPTION
Added TCP connection timeout for active tcp connection attempts.
When unreachable locations were being found in the OS interfaces
the connection attempt was hanging for an indefinite amount of time.
However, this was not configurable on the active side. Configurable
option (active_conn_timeout_period) was added as a TCP-specific option
with a default of 5 seconds.