### PR TITLE
Keep Linkage Private for OpenSSL on Android

### DIFF
--- a/MPC/config/dds_openssl.mpb
+++ b/MPC/config/dds_openssl.mpb
@@ -1,4 +1,16 @@
 feature(openssl): openssl {
+  // Android preloads the system SSL library (either OpenSSL or BoringSSL) for
+  // the Java Android API, so we must:
+  //   1. Statically link OpenSSL to this library
+  //   2. Keep our OpenSSL symbols internal
+  // Number 1 is described in android.md. We are doing number 2 here.
+  verbatim (gnuace, top) {
+    comma := ,
+    exclude_openssl_libs := -Wl$(comma)--exclude-libs$(comma)libcrypto.a -Wl$(comma)--exclude-libs$(comma)libssl.a
+  }
+  specific (gnuace) {
+    compile_flags += $(if $(ANDROID_ABI),$(exclude_openssl_libs))
+  }
 }
 
 feature(!no_vxworks_openssl) {

--- a/MPC/config/dds_openssl.mpb
+++ b/MPC/config/dds_openssl.mpb
@@ -4,7 +4,7 @@ feature(openssl): openssl {
   //   1. Statically link OpenSSL to this library
   //   2. Keep our OpenSSL symbols internal
   // Number 1 is described in android.md. We are doing number 2 here.
-  verbatim (gnuace, top) {
+  verbatim (gnuace, top, 1) {
     comma := ,
     exclude_openssl_libs := -Wl$(comma)--exclude-libs$(comma)libcrypto.a -Wl$(comma)--exclude-libs$(comma)libssl.a
   }


### PR DESCRIPTION
This is pulled from https://github.com/objectcomputing/OpenDDS/pull/1066. I thought it was fixed by https://github.com/DOCGroup/ACE_TAO/pull/858, but I didn't make sure OpenDDS was using `ace_openssl` instead of `openssl` directly. Now I see `ace_openssl` is broken in OpenDDS on top of the fact that the issue never was fixed. This applies the fix from #1066 to get around `ace_openssl`. Will have to create some sort of test for this at some point if we ever get Android testing.