### PR TITLE
Fix compiler warnings in RtpsRelay

### DIFF
--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -47,9 +47,8 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
 void PublicationListener::write_sample(const DDS::PublicationBuiltinTopicData& data,
                                        const DDS::SampleInfo& info)
 {
-  const OpenDDS::DCPS::RepoId id = participant_->get_repoid(info.instance_handle);
   GUID_t guid;
-  std::memcpy(&guid, &id, sizeof(GUID_t));
+  assign(guid, participant_->get_repoid(info.instance_handle));
 
   DDS::DataWriterQos data_writer_qos;
   data_writer_qos.durability = data.durability;
@@ -91,9 +90,8 @@ void PublicationListener::write_sample(const DDS::PublicationBuiltinTopicData& d
 
 void PublicationListener::unregister_instance(const DDS::SampleInfo& info)
 {
-  const OpenDDS::DCPS::RepoId id = participant_->get_repoid(info.instance_handle);
   GUID_t guid;
-  std::memcpy(&guid, &id, sizeof(GUID_t));
+  assign(guid, participant_->get_repoid(info.instance_handle));
 
   WriterEntry entry;
   entry.guid(guid);

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -33,7 +33,7 @@ namespace {
     OpenDDS::STUN::Message response;
     response.class_ = OpenDDS::STUN::ERROR_RESPONSE;
     response.method = a_message.method;
-    memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+    std::memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
     response.append_attribute(OpenDDS::STUN::make_error_code(OpenDDS::STUN::BAD_REQUEST, a_reason));
     response.append_attribute(OpenDDS::STUN::make_fingerprint());
     return response;
@@ -45,7 +45,7 @@ namespace {
     OpenDDS::STUN::Message response;
     response.class_ = OpenDDS::STUN::ERROR_RESPONSE;
     response.method = a_message.method;
-    memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
+    std::memcpy(response.transaction_id.data, a_message.transaction_id.data, sizeof(a_message.transaction_id.data));
     response.append_attribute(OpenDDS::STUN::make_error_code(OpenDDS::STUN::UNKNOWN_ATTRIBUTE, "Unknown Attributes"));
     response.append_attribute(OpenDDS::STUN::make_unknown_attributes(a_unknown_attributes));
     response.append_attribute(OpenDDS::STUN::make_fingerprint());
@@ -784,7 +784,7 @@ void StunHandler::process_message(const ACE_INET_Addr& remote_address,
       OpenDDS::STUN::Message response;
       response.class_ = OpenDDS::STUN::SUCCESS_RESPONSE;
       response.method = OpenDDS::STUN::BINDING;
-      memcpy(response.transaction_id.data, message.transaction_id.data, sizeof(message.transaction_id.data));
+      std::memcpy(response.transaction_id.data, message.transaction_id.data, sizeof(message.transaction_id.data));
       response.append_attribute(OpenDDS::STUN::make_mapped_address(remote_address));
       response.append_attribute(OpenDDS::STUN::make_xor_mapped_address(remote_address));
       response.append_attribute(OpenDDS::STUN::make_fingerprint());

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -47,9 +47,8 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
 void SubscriptionListener::write_sample(const DDS::SubscriptionBuiltinTopicData& data,
                                         const DDS::SampleInfo& info)
 {
-  const OpenDDS::DCPS::RepoId id = participant_->get_repoid(info.instance_handle);
   GUID_t guid;
-  std::memcpy(&guid, &id, sizeof(GUID_t));
+  assign(guid, participant_->get_repoid(info.instance_handle));
 
   DDS::DataReaderQos data_reader_qos;
   data_reader_qos.durability = data.durability;
@@ -88,9 +87,8 @@ void SubscriptionListener::write_sample(const DDS::SubscriptionBuiltinTopicData&
 
 void SubscriptionListener::unregister_instance(const DDS::SampleInfo& info)
 {
-  const OpenDDS::DCPS::RepoId id = participant_->get_repoid(info.instance_handle);
   GUID_t guid;
-  std::memcpy(&guid, &id, sizeof(GUID_t));
+  assign(guid, participant_->get_repoid(info.instance_handle));
 
   ReaderEntry entry;
   entry.guid(guid);

--- a/tools/rtpsrelay/utility.h
+++ b/tools/rtpsrelay/utility.h
@@ -73,6 +73,18 @@ struct GuidAddr {
   }
 };
 
+inline void assign(EntityId_t& eid, const OpenDDS::DCPS::EntityId_t& a_eid)
+{
+  std::memcpy(&eid._entityKey[0], a_eid.entityKey, sizeof(a_eid.entityKey));
+  eid.entityKind(a_eid.entityKind);
+}
+
+inline void assign(GUID_t& guid, const OpenDDS::DCPS::RepoId& a_guid)
+{
+  std::memcpy(&guid._guidPrefix[0], a_guid.guidPrefix, sizeof(a_guid.guidPrefix));
+  assign(guid.entityId(), a_guid.entityId);
+}
+
 }
 
 #endif // RTPSRELAY_UTILITY_H_


### PR DESCRIPTION
Root cause is copying GUIDs between C++11 and non-C++11 code.