### PR TITLE
Add SPDP ICE endpoint before SEDP is initialized

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1669,6 +1669,13 @@ Spdp::SpdpTransport::SpdpTransport(Spdp* outer, bool securityGuids)
        end = addrs.end(); it != end; ++it) {
     send_addrs_.insert(ACE_INET_Addr(it->c_str()));
   }
+
+#ifdef OPENDDS_SECURITY
+  ICE::Endpoint* endpoint = get_ice_endpoint();
+  if (endpoint) {
+    ICE::Agent::instance()->add_endpoint(endpoint);
+  }
+#endif
 }
 
 void
@@ -1708,13 +1715,6 @@ Spdp::SpdpTransport::open()
       outer_->config_->use_rtps_relay()) {
     relay_beacon_->enable(false, outer_->config_->spdp_rtps_relay_beacon_period());
   }
-
-#ifdef OPENDDS_SECURITY
-  ICE::Endpoint* endpoint = get_ice_endpoint();
-  if (endpoint) {
-    ICE::Agent::instance()->add_endpoint(endpoint);
-  }
-#endif
 }
 
 Spdp::SpdpTransport::~SpdpTransport()


### PR DESCRIPTION
This is to address a start-up condition where SEDP is already engaged
in ICE and needs the local agent info for SPDP but SPDP has not added
its endpoint to the ICE agent.