### PR TITLE
Update RtpsUdpDataLink::check_handshake_complete for reader-side handshake

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -380,6 +380,7 @@ private:
     bool remove_writer(const RepoId& id);
     size_t writer_count() const;
 
+    bool is_writer_handshake_done(const RepoId& id) const;
     bool should_nack_durable(const WriterInfo& info);
 
     bool process_heartbeat_i(const RTPS::HeartBeatSubmessage& heartbeat, const RepoId& src, MetaSubmessageVec& meta_submessages);

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -451,7 +451,6 @@ OpenDDS::DCPS::TcpDataLink::do_association_actions()
 {
   typedef std::vector<std::pair<RepoId, RepoId> > PairVec;
   PairVec to_send;
-  PairVec to_call;
 
   {
     GuardType guard(strategy_lock_);

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -458,20 +458,12 @@ OpenDDS::DCPS::TcpDataLink::do_association_actions()
 
     for (OnStartCallbackMap::const_iterator it = on_start_callbacks_.begin(); it != on_start_callbacks_.end(); ++it) {
       for (RepoToClientMap::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
-        GuidConverter conv(it2->first);
         to_send.push_back(std::make_pair(it2->first, it->first));
-        if (!conv.isWriter()) {
-          to_call.push_back(std::make_pair(it2->first, it->first));
-        }
       }
     }
   }
 
   send_strategy_->link_released(false);
-
-  for (PairVec::const_iterator it = to_call.begin(); it != to_call.end(); ++it) {
-    invoke_on_start_callbacks(it->first, it->second, true);
-  }
 
   for (PairVec::const_iterator it = to_send.begin(); it != to_send.end(); ++it) {
     send_association_msg(it->first, it->second);


### PR DESCRIPTION
Remove pointless TcpDataLink code that circumvents real reader-side association checking