### PR TITLE
RTPS Discovery: added a configurable way to start the participant counter in the GUID at 0

### DIFF
--- a/dds/DCPS/RTPS/GuidGenerator.h
+++ b/dds/DCPS/RTPS/GuidGenerator.h
@@ -53,6 +53,8 @@ public:
   /// doing so.
   void populate(DCPS::GUID_t& container);
 
+  void resetCounter() { counter_ = 0; }
+
 private:
   enum {NODE_ID_SIZE = 6};
 

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -485,6 +485,19 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               string_value.c_str(), rtps_name.c_str()), -1);
           }
+        } else if (name == "GuidParticipantCountUseRandomSeed") {
+          int value;
+          if (DCPS::convertToInteger(it->second, value)) {
+            if (!value) {
+              discovery->reset_guid_participant_counter();
+            }
+          } else {
+            ACE_ERROR_RETURN((LM_ERROR,
+              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+              ACE_TEXT("Invalid entry (%C) for GuidParticipantCountUseRandomSeed in ")
+              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+              it->second.c_str(), rtps_name.c_str()), -1);
+          }
         } else {
           ACE_ERROR_RETURN((LM_ERROR,
             ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -468,6 +468,8 @@ public:
   u_short max_spdp_sequence_msg_reset_check() const { return config_->max_spdp_sequence_msg_reset_check(); }
   void max_spdp_sequence_msg_reset_check(u_short reset_value) { config_->max_spdp_sequence_msg_reset_check(reset_value); }
 
+  void reset_guid_participant_counter() { guid_gen_.resetCounter(); }
+
   RtpsDiscoveryConfig_rch config() const { return config_; }
 
 #ifdef OPENDDS_SECURITY


### PR DESCRIPTION
... instead of letting it pick a random value