### PR TITLE
Change submodule retrieval protocol to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "tools/rapidjson"]
 	path = tools/rapidjson
-	url = git://github.com/miloyip/rapidjson.git
+	url = https://github.com/miloyip/rapidjson.git
 	branch = version1.1.0
 [submodule "tests/googletest"]
 	path = tests/googletest
-	url = git://github.com/google/googletest
+	url = https://github.com/google/googletest


### PR DESCRIPTION
Corporate firewalls tend to block `git:` protocol/port. For the retrieval and build process to work, the protocol must be changed to `https:`.