### PR TITLE
Fix Unlocked Removal Methods & Usage For TransportSendBuffer / SingleSendBuffer

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -149,8 +149,6 @@ SingleSendBuffer::remove_i(BufferMap::iterator buffer_iter, BufferVec& removed)
 
   if (buffer.first && buffer.second) {
     // not a fragment
-    RemoveAllVisitor visitor;
-    buffer.first->accept_remove_visitor(visitor);
     removed.push_back(buffer);
   } else {
     // data actually stored in fragments_
@@ -158,9 +156,7 @@ SingleSendBuffer::remove_i(BufferMap::iterator buffer_iter, BufferVec& removed)
     if (fm_it != fragments_.end()) {
       for (BufferMap::iterator bm_it = fm_it->second.begin();
            bm_it != fm_it->second.end(); ++bm_it) {
-        RemoveAllVisitor visitor;
-        bm_it->second.first->accept_remove_visitor(visitor);
-        removed.push_back(buffer);
+        removed.push_back(bm_it->second);
       }
       fragments_.erase(fm_it);
     }
@@ -265,6 +261,8 @@ SingleSendBuffer::insert(SequenceNumber sequence,
   }
   g.release();
   for (size_t i = 0; i < removed.size(); ++i) {
+    RemoveAllVisitor visitor;
+    removed[i].first->accept_remove_visitor(visitor);
     delete removed[i].first;
     removed[i].second->release();
   }
@@ -320,6 +318,8 @@ SingleSendBuffer::insert_fragment(SequenceNumber sequence,
   }
   g.release();
   for (size_t i = 0; i < removed.size(); ++i) {
+    RemoveAllVisitor visitor;
+    removed[i].first->accept_remove_visitor(visitor);
     delete removed[i].first;
     removed[i].second->release();
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -15,6 +15,7 @@
 #include "dds/DCPS/transport/framework/TransportSendElement.h"
 #include "dds/DCPS/transport/framework/TransportSendControlElement.h"
 #include "dds/DCPS/transport/framework/NetworkAddress.h"
+#include "dds/DCPS/transport/framework/RemoveAllVisitor.h"
 
 #include "dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h"
 #include "dds/DCPS/RTPS/BaseMessageUtils.h"
@@ -229,12 +230,14 @@ RtpsUdpDataLink::RtpsWriter::remove_sample(const DataSampleElement* sample)
   g.release();
 
   if (found) {
-    tqe->data_dropped(true);
     for (size_t i = 0; i < removed.size(); ++i) {
+      RemoveAllVisitor visitor;
+      removed[i].first->accept_remove_visitor(visitor);
       delete removed[i].first;
       removed[i].second->release();
     }
     removed.clear();
+    tqe->data_dropped(true);
     result = REMOVE_FOUND;
   }
   return result;


### PR DESCRIPTION
A number of things were wrong here. I hadn't pulled the RemoveAllVistitor usage out into RtpsUdpDatalink, I had accidentally copied the wrong buffer's iterator for fragments. I also wasn't checking to see if the buffer was non-null before calling release, but that only mattered because I was copying from incorrect buffer iterator.