### PR TITLE
Remove Manual Monotonic Time Support Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,19 @@ first -- the `configure` script will download it for you.
 
 There are two distributions of ACE/TAO that can be used with OpenDDS:
 
-* OCI ACE/TAO 2.2a patch 16
+* OCI ACE/TAO 2.2a patch 17 or later
   * This will be automatically downloaded by default when using the configure
     script.
   * Can be manually downloaded from:
     * http://download.objectcomputing.com/TAO-2.2a_patches/
-* DOC Group ACE 6.5.5 / TAO 2.5.5
+* DOC Group ACE 6.5.8 / TAO 2.5.8 or later
   * When using the configure script, DOC Group ACE/TAO can be downloaded using
     one of these arguments:
     * `--doc-group` for the latest release
     * `--ace-github-latest` to use the master branch of ACE/TAO as is. This
       also downloads the master branch of MPC as is.
   * Can be manually downloaded from:
-    * [`github.com/DOCGroup/ACE_TAO`](https://github.com/DOCGroup/ACE_TAO/releases)
+    * https://github.com/DOCGroup/ACE_TAO/releases
     * http://download.dre.vanderbilt.edu/
 
 ### Perl

--- a/dds/DCPS/TimeTypes.h
+++ b/dds/DCPS/TimeTypes.h
@@ -1,4 +1,5 @@
 /**
+ * \file
  * See the "Time" section in docs/guidelines.md for background and reasoning
  * for these types.
  */
@@ -6,12 +7,12 @@
 #ifndef OPENDDS_DCPS_TIME_TYPES_HEADER
 #define OPENDDS_DCPS_TIME_TYPES_HEADER
 
+#include "TimeDuration.h"
+#include "TimePoint_T.h"
+
 #include <ace/Monotonic_Time_Policy.h>
 #include <ace/Time_Policy.h>
 #include <ace/Condition_Attributes.h>
-
-#include "TimeDuration.h"
-#include "TimePoint_T.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #  pragma once
@@ -39,20 +40,6 @@ typedef TimePoint_T<SystemClock> SystemTimePoint;
  */
 ///@{
 #if defined(ACE_HAS_MONOTONIC_TIME_POLICY) && defined(ACE_HAS_MONOTONIC_CONDITIONS)
-#  define OPENDDS_USES_MONOTONIC_TIME
-/*
- * TODO: Remove this check once latest release of OCI ACE/TAO has the monotonic
- * support macros.
- */
-#elif defined(ACE_OCI_PATCHLEVEL) && \
-  (defined(ACE_WIN32) || \
-    (defined(ACE_HAS_CLOCK_GETTIME) && \
-    !defined(ACE_LACKS_MONOTONIC_TIME) && \
-    !defined(ACE_LACKS_CONDATTR) && \
-    ((defined(_POSIX_MONOTONIC_CLOCK) && (_POSIX_MONOTONIC_CLOCK != -1)) || \
-      defined(ACE_HAS_CLOCK_GETTIME_MONOTONIC)) && \
-    ((defined(_POSIX_CLOCK_SELECTION) && (_POSIX_CLOCK_SELECTION != -1)) && \
-      !defined(ACE_LACKS_CONDATTR_SETCLOCK))))
 #  define OPENDDS_USES_MONOTONIC_TIME
 #endif
 


### PR DESCRIPTION
OpenDDS will now need DOC Group ACE/TAO 2.5.7 or OCI TAO 2.2a patch 17 or later for monotonic time support.