### PR TITLE
Fix Mutex Contention Within ReactorInterceptor

### DIFF
--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -21,6 +21,7 @@ namespace DCPS {
 ReactorInterceptor::ReactorInterceptor(ACE_Reactor* reactor,
                                        ACE_thread_t owner)
   : owner_(owner)
+  , state_(NONE)
 {
   this->reactor(reactor);
 }
@@ -43,16 +44,22 @@ int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)
 
 void ReactorInterceptor::process_command_queue_i()
 {
-  ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
+  OPENDDS_QUEUE(CommandPtr) cq;
   ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
+
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  state_ = PROCESSING;
   while (!command_queue_.empty()) {
-    CommandPtr command = command_queue_.front();
-    command_queue_.pop();
-    ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock);
-    command->execute();
-    command->executed();
-    command.reset();
+    cq.swap(command_queue_);
+    ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rev_guard(rev_lock);
+    while (!cq.empty()) {
+      CommandPtr command = cq.front();
+      cq.pop();
+      command->execute();
+      command->executed();
+    }
   }
+  state_ = NONE;
 }
 
 }

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -44,7 +44,7 @@ int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)
 
 void ReactorInterceptor::process_command_queue_i()
 {
-  OPENDDS_QUEUE(CommandPtr) cq;
+  OPENDDS_DEQUE(CommandPtr) cq;
   ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -54,7 +54,7 @@ void ReactorInterceptor::process_command_queue_i()
     ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rev_guard(rev_lock);
     while (!cq.empty()) {
       CommandPtr command = cq.front();
-      cq.pop();
+      cq.pop_front();
       command->execute();
       command->executed();
     }

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -113,7 +113,7 @@ protected:
     const CommandPtr command(c, keep_count());
     {
       ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-      command_queue_.push(command);
+      command_queue_.push_back(command);
       if (state_ == NONE) {
         state_ = NOTIFIED;
         do_notify = true;
@@ -134,7 +134,7 @@ protected:
 
   ACE_thread_t owner_;
   ACE_Thread_Mutex mutex_;
-  OPENDDS_QUEUE(CommandPtr) command_queue_;
+  OPENDDS_DEQUE(CommandPtr) command_queue_;
   ReactorState state_;
 };
 

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -99,14 +99,27 @@ public:
 
 protected:
 
+  enum ReactorState {
+    NONE,
+    NOTIFIED,
+    PROCESSING
+  };
+
   CommandPtr enqueue_i(Command* c, bool immediate)
   {
     c->reset();
     c->set_reactor(reactor());
+    bool do_notify = false;
     const CommandPtr command(c, keep_count());
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, CommandPtr());
-    command_queue_.push(command);
-    if (!immediate) {
+    {
+      ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+      command_queue_.push(command);
+      if (state_ == NONE) {
+        state_ = NOTIFIED;
+        do_notify = true;
+      }
+    }
+    if (!immediate && do_notify) {
       reactor()->notify(this);
     }
     return command;
@@ -122,6 +135,7 @@ protected:
   ACE_thread_t owner_;
   ACE_Thread_Mutex mutex_;
   OPENDDS_QUEUE(CommandPtr) command_queue_;
+  ReactorState state_;
 };
 
 typedef RcHandle<ReactorInterceptor> ReactorInterceptor_rch;


### PR DESCRIPTION
The primary motivator for this was mutrace's output. When running a mutrace'd worker alongside a bench scenario, the ReactorInterceptor show up in most of the top contention slots, which I'm guessing comes mostly from holding the lock while calling notify when the reactor thread is idle (and so it immediately tries to grab the lock). The addition of the state flag and the queue swapping was intended to prevent some of the back & forth.