### PR TITLE
Use "-dev" version suffix to indicate development versions (master branch between releases)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -19,3 +19,19 @@ Fred Hornsey <hornseyf@objectcomputing.com> <fred@hornsey.us>
 Fred Hornsey <hornseyf@objectcomputing.com> Frederick Hornsey
 
 Doug Lewis <lewisdo@objectcomputing.com> unknown <lewisdo@objectcomputing.com>
+
+Jeremy Bratton <brattonj@objectcomputing.com> brattonj
+
+ceneblock <ceneblock@users.noreply.github.com> <ceneblock@ceneblock.com>
+
+Chip Jones <jonesc@objectcomputing.com> <chiphj@gmail.com>
+
+Mike Kuznetsov <kuznetsovm@objectcomputing.com> kuznetsovm@objectcomputing.com
+Mike Kuznetsov <kuznetsovm@objectcomputing.com> kuznetsovmoci <55456623+kuznetsovmoci@users.noreply.github.com>
+
+Jiang Li <lij@objectcomputing.com> lij-oci <55156341+lij-oci@users.noreply.github.com>
+
+Chad Elliott <elliottc@objectcomputing.com> <elliott_c@ociweb.com>
+Chad Elliott <elliottc@objectcomputing.com> ocielliottc
+
+Gary Wilson <wilsong@objectcomputing.com> wilsongOCI

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,16 @@
+Tobias A <tobias.o.aus@gmail.com>
+Jeremy Adams <adamsj@objectcomputing.com>
 ajkerzner <https://github.com/ajkerzner>
 Erik Andresen <ea@drshh.de>
 Tim Bradley <bradley_t@ociweb.com>
 Jeremy Bratton <brattonj@objectcomputing.com>
 Don Busch <buschd@ociweb.com>
 Paul Calabrese <calabrep@objectcomputing.com>
+ceneblock <https://github.com/ceneblock>
 James A. Chappell <chappell_j@ociweb.com>
 Chris Cleeland <cleeland@ociweb.com>
 Yan Dai <dai_y@ociweb.com>
-Chad Elliott <elliott_c@ociweb.com>
+Chad Elliott <elliottc@objectcomputing.com>
 Trevor Fields <fields_t@ociweb.com>
 Weiqi Gao <gaow@ociweb.com>
 Leif Gruenwoldt <leifer@gmail.com>
@@ -21,23 +24,27 @@ Iliyan Jeliazkov <iliyan@ociweb.com>
 jmmorato <jmmorato@enxarxats.com>
 Ciju John <johnc@ociweb.com>
 Brian Johnson <johnsonb@ociweb.com>
-Chip Jones <jonesc@ociweb.com>
+Chip Jones <jonesc@objectcomputing.com>
 Oliver Kellogg <okellogg@users.sourceforge.net>
+Mike Kuznetsov <kuznetsovm@objectcomputing.com>
 Phillip LaBanca <labancap@ociweb.com>
 Doug Lewis <lewisdo@objectcomputing.com>
+Jiang Li <lij@objectcomputing.com>
 Mike Martinez <martinez_m@ociweb.com>
 Michael Mathers <michael.p.mathers@live.com>
 Mason McParlane <mcparlanem@objectcomputing.com>
 Phil Mesnier <mesnier_p@ociweb.com>
 Adam Mitz <mitza@objectcomputing.com>
 Jose Morato <jose.morato@swisstiming.com>
-Marc Neeley <neeleym@ociweb.com>
+Mouse <https://github.com/mouse07410>
+Marc Neeley <neeleym@objectcomputing.com>
 Peter Oschwald <oschwaldp@objectcomputing.com>
 Ossama Othman <othmano@ociweb.com>
 Kevin Pansky <kevin.pansky@gmail.com>
 Jeff Parsons <j.parsons@vanderbilt.edu>
 Jonathan Pollack <pollack_j@ociweb.com>
 ran <ea@drshh.de>
+Vladyslav Samodelok <vladfux4@gmail.com>
 sarah <993273596@qq.com>
 Jeff Schmitz <schmitzj@ociweb.com>
 Rich Seibel <seibel_r@ociweb.com>
@@ -48,6 +55,8 @@ Steven Stallion <stallions@ociweb.com>
 Steve Totten <tottens@ociweb.com>
 Dean Wette <wette_d@ociweb.com>
 Johnny Willemsen <jwillemsen@remedy.nl>
+Gary Wilson <wilsong@objectcomputing.com>
 Justin Wilson <wilsonj@objectcomputing.com>
 Friedhelm Wolf <fwolf@dre.vanderbilt.edu>
+xieshuaix <xieshuaix@gmail.com>
 Wallace Zhang <zhang_w@ociweb.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # OpenDDS Releases
 
-## Version 3.14 of OpenDDS
-Released %TIMESTAMP%
+## Version 3.14.0 of OpenDDS
+OpenDDS 3.14.0 is currently in development, so this list might change.
 
 ### Additions:
 - Union topic types and IDL annotations for topic types (#1067):
@@ -20,8 +20,8 @@ Released %TIMESTAMP%
 - Java API can now be used on Android
 
 ### Notes:
-- Removed outdated `-Gws` option of `opendds_idl`. This option produced sample
-  descriptions for the Wireshark dissector before OpenDDS v3.7.
+- Removed outdated `-Gws` option of `opendds_idl`. This option produced topic
+  type descriptions for the Wireshark dissector before OpenDDS v3.7.
 
 ## Version 3.13.1 of OpenDDS
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # OpenDDS Releases
 
-## Version 3.14.0 of OpenDDS
-OpenDDS 3.14.0 is currently in development, so this list might change.
+## Version 3.14 of OpenDDS
+OpenDDS 3.14 is currently in development, so this list might change.
 
 ### Additions:
 - Union topic types and IDL annotations for topic types (#1067):
@@ -20,8 +20,8 @@ OpenDDS 3.14.0 is currently in development, so this list might change.
 - Java API can now be used on Android
 
 ### Notes:
-- Removed outdated `-Gws` option of `opendds_idl`. This option produced topic
-  type descriptions for the Wireshark dissector before OpenDDS v3.7.
+- Removed outdated `-Gws` option of `opendds_idl`. This option produced sample
+  descriptions for the Wireshark dissector before OpenDDS v3.7.
 
 ## Version 3.13.1 of OpenDDS
 

--- a/PROBLEM-REPORT-FORM
+++ b/PROBLEM-REPORT-FORM
@@ -1,6 +1,6 @@
-This is OpenDDS version 3.13, released Wed Aug 22 14:15:40 UTC 2018
+This is OpenDDS version 3.14.0-dev (NOT A RELEASE)
 
-    OpenDDS VERSION: 3.13
+    OpenDDS VERSION: 3.14.0-dev
     TAO VERSION:
 
     HOST MACHINE and OPERATING SYSTEM:

--- a/PROBLEM-REPORT-FORM
+++ b/PROBLEM-REPORT-FORM
@@ -1,6 +1,6 @@
-This is OpenDDS version 3.14.0-dev (NOT A RELEASE)
+This is OpenDDS version 3.14-dev (NOT A RELEASE)
 
-    OpenDDS VERSION: 3.14.0-dev
+    OpenDDS VERSION: 3.14-dev
     TAO VERSION:
 
     HOST MACHINE and OPERATING SYSTEM:

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,4 +1,4 @@
-This is OpenDDS version 3.13, released Wed Aug 22 14:15:40 UTC 2018
+This is OpenDDS version 3.14.0-dev (NOT A RELEASE)
 
 This software is open source and free of licensing fees.  See the
 LICENSE file (in this directory) for license details.

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,4 +1,4 @@
-This is OpenDDS version 3.14.0-dev (NOT A RELEASE)
+This is OpenDDS version 3.14-dev (NOT A RELEASE)
 
 This software is open source and free of licensing fees.  See the
 LICENSE file (in this directory) for license details.

--- a/dds/Version.h
+++ b/dds/Version.h
@@ -6,6 +6,7 @@
  */
 
 #define DDS_MAJOR_VERSION 3
-#define DDS_MINOR_VERSION 13
+#define DDS_MINOR_VERSION 14
 #define DDS_MICRO_VERSION 0
-#define DDS_VERSION "3.13"
+#define OPENDDS_IS_RELEASE 0
+#define DDS_VERSION "3.14.0-dev"

--- a/dds/Version.h
+++ b/dds/Version.h
@@ -9,4 +9,4 @@
 #define DDS_MINOR_VERSION 14
 #define DDS_MICRO_VERSION 0
 #define OPENDDS_IS_RELEASE 0
-#define DDS_VERSION "3.14.0-dev"
+#define DDS_VERSION "3.14-dev"

--- a/tools/scripts/gitrelease.pl
+++ b/tools/scripts/gitrelease.pl
@@ -12,10 +12,10 @@ use File::stat;
 use lib dirname (__FILE__) . "/modules";
 use ConvertFiles;
 use Pithub::Repos::Releases;
-use Data::Dumper;
 use Net::FTP::File;
 use File::Temp qw/ tempdir /;
 use File::Path qw(make_path);
+use Getopt::Long;
 
 my $base_name_prefix = "OpenDDS-";
 my $default_github_user = "objectcomputing";
@@ -28,18 +28,19 @@ my $ace_tao_filename = "ACE+TAO-2.2a_with_latest_patches_NO_makefiles.tar.gz";
 my $ace_tao_url = "http://download.ociweb.com/TAO-2.2a/$ace_tao_filename";
 my $ace_root = "ACE_wrappers";
 my $git_name_prefix = "DDS-";
+my $default_post_release_version_id = "dev";
 
 $ENV{TZ} = "UTC";
 Time::Piece::_tzset;
 my $timefmt = "%a %b %d %H:%M:%S %Z %Y";
 
-my $timestamp_marker = "%TIMESTAMP%";
+my $release_timestamp_fmt = "%b %e %Y";
 
 # Number of lines after start of file to insert news_template
 my $news_header_lines = 2;
 
 my $news_template = "## Version %s of OpenDDS\n" . <<"ENDOUT";
-Released %s
+%s
 
 ### Additions:
 - TODO: Add your features here
@@ -52,10 +53,28 @@ Released %s
 
 ENDOUT
 
+sub get_news_post_release_msg {
+  my $settings = shift();
+  my $ver = $settings->{parsed_next_version}->{release_string};
+  return "OpenDDS $ver is currently in development, so this list might change.";
+}
+
+sub get_news_release_msg {
+  my $settings = shift();
+  return "OpenDDS $settings->{version} was released on $settings->{timestamp}.";
+}
+
 my $insert_news_template_after_line = 1;
 sub insert_news_template($$) {
-  my $version = shift;
-  my $timestamp = shift;
+  my $settings = shift();
+  my $post_release = shift();
+
+  print("pr: $post_release\n");
+  my $version = ($post_release ?
+    $settings->{parsed_next_version} : $settings->{parsed_version})->{string};
+  print("$settings->{parsed_next_version}->{metadata}\n");
+  my $release_msg = $post_release ?
+    get_news_post_release_msg($settings) : get_news_release_msg($settings);
 
   # Read News File
   open my $news_file, '<', "NEWS.md";
@@ -65,7 +84,7 @@ sub insert_news_template($$) {
   # Insert Template
   my @new_lines = ();
   push(@new_lines, @lines[0..$insert_news_template_after_line]);
-  push(@new_lines, sprintf($news_template, $version, $timestamp));
+  push(@new_lines, sprintf($news_template, $version, $release_msg));
   push(@new_lines, @lines[$insert_news_template_after_line+1..scalar(@lines)-1]);
 
   # Write News File with Template
@@ -76,72 +95,99 @@ sub insert_news_template($$) {
   close $news_file;
 }
 
-sub usage {
-  return "gitrelease.pl WORKSPACE VERSION [STEPS] [options]\n" .
-         "gitrelease.pl --list | --help | -h\n" .
-         "\n" .
-         "Positional Arguments:\n" .
-         "    WORKSPACE:       Path of intermediate files directory. If it\n" .
-         "                     doesn't exist, it will be created.\n" .
-         "                     This should a new one for each release.\n" .
-         "    VERSION:         release version in a.b or a.b.c notation\n" .
-         "    STEPS:           Optional, Steps to perform, default is all\n" .
-         "                     See \"Step Expressions\" Below for what it accepts.\n" .
-         "\n" .
-         "Options:\n" .
-         "  --help | -h        Print this message\n" .
-         "  --list             just show step names (default perform check)\n" .
-         "  --remedy           remediate problems where possible\n" .
-         "  --force            keep going if possible\n" .
-         "  --remote=name      valid git remote for OpenDDS (default: ${default_remote})\n" .
-         "  --branch=name      valid git branch for cloning (default: ${default_branch})\n" .
-         "  --github-user=name user or organization name for github updates (default: ${default_github_user})\n" .
-         "  --download-url=url URL to verify FTP uploads (default: ${default_download_url}\n" .
-         "  --micro            Do a patch/micro level release\n" .
-         "                     The difference is we skip the following:\n" .
-         "                         devguide, doxygen, website, release branch, and adding NEWS Template\n" .
-         "                     Requires --branch\n" .
-         "  --skip-devguide    Skip getting and including the devguide\n" .
-         "  --skip-doxygen     Skip getting ACE/TAO and generating and including the doxygen docs\n" .
-         "  --skip-website     Skip updating the website\n" .
-         "  --skip-ftp         Skip the FTP upload\n" .
-         "\n" .
-         "Environment Variables:\n" .
-         "  GITHUB_TOKEN       GitHub token with repo access to publish release on GitHub.\n" .
-         "  FTP_USERNAME       FTP Username\n" .
-         "  FTP_PASSWD         FTP Password\n" .
-         "  FTP_HOST           FTP Server Address\n" .
-         "\n" .
-         "Step Expressions\n" .
-         "  The STEPS argument accepts a specific notation for what steps to run.\n" .
-         "  Later subexpressions override earlier ones and the initial list of\n" .
-         "  steps the expression is modifying is empty at the beginning unless the\n" .
-         "  first subexpression is negative, then it starts with all steps.\n" .
-         "  Here are some examples:\n" .
-         "    5\n" .
-         "      Just do step 5\n" .
-         "    3-7\n" .
-         "      Do steps 3, 4, 5, 6, and 7\n" .
-         "    -8\n" .
-         "      Do steps up to and including step 8 and stop\n" .
-         "    8-\n" .
-         "      Do step 8 and all the steps after that\n" .
-         "    ^5\n" .
-         "      Do all steps except 5\n" .
-         "    ^5-7\n" .
-         "      Do all steps except 5, 6, and 7\n" .
-         "    Finally you can combine subexpressions by delimiting them by commas:\n" .
-         "    1,2,3\n" .
-         "      Do steps 1, 2, and 3\n" .
-         "    ^5-,10\n" .
-         "      Don't do step 5 or any step after that, except for 10\n" .
-         "    3-20,^5-7,^14\n" .
-         "      Do steps 3 through 20, except for steps 5, 6, 7, and 14\n";
+sub get_version_line {
+  my $settings = shift();
+  my $post_release = shift() || 0;
+  my $line = "This is OpenDDS version ";
+  if ($post_release) {
+    $line .= "$settings->{next_version} (NOT A RELEASE)";
+  }
+  else {
+    $line .= "$settings->{version}, released $settings->{timestamp}";
+  }
+  return $line;
 }
 
-sub is_option {
-  my $arg = shift;
-  return $arg =~ m/^--/ || $arg eq "-h";
+sub usage {
+  return
+    "gitrelease.pl WORKSPACE VERSION [options]\n" .
+    "gitrelease.pl --help | -h\n" .
+    "\n" .
+    "Positional Arguments:\n" .
+    "    WORKSPACE:           Path of intermediate files directory. If it doesn't\n" .
+    "                         exist, it will be created. This should a new one for\n" .
+    "                         each release.\n" .
+    "    VERSION:             Release version in a.b or a.b.c notation\n" .
+    "\n" .
+    "Options:\n" .
+    "  --help | -h            Print this message\n" .
+    "  --list                 Just show step names that would run given the current\n" .
+    "                         options. (default perform check)\n" .
+    "  --list-all             Same as --list, but show every step regardless of\n" .
+    "                         options.\n" .
+    "  --steps                Optional, Steps to perform, default is all\n" .
+    "                         See \"Step Expressions\" Below for what it accepts.\n" .
+    "  --remedy               Remediate problems where possible\n" .
+    "  --force                Keep going if possible\n" .
+    "  --remote=NAME          Valid git remote for OpenDDS (default: ${default_remote})\n" .
+    "  --branch=NAME          Valid git branch for cloning (default: ${default_branch})\n" .
+    "  --github-user=NAME     User or organization name for github updates\n" .
+    "                         (default: ${default_github_user})\n" .
+    "  --download-url=URL     URL to verify FTP uploads\n" .
+    "                         (default: ${default_download_url})\n" .
+    "  --micro                Do a patch/micro level release. Requires --branch.\n" .
+    "                         (default is no)\n" .
+    "                         The difference from a regular release is that anything\n" .
+    "                         to do with the the devguide, the doxygen, the website,\n" .
+    "                         or creating or updating a release branch is skipped.\n" .
+    "                         Run gitrelease.pl --list --micro to see the exact steps.\n" .
+    "  --next-version=VERSION What to set the verion to after release. Must be the\n" .
+    "                         same format as the VERSION positional argument.\n" .
+    "                         (default is to increment the minor version field).\n" .
+    "  --version-id=ID        What to append to the post-release version string like\n" .
+    "                         X.Y.Z-ID (default: ${default_post_release_version_id})\n" .
+    "  --skip-devguide        Skip getting and including the devguide\n" .
+    "  --skip-doxygen         Skip getting ACE/TAO and generating and including the\n" .
+    "                         doxygen docs\n" .
+    "  --skip-website         Skip updating the website\n" .
+    "  --skip-ftp             Skip the FTP upload\n" .
+    "\n" .
+    "Environment Variables:\n" .
+    "  GITHUB_TOKEN           GitHub token with repo access to publish release on\n" .
+    "                         GitHub.\n" .
+    "  FTP_USERNAME           FTP Username\n" .
+    "  FTP_PASSWD             FTP Password\n" .
+    "  FTP_HOST               FTP Server Address\n" .
+    "\n" .
+    "Step Expressions\n" .
+    "  The STEPS argument accepts a specific notation for what steps to run.\n" .
+    "  They work like a bit map, with subexpressions enabling or disabling a step.\n" .
+    "  Later subexpressions can overrule earlier ones and the initial list of\n" .
+    "  steps the expression is modifying are all disabled at the beginning unless\n" .
+    "  the first subexpression is negative (starts with ^), then it starts with all\n" .
+    "  steps enabled.\n" .
+    "\n" .
+    "  If that doesn't make sense, here are some examples:\n" .
+    "    5\n" .
+    "      Just do step 5\n" .
+    "    3-7\n" .
+    "      Do steps 3, 4, 5, 6, and 7\n" .
+    "    -8\n" .
+    "      Do steps up to and including step 8 and stop\n" .
+    "    8-\n" .
+    "      Do step 8 and all the steps after that\n" .
+    "    ^5\n" .
+    "      Do all steps except 5\n" .
+    "    ^5-7\n" .
+    "      Do all steps except 5, 6, and 7\n" .
+    "\n" .
+    "  Finally you can combine subexpressions by delimiting them by commas:\n" .
+    "    1,2,3\n" .
+    "      Do steps 1, 2, and 3\n" .
+    "    ^5-,10\n" .
+    "      Don't do step 5 or any step after that, except for 10\n" .
+    "    3-20,^5-7,^14\n" .
+    "      Do steps 3 through 20, except for steps 5, 6, 7, and 14\n";
 }
 
 sub remove_end_slash {
@@ -325,28 +371,82 @@ sub parse_step_expr {
 sub parse_version {
   my $version = shift;
   my %result = ();
-  if ($version =~ /([0-9]+)\.([0-9]+)\.?([0-9]+)?/) {
+  if ($version =~ /^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)))?$/) {
+    $result{string} = "$version";
     $result{major} = $1;
     $result{minor} = $2;
-    if ($3) {
-      $result{micro} = $3;
-    } else {
-      $result{micro} = 0;
-    }
+    $result{micro} = $3 || "0";
+    $result{metadata} = $4 || "";
+    $result{series_string} = "$result{major}.$result{minor}";
+    $result{release_string} = "$result{series_string}.$result{micro}";
   }
   return %result;
 }
 
-# Given a version string, return a numeric value for sorting purposes
-sub version_to_value {
-  my $tag_value = 0;
-  my %result = parse_version(shift());
-  if (%result) {
-    $tag_value = (100.0 * ($result{major} || 0)) +
-                          ($result{minor} || 0) +
-                 ($result{micro} / 100.0);
+# Compare Versions According To Semver
+sub version_greater_equal {
+  my $left = shift();
+  my $right = shift();
+
+  if ($left->{major} > $right->{major}) {
+    return 1;
   }
-  return $tag_value;
+  elsif ($left->{major} < $right->{major}) {
+    return 0;
+  }
+
+  if ($left->{minor} > $right->{minor}) {
+    return 1;
+  }
+  elsif ($left->{minor} < $right->{minor}) {
+    return 0;
+  }
+
+  if ($left->{micro} > $right->{micro}) {
+    return 1;
+  }
+  elsif ($left->{micro} < $right->{micro}) {
+    return 0;
+  }
+
+  my @lfields = split(/\./, $left->{metadata});
+  my @rfields = split(/\./, $right->{metadata});
+  my $llen = scalar(@lfields);
+  my $rlen = scalar(@rfields);
+  my $mlen = $llen > $rlen ? $llen : $rlen;
+  for (my $i = 0; $i <= $mlen; $i += 1) {
+    return 1 if ($i >= $rlen);
+    return 0 if ($i >= $llen);
+    my $li = $lfields[$i];
+    my $lnum = $li =~ /^\d+$/ ? 1 : 0;
+    my $ri = $rfields[$i];
+    my $rnum = $ri =~ /^\d+$/ ? 1 : 0;
+    print("  $li($lnum) $ri($rnum)\n");
+    return 1 if (!$lnum && $rnum);
+    return 0 if ($lnum && !$rnum);
+    if ($lnum) {
+      return 1 if $li > $ri;
+      return 0 if $li < $ri;
+    }
+    else {
+      return 1 if $li gt $ri;
+      return 0 if $li lt $ri;
+    }
+  }
+  return 1;
+}
+
+sub version_greater {
+  my $left = shift();
+  my $right = shift();
+  return version_greater_equal($left, $right) &&
+    $left->{string} ne $right->{string};
+}
+
+sub version_lesser {
+  my $left = shift();
+  my $right = shift();
+  return !version_greater_equal($left, $right);
 }
 
 ############################################################################
@@ -424,15 +524,19 @@ sub remedy_git_status_clean {
   system("git commit -m '" . $message . "'") == 0 or die "Could not execute: git commit -m";
   return 1;
 }
+
 ############################################################################
+
 sub verify_update_version_file {
   my $settings = shift();
-  my $version = $settings->{version};
+  my $post_release = shift() || 0;
+
   my $correct = 0;
-  my $status = open(VERSION, 'VERSION.txt');
-  my $metaversion = quotemeta($version);
+  my $line = quotemeta(get_version_line($settings, $post_release));
+
+  open(VERSION, 'VERSION.txt') or die "Opening: $!";
   while (<VERSION>) {
-    if ($_ =~ /This is OpenDDS version $metaversion, released/) {
+    if ($_ =~ /$line/) {
       $correct = 1;
       last;
     }
@@ -448,45 +552,49 @@ sub message_update_version_file {
 
 sub remedy_update_version_file {
   my $settings = shift();
-  my $version = $settings->{version};
-  print "  >> Updating VERSION.txt file for $version\n";
-  my $timestamp = $settings->{timestamp};
-  my $outline = "This is OpenDDS version $version, released $timestamp";
+  my $post_release = shift() || 0;
+
+  print "  >> Updating VERSION.txt file\n";
+
   my $corrected = 0;
+  my $line = get_version_line($settings, $post_release);
+
   open(VERSION, "+< VERSION.txt") or die "Opening: $!";
   my $out = "";
-
   while (<VERSION>) {
-    if (s/This is OpenDDS version [^,]+, released (.*)/$outline/) {
+    if (!$corrected && s/^This is OpenDDS version .*$/$line/) {
       $corrected = 1;
     }
     $out .= $_;
   }
-  seek(VERSION,0,0)                        or die "Seeking: $!";
-  print VERSION $out                       or die "Printing: $!";
-  truncate(VERSION,tell(VERSION))          or die "Truncating: $!";
-  close(VERSION)                           or die "Closing: $!";
+
+  seek(VERSION, 0, 0) or die "Seeking: $!";
+  print VERSION $out or die "Printing: $!";
+  truncate(VERSION, tell(VERSION)) or die "Truncating: $!";
+  close(VERSION) or die "Closing: $!";
+
   return $corrected;
 }
+
 ############################################################################
 sub find_previous_tag {
   my $settings = shift();
   my $remote = $settings->{remote};
-  my $version = $settings->{version};
+  my $release_version = $settings->{parsed_version};
   my $prev_version_tag = "";
-  my $prev_version_value = 0;
-  my $release_version_value = version_to_value($version);
+  my %prev_version = parse_version("0.0.0");
 
   open(GITTAG, "git tag --list |") or die "Opening $!";
   while (<GITTAG>) {
     chomp;
-    next unless /^$git_name_prefix([\d\.]*)/;
-    my $tag_value = version_to_value($_);
+    next unless /^$git_name_prefix([\d\.]*)$/;
+    my $version = $1;
+    my %tag_version = parse_version($version);
     # If this is less than the release version, but the largest seen yet
-    if (($tag_value < $release_version_value) &&
-        ($tag_value > $prev_version_value)) {
+    if (version_lesser(\%tag_version, $release_version) &&
+        version_greater(\%tag_version, \%prev_version)) {
       $prev_version_tag = $_;
-      $prev_version_value = $tag_value;
+      %prev_version = %tag_version;
     }
   }
   close(GITTAG);
@@ -495,7 +603,6 @@ sub find_previous_tag {
 
 sub verify_changelog {
   my $settings = shift();
-  my $version = $settings->{version};
   my $status = open(CHANGELOG, $settings->{changelog});
   if ($status) {
     close(CHANGELOG);
@@ -505,7 +612,6 @@ sub verify_changelog {
 
 sub message_changelog {
   my $settings = shift();
-  my $version = $settings->{version};
   return "File $settings->{changelog} missing";
 }
 
@@ -566,7 +672,6 @@ sub format_comment {
 
 sub remedy_changelog {
   my $settings = shift();
-  my $version = $settings->{version};
   my $remote = $settings->{remote};
   my $branch = $settings->{branch};
   my $prev_tag = find_previous_tag($settings);
@@ -644,7 +749,7 @@ EOF
 }
 ############################################################################
 
-# See $DDS_ROOT/.mailmap file for to add individual corrections
+# See $DDS_ROOT/.mailmap file for how to add individual corrections
 
 my $github_email_re = qr/^(?:\d+\+)?(.*)\@users.noreply.github.com$/;
 
@@ -801,7 +906,7 @@ sub remedy_news_file_section {
   my $version = $settings->{version};
   print "  >> Adding $version section to NEWS.md\n";
   print "  !! Manual update to NEWS.md needed\n";
-  insert_news_template($version, $settings->{timestamp});
+  insert_news_template($settings, 0);
   return 0;
 }
 
@@ -835,16 +940,17 @@ sub message_update_news_file {
 ############################################################################
 
 sub verify_news_timestamp {
-  my $marker = quotemeta($timestamp_marker);
-  my $has_marker = 0;
+  my $settings = shift();
+  my $quoted_msg = quotemeta(get_news_post_release_msg($settings));
+  my $has_post_release_msg = 0;
   open(my $news_file, 'NEWS.md');
   while (<$news_file>) {
-    if ($_ =~ /$marker/) {
-      $has_marker = 1;
+    if ($_ =~ /$quoted_msg/) {
+      $has_post_release_msg = 1;
     }
   }
   close($news_file);
-  return !$has_marker;
+  return !$has_post_release_msg;
 }
 
 sub message_news_timestamp {
@@ -853,8 +959,8 @@ sub message_news_timestamp {
 
 sub remedy_news_timestamp {
   my $settings = shift();
-  my $timestamp = $settings->{timestamp};
-  my $marker = quotemeta($timestamp_marker);
+  my $quoted_msg = quotemeta(get_news_post_release_msg($settings));
+  my $release_msg = get_news_release_msg($settings);
 
   # Read News File
   open(my $news_file, '<', "NEWS.md");
@@ -863,7 +969,7 @@ sub remedy_news_timestamp {
 
   # Insert Template
   foreach my $line (@lines) {
-    last if $line =~ s/$marker/$timestamp/;
+    last if $line =~ s/$quoted_msg/$release_msg/;
   }
 
   # Write News File
@@ -876,31 +982,50 @@ sub remedy_news_timestamp {
 }
 
 ############################################################################
+
 sub verify_update_version_h_file {
   my $settings = shift();
-  my $version = $settings->{version};
-  my $matched_major  = 0;
-  my $matched_minor  = 0;
-  my $matched_micro  = 0;
-  my $matched_version = 0;
-  my $status = open(VERSION_H, 'dds/Version.h');
-  my $metaversion = quotemeta($version);
+  my $post_release = shift() || 0;
 
+  if (!$post_release && verify_update_version_h_file($settings, 1)) {
+    die "ERROR: Version.h already indicates that the post release was done!";
+  }
+
+  my $parsed_version = $post_release ?
+    $settings->{parsed_next_version} : $settings->{parsed_version};
+  my $version = $post_release ?
+    $settings->{parsed_next_version} : $settings->{parsed_version};
+  my $metaversion = quotemeta($parsed_version->{string});
+  my $release = $post_release ? "0" : "1";
+
+  my $matched_major = 0;
+  my $matched_minor = 0;
+  my $matched_micro = 0;
+  my $matched_release = 0;
+  my $matched_version = 0;
+
+  my $status = open(VERSION_H, 'dds/Version.h') or die("Opening: $!");
   while (<VERSION_H>) {
-    if ($_ =~ /^#define DDS_MAJOR_VERSION $settings->{major_version}$/) {
+    if ($_ =~ /^#define DDS_MAJOR_VERSION $parsed_version->{major}$/) {
       ++$matched_major;
-    } elsif ($_ =~ /^#define DDS_MINOR_VERSION $settings->{minor_version}$/) {
+    } elsif ($_ =~ /^#define DDS_MINOR_VERSION $parsed_version->{minor}$/) {
       ++$matched_minor;
-    } elsif ($_ =~ /^#define DDS_MICRO_VERSION $settings->{micro_version}$/) {
+    } elsif ($_ =~ /^#define DDS_MICRO_VERSION $parsed_version->{micro}$/) {
       ++$matched_micro;
+    } elsif ($_ =~ /^#define OPENDDS_IS_RELEASE $release$/) {
+      ++$matched_release;
     } elsif ($_ =~ /^#define DDS_VERSION "$metaversion"$/) {
       ++$matched_version;
     }
   }
   close(VERSION_H);
 
-  return (($matched_major == 1) && ($matched_minor   == 1) &&
-          ($matched_micro == 1) && ($matched_version == 1));
+  return
+    $matched_major == 1 &&
+    $matched_minor == 1 &&
+    $matched_micro == 1 &&
+    $matched_release == 1 &&
+    $matched_version == 1;
 }
 
 sub message_update_version_h_file {
@@ -909,54 +1034,79 @@ sub message_update_version_h_file {
 
 sub remedy_update_version_h_file {
   my $settings = shift();
-  my $version = $settings->{version};
-  print "  >> Updating dds/Version.h file for $version\n";
-  my $corrected_major  = 0;
-  my $corrected_minor  = 0;
-  my $corrected_micro  = 0;
-  my $corrected_version = 0;
-  my $major_line = "#define DDS_MAJOR_VERSION $settings->{major_version}";
-  my $minor_line = "#define DDS_MINOR_VERSION $settings->{minor_version}";
-  my $micro_line = "#define DDS_MICRO_VERSION $settings->{micro_version}";
-  my $version_line = "#define DDS_VERSION \"$settings->{version}\"";
+  my $post_release = shift() || 0;
 
-  open(VERSION_H, "+< dds/Version.h")                 or die "Opening: $!";
+  my $parsed_version = $post_release ?
+    $settings->{parsed_next_version} : $settings->{parsed_version};
+  my $version = $parsed_version->{string};
+  my $release = $post_release ? "0" : "1";
+
+  print "  >> Updating dds/Version.h file for $version\n";
+
+  my $corrected_major = 0;
+  my $corrected_minor = 0;
+  my $corrected_micro = 0;
+  my $corrected_release = 0;
+  my $corrected_version = 0;
+
+  my $major_line = "#define DDS_MAJOR_VERSION $parsed_version->{major}";
+  my $minor_line = "#define DDS_MINOR_VERSION $parsed_version->{minor}";
+  my $micro_line = "#define DDS_MICRO_VERSION $parsed_version->{micro}";
+  my $release_line = "#define OPENDDS_IS_RELEASE $release";
+  my $version_line = "#define DDS_VERSION \"$version\"";
+
+  open(VERSION_H, "+< dds/Version.h") or die "Opening: $!";
 
   my $out = "";
 
   while (<VERSION_H>) {
-    if (s/^#define DDS_MAJOR_VERSION +[0-9]+ *$/$major_line/) {
+    if (s/^#define DDS_MAJOR_VERSION .*$/$major_line/) {
       ++$corrected_major;
-    } elsif (s/^#define DDS_MINOR_VERSION +[0-9]+ *$/$minor_line/) {
+    }
+    elsif (s/^#define DDS_MINOR_VERSION .*$/$minor_line/) {
       ++$corrected_minor;
-    } elsif (s/^#define DDS_MICRO_VERSION +[0-9]+ *$/$micro_line/) {
+    }
+    elsif (s/^#define DDS_MICRO_VERSION .*$/$micro_line/) {
       ++$corrected_micro;
-    } elsif (s/^#define DDS_VERSION ".*" *$/$version_line/) {
+    }
+    elsif (s/^#define OPENDDS_IS_RELEASE .*$/$release_line/) {
+      ++$corrected_release;
+    }
+    elsif (s/^#define DDS_VERSION .*$/$version_line/) {
       ++$corrected_version;
     }
     $out .= $_;
   }
-  seek(VERSION_H,0,0)                        or die "Seeking: $!";
-  print VERSION_H $out                       or die "Printing: $!";
-  truncate(VERSION_H,tell(VERSION_H))        or die "Truncating: $!";
-  close(VERSION_H)                           or die "Closing: $!";
 
-  return (($corrected_major == 1) && ($corrected_minor   == 1) &&
-          ($corrected_micro == 1) && ($corrected_version == 1));
+  seek(VERSION_H, 0, 0) or die "Seeking: $!";
+  print VERSION_H $out or die "Printing: $!";
+  truncate(VERSION_H, tell(VERSION_H)) or die "Truncating: $!";
+  close(VERSION_H) or die "Closing: $!";
+
+  return
+    $corrected_major == 1 &&
+    $corrected_minor == 1 &&
+    $corrected_micro == 1 &&
+    $corrected_release == 1 &&
+    $corrected_version == 1;
 }
 ############################################################################
 sub verify_update_prf_file {
   my $settings = shift();
-  my $version = $settings->{version};
-  my $matched_header  = 0;
-  my $matched_version = 0;
-  my $status = open(PRF, 'PROBLEM-REPORT-FORM');
-  my $metaversion = quotemeta($version);
+  my $post_release = shift() || 0;
 
+  my $line = quotemeta(get_version_line($settings, $post_release));
+  my $metaversion = quotemeta($post_release ?
+    $settings->{next_version} : $settings->{version});
+  my $matched_header = 0;
+  my $matched_version = 0;
+
+  my $status = open(PRF, 'PROBLEM-REPORT-FORM') or die("Opening: $!");
   while (<PRF>) {
-    if ($_ =~ /^This is OpenDDS version $metaversion, released/) {
+    if ($_ =~ /^$line/) {
       ++$matched_header;
-    } elsif ($_ =~ /OpenDDS VERSION: $metaversion$/) {
+    }
+    elsif ($_ =~ /OpenDDS VERSION: $metaversion$/) {
       ++$matched_version;
     }
   }
@@ -971,30 +1121,33 @@ sub message_update_prf_file {
 
 sub remedy_update_prf_file {
   my $settings = shift();
-  my $version = $settings->{version};
+  my $post_release = shift() || 0;
+
+  my $version = $post_release ?
+    $settings->{next_version} : $settings->{version};
   print "  >> Updating PROBLEM-REPORT-FORM file for $version\n";
+
   my $corrected_header  = 0;
   my $corrected_version = 0;
-  open(PRF, '+< PROBLEM-REPORT-FORM') or die "Opening $!";
-  my $timestamp = $settings->{timestamp};
-  my $header_line = "This is OpenDDS version $version, released $timestamp";
+  my $header_line = get_version_line($settings, $post_release);
   my $version_line = "OpenDDS VERSION: $version";
 
   my $out = "";
-
+  open(PRF, '+< PROBLEM-REPORT-FORM') or die("Opening $!");
   while (<PRF>) {
-    if (s/^This is OpenDDS version .*, released.*$/$header_line/) {
+    if (s/^This is OpenDDS version .*$/$header_line/) {
       ++$corrected_header;
-    } elsif (s/OpenDDS VERSION: .*$/$version_line/) {
+    }
+    elsif (s/OpenDDS VERSION: .*$/$version_line/) {
       ++$corrected_version;
     }
     $out .= $_;
   }
 
-  seek(PRF,0,0)                        or die "Seeking: $!";
-  print PRF $out                       or die "Printing: $!";
-  truncate(PRF,tell(PRF))              or die "Truncating: $!";
-  close(PRF)                           or die "Closing: $!";
+  seek(PRF, 0, 0) or die("Seeking: $!");
+  print PRF $out or die("Printing: $!");
+  truncate(PRF, tell(PRF)) or die("Truncating: $!");
+  close(PRF) or die("Closing: $!");
 
   return (($corrected_header == 1) && ($corrected_version == 1));
 }
@@ -1305,7 +1458,7 @@ sub remedy_zip_source {
 sub verify_md5_checksum{
   my $settings = shift();
   my $file = join("/", $settings->{workspace}, $settings->{md5_src});
-  return (-f $file);
+  return run_command("md5sum --check --quiet $file");
 }
 
 sub message_md5_checksum{
@@ -1318,7 +1471,7 @@ sub remedy_md5_checksum{
   my $md5_file = join("/", $settings->{workspace}, $settings->{md5_src});
   my $tgz_file = join("/", $settings->{workspace}, $settings->{tgz_src});
   my $zip_file = join("/", $settings->{workspace}, $settings->{zip_src});
-  return !system("md5sum $tgz_file $zip_file > $md5_file");
+  return run_command("md5sum $tgz_file $zip_file > $md5_file");
 }
 ############################################################################
 
@@ -1781,11 +1934,14 @@ sub remedy_email_dds_release_announce {
 ############################################################################
 sub verify_news_template_file_section {
   my $settings = shift();
+  my $next_version = quotemeta($settings->{next_version});
+
   my $status = open(NEWS, 'NEWS.md');
   my $has_news_template = 0;
   while (<NEWS>) {
-    if ($_ =~ /^## Version X.Y.Z of OpenDDS/) {
+    if ($_ =~ /^## Version $next_version of OpenDDS/) {
       $has_news_template = 1;
+      last;
     }
   }
   close(NEWS);
@@ -1799,95 +1955,120 @@ sub message_news_template_file_section {
 
 sub remedy_news_template_file_section {
   my $settings = shift();
-
-  insert_news_template("X.Y.Z", $timestamp_marker);
-
+  insert_news_template($settings, 1);
   return 1;
 }
 
 ############################################################################
-sub any_arg_is {
-  my $match = shift;
-  foreach my $arg (@ARGV) {
-    if ($arg eq $match) {
-      return 1;
-    }
-  }
-  return 0;
-}
-
-sub numeric_arg_value {
-  my $name = shift;
-  my @args = @ARGV[1..$#ARGV];
-  my $arg_str = join(" ", @args);
-  if ($arg_str =~ /$name ?=? ?([0-9]+)/) {
-    return $1;
-  }
-}
-
-sub string_arg_value {
-  my $name = shift;
-  my @args = @ARGV[1..$#ARGV];
-  my $arg_str = join(" ", @args);
-  if ($arg_str =~ /$name ?=? ?([^ ]+)/) {
-    return $1;
-  }
-}
 
 my $status = 0;
 
-my $print_help = any_arg_is("-h") || any_arg_is("--help");
-my $print_list = any_arg_is("--list");
-my $is_micro = any_arg_is("--micro");
-my $github_user = string_arg_value("--github-user") || $default_github_user;
-my $branch = string_arg_value("branch");
+# Process Optional Arguments
+my $print_help = 0;
+my $print_list = 0;
+my $print_list_all = 0;
+my $step_expr = 0;
+my $remedy = 0;
+my $force = 0;
+my $remote = $default_remote;
+my $branch = $default_branch;
+my $github_user = $default_github_user;
+my $download_url = $default_download_url;
+my $micro = 0;
+my $next_version = "";
+my $version_id = $default_post_release_version_id;
+my $skip_devguide = 0;
+my $skip_doxygen = 0;
+my $skip_website = 0;
+my $skip_ftp = 0;
 
-if ($is_micro && !$branch) {
-  die "For micro releases, you must define the branch you want to use with --branch";
+GetOptions(
+  'help!' => \$print_help,
+  'list!' => \$print_list,
+  'list-all!' => \$print_list_all,
+  'steps=s' => \$step_expr,
+  'remedy!' => \$remedy,
+  'force!' => \$force,
+  'remote=s' => \$remote,
+  'branch=s' => \$branch,
+  'github-user=s' => \$github_user,
+  'download-url=s' => \$download_url,
+  'micro!' => \$micro,
+  'next-version=s' => \$next_version,
+  'version-id=s' => \$version_id,
+  'skip-devguide!' => \$skip_devguide,
+  'skip-doxygen!' => \$skip_doxygen ,
+  'skip-website!' => \$skip_website ,
+  'skip-ftp!' => \$skip_ftp,
+) or die "See --help for options.\nStopped";
+
+if (!(scalar(@ARGV) == 0 || scalar(@ARGV) == 2)) {
+  die "Expecting at 0 or 2 positional arugments. See --help.\nStopped";
 }
 
-# Process Workspace Argument
+if ($print_list_all) {
+  $print_list = 1;
+}
+
+if ($micro) {
+  if ($print_list && !$branch) {
+    die "For micro releases, you must define the branch you want to use with --branch";
+  }
+  $skip_devguide = 1;
+  $skip_doxygen = 1;
+  $skip_website = 1;
+}
+
+$download_url = remove_end_slash($download_url);
+
+# Process WORKSPACE Argument
 my $workspace = $ARGV[0] || "";
-$workspace = "" if is_option($workspace);
 if ($workspace) {
   $workspace = normalizePath($workspace);
-  if (!($print_help || $print_list) && !(-d $workspace)) {
-    make_path($workspace) or die("Failed to create workspace directory: $workspace");
-  }
 }
 
-# Validate and Normalize Version String
+# Process VERSION Argument
 my %parsed_version = parse_version($ARGV[1] || "");
+my %parsed_next_version = ();
 my $version = "";
-if (%parsed_version) {
-  if ($parsed_version{micro} > 0) {
-    $version = sprintf("%d.%d.%d",
-      $parsed_version{major}, $parsed_version{minor}, $parsed_version{micro});
-  } else {
-    $version = sprintf("%d.%d",
-      $parsed_version{major}, $parsed_version{minor});
-  }
-}
-
-my $base_name = "${base_name_prefix}${version}";
-
+my $base_name = "";
 my $release_branch = "";
-if (!$is_micro && %parsed_version) {
-  $release_branch = sprintf("%s%s%d.%d",
-    $release_branch_prefix, $git_name_prefix,
-    $parsed_version{major}, $parsed_version{minor});
+if (%parsed_version) {
+  $version = $parsed_version{string};
+  $base_name = "${base_name_prefix}${version}";
+  if (!$micro) {
+    $release_branch =
+      "${release_branch_prefix}${git_name_prefix}$parsed_version{series_string}";
+    if ($parsed_version{micro} != 0) {
+      print STDERR "WARNING: " .
+        "version looks like a micro release, but --micro wasn't passed!\n";
+    }
+  }
+  if (!$next_version) {
+    $next_version = sprintf("%s.%d.%s",
+      $parsed_version{major}, int($parsed_version{minor}) + 1, "0");
+  }
+  $next_version .= "-${version_id}";
+  %parsed_next_version = parse_version($next_version);
+  if (!%parsed_next_version) {
+    die "Invalid next version: $next_version";
+  }
 }
 
 my %global_settings = (
     list         => $print_list,
-    remedy       => any_arg_is("--remedy"),
-    force        => any_arg_is("--force"),
-    micro        => $is_micro,
-    remote       => string_arg_value("--remote") || $default_remote,
-    branch       => $branch || $default_branch,
+    list_all     => $print_list_all,
+    remedy       => $remedy,
+    force        => $force,
+    micro        => $micro,
+    remote       => $remote,
+    branch       => $branch,
     release_branch => $release_branch,
     github_user  => $github_user,
     version      => $version,
+    parsed_version => \%parsed_version,
+    next_version => $next_version,
+    parsed_next_version => \%parsed_next_version,
     base_name    => $base_name,
     git_tag      => "${git_name_prefix}${version}",
     clone_dir    => join("/", $workspace, ${base_name}),
@@ -1900,7 +2081,7 @@ my %global_settings = (
     zip_dox      => "${base_name}-doxygen.zip",
     devguide_ver => "${base_name}.pdf",
     devguide_lat => "${base_name_prefix}latest.pdf",
-    timestamp    => POSIX::strftime($timefmt, gmtime),
+    timestamp    => POSIX::strftime($release_timestamp_fmt, gmtime),
     git_url      => "git\@github.com:${github_user}/${repo_name}.git",
     github_repo  => $repo_name,
     github_token => $ENV{GITHUB_TOKEN},
@@ -1916,98 +2097,99 @@ my %global_settings = (
         "docs/history/ChangeLog-$version" => 1,
         "tools/scripts/gitrelease.pl" => 1,
     },
-    skip_ftp     => any_arg_is("--skip-ftp"),
-    skip_devguide=> any_arg_is("--skip-devguide") || $is_micro,
-    skip_doxygen => any_arg_is("--skip-doxygen") || $is_micro,
-    skip_website => any_arg_is("--skip-website") || $is_micro,
+    skip_ftp     => $skip_ftp,
+    skip_devguide=> $skip_devguide,
+    skip_doxygen => $skip_doxygen,
+    skip_website => $skip_website,
     workspace    => $workspace,
-    download_url => remove_end_slash(string_arg_value("--download-url")) || $default_download_url,
+    download_url => $download_url,
     ace_root     => "$workspace/$ace_root"
 );
 
-if (%parsed_version) {
-  $global_settings{major_version} = $parsed_version{major};
-  $global_settings{minor_version} = $parsed_version{minor};
-  $global_settings{micro_version} = $parsed_version{micro};
-}
-
 my @release_steps  = (
   {
-    name    => 'Update VERSION.txt',
+    name => 'Create Workspace Directory',
+    verify => sub{return -d $_[0]->{workspace};},
+    message => sub{return "Workspace directory needs to be created."},
+    remedy => sub{return make_path($_[0]->{workspace});},
+  },
+  {
+    name    => 'Update VERSION.txt File',
     verify  => sub{verify_update_version_file(@_)},
     message => sub{message_update_version_file(@_)},
     remedy  => sub{remedy_update_version_file(@_)},
     can_force => 1,
   },
   {
-    name    => 'Update Version.h',
+    name    => 'Update Version.h File',
     verify  => sub{verify_update_version_h_file(@_)},
     message => sub{message_update_version_h_file(@_)},
     remedy  => sub{remedy_update_version_h_file(@_)},
     can_force => 1,
   },
   {
-    name    => 'Update PROBLEM-REPORT-FORM',
+    name    => 'Update PROBLEM-REPORT-FORM File',
     verify  => sub{verify_update_prf_file(@_)},
     message => sub{message_update_prf_file(@_)},
     remedy  => sub{remedy_update_prf_file(@_)},
     can_force => 1,
   },
   {
-    name    => 'Verify remote arg',
+    name    => 'Verify Remote',
     verify  => sub{verify_git_remote(@_)},
     message => sub{message_git_remote(@_)},
     remedy  => sub{override_git_remote(@_)},
   },
   {
-    name    => 'Create ChangeLog',
+    name    => 'Create ChangeLog File',
     verify  => sub{verify_changelog(@_)},
     message => sub{message_changelog(@_)},
     remedy  => sub{remedy_changelog(@_)},
     can_force => 1,
   },
   {
-    name    => 'Update Authors',
+    name    => 'Update AUTHORS File',
+    prereqs => ['Create Workspace Directory'],
     verify  => sub{verify_authors(@_)},
     message => sub{message_authors(@_)},
     remedy  => sub{remedy_authors(@_)},
     can_force => 1,
   },
   {
-    name    => 'Add NEWS Section',
+    name    => 'Add NEWS File Section',
     verify  => sub{verify_news_file_section(@_)},
     message => sub{message_news_file_section(@_)},
     remedy  => sub{remedy_news_file_section(@_)},
     can_force => 1,
   },
   {
-    name    => 'Update NEWS Section',
+    name    => 'Update NEWS File Section',
     verify  => sub{verify_update_news_file(@_)},
     message => sub{message_update_news_file(@_)},
     can_force => 1,
   },
   {
-    name    => 'Update NEWS Section Timestamp',
+    name    => 'Update NEWS File Section Timestamp',
     verify  => sub{verify_news_timestamp(@_)},
     message => sub{message_news_timestamp(@_)},
     remedy  => sub{remedy_news_timestamp(@_)},
     can_force => 1,
   },
   {
-    name    => 'Commit changes to GIT',
+    name    => 'Commit Release Changes',
     verify  => sub{verify_git_status_clean(@_, 1)},
     message => sub{message_commit_git_changes(@_)},
     remedy  => sub{remedy_git_status_clean(@_)}
   },
   {
-    name    => 'Create git tag',
+    name    => 'Create Tag',
     verify  => sub{verify_git_tag(@_)},
     message => sub{message_git_tag(@_)},
     remedy  => sub{remedy_git_tag(@_)}
   },
   {
-    name    => 'Verify changes pushed',
-    prereqs => ['Verify remote arg'],
+    name    => 'Push Release Changes',
+    prereqs => ['Verify Remote'],
     verify  => sub{verify_git_changes_pushed(@_, 1)},
     message => sub{message_git_changes_pushed(@_)},
     remedy  => sub{remedy_git_changes_pushed(@_, 1)}
@@ -2021,39 +2203,42 @@ my @release_steps  = (
   },
   {
     name    => 'Push Release Branch',
-    prereqs => ['Create Release Branch', 'Verify remote arg'],
+    prereqs => ['Create Release Branch', 'Verify Remote'],
     verify  => sub{verify_push_release_branch(@_)},
     message => sub{message_push_release_branch(@_)},
     remedy  => sub{remedy_push_release_branch(@_)},
     skip    => !$global_settings{release_branch},
   },
   {
-    name    => 'Clone tag',
-    prereqs => ['Verify remote arg'],
+    name    => 'Clone Tag',
+    prereqs => ['Verify Remote'],
     verify  => sub{verify_clone_tag(@_)},
     message => sub{message_clone_tag(@_)},
     remedy  => sub{remedy_clone_tag(@_)}
   },
   {
-    name    => 'Move changelog',
+    name    => 'Move ChangeLog File',
     verify  => sub{verify_move_changelog(@_)},
     message => sub{message_move_changelog(@_)},
     remedy  => sub{remedy_move_changelog(@_)}
   },
   {
-    name    => 'Create unix release archive',
+    name    => 'Create Unix Release Archive',
+    prereqs => ['Create Workspace Directory'],
     verify  => sub{verify_tgz_source(@_)},
     message => sub{message_tgz_source(@_)},
     remedy  => sub{remedy_tgz_source(@_)}
   },
   {
-    name    => 'Create windows release archive',
+    name    => 'Create Windows Release Archive',
+    prereqs => ['Create Workspace Directory'],
     verify  => sub{verify_zip_source(@_)},
     message => sub{message_zip_source(@_)},
     remedy  => sub{remedy_zip_source(@_)}
   },
   {
     name    => 'Download OCI ACE/TAO',
+    prereqs => ['Create Workspace Directory'],
     verify  => sub{verify_download_ace_tao(@_)},
     message => sub{message_download_ace_tao(@_)},
     remedy  => sub{remedy_download_ace_tao(@_)},
@@ -2068,7 +2253,7 @@ my @release_steps  = (
     skip    => $global_settings{skip_doxygen},
   },
   {
-    name    => 'Generate doxygen',
+    name    => 'Generate Doxygen',
     prereqs => ['Extract OCI ACE/TAO'],
     verify  => sub{verify_gen_doxygen(@_)},
     message => sub{message_gen_doxygen(@_)},
@@ -2076,29 +2261,34 @@ my @release_steps  = (
     skip    => $global_settings{skip_doxygen},
   },
   {
-    name    => 'Create unix doxygen archive',
-    prereqs => ['Generate doxygen'],
+    name    => 'Create Unix Doxygen Archive',
+    prereqs => ['Generate Doxygen'],
     verify  => sub{verify_tgz_doxygen(@_)},
     message => sub{message_tgz_doxygen(@_)},
     remedy  => sub{remedy_tgz_doxygen(@_)},
     skip    => $global_settings{skip_doxygen},
   },
   {
-    name    => 'Create windows doxygen archive',
-    prereqs => ['Generate doxygen'],
+    name    => 'Create Windows Doxygen Archive',
+    prereqs => ['Generate Doxygen'],
     verify  => sub{verify_zip_doxygen(@_)},
     message => sub{message_zip_doxygen(@_)},
     remedy  => sub{remedy_zip_doxygen(@_)},
     skip    => $global_settings{skip_doxygen},
   },
   {
-    name    => 'Create md5 checksum',
+    name    => 'Create MD5 Checksum File',
+    prereqs => [
+      'Create Unix Release Archive',
+      'Create Windows Release Archive',
+    ],
     verify  => sub{verify_md5_checksum(@_)},
     message => sub{message_md5_checksum(@_)},
     remedy  => sub{remedy_md5_checksum(@_)},
   },
   {
     name    => 'Download Devguide',
+    prereqs => ['Create Workspace Directory'],
     verify  => sub{verify_devguide(@_)},
     message => sub{message_devguide(@_)},
     remedy  => sub{remedy_devguide(@_)},
@@ -2125,22 +2315,43 @@ my @release_steps  = (
     skip    => $global_settings{skip_website},
   },
   {
-    name    => 'Add NEWS Template Section',
+    name    => 'Update NEWS for Post-Release',
     verify  => sub{verify_news_template_file_section(@_)},
     message => sub{message_news_template_file_section(@_)},
     remedy  => sub{remedy_news_template_file_section(@_)},
     skip    => $global_settings{micro},
   },
   {
-    name    => 'Commit NEWS Template Section',
+    name    => 'Update VERSION.txt for Post-Release',
+    verify  => sub{verify_update_version_file(@_, 1)},
+    message => sub{message_update_version_file(@_)},
+    remedy  => sub{remedy_update_version_file(@_, 1)},
+    can_force => 1,
+  },
+  {
+    name    => 'Update Version.h for Post-Release',
+    verify  => sub{verify_update_version_h_file(@_, 1)},
+    message => sub{message_update_version_h_file(@_)},
+    remedy  => sub{remedy_update_version_h_file(@_, 1)},
+    can_force => 1,
+  },
+  {
+    name    => 'Update PROBLEM-REPORT-FORM for Post-Release',
+    verify  => sub{verify_update_prf_file(@_, 1)},
+    message => sub{message_update_prf_file(@_, 1)},
+    remedy  => sub{remedy_update_prf_file(@_, 1)},
+    can_force => 1,
+  },
+  {
+    name    => 'Commit Post-Release Changes',
     verify  => sub{verify_git_status_clean(@_, 1)},
     message => sub{message_commit_git_changes(@_)},
     remedy  => sub{remedy_git_status_clean(@_)},
     skip    => $global_settings{micro},
   },
   {
-    name    => 'Push NEWS Template Section',
-    prereqs => ['Verify remote arg'],
+    name    => 'Push Post-Release Changes',
+    prereqs => ['Verify Remote'],
     verify  => sub{verify_git_changes_pushed(@_, 1)},
     message => sub{message_git_changes_pushed(@_)},
     remedy  => sub{remedy_git_changes_pushed(@_, 0)}
@@ -2196,7 +2407,7 @@ sub run_step {
   my $step = $release_steps->[$step_count-1];
   my $title = $step->{name};
 
-  return if $step->{skip} || $step->{verified};
+  return if (!$settings->{list_all} && ($step->{skip} || $step->{verified}));
   print "$step_count: $title\n";
   return if $settings->{list};
 
@@ -2224,6 +2435,7 @@ sub run_step {
       } elsif (!$step->{verify}($settings)) {
         print "  !!!! Remediation did not pass verification\n";
       } else {
+        print "  Done!\n";
         $remedied = 1;
       }
     }
@@ -2247,27 +2459,31 @@ sub run_step {
     print "$divider\n";
   }
 
+  print "  OK!\n";
+
   $step->{verified} = 1;
 }
 
-if (!$print_help && ($global_settings{list} || %parsed_version)) {
+if ($print_help) {
+  print usage();
+}
+elsif ($global_settings{list} || ($workspace && %parsed_version)) {
   my @steps_to_do;
   my $no_steps = scalar(@release_steps);
-  if (defined($ARGV[1]) && !is_option($ARGV[2])) {
-    @steps_to_do = parse_step_expr($no_steps, $ARGV[2]);
-  } else {
+  if ($step_expr) {
+    @steps_to_do = parse_step_expr($no_steps, $step_expr);
+  }
+  else {
     @steps_to_do = 1..$no_steps;
   }
 
   foreach my $step_count (@steps_to_do) {
     run_step(\%global_settings, \@release_steps, $step_count);
   }
-} elsif (!$print_help) {
+}
+else {
   $status = 1;
-  $print_help = 1;
-  print "Invalid Arguments, see --help for Valid Usage\n";
-} else {
-  print usage();
+  print STDERR "ERROR: Invalid Arguments, see --help for Valid Usage\n";
 }
 
 exit $status;


### PR DESCRIPTION
- New version scheme where between releases OpenDDS master will have a version consisting of the next planned major or minor version and `-dev` (`3.14.0-dev` in the current case).
- Release Script Changes:
  - Modify for new version scheme, allowing next version to be overridden.
  - Use `Getopt::Long`.
  - Turn `STEPS` argument into an option because of issues with the step expressions and `Getopt::Long`
  - Release date inserted into files is now shorter: Feb 22 2020, for example.
  - Regularize step names.
- Added `OPENDDS_IS_RELEASE` to `dds/Version.h` which is defined as 1 in releases, 0 all other times.
- Update `AUTHORS` file.