### PR TITLE
Support recreating the service participant

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -274,6 +274,7 @@ Service_Participant::shutdown()
         ACE_GUARD(ACE_Thread_Mutex, guard, network_config_monitor_lock_);
         if (network_config_monitor_) {
           network_config_monitor_->close();
+          network_config_monitor_.reset();
         }
       }
 
@@ -2072,6 +2073,7 @@ NetworkConfigMonitor_rch Service_Participant::network_config_monitor()
     if (network_config_monitor_ && !network_config_monitor_->open()) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Service_Participant::network_config_monitor could not open network config monitor\n ")));
       network_config_monitor_->close();
+      network_config_monitor_.reset();
     }
   }
 

--- a/dds/DCPS/security/BuiltInPluginLoader.cpp
+++ b/dds/DCPS/security/BuiltInPluginLoader.cpp
@@ -22,8 +22,6 @@ static const std::string PLUGIN_NAME("BuiltIn");
 int
 BuiltInPluginLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 {
-  static bool initialized(false);
-
   if (initialized) return 0;  // already initialized
 
   SecurityPluginInst_rch plugin = DCPS::make_rch<BuiltInSecurityPluginInst>();

--- a/dds/DCPS/security/BuiltInPluginLoader.h
+++ b/dds/DCPS/security/BuiltInPluginLoader.h
@@ -29,7 +29,6 @@ public:
 
 private:
   bool initialized;
-  
 public:
   BuiltInPluginLoader() : initialized(false) {}
 };

--- a/dds/DCPS/security/BuiltInPluginLoader.h
+++ b/dds/DCPS/security/BuiltInPluginLoader.h
@@ -26,6 +26,9 @@ class DdsSecurity_Export BuiltInPluginLoader : public ACE_Service_Object
 {
 public:
   virtual int init(int argc, ACE_TCHAR* argv[]);
+
+private:
+  bool initialized = false;
 };
 
 ACE_STATIC_SVC_DECLARE_EXPORT(DdsSecurity, BuiltInPluginLoader)

--- a/dds/DCPS/security/BuiltInPluginLoader.h
+++ b/dds/DCPS/security/BuiltInPluginLoader.h
@@ -31,7 +31,7 @@ private:
   bool initialized;
   
 public:
-  BuiltinPluginLoader() : initialized(false) {}
+  BuiltInPluginLoader() : initialized(false) {}
 };
 
 ACE_STATIC_SVC_DECLARE_EXPORT(DdsSecurity, BuiltInPluginLoader)

--- a/dds/DCPS/security/BuiltInPluginLoader.h
+++ b/dds/DCPS/security/BuiltInPluginLoader.h
@@ -28,7 +28,10 @@ public:
   virtual int init(int argc, ACE_TCHAR* argv[]);
 
 private:
-  bool initialized = false;
+  bool initialized;
+  
+public:
+  BuiltinPluginLoader() : initialized(false) {}
 };
 
 ACE_STATIC_SVC_DECLARE_EXPORT(DdsSecurity, BuiltInPluginLoader)


### PR DESCRIPTION
Clean up NetworkConfigMonitor and BuiltinPluginLoader on shutdown.
This allows the service participant to be destroyed and recreated.