### PR TITLE
Control for Security Debug in PerlDDS

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -131,6 +131,7 @@ sub report_errors_in_file {
 my $config = new PerlACE::ConfigList;
 $PerlDDS::Coverage_Test = $config->check_config("Coverage");
 $PerlDDS::SafetyProfile = $config->check_config("OPENDDS_SAFETY_PROFILE");
+$PerlDDS::security = $config->check_config("OPENDDS_SECURITY");
 
 # used to prevent multiple special processes from running remotely
 $PerlDDS::Special_Process_Created = 0;
@@ -324,6 +325,10 @@ sub new {
   $self->{report_errors_in_log_file} = 1;
   $self->{dcps_debug_level} = 1;
   $self->{dcps_transport_debug_level} = 1;
+  $self->{dcps_security_debug} = defined $ENV{DCPSSecurityDebug} ?
+    $ENV{DCPSSecurityDebug} : "";
+  $self->{dcps_security_debug_level} = defined $ENV{DCPSSecurityDebugLevel} ?
+    $ENV{DCPSSecurityDebugLevel} : ($PerlDDS::security ? "9" : "");
   $self->{add_orb_log_file} = 1;
   $self->{wait_after_first_proc} = 25;
   $self->{finished} = 0;
@@ -573,6 +578,15 @@ sub process {
       $self->{dcps_transport_debug_level}) {
     my $debug = " -DCPSTransportDebugLevel $self->{dcps_transport_debug_level}";
     $params .= $debug;
+  }
+
+  if ($params !~ /-DCPSSecurityDebug(?:Level)? /) {
+    if ($self->{dcps_security_debug}) {
+      $params .=  " -DCPSSecurityDebug $self->{dcps_security_debug}";
+    }
+    elsif ($self->{dcps_security_debug_level}) {
+      $params .=  " -DCPSSecurityDebugLevel $self->{dcps_security_debug_level}";
+    }
   }
 
   if ($self->{add_orb_log_file} && $params !~ /-ORBLogFile ([^ ]+)/) {

--- a/tests/DCPS/Messenger/run_test.pl
+++ b/tests/DCPS/Messenger/run_test.pl
@@ -27,7 +27,6 @@ my $sub_opts = "$dbg_lvl";
 my $repo_bit_opt = "";
 my $stack_based = 0;
 my $is_rtps_disc = 0;
-my $secure = 0;
 my $DCPSREPO;
 
 my $thread_per_connection = "";
@@ -83,19 +82,16 @@ elsif ($test->flag('rtps_disc_half_sec_pub')) {
     $pub_opts .= " -DCPSConfigFile rtps_disc_sec.ini";
     $sub_opts .= " -DCPSConfigFile rtps_disc.ini";
     $is_rtps_disc = 1;
-    $secure = 1;
 }
 elsif ($test->flag('rtps_disc_half_sec_sub')) {
     $pub_opts .= " -DCPSConfigFile rtps_disc.ini";
     $sub_opts .= " -DCPSConfigFile rtps_disc_sec.ini";
     $is_rtps_disc = 1;
-    $secure = 1;
 }
 elsif ($test->flag('rtps_disc_sec')) {
     $pub_opts .= " -DCPSConfigFile rtps_disc_sec.ini";
     $sub_opts .= " -DCPSConfigFile rtps_disc_sec.ini";
     $is_rtps_disc = 1;
-    $secure = 1;
 }
 elsif ($test->flag('rtps_disc_tcp')) {
     $pub_opts .= " -DCPSConfigFile rtps_disc_tcp.ini";
@@ -134,12 +130,6 @@ else {
 }
 
 $test->report_unused_flags(!$flag_found);
-
-if ($secure) {
-  my $seclog = " -DCPSSecurityDebugLevel 9";
-  $pub_opts .= $seclog;
-  $sub_opts .= $seclog;
-}
 
 $pub_opts .= $thread_per_connection;
 


### PR DESCRIPTION
Default to passing `-DCPSSecurityDebug 9` when `-Config OPENDDS_SECURITY` is passed, unless `-DCPSSecurityDebug` or `-DCPSSecurityDebugLevel` was specified in the test or `DCPSSecurityDebug` or `DCPSSecurityDebugLevel` environment variables were set.

Fixes secure messenger test failing on non-secure scoreboard builds caused by #1572. `-Config OPENDDS_SECURITY` will have to be passed on all security builds, but I'm ready to commit that.