### PR TITLE
Increase pool_size and wait time parameters for WaitForAck Test

### DIFF
--- a/tests/DCPS/WaitForAck/Publisher.cpp
+++ b/tests/DCPS/WaitForAck/Publisher.cpp
@@ -273,7 +273,7 @@ Publisher::run()
   // Allow some traffic to occur before making any wait() calls.
   ACE_OS::sleep( 2);
 
-  ::DDS::Duration_t delay = { 5, 0 }; // Wait for up to 5 seconds.
+  ::DDS::Duration_t delay = { 15, 0 }; // Wait for up to 15 seconds.
   if (this->options_.publisher())
   {
     DDS::ReturnCode_t error =

--- a/tests/DCPS/WaitForAck/rtps.ini
+++ b/tests/DCPS/WaitForAck/rtps.ini
@@ -1,6 +1,6 @@
 [common]
 DCPSGlobalTransportConfig=$file
-pool_size=30000000
+pool_size=500000000
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp


### PR DESCRIPTION
In order to ensure safety profile build successes