### PR TITLE
Use reference counting for ICE

### DIFF
--- a/dds/DCPS/RTPS/ICE/AgentImpl.h
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.h
@@ -125,7 +125,7 @@ private:
     {}
     bool operator<(const Item& other) const
     {
-      return this->release_time_ > other.release_time_;
+      return release_time_ > other.release_time_;
     }
   };
   std::priority_queue<Item> tasks_;

--- a/dds/DCPS/RTPS/ICE/Checklist.cpp
+++ b/dds/DCPS/RTPS/ICE/Checklist.cpp
@@ -9,6 +9,7 @@
 
 #include "Checklist.h"
 
+#include "AgentImpl.h"
 #include "EndpointManager.h"
 #include "Ice.h"
 
@@ -85,7 +86,6 @@ ConnectivityCheck::ConnectivityCheck(const CandidatePair& a_candidate_pair,
 Checklist::Checklist(EndpointManager* a_endpoint_manager,
                      const AgentInfo& local, const AgentInfo& remote, ACE_UINT64 a_ice_tie_breaker)
   : Task(a_endpoint_manager->agent_impl)
-  , scheduled_for_destruction_(false)
   , endpoint_manager_(a_endpoint_manager)
   , local_agent_info_(local)
   , remote_agent_info_(remote)
@@ -96,33 +96,13 @@ Checklist::Checklist(EndpointManager* a_endpoint_manager,
   , nominated_(valid_list_.end())
   , nominated_is_live_(false)
 {
-  endpoint_manager_->set_responsible_checklist(remote_agent_info_.username, this);
+  endpoint_manager_->set_responsible_checklist(remote_agent_info_.username, rchandle_from(this));
 
   generate_candidate_pairs();
 }
 
-void Checklist::reset()
+Checklist::~Checklist()
 {
-  fix_foundations();
-
-  for (ConnectivityChecksType::const_iterator pos = connectivity_checks_.begin(),
-       limit = connectivity_checks_.end(); pos != limit; ++pos) {
-    endpoint_manager_->unset_responsible_checklist(pos->request().transaction_id, this);
-  }
-
-  frozen_.clear();
-  waiting_.clear();
-  in_progress_.clear();
-  succeeded_.clear();
-  failed_.clear();
-  triggered_check_queue_.clear();
-  valid_list_.clear();
-  nominating_ = valid_list_.end();
-  nominated_ = valid_list_.end();
-  nominated_is_live_ = false;
-  check_interval_ = TimeDuration::zero_value;
-  max_check_interval_ = TimeDuration::zero_value;
-  connectivity_checks_.clear();
 }
 
 void Checklist::generate_candidate_pairs()
@@ -492,7 +472,7 @@ void Checklist::success_response(const ACE_INET_Addr& local_address,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING Unknown comprehension required attributes\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
@@ -500,7 +480,7 @@ void Checklist::success_response(const ACE_INET_Addr& local_address,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No FINGERPRINT attribute\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
@@ -510,7 +490,7 @@ void Checklist::success_response(const ACE_INET_Addr& local_address,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No (XOR_)MAPPED_ADDRESS attribute\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
@@ -518,7 +498,7 @@ void Checklist::success_response(const ACE_INET_Addr& local_address,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING No MESSAGE_INTEGRITY attribute\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
@@ -527,13 +507,13 @@ void Checklist::success_response(const ACE_INET_Addr& local_address,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::success_response: WARNING MESSAGE_INTEGRITY check failed\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
   // At this point the check will either succeed or fail so remove from the list.
   connectivity_checks_.erase(pos);
-  endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+  endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
 
   const CandidatePair& cp = cc.candidate_pair();
 
@@ -595,7 +575,7 @@ void Checklist::error_response(const ACE_INET_Addr& /*local_address*/,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING Unknown comprehension required attributes\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
@@ -603,7 +583,7 @@ void Checklist::error_response(const ACE_INET_Addr& /*local_address*/,
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::error_response: WARNING No FINGERPRINT attribute\n")));
     failed(cc);
     connectivity_checks_.erase(pos);
-    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     return;
   }
 
@@ -626,7 +606,7 @@ void Checklist::error_response(const ACE_INET_Addr& /*local_address*/,
       // Waiting and/or resending won't fix these errors.
       failed(cc);
       connectivity_checks_.erase(pos);
-      endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, this);
+      endpoint_manager_->unset_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     }
   }
 
@@ -650,7 +630,7 @@ void Checklist::do_next_check(const MonotonicTimePoint& a_now)
 
     endpoint_manager_->send(cc.candidate_pair().remote.address, cc.request());
     connectivity_checks_.push_back(cc);
-    endpoint_manager_->set_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->set_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
     return;
   }
@@ -667,7 +647,7 @@ void Checklist::do_next_check(const MonotonicTimePoint& a_now)
 
     endpoint_manager_->send(cc.candidate_pair().remote.address, cc.request());
     connectivity_checks_.push_back(cc);
-    endpoint_manager_->set_responsible_checklist(cc.request().transaction_id, this);
+    endpoint_manager_->set_responsible_checklist(cc.request().transaction_id, rchandle_from(this));
     check_interval_ = endpoint_manager_->agent_impl->get_configuration().T_a();
     return;
   }
@@ -708,11 +688,6 @@ void Checklist::do_next_check(const MonotonicTimePoint& a_now)
 
 void Checklist::execute(const MonotonicTimePoint& a_now)
 {
-  if (scheduled_for_destruction_) {
-    delete this;
-    return;
-  }
-
   // Nominating check.
   if (frozen_.empty() &&
       waiting_.empty() &&
@@ -771,23 +746,25 @@ void Checklist::execute(const MonotonicTimePoint& a_now)
 void Checklist::add_guid(const GuidPair& a_guid_pair)
 {
   guids_.insert(a_guid_pair);
-  endpoint_manager_->set_responsible_checklist(a_guid_pair, this);
+  endpoint_manager_->set_responsible_checklist(a_guid_pair, rchandle_from(this));
 }
 
 void Checklist::remove_guid(const GuidPair& a_guid_pair)
 {
   guids_.erase(a_guid_pair);
-  endpoint_manager_->unset_responsible_checklist(a_guid_pair, this);
+  endpoint_manager_->unset_responsible_checklist(a_guid_pair, rchandle_from(this));
 
   if (guids_.empty()) {
     // Cleanup this checklist.
-    endpoint_manager_->unset_responsible_checklist(remote_agent_info_.username, this);
-    reset();
-    scheduled_for_destruction_ = true;
+    fix_foundations();
 
-    // Flush ourselves out of the task queue.
-    // Schedule for now but it may be later.
-    enqueue(MonotonicTimePoint::now());
+    for (ConnectivityChecksType::const_iterator pos = connectivity_checks_.begin(),
+           limit = connectivity_checks_.end(); pos != limit; ++pos) {
+      endpoint_manager_->unset_responsible_checklist(pos->request().transaction_id, rchandle_from(this));
+    }
+
+    // This should drop our ref-count to zero.
+    endpoint_manager_->unset_responsible_checklist(remote_agent_info_.username, rchandle_from(this));
   }
 }
 

--- a/dds/DCPS/RTPS/ICE/Checklist.h
+++ b/dds/DCPS/RTPS/ICE/Checklist.h
@@ -32,14 +32,14 @@ public:
   void add(const FoundationType& a_foundation)
   {
     std::pair<FoundationsType::iterator, bool> x = foundations_.insert(std::make_pair(a_foundation, 0));
-    x.first->second += 1;
+    ++x.first->second;
   }
 
   bool remove(const FoundationType& a_foundation)
   {
     FoundationsType::iterator pos = foundations_.find(a_foundation);
     OPENDDS_ASSERT(pos != foundations_.end());
-    pos->second -= 1;
+    --pos->second;
 
     if (pos->second == 0) {
       foundations_.erase(pos);

--- a/dds/DCPS/RTPS/ICE/EndpointManager.h
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.h
@@ -27,7 +27,6 @@ namespace OpenDDS {
 namespace ICE {
 
 class AgentImpl;
-struct Checklist;
 
 struct DeferredTriggeredCheck {
   ACE_INET_Addr local_address;
@@ -49,7 +48,7 @@ struct DeferredTriggeredCheck {
   {}
 };
 
-struct EndpointManager {
+struct EndpointManager : public DCPS::RcObject {
   AgentImpl* const agent_impl;
   Endpoint* const endpoint;
 
@@ -91,13 +90,13 @@ struct EndpointManager {
                const ACE_INET_Addr& a_remote_address,
                const STUN::Message& a_message);
 
-  void set_responsible_checklist(const STUN::TransactionId& a_transaction_id, Checklist* a_checklist)
+  void set_responsible_checklist(const STUN::TransactionId& a_transaction_id, ChecklistPtr a_checklist)
   {
     OPENDDS_ASSERT(!transaction_id_to_checklist_.count(a_transaction_id));
     transaction_id_to_checklist_[a_transaction_id] = a_checklist;
   }
 
-  void unset_responsible_checklist(const STUN::TransactionId& a_transaction_id, Checklist* a_checklist)
+  void unset_responsible_checklist(const STUN::TransactionId& a_transaction_id, ChecklistPtr a_checklist)
   {
     TransactionIdToChecklistType::iterator pos = transaction_id_to_checklist_.find(a_transaction_id);
     OPENDDS_ASSERT(pos != transaction_id_to_checklist_.end());
@@ -106,13 +105,13 @@ struct EndpointManager {
     transaction_id_to_checklist_.erase(pos);
   }
 
-  void set_responsible_checklist(const GuidPair& a_guid_pair, Checklist* a_checklist)
+  void set_responsible_checklist(const GuidPair& a_guid_pair, ChecklistPtr a_checklist)
   {
     OPENDDS_ASSERT(!guid_pair_to_checklist_.count(a_guid_pair));
     guid_pair_to_checklist_[a_guid_pair] = a_checklist;
   }
 
-  void unset_responsible_checklist(const GuidPair& a_guid_pair, Checklist* a_checklist)
+  void unset_responsible_checklist(const GuidPair& a_guid_pair, ChecklistPtr a_checklist)
   {
     GuidPairToChecklistType::iterator pos = guid_pair_to_checklist_.find(a_guid_pair);
     OPENDDS_ASSERT(pos != guid_pair_to_checklist_.end());
@@ -121,13 +120,13 @@ struct EndpointManager {
     guid_pair_to_checklist_.erase(pos);
   }
 
-  void set_responsible_checklist(const std::string& a_username, Checklist* a_checklist)
+  void set_responsible_checklist(const std::string& a_username, ChecklistPtr a_checklist)
   {
     OPENDDS_ASSERT(!username_to_checklist_.count(a_username));
     username_to_checklist_[a_username] = a_checklist;
   }
 
-  void unset_responsible_checklist(const std::string& a_username, Checklist* a_checklist)
+  void unset_responsible_checklist(const std::string& a_username, ChecklistPtr a_checklist)
   {
     UsernameToChecklistType::iterator pos = username_to_checklist_.find(a_username);
     OPENDDS_ASSERT(pos != username_to_checklist_.end());
@@ -144,8 +143,6 @@ struct EndpointManager {
 
   void check_invariants() const;
 
-  void schedule_for_destruction();
-
   void ice_connect(const GuidSetType& guids, const ACE_INET_Addr& addr)
   {
     endpoint->ice_connect(guids, addr);
@@ -160,8 +157,9 @@ struct EndpointManager {
 
   void send(const ACE_INET_Addr& address, const STUN::Message& message);
 
+  void purge();
+
 private:
-  bool scheduled_for_destruction_;
   AddressListType host_addresses_;          // Cached list of host addresses.
   ACE_INET_Addr server_reflexive_address_;  // Server-reflexive address (from STUN server).
   ACE_INET_Addr stun_server_address_;       // Address of the STUN server.
@@ -180,15 +178,15 @@ private:
   DeferredTriggeredChecksType deferred_triggered_checks_;
 
   // Managed by checklists.
-  typedef std::map<std::string, Checklist*> UsernameToChecklistType;
+  typedef std::map<std::string, ChecklistPtr> UsernameToChecklistType;
   UsernameToChecklistType username_to_checklist_;
 
   // Managed by checklists.
-  typedef std::map<STUN::TransactionId, Checklist*> TransactionIdToChecklistType;
+  typedef std::map<STUN::TransactionId, ChecklistPtr> TransactionIdToChecklistType;
   TransactionIdToChecklistType transaction_id_to_checklist_;
 
   // Managed by checklists.
-  typedef std::map<GuidPair, Checklist*> GuidPairToChecklistType;
+  typedef std::map<GuidPair, ChecklistPtr> GuidPairToChecklistType;
   GuidPairToChecklistType guid_pair_to_checklist_;
 
   typedef std::map<DCPS::RepoId, AgentInfoListener*, DCPS::GUID_tKeyLessThan> AgentInfoListenersType;
@@ -211,7 +209,7 @@ private:
 
   bool error_response(const STUN::Message& a_message);
 
-  Checklist* create_checklist(const AgentInfo& a_remote_agent_info);
+  ChecklistPtr create_checklist(const AgentInfo& a_remote_agent_info);
 
   // STUN Message processing.
   STUN::Message make_unknown_attributes_error_response(const STUN::Message& a_message,
@@ -239,17 +237,21 @@ private:
                       const STUN::Message& a_message);
 
   struct ServerReflexiveTask : public Task {
-    EndpointManager* endpoint_manager;
-    ServerReflexiveTask(EndpointManager* a_endpoint_manager);
+    DCPS::WeakRcHandle<EndpointManager> endpoint_manager;
+    ServerReflexiveTask(DCPS::RcHandle<EndpointManager> a_endpoint_manager);
     void execute(const DCPS::MonotonicTimePoint& a_now);
-  } server_reflexive_task_;
+  };
+  DCPS::RcHandle<ServerReflexiveTask> server_reflexive_task_;
 
   struct ChangePasswordTask : public Task {
-    EndpointManager* endpoint_manager;
-    ChangePasswordTask(EndpointManager* a_endpoint_manager);
+    DCPS::WeakRcHandle<EndpointManager> endpoint_manager;
+    ChangePasswordTask(DCPS::RcHandle<EndpointManager> a_endpoint_manager);
     void execute(const DCPS::MonotonicTimePoint& a_now);
-  } change_password_task_;
+  };
+  DCPS::RcHandle<ChangePasswordTask> change_password_task_;
 };
+
+typedef DCPS::RcHandle<EndpointManager> EndpointManagerPtr;
 
 } // namespace ICE
 } // namespace OpenDDS

--- a/dds/DCPS/RTPS/ICE/EndpointManager.h
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.h
@@ -238,14 +238,14 @@ private:
 
   struct ServerReflexiveTask : public Task {
     DCPS::WeakRcHandle<EndpointManager> endpoint_manager;
-    ServerReflexiveTask(DCPS::RcHandle<EndpointManager> a_endpoint_manager);
+    explicit ServerReflexiveTask(DCPS::RcHandle<EndpointManager> a_endpoint_manager);
     void execute(const DCPS::MonotonicTimePoint& a_now);
   };
   DCPS::RcHandle<ServerReflexiveTask> server_reflexive_task_;
 
   struct ChangePasswordTask : public Task {
     DCPS::WeakRcHandle<EndpointManager> endpoint_manager;
-    ChangePasswordTask(DCPS::RcHandle<EndpointManager> a_endpoint_manager);
+    explicit ChangePasswordTask(DCPS::RcHandle<EndpointManager> a_endpoint_manager);
     void execute(const DCPS::MonotonicTimePoint& a_now);
   };
   DCPS::RcHandle<ChangePasswordTask> change_password_task_;

--- a/dds/DCPS/RTPS/ICE/Task.cpp
+++ b/dds/DCPS/RTPS/ICE/Task.cpp
@@ -18,8 +18,7 @@ namespace ICE {
 
 void Task::enqueue(const DCPS::MonotonicTimePoint& a_release_time)
 {
-  release_time_ = a_release_time;
-  agent_impl_->enqueue(this);
+  agent_impl_->enqueue(a_release_time, rchandle_from(this));
 }
 
 #endif /* OPENDDS_SECURITY */

--- a/dds/DCPS/RTPS/ICE/Task.h
+++ b/dds/DCPS/RTPS/ICE/Task.h
@@ -12,8 +12,10 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "dds/Versioned_Namespace.h"
+#include "dds/DCPS/RcObject.h"
 #include "dds/DCPS/TimeTypes.h"
+#include "dds/Versioned_Namespace.h"
+
 #include <ace/Time_Value.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -23,17 +25,18 @@ namespace ICE {
 
 class AgentImpl;
 
-struct Task {
-  Task(AgentImpl* a_agent_impl) : agent_impl_(a_agent_impl), in_queue_(false) {}
+struct Task : public DCPS::RcObject {
+  Task(AgentImpl* a_agent_impl) : agent_impl_(a_agent_impl) {}
   virtual ~Task() {};
   virtual void execute(const DCPS::MonotonicTimePoint& a_now) = 0;
   void enqueue(const DCPS::MonotonicTimePoint& release_time);
 private:
   friend class AgentImpl;
   AgentImpl* agent_impl_;
-  DCPS::MonotonicTimePoint release_time_;
-  bool in_queue_;
 };
+
+typedef DCPS::RcHandle<Task> TaskPtr;
+typedef DCPS::WeakRcHandle<Task> WeakTaskPtr;
 
 } // namespace ICE
 } // namespace OpenDDS

--- a/dds/DCPS/RTPS/ICE/Task.h
+++ b/dds/DCPS/RTPS/ICE/Task.h
@@ -26,7 +26,7 @@ namespace ICE {
 class AgentImpl;
 
 struct Task : public DCPS::RcObject {
-  Task(AgentImpl* a_agent_impl) : agent_impl_(a_agent_impl) {}
+  explicit Task(AgentImpl* a_agent_impl) : agent_impl_(a_agent_impl) {}
   virtual ~Task() {};
   virtual void execute(const DCPS::MonotonicTimePoint& a_now) = 0;
   void enqueue(const DCPS::MonotonicTimePoint& release_time);


### PR DESCRIPTION
The time-based behavior of Checklists, ServerReflexiveTasks, and
ChangePasswordTasks is governed by the AgentImpl.  There was no way to
remove a Task from the queue of Tasks waiting on a timer.
Consequently, manual memory management was used to 1) prevent a Task
from entering the queue twice and 2) to destroy the Task as a
scheduled event.  The problem is the ServerReflexiveTask and
ChangePasswordTask have the same lifetime as their parent
object (EndpointManager) but the destruction was solely under the
control of the ServerReflexiveTask.  Thus, a destroyed
ChangePasswordTask may be in the queue of Tasks waiting on a timer.

Solution: Change the queue of Tasks to hold weak references.