### PR TITLE
Fix reliability in rtps_udp

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -109,6 +109,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
                      config.heartbeat_response_delay_)
   , heartbeat_(reactor_task->interceptor(), config.heartbeat_period_, *this, &RtpsUdpDataLink::send_heartbeats)
   , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
+  , reader_associator_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_association_ack_nacks)
   , relay_beacon_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_relay_beacon)
   , held_data_delivery_handler_(this)
   , max_bundle_size_(config.max_bundle_size_)
@@ -359,6 +360,8 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket)
                       ACE_TEXT("UdpDataLink::open: start failed!\n")),
                      false);
   }
+
+  reader_associator_.enable(false, cfg.heartbeat_period_);
 
   if (cfg.rtps_relay_address() != ACE_INET_Addr() ||
       cfg.use_rtps_relay_) {
@@ -822,6 +825,7 @@ RtpsUdpDataLink::stop_i()
   heartbeat_reply_.cancel();
   heartbeat_.disable_and_wait();
   heartbeatchecker_.disable_and_wait();
+  reader_associator_.disable_and_wait();
   relay_beacon_.disable_and_wait();
   unicast_socket_.close();
   multicast_socket_.close();
@@ -2073,6 +2077,60 @@ RtpsUdpDataLink::RtpsReader::gather_ack_nacks_i(MetaSubmessageVec& meta_submessa
   }
 }
 
+void
+RtpsUdpDataLink::RtpsReader::gather_association_ack_nacks(MetaSubmessageVec& meta_submessages)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+  gather_association_ack_nacks_i(meta_submessages);
+}
+
+void
+RtpsUdpDataLink::RtpsReader::gather_association_ack_nacks_i(MetaSubmessageVec& meta_submessages)
+{
+  using namespace OpenDDS::RTPS;
+
+  RtpsUdpDataLink_rch link = link_.lock();
+
+  if (!link) {
+    return;
+  }
+
+  GuardType guard(link->strategy_lock_);
+  if (link->receive_strategy() == 0) {
+    return;
+  }
+
+  for (WriterInfoMap::iterator wi = remote_writers_.begin(); wi != remote_writers_.end(); ++wi) {
+    if (wi->second.first_valid_hb_ && wi->second.first_delivered_data_) {
+      MetaSubmessage meta_submessage(id_, wi->first);
+
+      AckNackSubmessage acknack = {
+        {
+          ACKNACK,
+          CORBA::Octet(FLAG_E),
+          0 /*length*/
+        },
+        id_.entityId,
+        wi->first.entityId,
+        { // SequenceNumberSet: acking bitmapBase - 1
+          {
+            0,
+            1
+          },
+          0,
+          LongSeq8()
+        },
+        {
+          ++wi->second.acknack_count_
+        }
+      };
+      meta_submessage.sm_.acknack_sm(acknack);
+
+      meta_submessages.push_back(meta_submessage);
+    }
+  }
+}
+
 #ifdef OPENDDS_SECURITY
 namespace {
   const ACE_INET_Addr BUNDLING_PLACEHOLDER;
@@ -2800,6 +2858,9 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   // we don't need to do anything further.
   if (!is_final || bitmapNonEmpty(acknack.readerSNState)) {
     ri->second.requested_changes_.push_back(acknack.readerSNState);
+    // Determine if the reader needs a heartbeat.
+    DisjointSequence reqs;
+    ri->second.requires_heartbeat_ = process_requested_changes_i(reqs, ri->second);
   }
 
   TqeSet to_deliver;
@@ -2928,7 +2989,7 @@ RtpsUdpDataLink::RtpsWriter::send_and_gather_nack_replies(MetaSubmessageVec& met
         }
         if (Transport_debug_level > 5) {
           const GuidConverter local_conv(id_), remote_conv(ri->first);
-          ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::send_nack_replies "
+          ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::send_and_gather_nack_replies "
                      "local %C remote %C requested resend\n",
                      OPENDDS_STRING(local_conv).c_str(),
                      OPENDDS_STRING(remote_conv).c_str()));
@@ -3055,10 +3116,11 @@ RtpsUdpDataLink::RtpsWriter::send_nackfrag_replies_i(DisjointSequence& gaps,
   }
 }
 
-void
+bool
 RtpsUdpDataLink::RtpsWriter::process_requested_changes_i(DisjointSequence& requests,
                                                          const ReaderInfo& reader)
 {
+  bool inserted = false;
   for (size_t i = 0; i < reader.requested_changes_.size(); ++i) {
     const RTPS::SequenceNumberSet& sn_state = reader.requested_changes_[i];
     SequenceNumber base;
@@ -3070,11 +3132,14 @@ RtpsUdpDataLink::RtpsWriter::process_requested_changes_i(DisjointSequence& reque
       // the heartbeat range, treat it as a request for that seq#.
       if (!send_buff_.is_nil() && send_buff_->contains(base)) {
         requests.insert(base);
+        inserted = true;
       }
     } else {
       requests.insert(base, sn_state.numBits, sn_state.bitmap.get_buffer());
+      inserted = true;
     }
   }
+  return inserted;
 }
 
 void
@@ -3094,7 +3159,7 @@ RtpsUdpDataLink::RtpsWriter::send_directed_nack_replies_i(const RepoId& readerId
   }
 
   DisjointSequence requests;
-  process_requested_changes_i(requests, reader);
+  reader.requires_heartbeat_ = !process_requested_changes_i(requests, reader);
   reader.requested_changes_.clear();
 
   DisjointSequence gaps;
@@ -3332,6 +3397,9 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
   // Directed, non-final pre-association heartbeats
   RepoIdSet pre_assoc_hb_guids;
 
+  // Directed, final mid-association heartbeats.
+  RepoIdSet mid_assoc_hb_guids;
+
   typedef ReaderInfoMap::iterator ri_iter;
   const ri_iter end = remote_readers_.end();
   for (ri_iter ri = remote_readers_.begin(); ri != end; ++ri) {
@@ -3367,8 +3435,13 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
         marked_to = true;
       }
     }
-    if (!marked_to && !ri->second.handshake_done_) {
-      pre_assoc_hb_guids.insert(ri->first);
+    if (!marked_to) {
+      if (!ri->second.handshake_done_) {
+        pre_assoc_hb_guids.insert(ri->first);
+      } else if (ri->second.requires_heartbeat_) {
+        mid_assoc_hb_guids.insert(ri->first);
+        ri->second.requires_heartbeat_ = false;
+      }
     }
   }
 
@@ -3404,6 +3477,16 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
     pre_assoc_hb.dst_guid_ = (*it);
     pre_assoc_hb.sm_.heartbeat_sm().readerId = it->entityId;
     meta_submessages.push_back(pre_assoc_hb);
+  }
+
+  // Directed, final mid-association heartbeats
+  MetaSubmessage mid_assoc_hb = meta_submessage;
+  mid_assoc_hb.to_guids_.clear();
+  mid_assoc_hb.sm_.heartbeat_sm().smHeader.flags |= FLAG_F;
+  for (RepoIdSet::const_iterator it = mid_assoc_hb_guids.begin(); it != mid_assoc_hb_guids.end(); ++it) {
+    mid_assoc_hb.dst_guid_ = (*it);
+    mid_assoc_hb.sm_.heartbeat_sm().readerId = it->entityId;
+    meta_submessages.push_back(mid_assoc_hb);
   }
 
   if (is_final && !has_data && !has_durable_data) {
@@ -3457,6 +3540,21 @@ RtpsUdpDataLink::check_heartbeats(const DCPS::MonotonicTimePoint& now)
     const InterestingRemote& remote = iter->second;
     remote.listener->writer_does_not_exist(rid, remote.localid);
   }
+}
+
+void
+RtpsUdpDataLink::send_association_ack_nacks(const DCPS::MonotonicTimePoint& /*now*/)
+{
+  MetaSubmessageVec meta_submessages;
+
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, readers_lock_);
+    for (RtpsReaderMap::const_iterator pos = readers_.begin(), limit = readers_.end(); pos != limit; ++pos) {
+      pos->second->gather_association_ack_nacks(meta_submessages);
+    }
+  }
+
+  send_bundled_submessages(meta_submessages);
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -269,6 +269,7 @@ private:
   struct ReaderInfo {
     CORBA::Long acknack_recvd_count_, nackfrag_recvd_count_;
     OPENDDS_VECTOR(RTPS::SequenceNumberSet) requested_changes_;
+    bool requires_heartbeat_;
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumberSet) requested_frags_;
     SequenceNumber cur_cumulative_ack_;
     bool handshake_done_, durable_;
@@ -278,6 +279,7 @@ private:
     explicit ReaderInfo(bool durable)
       : acknack_recvd_count_(0)
       , nackfrag_recvd_count_(0)
+      , requires_heartbeat_(false)
       , handshake_done_(false)
       , durable_(durable)
     {}
@@ -316,7 +318,7 @@ private:
                        MetaSubmessageVec& meta_submessages);
     void acked_by_all_helper_i(TqeSet& to_deliver);
     void send_directed_nack_replies_i(const RepoId& readerId, ReaderInfo& reader, MetaSubmessageVec& meta_submessages);
-    void process_requested_changes_i(DisjointSequence& requests, const ReaderInfo& reader);
+    bool process_requested_changes_i(DisjointSequence& requests, const ReaderInfo& reader);
     void send_nackfrag_replies_i(DisjointSequence& gaps, AddrSet& gap_recipients);
 
   public:
@@ -405,11 +407,13 @@ private:
     bool process_hb_frag_i(const RTPS::HeartBeatFragSubmessage& hb_frag, const RepoId& src, MetaSubmessageVec& meta_submessages);
 
     void gather_ack_nacks(MetaSubmessageVec& meta_submessages, bool finalFlag = false);
+    void gather_association_ack_nacks(MetaSubmessageVec& meta_submessages);
 
   protected:
     void gather_ack_nacks_i(MetaSubmessageVec& meta_submessages, bool finalFlag = false);
     void generate_nack_frags_i(NackFragSubmessageVec& nack_frags,
                                WriterInfo& wi, const RepoId& pub_id);
+    void gather_association_ack_nacks_i(MetaSubmessageVec& meta_submessages);
 
     mutable ACE_Thread_Mutex mutex_;
     WeakRcHandle<RtpsUdpDataLink> link_;
@@ -540,6 +544,7 @@ private:
   void send_directed_heartbeats(OPENDDS_VECTOR(RTPS::HeartBeatSubmessage)& hbs);
   void check_heartbeats(const DCPS::MonotonicTimePoint& now);
   void send_heartbeat_replies();
+  void send_association_ack_nacks(const DCPS::MonotonicTimePoint& now);
   void send_relay_beacon(const DCPS::MonotonicTimePoint& now);
 
   CORBA::Long best_effort_heartbeat_count_;
@@ -576,7 +581,7 @@ private:
   Multi heartbeat_;
 
   typedef PmfPeriodicTask<RtpsUdpDataLink> Periodic;
-  Periodic heartbeatchecker_, relay_beacon_;
+  Periodic heartbeatchecker_, reader_associator_, relay_beacon_;
 
   /// Data structure representing an "interesting" remote entity for static discovery.
   struct InterestingRemote {


### PR DESCRIPTION
The association design requires that a writer receive an acknack from
a reader and reader receives data or a heartbeat from writer.  There
were two issues with this design.

If writer has no data, it will not respond to the acknack with a
heartbeat so the writer will be associated but the reader will not.

There was no reliability in the design as the reader would not retry
to send the acknack.

Solution: Add retry logic to the reader so it will resend acknacks and
add logic to the writer so that it will respond with a heartbeat.