### PR TITLE
Adding Missing Exports for Getting InfoRepo Disc. Working on Android

### DIFF
--- a/dds/DCPS/DataReaderCallbacks.h
+++ b/dds/DCPS/DataReaderCallbacks.h
@@ -32,7 +32,7 @@ namespace DCPS {
 * @brief Defines the interface for Discovery callbacks into the DataReader.
 *
 */
-class DataReaderCallbacks
+class OpenDDS_Dcps_Export DataReaderCallbacks
   : public virtual RcObject {
 public:
 

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -31,7 +31,7 @@ namespace DCPS {
 * @brief Defines the interface for Discovery callbacks into the DataWriter.
 *
 */
-class DataWriterCallbacks
+class OpenDDS_Dcps_Export DataWriterCallbacks
   : public virtual RcObject {
 public:
 


### PR DESCRIPTION
Fix for #1594

These exports are required in order for the messenger example ( and likely other opendds) to run on android when compiled with clang.  There was a dynamic cast failing during info repo discovery because these exports were missing.