### PR TITLE
Fix race condition between SEDP STUN and SPDP

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3144,7 +3144,7 @@ Sedp::Writer::write_dcps_participant_secure(const Security::SPDPdiscoveredPartic
   if (sedp_endpoint) {
     ai_map["SEDP"] = ICE::Agent::instance()->get_local_agent_info(sedp_endpoint);
   }
-  ICE::Endpoint* spdp_endpoint = sedp_.spdp_.get_ice_endpoint();
+  ICE::Endpoint* spdp_endpoint = sedp_.spdp_.get_ice_endpoint_if_added();
   if (spdp_endpoint) {
     ai_map["SPDP"] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
   }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -160,7 +160,7 @@ public:
 
   BuiltinEndpointSet_t available_builtin_endpoints() const { return available_builtin_endpoints_; }
 
-  ICE::Endpoint* get_ice_endpoint();
+  ICE::Endpoint* get_ice_endpoint_if_added();
 
   ParticipantData_t build_local_pdata(
 #ifdef OPENDDS_SECURITY
@@ -281,6 +281,7 @@ private:
     void send_relay_beacon(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpPeriodic> relay_beacon_;
     bool network_is_unreachable_;
+    bool ice_endpoint_added_;
   } *tport_;
 
   struct ChangeMulticastGroup : public DCPS::JobQueue::Job {


### PR DESCRIPTION
SEDP can determine a server reflexive address before SPDP has
registered its endpoint with the ICE Agent.  For secure updates, SEDP
will incorporate the local agent info for the SPDP endpoint.  These
leads to an assert since SPDP has not registered its endpoint.

Solution: Check that the endpoint has registered with the ICE Agent.