### PR TITLE
Fix Fragmentation Issues

### DIFF
--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -963,10 +963,10 @@ DataLink::release_resources()
 }
 
 bool
-DataLink::is_target(const RepoId& remote_sub_id)
+DataLink::is_target(const RepoId& remote_id)
 {
   GuardType guard(this->pub_sub_maps_lock_);
-  return assoc_by_remote_.count(remote_sub_id);
+  return assoc_by_remote_.count(remote_id);
 }
 
 GUIDSeq*

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -202,8 +202,9 @@ public:
   void terminate_send_if_suspended();
 
   /// This is called on publisher side to see if this link communicates
-  /// with the provided sub.
-  bool is_target(const RepoId& remote_sub_id);
+  /// with the provided sub or by the subscriber side to see if this link
+  /// communicates with the provided pub
+  bool is_target(const RepoId& remote_id);
 
   /// This is called by DataLinkCleanupTask thread to remove the associations
   /// based on the snapshot in release_resources().

--- a/dds/DCPS/transport/framework/TransportReassembly.cpp
+++ b/dds/DCPS/transport/framework/TransportReassembly.cpp
@@ -160,19 +160,6 @@ TransportReassembly::has_frags(const SequenceNumber& seq,
   return fragments_.count(FragKey(pub_id, seq)) > 0;
 }
 
-bool
-TransportReassembly::has_frags(const SequenceNumber& seq,
-                               const RepoId& pub_id,
-                               ACE_UINT32& total_frags) const
-{
-  FragKey key(pub_id, seq);
-  FragTotalMap::const_iterator iter = total_fragments_.find(key);
-  if (iter != total_fragments_.end()) {
-    total_frags = iter->second;
-  }
-  return fragments_.count(key) > 0;
-}
-
 CORBA::ULong
 TransportReassembly::get_gaps(const SequenceNumber& seq, const RepoId& pub_id,
                               CORBA::Long bitmap[], CORBA::ULong length,
@@ -180,7 +167,7 @@ TransportReassembly::get_gaps(const SequenceNumber& seq, const RepoId& pub_id,
 {
   // length is number of (allocated) words in bitmap, max of 8
   // numBits is number of valid bits in the bitmap, <= length * 32, to account for partial words
-  const FragMap::const_iterator iter = fragments_.find(FragKey(pub_id, seq));
+  const FragInfoMap::const_iterator iter = fragments_.find(FragKey(pub_id, seq));
   if (iter == fragments_.end() || length == 0) {
     // Nothing missing
     return 0;
@@ -190,7 +177,7 @@ TransportReassembly::get_gaps(const SequenceNumber& seq, const RepoId& pub_id,
   // low 32 bits of the 64-bit generalized sequence numbers in
   // FragRange::transport_seq_.
 
-  const OPENDDS_LIST(FragRange)& flist = iter->second;
+  const OPENDDS_LIST(FragRange)& flist = iter->second.range_list_;
   const SequenceNumber& first = flist.front().transport_seq_.first;
   const CORBA::ULong base = (first == 1)
     ? flist.front().transport_seq_.second.getLow() + 1
@@ -203,8 +190,14 @@ TransportReassembly::get_gaps(const SequenceNumber& seq, const RepoId& pub_id,
                                         bitmap, length, numBits);
   } else if (flist.size() == 1) {
     // No gaps, but we know there is (at least 1) more_framents
-    DisjointSequence::fill_bitmap_range(0, 0,
-                                        bitmap, length, numBits);
+    if (iter->second.total_frags_ == 0) {
+      DisjointSequence::fill_bitmap_range(0, 0, bitmap, length, numBits);
+    } else {
+      CORBA::ULong ulimit = iter->second.total_frags_ - flist.back().transport_seq_.second.getValue() - 1;
+      DisjointSequence::fill_bitmap_range(0,
+                                          ulimit,
+                                          bitmap, length, numBits);
+    }
     // NOTE: this could send a nack for fragments that are in flight
     // need to defer setting bitmap till heartbeat extending logic
     // in RtpsUdpDataLink::generate_nack_frags
@@ -259,29 +252,23 @@ TransportReassembly::reassemble_i(const SequenceRange& seqRange,
 
   const FragKey key(data.header_.publication_id_, data.header_.sequence_);
 
-  if (firstFrag) {
-    have_first_.insert(key);
-  }
-
-  if (total_frags) {
-    FragTotalMap::iterator iter = total_fragments_.find(key);
-    if (iter == total_fragments_.end()) {
-      total_fragments_[key] = total_frags;
-    } else if (iter->second < total_frags) {
-      iter->second = total_frags;
-    }
-  }
-
-  FragMap::iterator iter = fragments_.find(key);
+  FragInfoMap::iterator iter = fragments_.find(key);
   if (iter == fragments_.end()) {
-    fragments_[key].push_back(FragRange(seqRange, data));
+    fragments_[key] = FragInfo(firstFrag, FragRangeList(1, FragRange(seqRange, data)), total_frags);
     // since this is the first fragment we've seen, it can't possibly be done
     VDBG((LM_DEBUG, "(%P|%t) DBG:   TransportReassembly::reassemble() "
       "stored first frag, returning false (incomplete)\n"));
     return false;
+  } else {
+    if (firstFrag) {
+      iter->second.have_first_ = true;
+    }
+    if (iter->second.total_frags_ < total_frags) {
+      iter->second.total_frags_ = total_frags;
+    }
   }
 
-  if (!insert(iter->second, seqRange, data)) {
+  if (!insert(iter->second.range_list_, seqRange, data)) {
     // error condition, already logged by insert()
     return false;
   }
@@ -290,13 +277,11 @@ TransportReassembly::reassemble_i(const SequenceRange& seqRange,
   // 1. we've seen the "first fragment" flag  [first frag is here]
   // 2. all fragments have been coalesced     [no gaps in the seq numbers]
   // 3. the "more fragments" flag is not set  [last frag is here]
-  if (have_first_.count(key)
-      && iter->second.size() == 1
-      && !iter->second.front().rec_ds_.header_.more_fragments_) {
-    swap(data, iter->second.front().rec_ds_);
+  if (iter->second.have_first_
+      && iter->second.range_list_.size() == 1
+      && !iter->second.range_list_.front().rec_ds_.header_.more_fragments_) {
+    swap(data, iter->second.range_list_.front().rec_ds_);
     fragments_.erase(iter);
-    total_fragments_.erase(key);
-    have_first_.erase(key);
     VDBG((LM_DEBUG, "(%P|%t) DBG:   TransportReassembly::reassemble() "
       "removed frag, returning %C\n", data.sample_ ? "true" : "false"));
     return data.sample_.get(); // could be false if we had data_unavailable()
@@ -314,10 +299,10 @@ TransportReassembly::data_unavailable(const SequenceRange& dropped)
     "dropped %q-%q\n", dropped.first.getValue(), dropped.second.getValue()));
   typedef OPENDDS_LIST(FragRange)::iterator list_iterator;
 
-  for (FragMap::iterator iter = fragments_.begin(); iter != fragments_.end();
+  for (FragInfoMap::iterator iter = fragments_.begin(); iter != fragments_.end();
        ++iter) {
     const FragKey& key = iter->first;
-    OPENDDS_LIST(FragRange)& flist = iter->second;
+    OPENDDS_LIST(FragRange)& flist = iter->second.range_list_;
 
     ReceivedDataSample dummy(0);
     dummy.header_.sequence_ = key.data_sample_seq_;
@@ -325,8 +310,8 @@ TransportReassembly::data_unavailable(const SequenceRange& dropped)
     // check if we should expand the front element (only if !have_first)
     const SequenceNumber::Value prev =
       flist.front().transport_seq_.first.getValue() - 1;
-    if (dropped.second.getValue() == prev && !have_first_.count(key)) {
-      have_first_.insert(key);
+    if (dropped.second.getValue() == prev && !iter->second.have_first_) {
+      iter->second.have_first_ = true;
       dummy.header_.more_fragments_ = true;
       insert(flist, dropped, dummy);
       continue;
@@ -365,8 +350,6 @@ TransportReassembly::data_unavailable(const SequenceNumber& dataSampleSeq,
 {
   const FragKey key(pub_id, dataSampleSeq);
   fragments_.erase(key);
-  total_fragments_.erase(key);
-  have_first_.erase(key);
 }
 
 }

--- a/dds/DCPS/transport/framework/TransportReassembly.h
+++ b/dds/DCPS/transport/framework/TransportReassembly.h
@@ -25,9 +25,9 @@ public:
   /// is set.  Returns true/false to indicate if data should be delivered to
   /// the datalink.  The 'data' argument may be modified by this method.
   bool reassemble(const SequenceNumber& transportSeq, bool firstFrag,
-                  ReceivedDataSample& data);
+                  ReceivedDataSample& data, ACE_UINT32 total_frags = 0);
 
-  bool reassemble(const SequenceRange& seqRange, ReceivedDataSample& data);
+  bool reassemble(const SequenceRange& seqRange, ReceivedDataSample& data, ACE_UINT32 total_frags = 0);
 
   /// Called by TransportReceiveStrategy to indicate that we can
   /// stop tracking partially-reassembled messages when we know the
@@ -41,6 +41,10 @@ public:
   /// DataSampleHeader sequence number from the given publication.
   bool has_frags(const SequenceNumber& seq, const RepoId& pub_id) const;
 
+  /// Returns true if this object is storing fragments for the given
+  /// DataSampleHeader sequence number from the given publication.
+  bool has_frags(const SequenceNumber& seq, const RepoId& pub_id, ACE_UINT32& total_frags) const;
+
   /// Populates bitmap for missing fragment sequence numbers and set numBits
   /// for the given message sequence and publisher ID.
   /// @returns the base fragment sequence number for bit zero in the bitmap
@@ -51,7 +55,7 @@ public:
 private:
 
   bool reassemble_i(const SequenceRange& seqRange, bool firstFrag,
-                    ReceivedDataSample& data);
+                    ReceivedDataSample& data, ACE_UINT32 total_frags);
 
   // A FragKey represents the identifier for an original (pre-fragmentation)
   // message.  Since DataSampleHeader sequence numbers are distinct for each
@@ -90,6 +94,9 @@ private:
   // a null ACE_Message_Block*, it's one that was data_unavailable().
   typedef OPENDDS_MAP(FragKey, OPENDDS_LIST(FragRange) ) FragMap;
   FragMap fragments_;
+
+  typedef OPENDDS_MAP(FragKey, ACE_UINT32) FragTotalMap;
+  FragTotalMap total_fragments_;
 
   OPENDDS_SET(FragKey) have_first_;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -943,17 +943,14 @@ RtpsUdpReceiveStrategy::remove_fragments(const SequenceRange& range,
 bool
 RtpsUdpReceiveStrategy::has_fragments(const SequenceRange& range,
                                       const RepoId& pub_id,
-                                      FragmentInfo* frag_info,
-                                      FragmentTotalInfo* total_info)
+                                      FragmentInfo* frag_info)
 {
   for (SequenceNumber sn = range.first; sn <= range.second; ++sn) {
-    ACE_UINT32 total_frags = 0;
-    if (reassembly_.has_frags(sn, pub_id, total_frags)) {
-      if (frag_info && total_info) {
+    if (reassembly_.has_frags(sn, pub_id)) {
+      if (frag_info) {
         std::pair<SequenceNumber, RTPS::FragmentNumberSet> p;
         p.first = sn;
         frag_info->push_back(p);
-        total_info->push_back(total_frags);
         RTPS::FragmentNumberSet& missing_frags = frag_info->back().second;
         missing_frags.numBits = 0; // make sure this is a valid number before passing to get_gaps
         missing_frags.bitmap.length(8); // start at max length

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -58,10 +58,8 @@ public:
 
   typedef std::pair<SequenceNumber, RTPS::FragmentNumberSet> SeqFragPair;
   typedef OPENDDS_VECTOR(SeqFragPair) FragmentInfo;
-  typedef OPENDDS_VECTOR(ACE_UINT32) FragmentTotalInfo;
 
-  bool has_fragments(const SequenceRange& range, const RepoId& pub_id,
-                     FragmentInfo* frag_info = 0, FragmentTotalInfo* total_info = 0);
+  bool has_fragments(const SequenceRange& range, const RepoId& pub_id, FragmentInfo* frag_info = 0);
 
   /// Prevent delivery of the currently in-progress data sample to the
   /// subscription sub_id.  Returns pointer to the in-progress data so

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -58,9 +58,10 @@ public:
 
   typedef std::pair<SequenceNumber, RTPS::FragmentNumberSet> SeqFragPair;
   typedef OPENDDS_VECTOR(SeqFragPair) FragmentInfo;
+  typedef OPENDDS_VECTOR(ACE_UINT32) FragmentTotalInfo;
 
   bool has_fragments(const SequenceRange& range, const RepoId& pub_id,
-                     FragmentInfo* frag_info = 0);
+                     FragmentInfo* frag_info = 0, FragmentTotalInfo* total_info = 0);
 
   /// Prevent delivery of the currently in-progress data sample to the
   /// subscription sub_id.  Returns pointer to the in-progress data so
@@ -120,6 +121,7 @@ private:
   RepoIdSet readers_withheld_, readers_selected_;
 
   SequenceRange frags_;
+  ACE_UINT32 total_frags_;
   TransportReassembly reassembly_;
 
   struct MessageReceiver {

--- a/performance-tests/bench_2/control_opendds_config.ini
+++ b/performance-tests/bench_2/control_opendds_config.ini
@@ -1,6 +1,10 @@
 [common]
-DCPSDefaultDiscovery=DEFAULT_RTPS
 DCPSGlobalTransportConfig=$file
+DCPSDefaultDiscovery=fast_rtps
+
+[rtps_discovery/fast_rtps]
+ResendPeriod=15
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp
+max_bundle_size=64000

--- a/performance-tests/bench_2/node_controller/main.cpp
+++ b/performance-tests/bench_2/node_controller/main.cpp
@@ -519,14 +519,17 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     }
     ACE_Reactor::instance()->run_reactor_event_loop();
   });
-  ACE_Process_Manager process_manager(ACE_Process_Manager::DEFAULT_SIZE, ACE_Reactor::instance());
-  int exit_status = 0;
-  while (true) {
-    exit_status = run_cycle(name, process_manager, participant,
-      status_writer_impl, config_reader_impl, report_writer_impl);
 
-    if (run_mode == RunMode::one_shot || (run_mode == RunMode::daemon_exit_on_error && exit_status != 0)) {
-      break;
+  int exit_status = 0;
+  {
+    ACE_Process_Manager process_manager(ACE_Process_Manager::DEFAULT_SIZE, ACE_Reactor::instance());
+    while (true) {
+      exit_status = run_cycle(name, process_manager, participant,
+        status_writer_impl, config_reader_impl, report_writer_impl);
+
+      if (run_mode == RunMode::one_shot || (run_mode == RunMode::daemon_exit_on_error && exit_status != 0)) {
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
Fixing a number of issues with fragmentation:
1) Not handling duplicate fragments correctly (combined ranges can exceed duplicate range).
2) Storing fragments for writers we've never associated with (potentially never cleaned)
3) For RTPS, where we can calculate total # of fragments, we only ever nack the 'next' fragment, wasting time.

Minor tweaks to node_controller & control domain