### PR TITLE
Replace Manual BIT Topic Check

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -173,7 +173,7 @@ void DataReaderImpl::init(
 #ifndef DDS_HAS_MINIMUM_BIT
   CORBA::String_var topic_name = a_topic_desc->get_name();
   CORBA::String_var topic_type_name = a_topic_desc->get_type_name();
-  is_bit_ = topicIsBIT(topic_name.in(), topic_type_name.in());
+  is_bit_ = topicIsBIT(topic_name, topic_type_name);
 #endif // !defined (DDS_HAS_MINIMUM_BIT)
 
   qos_ = qos;

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -173,10 +173,7 @@ void DataReaderImpl::init(
   CORBA::String_var topic_name = a_topic_desc->get_name();
 
 #if !defined (DDS_HAS_MINIMUM_BIT)
-  is_bit_ = ACE_OS::strcmp(topic_name.in(), BUILT_IN_PARTICIPANT_TOPIC) == 0
-      || ACE_OS::strcmp(topic_name.in(), BUILT_IN_TOPIC_TOPIC) == 0
-      || ACE_OS::strcmp(topic_name.in(), BUILT_IN_SUBSCRIPTION_TOPIC) == 0
-      || ACE_OS::strcmp(topic_name.in(), BUILT_IN_PUBLICATION_TOPIC) == 0;
+  is_bit_ = topicIsBIT(topic_name.in(), topic_servant_->type_name());
 #endif // !defined (DDS_HAS_MINIMUM_BIT)
 
   qos_ = qos;

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -170,10 +170,10 @@ void DataReaderImpl::init(
     topic_servant_ = a_topic;
   }
 
+#ifndef DDS_HAS_MINIMUM_BIT
   CORBA::String_var topic_name = a_topic_desc->get_name();
-
-#if !defined (DDS_HAS_MINIMUM_BIT)
-  is_bit_ = topicIsBIT(topic_name.in(), topic_servant_->type_name());
+  CORBA::String_var topic_type_name = a_topic_desc->get_type_name();
+  is_bit_ = topicIsBIT(topic_name.in(), topic_type_name.in());
 #endif // !defined (DDS_HAS_MINIMUM_BIT)
 
   qos_ = qos;


### PR DESCRIPTION
It looks like I missed this case back in https://github.com/objectcomputing/OpenDDS/pull/863. All checks for if a given topic is a BIT should be done using the `topicIsBIT` function I added in that PR.