### PR TITLE
Do not use NetworkConfigModifier for Linux builds.

### DIFF
--- a/dds/DCPS/NetworkConfigModifier.h
+++ b/dds/DCPS/NetworkConfigModifier.h
@@ -10,7 +10,7 @@
 
 #include "ace/config.h"
 
-#if defined(ACE_HAS_GETIFADDRS) && !defined(OPENDDS_SAFETY_PROFILE)
+#if defined(ACE_HAS_GETIFADDRS) && !defined(OPENDDS_SAFETY_PROFILE) && !defined (ACE_LINUX)
 
 #define OPENDDS_NETWORK_CONFIG_MODIFIER
 


### PR DESCRIPTION
Linux builds use LinuxNetworkConfigMonitor. Trying to build with
NetworkConfigModifier will fail unless ipv6 is enabled, since
ACE_OS::if_nametoindex is not defined.