### PR TITLE
Try to join IPV4 and IPV6 multicast groups when no NCM

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1865,7 +1865,13 @@ Spdp::SpdpTransport::open()
     ncm->add_listener(*this);
   } else {
     DCPS::NetworkInterface nic(0, multicast_interface_, true);
-    nic.addresses.insert(ACE_INET_Addr());
+    ACE_INET_Addr addr;
+    addr.set_type(AF_INET);
+    nic.addresses.insert(addr);
+#ifdef ACE_HAS_IPV6
+    addr.set_type(AF_INET6);
+    nic.addresses.insert(addr);
+#endif
     join_multicast_group(nic, true);
   }
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -451,10 +451,9 @@ RtpsUdpDataLink::join_multicast_group(const DCPS::NetworkInterface& nic,
     if (DCPS::DCPS_debug_level > 3) {
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::join_multicast_group ")
-                 ACE_TEXT("joining group %C %C:%hu\n"),
+                 ACE_TEXT("joining group %C %C\n"),
                  nic.name().c_str(),
-                 config().multicast_group_address_str_.c_str(),
-                 config().multicast_group_address_.get_port_number()));
+                 config().multicast_group_address_str_.c_str()));
     }
 
     if (0 == multicast_socket_.join(config().multicast_group_address_, 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
@@ -477,10 +476,9 @@ RtpsUdpDataLink::join_multicast_group(const DCPS::NetworkInterface& nic,
     if (DCPS::DCPS_debug_level > 3) {
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::join_multicast_group ")
-                 ACE_TEXT("joining group %C %C:%hu\n"),
+                 ACE_TEXT("joining group %C %C\n"),
                  nic.name().c_str(),
-                 config().ipv6_multicast_group_address_str_.c_str(),
-                 config().ipv6_multicast_group_address_.get_port_number()));
+                 config().ipv6_multicast_group_address_str_.c_str()));
     }
 
     if (0 == ipv6_multicast_socket_.join(config().ipv6_multicast_group_address_, 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {


### PR DESCRIPTION
Problem: The logic to join multicast groups on platforms that don't
have a network config monitor (NCM) creates a default NIC and populates it
with an address to be compatible with the NCM logic.  If IPV6 is
enabled, then the default address will be an IPV6 address meaning that
the IPV4 multicast groups will never be joined.

Solution: Always add an IPV4 address to the default NIC and add an
IPV6 address if appropriate.