### PR TITLE
Add a simpler 'handle_dds_input' for UDP protocols

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -131,18 +131,22 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
   cur_rb->wr_ptr(bytes_remaining);
 
   if (stop) {
+    cur_rb->reset();
     return 0;
   }
 
   if (bytes_remaining < 0) {
+    cur_rb->reset();
     relink();
     return -1;
   }
 
   if (bytes_remaining == 0) {
     if (gracefully_disconnected_) {
+      cur_rb->reset();
       return -1;
     } else {
+      cur_rb->reset();
       relink();
       return -1;
     }
@@ -161,6 +165,7 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
 
   bytes_remaining = receive_transport_header_.length_;
   if (!check_header(receive_transport_header_)) {
+    cur_rb->reset();
     return 0;
   }
 
@@ -169,6 +174,7 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
     data_sample_header_ = *cur_rb;
     bytes_remaining -= data_sample_header_.marshaled_size();
     if (!check_header(data_sample_header_)) {
+      cur_rb->reset();
       return 0;
     }
     const size_t dsh_ml = data_sample_header_.message_length();

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -78,6 +78,172 @@ TransportReceiveStrategy<TH, DSH>::check_header(const DSH& /*header*/)
   return true;
 }
 
+template<typename TH, typename DSH>
+int
+TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
+{
+  DBG_ENTRY_LVL("TransportReceiveStrategy", "handle_simple_dds_input", 6);
+
+  for (int index = 0; index < RECEIVE_BUFFERS; ++index) {
+    if (receive_buffers_[index] == 0) {
+      ACE_NEW_MALLOC_RETURN(
+        receive_buffers_[index],
+        (ACE_Message_Block*) mb_allocator_.malloc(sizeof(ACE_Message_Block)),
+        ACE_Message_Block(
+          RECEIVE_DATA_BUFFER_SIZE,           // Buffer size
+          ACE_Message_Block::MB_DATA,         // Default
+          0,                                  // Start with no continuation
+          0,                                  // Let the constructor allocate
+          &data_allocator_,                   // Our buffer cache
+          &receive_lock_,                     // Our locking strategy
+          ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY, // Default
+          ACE_Time_Value::zero,               // Default
+          ACE_Time_Value::max_time,           // Default
+          &db_allocator_,                     // Our data block cache
+          &mb_allocator_                      // Our message block cache
+        ),
+        -1);
+    }
+  }
+
+  ACE_Message_Block* cur_rb = receive_buffers_[buffer_index_];
+  iovec iov[1];
+#ifdef _MSC_VER
+#pragma warning(push)
+// iov_len is 32-bit on 64-bit VC++, but we don't want a cast here
+// since on other platforms iov_len is 64-bit
+#pragma warning(disable : 4267)
+#endif
+  iov[0].iov_len = cur_rb->space();
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+  iov[0].iov_base = cur_rb->wr_ptr();
+
+  ACE_INET_Addr remote_address;
+  bool stop = false;
+  ssize_t bytes_remaining = receive_bytes(iov,
+                                          1,
+                                          remote_address,
+                                          fd,
+                                          stop);
+
+  //ACE_DEBUG((LM_DEBUG, "TransportReceiveStrategy[%@]::handle_simple_dds_input(%d) - read %d bytes (stop = %C)\n", this, fd, bytes_remaining, stop ? "true" : "false"));
+
+  cur_rb->wr_ptr(bytes_remaining);
+
+  if (stop) {
+    return 0;
+  }
+
+  if (bytes_remaining < 0) {
+    relink();
+    return -1;
+  }
+
+  if (bytes_remaining == 0) {
+    if (gracefully_disconnected_) {
+      return -1;
+    } else {
+      relink();
+      return -1;
+    }
+  }
+
+  if (!pdu_remaining_) {
+    receive_transport_header_.length_ = static_cast<ACE_UINT32>(bytes_remaining);
+  }
+
+  receive_transport_header_ = *cur_rb;
+  if (!receive_transport_header_.valid()) {
+    cur_rb->reset();
+    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: TransportHeader invalid.\n")), -1);
+  }
+
+
+  bytes_remaining = receive_transport_header_.length_;
+  if (!check_header(receive_transport_header_)) {
+    return 0;
+  }
+
+  while (bytes_remaining > 0) {
+    data_sample_header_.pdu_remaining(bytes_remaining);
+    data_sample_header_ = *cur_rb;
+    bytes_remaining -= data_sample_header_.marshaled_size();
+    if (!check_header(data_sample_header_)) {
+      return 0;
+    }
+    size_t dsh_ml = data_sample_header_.message_length();
+    ACE_Message_Block* current_sample_block = 0;
+    ACE_NEW_MALLOC_RETURN(
+      current_sample_block,
+      (ACE_Message_Block*) mb_allocator_.malloc(sizeof(ACE_Message_Block)),
+      ACE_Message_Block(
+        cur_rb->data_block()->duplicate(),
+        0,
+        &mb_allocator_),
+      -1);
+    current_sample_block->rd_ptr(cur_rb->rd_ptr());
+    current_sample_block->wr_ptr(current_sample_block->rd_ptr() + dsh_ml);
+    cur_rb->rd_ptr(current_sample_block->rd_ptr() + dsh_ml);
+    bytes_remaining -= dsh_ml;
+    ReceivedDataSample rds(current_sample_block);
+    if (data_sample_header_.into_received_data_sample(rds)) {
+
+      if (data_sample_header_.more_fragments() || receive_transport_header_.last_fragment()) {
+        VDBG((LM_DEBUG,"(%P|%t) DBG:   Attempt reassembly of fragments\n"));
+
+        if (reassemble(rds)) {
+          VDBG((LM_DEBUG,"(%P|%t) DBG:   Reassembled complete message\n"));
+          deliver_sample(rds, remote_address);
+        }
+        // If reassemble() returned false, it takes ownership of the data
+        // just like deliver_sample() does.
+
+      } else {
+        deliver_sample(rds, remote_address);
+      }
+    }
+
+    // For the reassembly algorithm, the 'last_fragment_' header bit only
+    // applies to the first DataSampleHeader in the TransportHeader
+    receive_transport_header_.last_fragment(false);
+  }
+
+
+  if (cur_rb->data_block()->reference_count() > 1) {
+    ACE_DES_FREE(
+      cur_rb,
+      mb_allocator_.free,
+      ACE_Message_Block);
+
+    ACE_NEW_MALLOC_RETURN(
+      receive_buffers_[buffer_index_],
+      (ACE_Message_Block*) mb_allocator_.malloc(sizeof(ACE_Message_Block)),
+      ACE_Message_Block(
+        RECEIVE_DATA_BUFFER_SIZE,           // Buffer size
+        ACE_Message_Block::MB_DATA,         // Default
+        0,                                  // Start with no continuation
+        0,                                  // Let the constructor allocate
+        &data_allocator_,                   // Our buffer cache
+        &receive_lock_,                     // Our locking strategy
+        ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY, // Default
+        ACE_Time_Value::zero,               // Default
+        ACE_Time_Value::max_time,           // Default
+        &db_allocator_,                     // Our data block cache
+        &mb_allocator_                      // Our message block cache
+      ),
+      -1);
+  } else {
+    //ACE_DEBUG((LM_DEBUG, "DON'T NEED REALLOCATE - SAVING BUFFER!\n"));
+    cur_rb->reset();
+  }
+
+  //buffer_index_ = successor_index(buffer_index_);
+
+  return 0;
+}
+
 /// Note that this is just an initial implementation.  We may take
 /// some shortcuts (we will) that will need to be dealt with later once
 /// a more robust implementation can be put in place.

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -37,6 +37,7 @@ public:
   int start();
   void stop();
 
+  int handle_simple_dds_input(ACE_HANDLE fd);
   int handle_dds_input(ACE_HANDLE fd);
 
   /// The subclass needs to provide the implementation

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -37,7 +37,13 @@ public:
   int start();
   void stop();
 
+  /// Useful as a simpler altnernative to handle_dds_input
+  /// when dealing with UDP protocols with maximum packet size.
+  /// Behaves the same as handle_dds_input, but only makes use
+  /// of a single recieve buffer and doesn't require message block
+  /// chains that need to be updated / maintained
   int handle_simple_dds_input(ACE_HANDLE fd);
+
   int handle_dds_input(ACE_HANDLE fd);
 
   /// The subclass needs to provide the implementation

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -45,7 +45,7 @@ RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const Guid
 int
 RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
 {
-  return handle_dds_input(fd);
+  return handle_simple_dds_input(fd);
 }
 
 ssize_t


### PR DESCRIPTION
And where max packet size can be assumed and the buffer chain doesn't have to be so long / constantly checked.

The implementation is basically a copied & pared-down version of handle_dds_input, but it should only ever really need to use a single buffer at a time and not worry about reallocating / maintaining a giant read buffer chain (1000's of calls to ACE_Message_Block::total_length(), which then iterates over the whole chain).