### PR TITLE
Docker updates for ubuntu focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASIS=ubuntu:bionic
 FROM $BASIS
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     cmake \
     curl \
@@ -15,9 +16,9 @@ RUN apt-get update && apt-get install -y \
     git
 
 WORKDIR /usr/src/gtest
-RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
+RUN cmake CMakeLists.txt && make && cp $(find . -name "*.a") /usr/lib
 WORKDIR /usr/src/gmock
-RUN cmake CMakeLists.txt && make && cp ./*.a /usr/lib
+RUN cmake CMakeLists.txt && make && cp $(find . -name "*.a") /usr/lib
 
 ADD . /opt/OpenDDS
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,25 +6,19 @@ RUN apt-get update && apt-get install -y \
     cmake \
     curl \
     g++ \
-    google-mock \
     make \
-    libgtest-dev \
     libxerces-c-dev \
     libssl-dev \
     perl-base \
     perl-modules \
     git
 
-WORKDIR /usr/src/gtest
-RUN cmake CMakeLists.txt && make && cp $(find . -name "*.a") /usr/lib
-WORKDIR /usr/src/gmock
-RUN cmake CMakeLists.txt && make && cp $(find . -name "*.a") /usr/lib
-
 ADD . /opt/OpenDDS
 
 ARG ACE_CONFIG_OPTION="--doc-group"
 RUN cd /opt/OpenDDS && \
-    ./configure --prefix=/usr/local --security --std=c++11 ${ACE_CONFIG_OPTION} && \
+    ./configure --prefix=/usr/local --security ${ACE_CONFIG_OPTION} && \
+    ./tools/scripts/show_build_config.pl && \
     make && \
     make install && \
     ldconfig && \


### PR DESCRIPTION
The RMW project is preparing to use ROS2 Foxy which is built on **Ubuntu Focal** (20.04). I tested the OpenDDS docker and found it needed a few changes. I also did some cleanup (removing gtest/gmock) and running the `show_build_config.pl` script after config based on @mitza-oci's request. 