### PR TITLE
Fixed a corner case for IDL union code generation in Java

### DIFF
--- a/java/idl2jni/codegen/im_jni.cpp
+++ b/java/idl2jni/codegen/im_jni.cpp
@@ -1641,14 +1641,17 @@ ostream &operator<< (ostream &o, AST_Expression::AST_ExprValue *ev)
 }
 
 bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
-                                const std::vector<AST_UnionBranch *> &branches, AST_Type *discriminator,
-                                AST_Expression::ExprType, const AST_Union::DefaultValue &, const char *)
+                                const std::vector<AST_UnionBranch *> &branches,
+                                AST_Type *discriminator,
+                                AST_Expression::ExprType,
+                                const AST_Union::DefaultValue &default_value,
+                                const char *)
 {
   string disc_ty = type(discriminator),
-                   disc_sig = jvmSignature(discriminator),
-                              disc_meth = jniFnName(discriminator),
-                                          branchesToCxx, branchesToJava;
-  bool someBranchUsesExplicitDisc(false);
+    disc_sig = jvmSignature(discriminator),
+    disc_meth = jniFnName(discriminator),
+    branchesToCxx, branchesToJava;
+  bool someBranchUsesExplicitDisc(false), hasDefault(false);
 
   for (size_t i = 0; i < branches.size(); ++i) {
     unsigned long n_labels = branches[i]->label_list_length();
@@ -1659,6 +1662,7 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
       ostringstream oss;
 
       if (ul->label_kind() == AST_UnionLabel::UL_default) {
+        hasDefault = true;
         useExplicitDisc = true;
         branchesToCxx  += "    default:\n";
         branchesToJava += "    default:\n";
@@ -1764,16 +1768,16 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   string unionJVMsig = scoped_helper(name, "/");
   bool disc_is_enum(disc_meth == "Object");
   string disc_name = disc_is_enum ? "disc_val" : "disc",
-                     extra_enum1 = disc_is_enum ?
-                                   "  jmethodID mid_disc_val = jni->GetMethodID (jni->GetObjectClass "
-                                   "(disc), \"value\", \"()I\");\n"
-                                   "  jint disc_val = jni->CallIntMethod (disc, mid_disc_val);\n"
-                                   "  jni->DeleteLocalRef (disc);\n"
-                                   : "",
-                                   extra_enum2 = disc_is_enum ?
-                                                 "static_cast<" + taoType(discriminator) + "> (disc_val)"
-                                                 : "disc",
-                                                 explicitDiscSetup, explicitDiscCleanup;
+    extra_enum1 = disc_is_enum ?
+    "  jmethodID mid_disc_val = jni->GetMethodID (jni->GetObjectClass "
+    "(disc), \"value\", \"()I\");\n"
+    "  jint disc_val = jni->CallIntMethod (disc, mid_disc_val);\n"
+    "  jni->DeleteLocalRef (disc);\n"
+    : "",
+    extra_enum2 = disc_is_enum ?
+    "static_cast<" + taoType(discriminator) + "> (disc_val)"
+    : "disc",
+    explicitDiscSetup, explicitDiscCleanup;
 
   if (someBranchUsesExplicitDisc && disc_is_enum) {
     string enum_sig = scoped_helper(discriminator->name(), "/");
@@ -1789,6 +1793,30 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   } else if (someBranchUsesExplicitDisc) {
     explicitDiscSetup =
       "  " + disc_ty + " jdisc = source._d ();\n";
+  }
+
+  if (!hasDefault && default_value.computed_ != 0) {
+    branchesToJava +=
+      "    default:\n"
+      "      {\n"
+      "        jmethodID mid = jni->GetMethodID (clazz, \"__default\", \"("
+      + disc_sig + ")V\");\n";
+    if (disc_is_enum) {
+      branchesToJava +=
+        "        jobject disc;\n"
+        "        copyToJava (jni, disc, source._d ());\n";
+    } else {
+      branchesToJava +=
+        "        " + disc_ty + " disc = source._d ();\n";
+    }
+    branchesToJava +=
+      "        jni->CallVoidMethod (target, mid, disc);\n";
+    if (disc_is_enum) {
+      branchesToJava +=
+        "        jni->DeleteLocalRef (disc);\n";
+    }
+    branchesToJava +=
+      "      }\n";
   }
 
   c.cppfile <<

--- a/java/idl2jni/tests/union/.gitignore
+++ b/java/idl2jni/tests/union/.gitignore
@@ -2,9 +2,9 @@
 /E.java
 /EHelper.java
 /EHolder.java
-/U.java
-/UHelper.java
-/UHolder.java
+/NoDefault.java
+/NoDefaultHelper.java
+/NoDefaultHolder.java
 /UnionTestC.cpp
 /UnionTestC.h
 /UnionTestC.inl
@@ -14,3 +14,6 @@
 /UnionTestJS.h
 /UnionTestS.cpp
 /UnionTestS.h
+/WithDefault.java
+/WithDefaultHelper.java
+/WithDefaultHolder.java

--- a/java/idl2jni/tests/union/.gitignore
+++ b/java/idl2jni/tests/union/.gitignore
@@ -1,0 +1,16 @@
+/classes/
+/E.java
+/EHelper.java
+/EHolder.java
+/U.java
+/UHelper.java
+/UHolder.java
+/UnionTestC.cpp
+/UnionTestC.h
+/UnionTestC.inl
+/UnionTestJC.cpp
+/UnionTestJC.h
+/UnionTestJS.cpp
+/UnionTestJS.h
+/UnionTestS.cpp
+/UnionTestS.h

--- a/java/idl2jni/tests/union/TestUnion.cpp
+++ b/java/idl2jni/tests/union/TestUnion.cpp
@@ -1,9 +1,19 @@
 #include "UnionTestJC.h"
 
 extern "C" JNIEXPORT jobject JNICALL
-Java_TestUnion_getUnion(JNIEnv* jni, jclass, jobject src)
+Java_TestUnion_getUnionND(JNIEnv* jni, jclass, jobject src)
 {
-  U u;
+  NoDefault u;
+  copyToCxx(jni, u, src);
+  jobject u2;
+  copyToJava(jni, u2, u, true);
+  return u2;
+}
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_TestUnion_getUnionWD(JNIEnv* jni, jclass, jobject src)
+{
+  WithDefault u;
   copyToCxx(jni, u, src);
   jobject u2;
   copyToJava(jni, u2, u, true);

--- a/java/idl2jni/tests/union/TestUnion.cpp
+++ b/java/idl2jni/tests/union/TestUnion.cpp
@@ -1,0 +1,11 @@
+#include "UnionTestJC.h"
+
+extern "C" JNIEXPORT jobject JNICALL
+Java_TestUnion_getUnion(JNIEnv* jni, jclass, jobject src)
+{
+  U u;
+  copyToCxx(jni, u, src);
+  jobject u2;
+  copyToJava(jni, u2, u, true);
+  return u2;
+}

--- a/java/idl2jni/tests/union/TestUnion.java
+++ b/java/idl2jni/tests/union/TestUnion.java
@@ -1,0 +1,25 @@
+public class TestUnion {
+
+  private static native U getUnion(U u);
+
+  public static void main(String[] args) {
+    String lib = "idl2jni_test_union";
+    String propVal = System.getProperty("opendds.native.debug");
+    if (propVal != null && ("1".equalsIgnoreCase(propVal) ||
+        "y".equalsIgnoreCase(propVal) ||
+        "yes".equalsIgnoreCase(propVal) ||
+        "t".equalsIgnoreCase(propVal) ||
+        "true".equalsIgnoreCase(propVal)))
+      lib += "d";
+    System.loadLibrary(lib);
+
+    U[] us = {new U(), new U(), new U()};
+    us[0].__default(E.E1);
+    us[1].o((byte) 1);
+    us[2].s((short) 2);
+
+    for (U u : us) {
+      System.out.println("Discriminator: " + getUnion(u).discriminator().value());
+    }
+  }
+}

--- a/java/idl2jni/tests/union/TestUnion.java
+++ b/java/idl2jni/tests/union/TestUnion.java
@@ -1,6 +1,7 @@
 public class TestUnion {
 
-  private static native U getUnion(U u);
+  private static native NoDefault getUnionND(NoDefault u);
+  private static native WithDefault getUnionWD(WithDefault u);
 
   public static void main(String[] args) {
     String lib = "idl2jni_test_union";
@@ -13,13 +14,39 @@ public class TestUnion {
       lib += "d";
     System.loadLibrary(lib);
 
-    U[] us = {new U(), new U(), new U()};
-    us[0].__default(E.E1);
-    us[1].o((byte) 1);
-    us[2].s((short) 2);
+    NoDefault[] nds = {new NoDefault(), new NoDefault(), new NoDefault(), new NoDefault()};
+    nds[0].__default(E.E1);
+    nds[1].o((byte) 1);
+    nds[2].s((short) 2);
+    nds[3].s(E.E4, (short) 3);
 
-    for (U u : us) {
-      System.out.println("Discriminator: " + getUnion(u).discriminator().value());
+    boolean failed = false;
+    for (NoDefault u1 : nds) {
+      final NoDefault u2 = getUnionND(u1);
+      if (u1.discriminator() != u2.discriminator()) {
+        System.out.println("ERROR: NoDefault expected discriminator " +
+                           u1.discriminator() + " != actual " +
+                           u2.discriminator());
+        failed = true;
+      }
     }
+
+    WithDefault[] wds = {new WithDefault(), new WithDefault(), new WithDefault(), new WithDefault()};
+    wds[0].b(true);
+    wds[1].s(E.E2, "");
+    wds[2].s(E.E3, "");
+    wds[3].s(E.E4, "");
+
+    for (WithDefault u1 : wds) {
+      final WithDefault u2 = getUnionWD(u1);
+      if (u1.discriminator() != u2.discriminator()) {
+        System.out.println("ERROR: WithDefault expected discriminator " +
+                           u1.discriminator() + " != actual " +
+                           u2.discriminator());
+        failed = true;
+      }
+    }
+
+    System.exit(failed ? 1 : 0);
   }
 }

--- a/java/idl2jni/tests/union/UnionTest.idl
+++ b/java/idl2jni/tests/union/UnionTest.idl
@@ -1,7 +1,15 @@
-enum E { E1, E2, E3 };
-union U switch (E) {
+enum E { E1, E2, E3, E4 };
+union NoDefault switch (E) {
  case E2:
    octet o;
  case E3:
+ case E4:
    short s;
+};
+
+union WithDefault switch (E) {
+ case E1:
+   boolean b;
+ default:
+   string s;
 };

--- a/java/idl2jni/tests/union/UnionTest.idl
+++ b/java/idl2jni/tests/union/UnionTest.idl
@@ -1,0 +1,7 @@
+enum E { E1, E2, E3 };
+union U switch (E) {
+ case E2:
+   octet o;
+ case E3:
+   short s;
+};

--- a/java/idl2jni/tests/union/idl2jni_test_union.mpc
+++ b/java/idl2jni/tests/union/idl2jni_test_union.mpc
@@ -1,0 +1,3 @@
+project: idl2jni, dcps_test {
+
+}

--- a/java/idl2jni/tests/union/run_test.pl
+++ b/java/idl2jni/tests/union/run_test.pl
@@ -1,0 +1,22 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+
+# -*- perl -*-
+
+use Env qw(ACE_ROOT DDS_ROOT);
+use lib "$ACE_ROOT/bin";
+use lib "$DDS_ROOT/bin";
+use PerlDDS::Run_Test;
+use PerlDDS::Process_Java;
+use strict;
+
+PerlACE::add_lib_path ('.');
+my $CL = new PerlDDS::Process_Java ('TestUnion');
+my $client_status = $CL->SpawnWaitKill (300);
+
+if ($client_status != 0) {
+    print STDERR "ERROR: client returned $client_status\n";
+}
+
+exit $client_status;

--- a/java/tests/dcps_java_tests.lst
+++ b/java/tests/dcps_java_tests.lst
@@ -9,6 +9,7 @@
 # Paths are relative to $DDS_ROOT
 
 java/tests/hello/run_test.pl
+java/idl2jni/tests/union/run_test.pl
 java/tests/builtintopics/run_test.pl: !NO_BUILT_IN_TOPICS
 java/tests/complex_idl/run_test.pl
 java/tests/multirepo/run_test.pl
@@ -45,4 +46,3 @@ java/tests/messenger/both/run_test.pl
 java/tests/zerocopy/run_test.pl
 
 java/tests/participant_location/run_test.pl -noice: !DCPS_MIN CXX11 RTPS !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !IPV6
-


### PR DESCRIPTION
Unions with implicit defaults that don't have a branch selected need their discriminator values copied from C++ to Java.
There may be one more issue with unions that I'll add to this PR, but I wanted to get CI going on this part of it.