### PR TITLE
XTypes: Default data representation fixes

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -854,13 +854,7 @@ DDS::ReturnCode_t DataReaderImpl::set_qos(const DDS::DataReaderQos& qos_arg)
 
   if (Qos_Helper::valid(qos) && Qos_Helper::consistent(qos)) {
     // Make sure Data Representation QoS is initialized
-    topic_servant_->check_data_representation_qos(qos_.representation.value);
-
-    if (qos.representation.value.length() == 0) {
-      qos.representation.value.length(2);
-      qos.representation.value[0] = DDS::XCDR_DATA_REPRESENTATION;
-      qos.representation.value[1] = UNALIGNED_CDR_DATA_REPRESENTATION;
-    }
+    topic_servant_->check_data_representation_qos(qos.representation.value);
 
     if (qos_ == qos)
       return DDS::RETCODE_OK;

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -856,6 +856,12 @@ DDS::ReturnCode_t DataReaderImpl::set_qos(const DDS::DataReaderQos& qos_arg)
     // Make sure Data Representation QoS is initialized
     topic_servant_->check_data_representation_qos(qos_.representation.value);
 
+    if (qos.representation.value.length() == 0) {
+      qos.representation.value.length(2);
+      qos.representation.value[0] = DDS::XCDR_DATA_REPRESENTATION;
+      qos.representation.value[1] = UNALIGNED_CDR_DATA_REPRESENTATION;
+    }
+
     if (qos_ == qos)
       return DDS::RETCODE_OK;
 

--- a/dds/DCPS/Qos_Helper.inl
+++ b/dds/DCPS/Qos_Helper.inl
@@ -341,13 +341,27 @@ bool operator==(
   const DDS::DataRepresentationQosPolicy& qos1,
   const DDS::DataRepresentationQosPolicy& qos2)
 {
-  const CORBA::ULong count = qos1.value.length();
-  const CORBA::ULong count2 = qos1.value.length();
+  DDS::DataRepresentationQosPolicy newqos1 = qos1;
+  if (newqos1.value.length() == 0) {
+    newqos1.value.length(2);
+    newqos1.value[0] = DDS::XCDR_DATA_REPRESENTATION;
+    newqos1.value[1] = UNALIGNED_CDR_DATA_REPRESENTATION;
+  }
+
+  DDS::DataRepresentationQosPolicy newqos2 = qos2;
+  if (newqos2.value.length() == 0) {
+    newqos2.value.length(2);
+    newqos2.value[0] = DDS::XCDR_DATA_REPRESENTATION;
+    newqos2.value[1] = UNALIGNED_CDR_DATA_REPRESENTATION;
+  }
+
+  const CORBA::ULong count = newqos1.value.length();
+  const CORBA::ULong count2 = newqos2.value.length();
   if (count != count2) {
     return false;
   }
   for (CORBA::ULong i = 0; i < count; ++i) {
-    if (qos1.value[i] != qos2.value[i]) {
+    if (newqos1.value[i] != newqos2.value[i]) {
       return false;
     }
   }


### PR DESCRIPTION
There appears to be widespread issues with the way DataRepresentation QoS is being defaulted.   In the spec, it specifies that the default DataRepresentation QoS should be empty and be used as if it were set to XCDR.  Our implementation handles this by explicitly adding XCDR and UNALIGNED_CDR when the list is empty.  This causes a large variety of problems in different tests.  

For example, in the SetQosDeadline test, set_qos was failing because it was trying to change a QoS it viewed as unchangable. It also had a problem trying to compare QoS when the list was empty.

FooTest3_0 was also having problems where the default DataRepresentation QoS was set to the empty list.  

FooTest4 had almost the exact same issue as SetQosDeadline being that it had comparison problems when the list was empty.

The fixes in this PR are inelegant but "fix" well over a dozen tests.  I will check to see how many more tests are fixed by this to get an idea of how much work needs to be done by Tuesday.  

A previous PR was for the DCPSInfoRepo test, which required fixes in the test itself to initialize a DataRepresentation QoS in order to function.

There is probably a better way of handling these fixes and this PR should be seen as triage rather than a long term solution. Long story short, the way we are handling DataRepresentation QoS defaulting is problematic, and there may be more similar changes needed for other tests.  Maybe there is a better way to handle the defaulting  DataRepresentation QoS.
