### PR TITLE
Only send auth replies for auth requests

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1666,6 +1666,7 @@ namespace OpenDDS {
         bool has_last_stateless_msg_;
         MonotonicTimePoint stateless_msg_deadline_;
         DDS::Security::ParticipantStatelessMessage last_stateless_msg_;
+        DDS::Security::HandshakeMessageToken last_handshake_request_data_;
 
         MonotonicTimePoint auth_deadline_;
         AuthState auth_state_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -915,7 +915,23 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
   DCPS::RepoId reader = src_participant;
   reader.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
 
-  if (iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REPLY && msg.related_message_identity.source_guid == GUID_UNKNOWN) {
+  if ((iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REPLY || iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REPLY_SENT) && msg.related_message_identity.source_guid == GUID_UNKNOWN) {
+    // The initiator will retry using the same request.  If the
+    // initiator retries very quickly and we change the response,
+    // i.e., different diffie, then we will never authenticate.  Thus,
+    // if the initiator sends the same request, then we should send
+    // the same response.
+    if (iter->second.has_last_stateless_msg_ &&
+        iter->second.last_handshake_request_data_ == msg.message_data[0]) {
+      if (sedp_.write_stateless_message(iter->second.last_stateless_msg_, reader) != DDS::RETCODE_OK) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Unable to write stateless message for handshake reply.\n")));
+        }
+        return;
+      }
+    }
+
     DDS::Security::ParticipantBuiltinTopicDataSecure pbtds = {
       {
         {
@@ -985,11 +1001,9 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
         return;
       }
       iter->second.has_last_stateless_msg_ = true;
-      iter->second.stateless_msg_deadline_ = MonotonicTimePoint::now() + config_->auth_resend_period();
       iter->second.last_stateless_msg_ = reply;
+      iter->second.last_handshake_request_data_ = msg.message_data[0];
       iter->second.auth_state_ = DCPS::AS_HANDSHAKE_REPLY_SENT;
-      auth_resends_.insert(std::make_pair(iter->second.stateless_msg_deadline_, src_participant));
-      tport_->auth_resend_processor_->schedule(config_->auth_resend_period());
       return;
     } else if (vr == DDS::Security::VALIDATION_OK_FINAL_MESSAGE) {
       // Theoretically, this shouldn't happen unless handshakes can involve fewer than 3 messages
@@ -1002,22 +1016,16 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
       }
       iter->second.has_last_stateless_msg_ = false;
       iter->second.auth_state_ = DCPS::AS_AUTHENTICATED;
-      purge_auth_deadlines(participants_.find(src_participant));
+      purge_auth_deadlines(iter);
       match_authenticated(src_participant, iter);
     } else if (vr == DDS::Security::VALIDATION_OK) {
       // Theoretically, this shouldn't happen unless handshakes can involve fewer than 3 messages
       iter->second.has_last_stateless_msg_ = false;
       iter->second.auth_state_ = DCPS::AS_AUTHENTICATED;
-      purge_auth_deadlines(participants_.find(src_participant));
+      purge_auth_deadlines(iter);
       match_authenticated(src_participant, iter);
     }
-  }
-
-  if (iter == participants_.end()) {
-    return;
-  }
-
-  if ((iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REQUEST_SENT || iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REPLY_SENT) && msg.related_message_identity.source_guid == guid_) {
+  } else if ((iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REQUEST_SENT || iter->second.auth_state_ == DCPS::AS_HANDSHAKE_REPLY_SENT) && msg.related_message_identity.source_guid == guid_) {
     DDS::Security::ParticipantStatelessMessage reply;
     reply.message_identity.source_guid = guid_;
     reply.message_identity.sequence_number = 0;
@@ -1055,7 +1063,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
       iter->second.has_last_stateless_msg_ = true;
       iter->second.stateless_msg_deadline_ = MonotonicTimePoint::now() + config_->auth_resend_period();
       iter->second.last_stateless_msg_ = reply;
-      purge_auth_resends(participants_.find(src_participant));
+      purge_auth_resends(iter);
       auth_resends_.insert(std::make_pair(iter->second.stateless_msg_deadline_, src_participant));
       tport_->auth_resend_processor_->schedule(config_->auth_resend_period());
       // cache the outbound message, but don't change state, since roles shouldn't have changed?
@@ -1069,17 +1077,15 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
       }
       iter->second.has_last_stateless_msg_ = false;
       iter->second.auth_state_ = DCPS::AS_AUTHENTICATED;
-      purge_auth_deadlines(participants_.find(src_participant));
+      purge_auth_deadlines(iter);
       match_authenticated(src_participant, iter);
     } else if (vr == DDS::Security::VALIDATION_OK) {
       iter->second.has_last_stateless_msg_ = false;
       iter->second.auth_state_ = DCPS::AS_AUTHENTICATED;
-      purge_auth_deadlines(participants_.find(src_participant));
+      purge_auth_deadlines(iter);
       match_authenticated(src_participant, iter);
     }
   }
-
-  return;
 }
 
 void
@@ -1137,9 +1143,9 @@ Spdp::process_auth_resends(const DCPS::MonotonicTimePoint& now)
        pos != limit && pos->first <= now;) {
 
     DiscoveredParticipantIter pit = participants_.find(pos->second);
-    if (pit != participants_.end() && pit->second.stateless_msg_deadline_ <= now &&
-        (pit->second.auth_state_ == DCPS::AS_HANDSHAKE_REQUEST_SENT ||
-         pit->second.auth_state_ == DCPS::AS_HANDSHAKE_REPLY_SENT)) {
+    if (pit != participants_.end() &&
+        pit->second.stateless_msg_deadline_ <= now &&
+        pit->second.auth_state_ == DCPS::AS_HANDSHAKE_REQUEST_SENT) {
       RepoId reader = pit->first;
       reader.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
       pit->second.stateless_msg_deadline_ = now + config_->auth_resend_period();

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -394,7 +394,7 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
   remote_data.diffie_hellman = DCPS::move(diffie_hellman);
   remote_data.hash_c1 = hash_c1;
 
-  if (handshake_handle != DDS::HANDLE_NIL) {
+  if (handshake_handle == DDS::HANDLE_NIL) {
     handshake_handle = get_next_handle();
   }
 
@@ -633,8 +633,8 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
     return Failure;
   }
 
-  LocalParticipantData& local_data = *(handshake_data.first);
-  RemoteParticipantData& remote_data = *(handshake_data.second);
+  const LocalParticipantData& local_data = *handshake_data.first;
+  RemoteParticipantData& remote_data = *handshake_data.second;
 
   DDS::Security::HandshakeMessageToken message_data_in(request_token);
   TokenReader message_in(message_data_in);
@@ -782,7 +782,10 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
   remote_data.hash_c1 = hash_c1;
   remote_data.hash_c2 = hash_c2;
 
-  handshake_handle = get_next_handle();
+  if (handshake_handle == DDS::HANDLE_NIL) {
+    handshake_handle = get_next_handle();
+  }
+
   {
     ACE_Guard<ACE_Thread_Mutex> guard(handshake_mutex_);
     handshake_data_[handshake_handle] = handshake_data;

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -332,10 +332,10 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
     return DDS::Security::VALIDATION_FAILED;
   }
 
-  const LocalParticipantData& local_data = *(handshake_data.first);
-  RemoteParticipantData& remote_data = *(handshake_data.second);
+  const LocalParticipantData& local_data = *handshake_data.first;
+  RemoteParticipantData& remote_data = *handshake_data.second;
 
-  const LocalAuthCredentialData& local_credential_data = *(local_data.credentials);
+  const LocalAuthCredentialData& local_credential_data = *local_data.credentials;
 
   SSL::DiffieHellman::unique_ptr diffie_hellman(new SSL::DiffieHellman(new SSL::ECDH_PRIME_256_V1_CEUM));
 

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -332,7 +332,7 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
     return DDS::Security::VALIDATION_FAILED;
   }
 
-  LocalParticipantData& local_data = *(handshake_data.first);
+  const LocalParticipantData& local_data = *(handshake_data.first);
   RemoteParticipantData& remote_data = *(handshake_data.second);
 
   const LocalAuthCredentialData& local_credential_data = *(local_data.credentials);
@@ -384,7 +384,6 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
   } else {
     const DDS::OctetSeq& challenge_data = auth_wrapper.get_bin_property_value("future_challenge");
     message_out.add_bin_property("challenge1", challenge_data);
-
   }
 
   remote_data.initiator_identity = initiator_identity_handle;
@@ -395,7 +394,10 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
   remote_data.diffie_hellman = DCPS::move(diffie_hellman);
   remote_data.hash_c1 = hash_c1;
 
-  handshake_handle = get_next_handle();
+  if (handshake_handle != DDS::HANDLE_NIL) {
+    handshake_handle = get_next_handle();
+  }
+
   {
     ACE_Guard<ACE_Thread_Mutex> identity_data_guard(handshake_mutex_);
     handshake_data_[handshake_handle] = handshake_data;
@@ -623,12 +625,12 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
 
   if (! handshake_data.first) {
     set_security_error(ex, -1, 0, "Unknown local participant");
-    return DDS::Security::VALIDATION_FAILED;
+    return Failure;
   }
 
   if (! handshake_data.second) {
     set_security_error(ex, -1, 0, "Unknown remote participant");
-    return DDS::Security::VALIDATION_FAILED;
+    return Failure;
   }
 
   LocalParticipantData& local_data = *(handshake_data.first);

--- a/tests/security/AccessControlTest.cpp
+++ b/tests/security/AccessControlTest.cpp
@@ -22,8 +22,6 @@ using DDS::DomainParticipantQos;
 using namespace testing;
 
 
-static const ::CORBA::Boolean CFALSE(false);
-static const ::CORBA::Boolean CTRUE(true);
 static const char* Expected_Permissions_Token_Class_Id ="DDS:Access:Permissions:1.0";
 static const char* Expected_Permissions_Cred_Token_Class_Id ="DDS:Access:PermissionsCredential";
 //static const char* identity_ca_file = "certs/opendds_identity_ca_cert.pem";

--- a/tests/security/Authentication/AuthenticationTest.cpp
+++ b/tests/security/Authentication/AuthenticationTest.cpp
@@ -1073,7 +1073,7 @@ TEST_F(AuthenticationTest, GetSharedSecret_InitiatorAndReplier_Match)
   ASSERT_EQ(r, DDS::Security::VALIDATION_OK);
 
   SharedSecretHandle_var secret1 = mp1.auth.get_shared_secret(mp1.handshake_handle, ex);
-  SharedSecretHandle_var secret2 = mp1.auth.get_shared_secret(mp2.handshake_handle, ex);
+  SharedSecretHandle_var secret2 = mp2.auth.get_shared_secret(mp2.handshake_handle, ex);
   ASSERT_NE((void*)0, secret1);
   ASSERT_NE((void*)0, secret2);
   DDS::OctetSeq_var secret1_data = secret1->sharedSecret();

--- a/tests/security/Authentication/AuthenticationTest.cpp
+++ b/tests/security/Authentication/AuthenticationTest.cpp
@@ -424,6 +424,7 @@ TEST_F(AuthenticationTest, BeginHandshakeRequest_UsingLocalAuthRequestToken_Succ
                                    ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   // Since many of the out-params are randomly-generated it is only
   // practical to check the lengths of the resultant parameters
@@ -523,6 +524,7 @@ TEST_F(BeginHandshakeReplyTest, BeginHandshakeReply_PendingHandshakeMessage_Succ
                                    ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   r = auth.validate_remote_identity(mp1.id_handle,
                                     mp2.auth_request_message_token,
@@ -609,6 +611,7 @@ TEST_F(AuthenticationTest, BeginHandshakeRequest_BeginHandshakeReply_ProcessHand
                                    ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   IdentityHandle mp2_remote_mp1;
   r = auth.validate_remote_identity(mp2_remote_mp1,
@@ -637,6 +640,7 @@ TEST_F(AuthenticationTest, BeginHandshakeRequest_BeginHandshakeReply_ProcessHand
                                  ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp2.handshake_handle, DDS::HANDLE_NIL);
 
   // Process handshake on mp1
   DDS::Security::HandshakeMessageToken final_token;
@@ -697,13 +701,14 @@ TEST_F(AuthenticationTest, SeparateAuthImpls_BeginHandshakeRequest_BeginHandshak
 
   // Since mp1 received VALIDATION_PENDING_HANDSHAKE_REQUEST: mp1 = initiator, mp2 = replier
   r = mp1.auth.begin_handshake_request(mp1.handshake_handle,
-                                    request_token,
-                                    mp1.id_handle,
-                                    mp1.id_handle_remote,
-                                    mp1.mock_participant_builtin_topic_data,
-                                    ex);
+                                       request_token,
+                                       mp1.id_handle,
+                                       mp1.id_handle_remote,
+                                       mp1.mock_participant_builtin_topic_data,
+                                       ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   // Pretend like we're passing messages here ... tokens and guids are transfered OK
   mp2.id_token_remote = mp1.id_token;
@@ -729,13 +734,14 @@ TEST_F(AuthenticationTest, SeparateAuthImpls_BeginHandshakeRequest_BeginHandshak
   DDS::Security::HandshakeMessageToken reply_token(request_token); // Request was an in-out param
 
   r = mp2.auth.begin_handshake_reply(mp2.handshake_handle,
-                                  reply_token,
-                                  mp2.id_handle_remote,
-                                  mp2.id_handle,
-                                  mp2.mock_participant_builtin_topic_data,
-                                  ex);
+                                     reply_token,
+                                     mp2.id_handle_remote,
+                                     mp2.id_handle,
+                                     mp2.mock_participant_builtin_topic_data,
+                                     ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp2.handshake_handle, DDS::HANDLE_NIL);
 
   // Process handshake on mp1
   DDS::Security::HandshakeMessageToken final_token;
@@ -796,13 +802,14 @@ TEST_F(AuthenticationTest, SeparateAuthImpls_FullHandshake_NoAuthTokenTransfer_S
 
   // Since mp1 received VALIDATION_PENDING_HANDSHAKE_REQUEST: mp1 = initiator, mp2 = replier
   r = mp1.auth.begin_handshake_request(mp1.handshake_handle,
-                                    request_token,
-                                    mp1.id_handle,
-                                    mp1.id_handle_remote,
-                                    mp1.mock_participant_builtin_topic_data,
-                                    ex);
+                                       request_token,
+                                       mp1.id_handle,
+                                       mp1.id_handle_remote,
+                                       mp1.mock_participant_builtin_topic_data,
+                                       ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   // Pretend like we're passing messages here ... tokens and guids are transfered OK
   mp2.id_token_remote = mp1.id_token;
@@ -827,13 +834,14 @@ TEST_F(AuthenticationTest, SeparateAuthImpls_FullHandshake_NoAuthTokenTransfer_S
   DDS::Security::HandshakeMessageToken reply_token(request_token); // Request was an in-out param
 
   r = mp2.auth.begin_handshake_reply(mp2.handshake_handle,
-                                  reply_token,
-                                  mp2.id_handle_remote,
-                                  mp2.id_handle,
-                                  mp2.mock_participant_builtin_topic_data,
-                                  ex);
+                                     reply_token,
+                                     mp2.id_handle_remote,
+                                     mp2.id_handle,
+                                     mp2.mock_participant_builtin_topic_data,
+                                     ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp2.handshake_handle, DDS::HANDLE_NIL);
 
   // Process handshake on mp1
   DDS::Security::HandshakeMessageToken final_token;
@@ -894,13 +902,14 @@ TEST_F(AuthenticationTest, GetAuthenticationPeerCredentialToken_InitiatorAndRepl
 
   // Since mp1 received VALIDATION_PENDING_HANDSHAKE_REQUEST: mp1 = initiator, mp2 = replier
   r = mp1.auth.begin_handshake_request(mp1.handshake_handle,
-                                    request_token,
-                                    mp1.id_handle,
-                                    mp1.id_handle_remote,
-                                    mp1.mock_participant_builtin_topic_data,
-                                    ex);
+                                       request_token,
+                                       mp1.id_handle,
+                                       mp1.id_handle_remote,
+                                       mp1.mock_participant_builtin_topic_data,
+                                       ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   // Pretend like we're passing messages here ... tokens and guids are transfered OK
   mp2.id_token_remote = mp1.id_token;
@@ -926,13 +935,14 @@ TEST_F(AuthenticationTest, GetAuthenticationPeerCredentialToken_InitiatorAndRepl
   DDS::Security::HandshakeMessageToken reply_token(request_token); // Request was an in-out param
 
   r = mp2.auth.begin_handshake_reply(mp2.handshake_handle,
-                                  reply_token,
-                                  mp2.id_handle_remote,
-                                  mp2.id_handle,
-                                  mp2.mock_participant_builtin_topic_data,
-                                  ex);
+                                     reply_token,
+                                     mp2.id_handle_remote,
+                                     mp2.id_handle,
+                                     mp2.mock_participant_builtin_topic_data,
+                                     ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp2.handshake_handle, DDS::HANDLE_NIL);
 
   // Process handshake on mp1
   DDS::Security::HandshakeMessageToken final_token;
@@ -1014,13 +1024,14 @@ TEST_F(AuthenticationTest, GetSharedSecret_InitiatorAndReplier_Match)
 
   // Since mp1 received VALIDATION_PENDING_HANDSHAKE_REQUEST: mp1 = initiator, mp2 = replier
   r = mp1.auth.begin_handshake_request(mp1.handshake_handle,
-                                    request_token,
-                                    mp1.id_handle,
-                                    mp1.id_handle_remote,
-                                    mp1.mock_participant_builtin_topic_data,
-                                    ex);
+                                       request_token,
+                                       mp1.id_handle,
+                                       mp1.id_handle_remote,
+                                       mp1.mock_participant_builtin_topic_data,
+                                       ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp1.handshake_handle, DDS::HANDLE_NIL);
 
   // Pretend like we're passing messages here ... tokens and guids are transfered OK
   mp2.id_token_remote = mp1.id_token;
@@ -1046,13 +1057,14 @@ TEST_F(AuthenticationTest, GetSharedSecret_InitiatorAndReplier_Match)
   DDS::Security::HandshakeMessageToken reply_token(request_token); // Request was an in-out param
 
   r = mp2.auth.begin_handshake_reply(mp2.handshake_handle,
-                                  reply_token,
-                                  mp2.id_handle_remote,
-                                  mp2.id_handle,
-                                  mp2.mock_participant_builtin_topic_data,
-                                  ex);
+                                     reply_token,
+                                     mp2.id_handle_remote,
+                                     mp2.id_handle,
+                                     mp2.mock_participant_builtin_topic_data,
+                                     ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp2.handshake_handle, DDS::HANDLE_NIL);
 
   // Process handshake on mp1
   DDS::Security::HandshakeMessageToken final_token;

--- a/tests/security/Authentication/AuthenticationTest.cpp
+++ b/tests/security/Authentication/AuthenticationTest.cpp
@@ -543,13 +543,27 @@ TEST_F(BeginHandshakeReplyTest, BeginHandshakeReply_PendingHandshakeMessage_Succ
   DDS::Security::HandshakeMessageToken reply_token(request_token);
 
   r = auth.begin_handshake_reply(mp2.handshake_handle,
-                                 reply_token, // Token received from mp1 after it called begin_handhsake_request
+                                 reply_token, // Token received from mp1 after it called begin_handshake_request
+                                 mp1.id_handle,
+                                 mp2.id_handle,
+                                 mp2.mock_participant_builtin_topic_data,
+                                 ex);
+  const DDS::Security::HandshakeHandle mp2_handshake_handle = mp2.handshake_handle;
+
+  ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_NE(mp2_handshake_handle, DDS::HANDLE_NIL);
+
+  // Suppose the initiator didn't get the reply and resends the request.
+
+  r = auth.begin_handshake_reply(mp2.handshake_handle,
+                                 reply_token, // Token received from mp1 after it called begin_handshake_request
                                  mp1.id_handle,
                                  mp2.id_handle,
                                  mp2.mock_participant_builtin_topic_data,
                                  ex);
 
   ASSERT_EQ(r, DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE);
+  ASSERT_EQ(mp2_handshake_handle, mp2.handshake_handle);
 }
 
 TEST_F(AuthenticationTest, BeginHandshakeRequest_BeginHandshakeReply_ProcessHandshake_Success)


### PR DESCRIPTION
One participant (the initiator) has discovered another
participant (the replier) and sent an auth request.  Due to SPDP
reset, it removes the participant but immediately rediscovers it and
sends another auth request.  If the replier receives the first auth
request, it will continue to respond to it but authentication will
fail as the initiator has changed the Diffie-Hellman parameters.

Solution:

1. The replier will not periodically resend replies.  It will only
send auth replies in response to an auth request.
2. If the replier detects that the auth request has changed, it will
recompute a new auth reply.