### PR TITLE
Fix to make master build on VS 2019 Version 16.7.0 Preview 1.0

### DIFF
--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -20,6 +20,8 @@
 
 #include "dds/DCPS/Definitions.h"
 
+#include <string>
+
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Message_Block;
 ACE_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
Discussed on the mailing list, with VS 2019 V16.7.0 Preview 1.0 there are 9 projects that don't build after doing a default "configure" -> "devenv DDS_TAOv2.sln" -> "Build Solution".

A fix is attached where #include <string> is added to dds/DCPS/Serializer.h so, presumably, something changed recently in VS2019 in relation to its mechanism for working out dependencies.