### PR TITLE
Unlock for ParticipantLocationTopic unregister/dispose

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1712,26 +1712,25 @@ namespace OpenDDS {
         if (removed) {
 #ifndef DDS_HAS_MINIMUM_BIT
           ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
-          // bit may be null if the DomainParticipant is shutting down
-          if (bit && iter->second.bit_ih_ != DDS::HANDLE_NIL) {
-            ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
-            bit->set_instance_state(iter->second.bit_ih_,
-                                    DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
-          }
-          iter = participants_.find(part_id);
-          if (iter == participants_.end()) {
-            return;
-          }
           ParticipantLocationBuiltinTopicDataDataReaderImpl* loc_bit = part_loc_bit();
           // bit may be null if the DomainParticipant is shutting down
-          if (loc_bit && iter->second.location_ih_ != DDS::HANDLE_NIL) {
-            ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
-            loc_bit->set_instance_state(iter->second.location_ih_,
+          if ((bit && iter->second.bit_ih_ != DDS::HANDLE_NIL) ||
+              (loc_bit && iter->second.location_ih_ != DDS::HANDLE_NIL)) {
+            {
+              ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
+              if (bit && iter->second.bit_ih_ != DDS::HANDLE_NIL) {
+                bit->set_instance_state(iter->second.bit_ih_,
                                         DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
-          }
-          iter = participants_.find(part_id);
-          if (iter == participants_.end()) {
-            return;
+              }
+              if (loc_bit && iter->second.location_ih_ != DDS::HANDLE_NIL) {
+                loc_bit->set_instance_state(iter->second.location_ih_,
+                                            DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
+              }
+            }
+            iter = participants_.find(part_id);
+            if (iter == participants_.end()) {
+              return;
+            }
           }
 #endif /* DDS_HAS_MINIMUM_BIT */
           if (DCPS_debug_level > 3) {

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1714,14 +1714,24 @@ namespace OpenDDS {
           ParticipantBuiltinTopicDataDataReaderImpl* bit = part_bit();
           // bit may be null if the DomainParticipant is shutting down
           if (bit && iter->second.bit_ih_ != DDS::HANDLE_NIL) {
+            ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
             bit->set_instance_state(iter->second.bit_ih_,
                                     DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
+          }
+          iter = participants_.find(part_id);
+          if (iter == participants_.end()) {
+            return;
           }
           ParticipantLocationBuiltinTopicDataDataReaderImpl* loc_bit = part_loc_bit();
           // bit may be null if the DomainParticipant is shutting down
           if (loc_bit && iter->second.location_ih_ != DDS::HANDLE_NIL) {
+            ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
             loc_bit->set_instance_state(iter->second.location_ih_,
                                         DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
+          }
+          iter = participants_.find(part_id);
+          if (iter == participants_.end()) {
+            return;
           }
 #endif /* DDS_HAS_MINIMUM_BIT */
           if (DCPS_debug_level > 3) {


### PR DESCRIPTION
This was motivated by a deadlock.  The first thread was adding a
participant on the basis of a successful security handshake.  This
thread unlocks the SPDP lock so that it can call into the
ParticipantLocationTopic which acquires the sample lock and then
reacquires the SPDP lock.  The second thread was sending a periodic
announcement and, as a by-product, cleaning up expired participants.
This thread acquired the SPDP lock before calling into DiscoveryBase
to remove the participant.  The code in discovery base called into the
ParticipantLocationTopic with the SPDP lock.  The second thread then
attempts to acquire the sample lock.

Solution: Unlock the SPDP lock before interacting with the
ParticipantLocationTopic reader when removing a discovered participant.