### PR TITLE
Associations are removed after expire-associate

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -259,13 +259,15 @@ DataReaderImpl::add_association(const RepoId& yourId,
           writer_id,
           info));
 
-      // Schedule timer if necessary
-      //   - only need to check reader qos - we know the writer must be >= reader
-      if (this->qos_.durability.kind > DDS::VOLATILE_DURABILITY_QOS) {
-        info->waiting_for_end_historic_samples_ = true;
-      }
+    // Schedule timer if necessary
+    //   - only need to check reader qos - we know the writer must be >= reader
+    if (this->qos_.durability.kind > DDS::VOLATILE_DURABILITY_QOS) {
+      info->waiting_for_end_historic_samples_ = true;
+    }
 
-      this->statistics_.insert(
+    remove_association_sweeper_->cancel_timer(writer_id);
+
+    this->statistics_.insert(
         StatsMapType::value_type(
             writer_id,
             WriterStats(raw_latency_buffer_size_, raw_latency_buffer_type_)));

--- a/dds/DCPS/RemoveAssociationSweeper.h
+++ b/dds/DCPS/RemoveAssociationSweeper.h
@@ -25,6 +25,17 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace DCPS {
+namespace {
+
+struct Predicate {
+  explicit Predicate(const PublicationId writer_id) : writer_id_(writer_id) {}
+  PublicationId writer_id_;
+  bool operator() (const RcHandle<WriterInfo>& info) const {
+    return writer_id_ == info->writer_id_;
+  }
+};
+
+}
 
 // Class to cleanup associations scheduled for removal
 template <typename T>
@@ -34,9 +45,9 @@ public:
                            ACE_thread_t owner,
                            T* reader);
 
-  void schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info, bool callback);
-  ReactorInterceptor::CommandPtr cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info);
-  void cancel_timer(OpenDDS::DCPS::PublicationId writer_id);
+  void schedule_timer(RcHandle<WriterInfo>& info, bool callback);
+  ReactorInterceptor::CommandPtr cancel_timer(RcHandle<WriterInfo>& info);
+  void cancel_timer(const PublicationId& writer_id);
 
   // Arg will be PublicationId
   int handle_timeout(const ACE_Time_Value& current_time, const void* arg);
@@ -65,7 +76,7 @@ private:
 
   protected:
     RemoveAssociationSweeper<T>* sweeper_;
-    RcHandle<OpenDDS::DCPS::WriterInfo> info_;
+    RcHandle<WriterInfo> info_;
   };
 
   class ScheduleCommand : public CommandBase {
@@ -103,7 +114,7 @@ RemoveAssociationSweeper<T>::~RemoveAssociationSweeper()
 { }
 
 template <typename T>
-void RemoveAssociationSweeper<T>::schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info, bool callback)
+void RemoveAssociationSweeper<T>::schedule_timer(RcHandle<WriterInfo>& info, bool callback)
 {
   info->scheduled_for_removal_ = true;
   info->notify_lost_ = callback;
@@ -114,7 +125,7 @@ void RemoveAssociationSweeper<T>::schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS
 
 template <typename T>
 ReactorInterceptor::CommandPtr
-RemoveAssociationSweeper<T>::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
+RemoveAssociationSweeper<T>::cancel_timer(RcHandle<WriterInfo>& info)
 {
   info->scheduled_for_removal_ = false;
   info->removal_deadline_ = MonotonicTimePoint::zero_value;
@@ -123,15 +134,8 @@ RemoveAssociationSweeper<T>::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS:
 
 template <typename T>
 void
-RemoveAssociationSweeper<T>::cancel_timer(OpenDDS::DCPS::PublicationId writer_id)
+RemoveAssociationSweeper<T>::cancel_timer(const PublicationId& writer_id)
 {
-  struct Predicate {
-    Predicate(const OpenDDS::DCPS::PublicationId writer_id) : writer_id_(writer_id) {}
-    OpenDDS::DCPS::PublicationId writer_id_;
-    bool operator() (const RcHandle<WriterInfo>& info) const {
-      return writer_id_ == info->writer_id_;
-    }
-  };
   OPENDDS_VECTOR(RcHandle<WriterInfo>)::iterator pos = std::find_if(info_set_.begin(), info_set_.end(), Predicate(writer_id));
   if (pos != info_set_.end()) {
     cancel_timer(*pos);

--- a/dds/DCPS/RemoveAssociationSweeper.h
+++ b/dds/DCPS/RemoveAssociationSweeper.h
@@ -28,7 +28,7 @@ namespace DCPS {
 namespace {
 
 struct Predicate {
-  explicit Predicate(const PublicationId writer_id) : writer_id_(writer_id) {}
+  explicit Predicate(const PublicationId& writer_id) : writer_id_(writer_id) {}
   PublicationId writer_id_;
   bool operator() (const RcHandle<WriterInfo>& info) const {
     return writer_id_ == info->writer_id_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -219,7 +219,8 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
     if (sender == DDS::HANDLE_NIL) {
       if (security_debug.encdec_warn) {
         ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy::receive_bytes: ")
-          ACE_TEXT("decode_rtps_message no remote participant crypto handle, dropping\n")));
+                   ACE_TEXT("decode_rtps_message no remote participant crypto handle for %C, dropping\n"),
+                   OPENDDS_STRING(GuidConverter(peer)).c_str()));
       }
       stop = true;
       return ret;


### PR DESCRIPTION
Suppose that a Participant A is suspended long enough that it expires
for Participant B.  Participant A is then resumed.  In RTPS, this will
most likely cause a number of timers to fire include the one that will
cause Participant A to 1) expire Participant B and 2) send SPDP.  As
part of expiring Participant B, associations between writers in
Participant B and readers in Participant A will be scheduled for
removal (in Participant A).  Sending SPDP will restart the discovery
process.  This may cause associations between the readers and writers
to complete for the timer fires that causes the association to be
removed.  Finally, that timer will fire and remove the association
that was just added.

Solution: When adding an association to a reader, cancel any
RemoveAssociationSweeper that will remove the writer.