### PR TITLE
DCPSDefaultAddress parsing

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -125,16 +125,8 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
       RtpsDiscoveryConfig_rch config = discovery->config();
 
       // spdpaddr defaults to DCPSDefaultAddress if set
-      if (!TheServiceParticipant->default_address().empty()) {
-        ACE_INET_Addr addr;
-        if (addr.set(TheServiceParticipant->default_address().c_str())) {
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) ERROR: RtpsDiscovery::Config::discovery_config(): ")
-                            ACE_TEXT("failed to parse Service Participant default address %C\n"),
-                            TheServiceParticipant->default_address().c_str()),
-                           -1);
-        }
-        config->spdp_local_address(addr);
+      if (TheServiceParticipant->default_address() != ACE_INET_Addr()) {
+        config->spdp_local_address(TheServiceParticipant->default_address());
       }
 
       DCPS::ValueMap values;

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -597,7 +597,13 @@ Service_Participant::parse_args(int &argc, ACE_TCHAR *argv[])
       got_log_verbose = true;
 
     } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSDefaultAddress"))) != 0) {
-      this->default_address_ = ACE_TEXT_ALWAYS_CHAR(currentArg);
+      if (default_address_.set(u_short(0), currentArg)) {
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("(%P|%t) ERROR: Service_Participant::parse_args: ")
+                          ACE_TEXT("failed to parse default address %C\n"),
+                          currentArg),
+                         -1);
+      }
       arg_shifter.consume_arg();
       got_default_address = true;
 
@@ -1679,7 +1685,15 @@ Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
     if (got_default_address) {
       ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSDefaultAddress")));
     } else {
-      GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("DCPSDefaultAddress"), this->default_address_)
+      ACE_TString default_address_str;
+      GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DCPSDefaultAddress"), default_address_str);
+      if (default_address_.set(u_short(0), default_address_str.c_str())) {
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("(%P|%t) ERROR: Service_Participant::load_common_configuration: ")
+                          ACE_TEXT("failed to parse default address %C\n"),
+                          default_address_str.c_str()),
+                         -1);
+      }
     }
 
     if (got_monitor) {

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -319,7 +319,7 @@ public:
     bit_enabled_ = b;
   }
 
-  ACE_CString default_address() const;
+  const ACE_INET_Addr& default_address() const { return default_address_; }
 
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
   /// Get the data durability cache corresponding to the given
@@ -545,7 +545,7 @@ private:
   int bit_lookup_duration_msec_;
 
   /// The default network address to use.
-  ACE_CString default_address_;
+  ACE_INET_Addr default_address_;
 
   /// The configuration object that imports the configuration
   /// file.

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -349,13 +349,6 @@ Service_Participant::is_shut_down() const
 }
 
 ACE_INLINE
-ACE_CString
-Service_Participant::default_address() const
-{
-  return this->default_address_;
-}
-
-ACE_INLINE
 bool
 Service_Participant::use_bidir_giop() const
 {

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -332,9 +332,9 @@ bool
 MulticastTransport::configure_i(MulticastInst& config)
 {
   // Override with DCPSDefaultAddress.
-  if (config.local_address_.empty () &&
-      !TheServiceParticipant->default_address ().empty ()) {
-    config.local_address_ = TheServiceParticipant->default_address ().c_str ();
+  if (config.local_address_.empty() &&
+      TheServiceParticipant->default_address() != ACE_INET_Addr()) {
+    config.local_address_ = TheServiceParticipant->default_address().get_host_name();
   }
 
   if (!config.group_address_.is_multicast()) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -367,10 +367,9 @@ bool
 RtpsUdpTransport::configure_i(RtpsUdpInst& config)
 {
   // Override with DCPSDefaultAddress.
-  if (config.local_address() == ACE_INET_Addr () &&
-      !TheServiceParticipant->default_address ().empty ()) {
-    ACE_INET_Addr addr(u_short(0), TheServiceParticipant->default_address().c_str());
-    config.local_address(addr);
+  if (config.local_address() == ACE_INET_Addr() &&
+      TheServiceParticipant->default_address() != ACE_INET_Addr()) {
+    config.local_address(TheServiceParticipant->default_address());
   }
 
   // Open the socket here so that any addresses/ports left

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -99,6 +99,12 @@ public:
 
   OPENDDS_STRING local_address_string() const { return local_address_str_; }
   ACE_INET_Addr local_address() const { return local_address_; }
+  void local_address(const ACE_INET_Addr& addr)
+  {
+    local_address_str_ = addr.get_host_name();
+    local_address_str_ += ':' + to_dds_string(addr.get_port_number());
+    local_address_ = addr;
+  }
   void local_address(const char* str)
   {
     local_address_str_ = str;

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -338,9 +338,9 @@ TcpTransport::configure_i(TcpInst& config)
   connector_.open(reactor_task()->get_reactor());
 
   // Override with DCPSDefaultAddress.
-  if (config.local_address() == ACE_INET_Addr () &&
-      !TheServiceParticipant->default_address ().empty ()) {
-    config.local_address(0, TheServiceParticipant->default_address ().c_str ());
+  if (config.local_address() == ACE_INET_Addr() &&
+      TheServiceParticipant->default_address() != ACE_INET_Addr()) {
+    config.local_address(TheServiceParticipant->default_address());
   }
 
   // Open our acceptor object so that we can accept passive connections

--- a/dds/DCPS/transport/udp/UdpInst.h
+++ b/dds/DCPS/transport/udp/UdpInst.h
@@ -38,6 +38,12 @@ public:
 
   OPENDDS_STRING local_address_string() const { return local_address_config_str_; }
   ACE_INET_Addr local_address() const { return local_address_; }
+  void local_address(const ACE_INET_Addr& addr)
+  {
+    local_address_config_str_ = addr.get_host_name();
+    local_address_config_str_ += ':' + to_dds_string(addr.get_port_number());
+    local_address_ = addr;
+  }
   void local_address(const char* str)
   {
     local_address_config_str_ = str;

--- a/dds/DCPS/transport/udp/UdpTransport.cpp
+++ b/dds/DCPS/transport/udp/UdpTransport.cpp
@@ -156,10 +156,9 @@ UdpTransport::configure_i(UdpInst& config)
   create_reactor_task();
 
   // Override with DCPSDefaultAddress.
-  if (config.local_address() == ACE_INET_Addr () &&
-      !TheServiceParticipant->default_address ().empty ()) {
-
-    config.local_address(0, TheServiceParticipant->default_address ().c_str ());
+  if (config.local_address() == ACE_INET_Addr() &&
+      TheServiceParticipant->default_address() != ACE_INET_Addr()) {
+    config.local_address(TheServiceParticipant->default_address());
   }
 
   // Our "server side" data link is created here, similar to the acceptor_

--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -51,6 +51,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(TheServiceParticipant->pending_timeout() == TimeDuration(10));
     TEST_CHECK(TheServiceParticipant->publisher_content_filter() == false);
     TEST_CHECK(TheServiceParticipant->get_default_discovery() == "MyDefaultDiscovery");
+    TEST_CHECK(TheServiceParticipant->default_address() == ACE_INET_Addr(u_short(0), "127.0.0.1"));
     TEST_CHECK(TheServiceParticipant->federation_recovery_duration() == 800);
     TEST_CHECK(TheServiceParticipant->federation_initial_backoff_seconds() == 2);
     TEST_CHECK(TheServiceParticipant->federation_backoff_multiplier() == 3);

--- a/tests/DCPS/ConfigFile/test1.ini
+++ b/tests/DCPS/ConfigFile/test1.ini
@@ -14,6 +14,7 @@ DCPSPersistentDataDir=my-data
 DCPSPendingTimeout=10
 DCPSPublisherContentFilter=0
 DCPSDefaultDiscovery=MyDefaultDiscovery
+DCPSDefaultAddress=127.0.0.1
 FederationRecoveryDuration=800
 FederationInitialBackoffSeconds=2
 FederationBackoffMultiplier=3

--- a/tests/DCPS/ConfigFile/test1_nobits.ini
+++ b/tests/DCPS/ConfigFile/test1_nobits.ini
@@ -14,6 +14,7 @@ DCPSPersistentDataDir=my-data
 DCPSPendingTimeout=10
 DCPSPublisherContentFilter=0
 DCPSDefaultDiscovery=MyDefaultDiscovery
+DCPSDefaultAddress=127.0.0.1
 FederationRecoveryDuration=800
 FederationInitialBackoffSeconds=2
 FederationBackoffMultiplier=3


### PR DESCRIPTION
Use ACE_INET_Addr as the internal representation of DCPSDefaultAddress
Update transports and RtpsDiscovery to match

Fixes #1717