### PR TITLE
Participants cannot reauthenticate

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
       echo ##vso[task.setvariable variable=VcVarsArch]%VCVARS_ARCH%
     displayName: Set VcVarsArch
   - script: |
-      git clone -q --depth 1 git://github.com/Microsoft/vcpkg.git %VCPKG_ROOT%
+      git clone -q --depth 1 -b 2020.06 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
       call %VCPKG_ROOT%\bootstrap-vcpkg.bat
       set VCPKG_ARCH=$(VcVarsArch)-windows
       %VCPKG_ROOT%\vcpkg install --triplet %VCPKG_ARCH% openssl xerces-c
@@ -127,7 +127,7 @@ jobs:
       echo ##vso[task.setvariable variable=VcVarsArch]%VCVARS_ARCH%
     displayName: Set VcVarsArch
   - script: |
-      git clone -q --depth 1 git://github.com/Microsoft/vcpkg.git %VCPKG_ROOT%
+      git clone -q --depth 1 -b 2020.06 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
       call %VCPKG_ROOT%\bootstrap-vcpkg.bat
       set VCPKG_ARCH=$(VcVarsArch)-windows
       %VCPKG_ROOT%\vcpkg install --triplet %VCPKG_ARCH% openssl xerces-c

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
       echo ##vso[task.setvariable variable=VcVarsArch]%VCVARS_ARCH%
     displayName: Set VcVarsArch
   - script: |
-      git clone -q --depth 1 -b 2020.06 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
+      git clone -q --depth 1 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
       call %VCPKG_ROOT%\bootstrap-vcpkg.bat
       set VCPKG_ARCH=$(VcVarsArch)-windows
       %VCPKG_ROOT%\vcpkg install --triplet %VCPKG_ARCH% openssl xerces-c
@@ -127,7 +127,7 @@ jobs:
       echo ##vso[task.setvariable variable=VcVarsArch]%VCVARS_ARCH%
     displayName: Set VcVarsArch
   - script: |
-      git clone -q --depth 1 -b 2020.06 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
+      git clone -q --depth 1 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
       call %VCPKG_ROOT%\bootstrap-vcpkg.bat
       set VCPKG_ARCH=$(VcVarsArch)-windows
       %VCPKG_ROOT%\vcpkg install --triplet %VCPKG_ARCH% openssl xerces-c

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -689,6 +689,8 @@ DataReaderImpl::remove_all_associations()
                ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::remove_all_associations() - ")
                ACE_TEXT("caught exception from remove_associations.\n")));
   }
+
+  transport_stop();
 }
 
 void

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -715,6 +715,11 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
   }
 }
 
+void DataWriterImpl::replay_durable_data_for(const RepoId& remote_sub_id)
+{
+  ACE_DEBUG((LM_DEBUG, "DataWriterImpl::replay_durable_data_for TODO\n"));
+}
+
 void DataWriterImpl::remove_all_associations()
 {
   DBG_ENTRY_LVL("DataWriterImpl", "remove_all_associations", 6);

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -540,8 +540,6 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
 
       for (SendStateDataSampleList::iterator list_el = list.begin();
            list_el != list.end(); ++list_el) {
-        list_el->get_header().historic_sample_ = true;
-
         if (list_el->get_header().sequence_ > seq) {
           seq = list_el->get_header().sequence_;
         }
@@ -715,9 +713,102 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
   }
 }
 
-void DataWriterImpl::replay_durable_data_for(const RepoId& remote_sub_id)
+void DataWriterImpl::replay_durable_data_for(const RepoId& remote_id)
 {
-  ACE_DEBUG((LM_DEBUG, "DataWriterImpl::replay_durable_data_for TODO\n"));
+  DBG_ENTRY_LVL("DataWriterImpl", "replay_durable_data_for", 6);
+
+  bool reader_durable = false;
+#ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
+  OPENDDS_STRING filterClassName;
+  RcHandle<FilterEvaluator> eval;
+  DDS::StringSeq expression_params;
+#endif
+
+  {
+    ACE_GUARD(ACE_Thread_Mutex, reader_info_guard, this->reader_info_lock_);
+    RepoIdToReaderInfoMap::const_iterator it = reader_info_.find(remote_id);
+
+    if (it != reader_info_.end()) {
+      reader_durable = it->second.durable_;
+#ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
+      filterClassName = it->second.filter_class_name_;
+      eval = it->second.eval_;
+      expression_params = it->second.expression_params_;
+#endif
+    }
+  }
+
+  // Support DURABILITY QoS
+  if (reader_durable) {
+    // Tell the WriteDataContainer to resend all sending/sent
+    // samples.
+    this->data_container_->reenqueue_all(remote_id, this->qos_.lifespan
+#ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
+                                         , filterClassName, eval.in(), expression_params
+#endif
+                                         );
+
+    // Acquire the data writer container lock to avoid deadlock. The
+    // thread calling association_complete() has to acquire lock in the
+    // same order as the write()/register() operation.
+
+    // Since the thread calling association_complete() is the ORB
+    // thread, it may have some performance penalty. If the
+    // performance is an issue, we may need a new thread to handle the
+    // data_available() calls.
+    ACE_GUARD(ACE_Recursive_Thread_Mutex,
+              guard,
+              this->get_lock());
+
+    SendStateDataSampleList list = this->get_resend_data();
+    {
+      ACE_GUARD(ACE_Thread_Mutex, reader_info_guard, this->reader_info_lock_);
+      // Update the reader's expected sequence
+      SequenceNumber& seq =
+        reader_info_.find(remote_id)->second.expected_sequence_;
+
+      for (SendStateDataSampleList::iterator list_el = list.begin();
+           list_el != list.end(); ++list_el) {
+        if (list_el->get_header().sequence_ > seq) {
+          seq = list_el->get_header().sequence_;
+        }
+      }
+    }
+
+    RcHandle<PublisherImpl> publisher = this->publisher_servant_.lock();
+    if (!publisher || publisher->is_suspended()) {
+      this->available_data_list_.enqueue_tail(list);
+
+    } else {
+      if (DCPS_debug_level >= 4) {
+        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) DataWriterImpl::replay_durable_data_for: Sending historic samples\n")));
+      }
+
+      size_t size = 0, padding = 0;
+      gen_find_size(remote_id, size, padding);
+      Message_Block_Ptr data(
+                             new ACE_Message_Block(size, ACE_Message_Block::MB_DATA, 0, 0, 0,
+                                                   get_db_lock()));
+      Serializer ser(data.get());
+      ser << remote_id;
+
+      DataSampleHeader header;
+      Message_Block_Ptr end_historic_samples(
+                                             create_control_message(
+                                                                    END_HISTORIC_SAMPLES, header, move(data),
+                                                                    SystemTimePoint::now().to_dds_time()));
+
+      this->controlTracker.message_sent();
+      guard.release();
+      SendControlStatus ret = send_w_control(list, header, move(end_historic_samples), remote_id);
+      if (ret == SEND_CONTROL_ERROR) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+                   ACE_TEXT("DataWriterImpl::replay_durable_data_for: ")
+                   ACE_TEXT("send_w_control failed.\n")));
+        this->controlTracker.message_dropped();
+      }
+    }
+  }
 }
 
 void DataWriterImpl::remove_all_associations()

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -860,6 +860,8 @@ void DataWriterImpl::remove_all_associations()
                  ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::remove_all_associations() - ")
                  ACE_TEXT("caught exception from remove_associations.\n")));
   }
+
+  transport_stop();
 }
 
 void

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -179,6 +179,8 @@ public:
   virtual void remove_associations(const ReaderIdSeq & readers,
                                    bool callback);
 
+  virtual void replay_durable_data_for(const RepoId& remote_sub_id);
+
   virtual void update_incompatible_qos(const IncompatibleQosStatus& status);
 
   virtual void update_subscription_params(const RepoId& readerId,

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -54,14 +54,19 @@ namespace OpenDDS {
       EndpointSecurityAttributesMap;
 
     enum AuthState {
-      AS_UNKNOWN,
-      AS_VALIDATING_REMOTE,
-      AS_HANDSHAKE_REQUEST,
-      AS_HANDSHAKE_REQUEST_SENT,
-      AS_HANDSHAKE_REPLY,
-      AS_HANDSHAKE_REPLY_SENT,
-      AS_AUTHENTICATED,
-      AS_UNAUTHENTICATED
+      AUTH_STATE_UNKNOWN,
+      AUTH_STATE_VALIDATING_REMOTE,
+      AUTH_STATE_HANDSHAKE,
+      AUTH_STATE_AUTHENTICATED,
+      AUTH_STATE_UNAUTHENTICATED
+    };
+
+    enum HandshakeState {
+      HANDSHAKE_STATE_UNKNOWN,
+      HANDSHAKE_STATE_REQUEST,
+      HANDSHAKE_STATE_REQUEST_SENT,
+      HANDSHAKE_STATE_REPLY,
+      HANDSHAKE_STATE_REPLY_SENT
     };
 #endif
 
@@ -1586,7 +1591,9 @@ namespace OpenDDS {
         , seq_reset_count_(0)
 #ifdef OPENDDS_SECURITY
         , has_last_stateless_msg_(false)
-        , auth_state_(AS_UNKNOWN)
+        , auth_state_(AUTH_STATE_UNKNOWN)
+        , handshake_state_(HANDSHAKE_STATE_UNKNOWN)
+        , is_requester_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1611,7 +1618,9 @@ namespace OpenDDS {
         , seq_reset_count_(0)
 #ifdef OPENDDS_SECURITY
         , has_last_stateless_msg_(false)
-        , auth_state_(AS_UNKNOWN)
+        , auth_state_(AUTH_STATE_UNKNOWN)
+        , handshake_state_(HANDSHAKE_STATE_UNKNOWN)
+        , is_requester_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1670,6 +1679,8 @@ namespace OpenDDS {
 
         MonotonicTimePoint auth_deadline_;
         AuthState auth_state_;
+        HandshakeState handshake_state_;
+        bool is_requester_;
 
         DDS::Security::IdentityToken identity_token_;
         DDS::Security::PermissionsToken permissions_token_;

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1749,9 +1749,14 @@ namespace OpenDDS {
             ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) LocalParticipant::remove_discovered_participant")
                        ACE_TEXT(" - erasing %C\n"), OPENDDS_STRING(conv).c_str()));
           }
+
+          remove_discovered_participant_i(iter);
+
           participants_.erase(iter);
         }
       }
+
+      virtual void remove_discovered_participant_i(DiscoveredParticipantIter) {}
 
 #ifndef DDS_HAS_MINIMUM_BIT
     DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit()

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1595,6 +1595,7 @@ namespace OpenDDS {
         , auth_state_(AUTH_STATE_UNKNOWN)
         , is_requester_(false)
         , security_builtins_associated_(false)
+        , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1623,6 +1624,7 @@ namespace OpenDDS {
         , auth_state_(AUTH_STATE_UNKNOWN)
         , is_requester_(false)
         , security_builtins_associated_(false)
+        , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1685,6 +1687,7 @@ namespace OpenDDS {
         HandshakeState handshake_state_;
         bool is_requester_;
         bool security_builtins_associated_;
+        bool seen_some_crypto_tokens_;
 
         DDS::Security::IdentityToken identity_token_;
         DDS::Security::PermissionsToken permissions_token_;

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -62,11 +62,11 @@ namespace OpenDDS {
     };
 
     enum HandshakeState {
-      HANDSHAKE_STATE_UNKNOWN,
-      HANDSHAKE_STATE_REQUEST,
-      HANDSHAKE_STATE_REQUEST_SENT,
-      HANDSHAKE_STATE_REPLY,
-      HANDSHAKE_STATE_REPLY_SENT
+      // Requester/Replier
+      HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL,
+
+      // Replier
+      HANDSHAKE_STATE_EXPECTING_REQUEST
     };
 #endif
 
@@ -1590,9 +1590,9 @@ namespace OpenDDS {
         , bit_ih_(DDS::HANDLE_NIL)
         , seq_reset_count_(0)
 #ifdef OPENDDS_SECURITY
-        , has_last_stateless_msg_(false)
+        , have_auth_req_msg_(false)
+        , have_handshake_msg_(false)
         , auth_state_(AUTH_STATE_UNKNOWN)
-        , handshake_state_(HANDSHAKE_STATE_UNKNOWN)
         , is_requester_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
@@ -1617,9 +1617,9 @@ namespace OpenDDS {
         , last_seq_(seq)
         , seq_reset_count_(0)
 #ifdef OPENDDS_SECURITY
-        , has_last_stateless_msg_(false)
+        , have_auth_req_msg_(false)
+        , have_handshake_msg_(false)
         , auth_state_(AUTH_STATE_UNKNOWN)
-        , handshake_state_(HANDSHAKE_STATE_UNKNOWN)
         , is_requester_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
@@ -1672,10 +1672,11 @@ namespace OpenDDS {
         ACE_UINT16 seq_reset_count_;
 
 #ifdef OPENDDS_SECURITY
-        bool has_last_stateless_msg_;
+        bool have_auth_req_msg_;
+        DDS::Security::ParticipantStatelessMessage auth_req_msg_;
+        bool have_handshake_msg_;
+        DDS::Security::ParticipantStatelessMessage handshake_msg_;
         MonotonicTimePoint stateless_msg_deadline_;
-        DDS::Security::ParticipantStatelessMessage last_stateless_msg_;
-        DDS::Security::HandshakeMessageToken last_handshake_request_data_;
 
         MonotonicTimePoint auth_deadline_;
         AuthState auth_state_;

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1594,6 +1594,7 @@ namespace OpenDDS {
         , have_handshake_msg_(false)
         , auth_state_(AUTH_STATE_UNKNOWN)
         , is_requester_(false)
+        , security_builtins_associated_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1621,6 +1622,7 @@ namespace OpenDDS {
         , have_handshake_msg_(false)
         , auth_state_(AUTH_STATE_UNKNOWN)
         , is_requester_(false)
+        , security_builtins_associated_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1682,6 +1684,7 @@ namespace OpenDDS {
         AuthState auth_state_;
         HandshakeState handshake_state_;
         bool is_requester_;
+        bool security_builtins_associated_;
 
         DDS::Security::IdentityToken identity_token_;
         DDS::Security::PermissionsToken permissions_token_;

--- a/dds/DCPS/GuidConverter.cpp
+++ b/dds/DCPS/GuidConverter.cpp
@@ -206,14 +206,6 @@ GuidConverter::uniqueId() const
   return id;
 }
 
-#ifdef OPENDDS_SECURITY
-bool
-GuidConverter::isSecure() const
-{
-  return isBuiltinDomainEntity() && guid_.entityId.entityKey[0] == 0xff;
-}
-#endif
-
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/GuidConverter.cpp
+++ b/dds/DCPS/GuidConverter.cpp
@@ -206,6 +206,14 @@ GuidConverter::uniqueId() const
   return id;
 }
 
+#ifdef OPENDDS_SECURITY
+bool
+GuidConverter::isSecure() const
+{
+  return guid_.entityId.entityKey[0] == 0xff;
+}
+#endif
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/GuidConverter.cpp
+++ b/dds/DCPS/GuidConverter.cpp
@@ -210,7 +210,7 @@ GuidConverter::uniqueId() const
 bool
 GuidConverter::isSecure() const
 {
-  return guid_.entityId.entityKey[0] == 0xff;
+  return isBuiltinDomainEntity() && guid_.entityId.entityKey[0] == 0xff;
 }
 #endif
 

--- a/dds/DCPS/GuidConverter.h
+++ b/dds/DCPS/GuidConverter.h
@@ -108,6 +108,10 @@ public:
 
   OPENDDS_STRING uniqueId() const;
 
+#ifdef OPENDDS_SECURITY
+  bool isSecure() const;
+#endif
+
 protected:
   const GUID_t guid_;
 };

--- a/dds/DCPS/GuidConverter.h
+++ b/dds/DCPS/GuidConverter.h
@@ -108,10 +108,6 @@ public:
 
   OPENDDS_STRING uniqueId() const;
 
-#ifdef OPENDDS_SECURITY
-  bool isSecure() const;
-#endif
-
 protected:
   const GUID_t guid_;
 };

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3011,6 +3011,7 @@ ICE::Endpoint* Sedp::get_ice_endpoint() {
 Sedp::Endpoint::~Endpoint()
 {
   remove_all_msgs();
+  transport_stop();
 }
 
 //---------------------------------------------------------------

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1846,7 +1846,7 @@ void Sedp::process_discovered_writer_data(DCPS::MessageId message_id,
           data.topic_data = wdata.ddsPublicationData.topic_data;
 
           DCPS::AuthState auth_state = spdp_.lookup_participant_auth_state(participant_id);
-          if (auth_state == DCPS::AS_AUTHENTICATED) {
+          if (auth_state == DCPS::AUTH_STATE_AUTHENTICATED) {
 
             DDS::Security::PermissionsHandle remote_permissions = spdp_.lookup_participant_permissions(participant_id);
 
@@ -1892,7 +1892,7 @@ void Sedp::process_discovered_writer_data(DCPS::MessageId message_id,
                 topic_name.data(), ex.code, ex.minor_code, ex.message.in()));
               return;
             }
-          } else if (auth_state != DCPS::AS_UNAUTHENTICATED) {
+          } else if (auth_state != DCPS::AUTH_STATE_UNAUTHENTICATED) {
             ACE_ERROR((LM_WARNING,
               ACE_TEXT("(%P|%t) WARNING: ")
               ACE_TEXT("Sedp::data_received(dwd) - ")
@@ -2169,7 +2169,7 @@ void Sedp::process_discovered_reader_data(DCPS::MessageId message_id,
           data.topic_data = rdata.ddsSubscriptionData.topic_data;
 
           DCPS::AuthState auth_state = spdp_.lookup_participant_auth_state(participant_id);
-          if (auth_state == DCPS::AS_AUTHENTICATED) {
+          if (auth_state == DCPS::AUTH_STATE_AUTHENTICATED) {
 
             DDS::Security::PermissionsHandle remote_permissions = spdp_.lookup_participant_permissions(participant_id);
 
@@ -2223,7 +2223,7 @@ void Sedp::process_discovered_reader_data(DCPS::MessageId message_id,
             } else {
               relay_only_readers_.erase(guid);
             }
-          } else if (auth_state != DCPS::AS_UNAUTHENTICATED) {
+          } else if (auth_state != DCPS::AUTH_STATE_UNAUTHENTICATED) {
             ACE_ERROR((LM_WARNING,
               ACE_TEXT("(%P|%t) WARNING: ")
               ACE_TEXT("Sedp::data_received(dwd) - ")

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -987,6 +987,8 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
   ACE_DEBUG((LM_DEBUG, "Sedp::rekey_volatile complete\n"));
 }
 
+#endif // OPENDDS_SECURITY
+
 void Sedp::disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
                                const RepoId& id, const EntityId_t& ent, DCPS::TransportClient& client)
 {
@@ -1028,6 +1030,8 @@ void Sedp::disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::U
     client.disassociate(temp);
   }
 }
+
+#ifdef OPENDDS_SECURITY
 
 void Sedp::associate_secure_writers_to_readers(const Security::SPDPdiscoveredParticipantData& pdata)
 {

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1438,7 +1438,7 @@ Sedp::disassociate(const ParticipantData_t& pdata)
     const RepoId remote_volatile = make_id(part, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
     associated_volatile_readers_.erase(remote_volatile);
     pending_volatile_readers_.erase(remote_volatile);
-  
+
     const DDS::Security::CryptoKeyFactory_var key_factory = spdp_.get_security_config()->get_crypto_key_factory();
     DDS::Security::SecurityException se;
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -931,7 +931,7 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
   CryptoKeyFactory_var key_factory = spdp_.get_security_config()->get_crypto_key_factory();
   const DCPS::RepoId part_guid = make_id(pdata.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
   const Spdp::ParticipantCryptoInfoPair peer_participant = spdp_.lookup_participant_crypto_info(part_guid);
-  if (peer_participant.first != DDS::HANDLE_NIL && peer_participant.second) {
+  if (peer_participant.first == DDS::HANDLE_NIL || !peer_participant.second) {
     ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::rekey_volatile() - ")
                ACE_TEXT("Unable to lookup remote participant crypto info.\n")));
     return;
@@ -949,6 +949,8 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
                  ACE_TEXT("Failure calling register_matched_remote_datawriter(). Security Exception[%d.%d]: %C\n"),
                  se.code, se.minor_code, se.message.in()));
     } else if (remote_writer_crypto_handles_[writer_guid] != remote_dwch) {
+      ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::rekey_volatile() - ")
+                 ACE_TEXT("Unexpected new handle %d for remote writer\n"), remote_dwch));
       key_factory->unregister_datawriter(remote_dwch, se);
     }
   }
@@ -966,6 +968,8 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
                  ACE_TEXT("Failure calling register_matched_remote_datareader(). Security Exception[%d.%d]: %C\n"),
                  se.code, se.minor_code, se.message.in()));
     } else if (remote_reader_crypto_handles_[reader_guid] != remote_drch) {
+      ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::rekey_volatile() - ")
+                 ACE_TEXT("Unexpected new handle %d for remote reader\n"), remote_drch));
       key_factory->unregister_datareader(remote_drch, se);
     }
 
@@ -977,6 +981,8 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
       resend_user_crypto_tokens(part_guid);
     }
   }
+
+  ACE_DEBUG((LM_DEBUG, "Sedp::rekey_volatile complete\n"));
 }
 
 void Sedp::disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
@@ -996,7 +1002,7 @@ void Sedp::disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::U
       if (traits.isReader()) {
         const DatareaderCryptoHandle drch = remote_reader_crypto_handles_[temp];
         if (!key_factory->unregister_datareader(drch, se)) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::dissociate_volatile() - ")
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::disassociate_helper() - ")
                      ACE_TEXT("Failure calling unregister_datareader(). Security Exception[%d.%d]: %C\n"),
                      se.code, se.minor_code, se.message.in()));
         }
@@ -1007,7 +1013,7 @@ void Sedp::disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::U
       if (traits.isWriter()) {
         const DatawriterCryptoHandle dwch = remote_writer_crypto_handles_[temp];
         if (!key_factory->unregister_datawriter(dwch, se)) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::dissociate_volatile() - ")
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: Sedp::disassociate_helper() - ")
                      ACE_TEXT("Failure calling unregister_datawriter(). Security Exception[%d.%d]: %C\n"),
                      se.code, se.minor_code, se.message.in()));
         }
@@ -2836,7 +2842,12 @@ Sedp::received_volatile_message_secure(DCPS::MessageId /* message_id */,
 
   if (0 == std::strcmp(msg.message_class_id,
                        DDS::Security::GMCLASSID_SECURITY_PARTICIPANT_CRYPTO_TOKENS)) {
-    if (spdp_.handle_participant_crypto_tokens(msg)) {
+    bool remote_is_replier;
+    if (!spdp_.handle_participant_crypto_tokens(msg, remote_is_replier)) {
+      ACE_DEBUG((LM_DEBUG, "Sedp::received_volatile_message_secure handle_participant_crypto_tokens failed\n"));
+      return;
+    }
+    if (remote_is_replier) {
       const DCPS::RepoId remote_volatile_reader = make_id(msg.message_identity.source_guid, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
       if (associated_volatile_readers_.count(remote_volatile_reader) != 0) {
         ACE_DEBUG((LM_DEBUG, "Sedp::received_volatile_message_secure calling send_participant_crypto_token\n"));
@@ -2856,7 +2867,6 @@ Sedp::received_volatile_message_secure(DCPS::MessageId /* message_id */,
                               DDS::Security::GMCLASSID_SECURITY_DATAREADER_CRYPTO_TOKENS)) {
     handle_datareader_crypto_tokens(msg);
   }
-  return;
 }
 #endif
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -109,17 +109,13 @@ public:
   void associate_secure_readers_to_writers(const Security::SPDPdiscoveredParticipantData& pdata);
 
   /// Create and send keys the first time
-  void send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& pdata);
+  void send_builtin_crypto_tokens(const DCPS::RepoId& remote_participant);
 
   /// Create and send keys for individual endpoints.
   void send_builtin_crypto_tokens(const DCPS::RepoId& dstParticipant,
                                   const DCPS::EntityId_t& dstEntity, const DCPS::RepoId& src);
 
   void resend_user_crypto_tokens(const DCPS::RepoId& remote_participant);
-
-  void send_datareader_crypto_tokens(const DCPS::RepoId& remote_participant);
-  void send_datawriter_crypto_tokens(const DCPS::RepoId& remote_participant);
-
 #endif
 
   bool disassociate(const ParticipantData_t& pdata);
@@ -771,24 +767,7 @@ protected:
   DDS::DomainId_t get_domain_id() const;
 
   DCPS::RepoIdSet associated_volatile_readers_;
-
-  struct RemoteWriter {
-    DCPS::RepoId local_reader, remote_writer;
-    DDS::Security::DatareaderCryptoTokenSeq reader_tokens;
-  };
-  typedef OPENDDS_VECTOR(RemoteWriter) RemoteWriterVector;
-  typedef OPENDDS_MAP_CMP(
-    DCPS::RepoId, RemoteWriterVector, DCPS::GUID_tKeyLessThan) RemoteWriterVectors;
-  RemoteWriterVectors datareader_crypto_tokens_;
-
-  struct RemoteReader {
-    DCPS::RepoId local_writer, remote_reader;
-    DDS::Security::DatawriterCryptoTokenSeq writer_tokens;
-  };
-  typedef OPENDDS_VECTOR(RemoteReader) RemoteReaderVector;
-  typedef OPENDDS_MAP_CMP(
-    DCPS::RepoId, RemoteReaderVector, DCPS::GUID_tKeyLessThan) RemoteReaderVectors;
-  RemoteReaderVectors datawriter_crypto_tokens_;
+  DCPS::RepoIdSet pending_volatile_readers_;
 
 #endif
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -109,7 +109,7 @@ public:
   void associate_secure_readers_to_writers(const Security::SPDPdiscoveredParticipantData& pdata);
 
   /// Create and send keys the first time
-  void send_builtin_crypto_tokens(const DCPS::RepoId& remote_participant);
+  void send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& pdata);
 
   /// Create and send keys for individual endpoints.
   void send_builtin_crypto_tokens(const DCPS::RepoId& dstParticipant,
@@ -764,9 +764,29 @@ protected:
   void handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
   void handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
 
+  void send_cached_crypto_tokens(const DCPS::RepoId& remote_participant);
+
   DDS::DomainId_t get_domain_id() const;
 
   DCPS::RepoIdSet associated_volatile_readers_;
+
+  struct RemoteWriter {
+    DCPS::RepoId local_reader, remote_writer;
+    DDS::Security::DatareaderCryptoTokenSeq reader_tokens;
+  };
+  typedef OPENDDS_VECTOR(RemoteWriter) RemoteWriterVector;
+  typedef OPENDDS_MAP_CMP(
+    DCPS::RepoId, RemoteWriterVector, DCPS::GUID_tKeyLessThan) RemoteWriterVectors;
+  RemoteWriterVectors datareader_crypto_tokens_;
+
+  struct RemoteReader {
+    DCPS::RepoId local_writer, remote_reader;
+    DDS::Security::DatawriterCryptoTokenSeq writer_tokens;
+  };
+  typedef OPENDDS_VECTOR(RemoteReader) RemoteReaderVector;
+  typedef OPENDDS_MAP_CMP(
+    DCPS::RepoId, RemoteReaderVector, DCPS::GUID_tKeyLessThan) RemoteReaderVectors;
+  RemoteReaderVectors datawriter_crypto_tokens_;
   DCPS::RepoIdSet pending_volatile_readers_;
 
 #endif

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -104,6 +104,7 @@ public:
 #ifdef OPENDDS_SECURITY
   void associate_preauth(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
+  void rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_writers_to_readers(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_readers_to_writers(const Security::SPDPdiscoveredParticipantData& pdata);
 
@@ -348,6 +349,7 @@ private:
     void notify_publication_reconnected(const DCPS::ReaderIdSeq&) {}
     void notify_publication_lost(const DCPS::ReaderIdSeq&) {}
     void remove_associations(const DCPS::ReaderIdSeq&, bool) {}
+    void replay_durable_data_for(const DCPS::RepoId& remote_sub_id);
     void retrieve_inline_qos_data(InlineQosData&) const {}
 
     void send_sample(const ACE_Message_Block& data,
@@ -820,6 +822,7 @@ protected:
 
   void disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
                            const DCPS::RepoId& id, const EntityId_t& ent, DCPS::TransportClient& client);
+  void replay_durable_data_for(const DCPS::RepoId& remote_sub_id);
 };
 
 /// A class to wait on acknowledgments from other threads

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -114,6 +114,8 @@ public:
   /// Create and send keys for individual endpoints.
   void send_builtin_crypto_tokens(const DCPS::RepoId& dstParticipant,
                                   const DCPS::EntityId_t& dstEntity, const DCPS::RepoId& src);
+
+  void resend_user_crypto_tokens(const DCPS::RepoId& remote_participant);
 #endif
 
   bool disassociate(const ParticipantData_t& pdata);

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -817,6 +817,9 @@ protected:
   void start_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub);
   void stop_ice(const DCPS::RepoId& guid, const DiscoveredPublication& dpub);
   void stop_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub);
+
+  void disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
+                           const DCPS::RepoId& id, const EntityId_t& ent, DCPS::TransportClient& client);
 };
 
 /// A class to wait on acknowledgments from other threads

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -116,6 +116,10 @@ public:
                                   const DCPS::EntityId_t& dstEntity, const DCPS::RepoId& src);
 
   void resend_user_crypto_tokens(const DCPS::RepoId& remote_participant);
+
+  void send_datareader_crypto_tokens(const DCPS::RepoId& remote_participant);
+  void send_datawriter_crypto_tokens(const DCPS::RepoId& remote_participant);
+
 #endif
 
   bool disassociate(const ParticipantData_t& pdata);

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -107,6 +107,9 @@ public:
   void rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_writers_to_readers(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_readers_to_writers(const Security::SPDPdiscoveredParticipantData& pdata);
+  void disassociate_security_builtins(BuiltinEndpointSet_t local_avail, BuiltinEndpointSet_t avail,
+                                      const DCPS::RepoId& part);
+  void remove_remote_crypto_handle(const DCPS::RepoId& participant, const EntityId_t& entity);
 
   /// Create and send keys the first time
   void send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& pdata);

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -764,8 +764,10 @@ protected:
     const DDS::Security::DatawriterCryptoHandle& dwch, const DCPS::RepoId& local_writer,
     const DDS::Security::DatareaderCryptoHandle& drch, const DCPS::RepoId& remote_reader);
 
-  void handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
-  void handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
+  bool handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
+                                       bool& send_our_tokens);
+  bool handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
+                                       bool& send_our_tokens);
 
   void send_cached_crypto_tokens(const DCPS::RepoId& remote_participant);
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -789,9 +789,6 @@ protected:
   RemoteReaderVectors datawriter_crypto_tokens_;
   DCPS::RepoIdSet pending_volatile_readers_;
 
-#endif
-
-#ifdef OPENDDS_SECURITY
   struct PublicationAgentInfoListener : public ICE::AgentInfoListener
   {
     Sedp& sedp;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1405,9 +1405,10 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
   }
 
   if (!dp.is_requester_) {
-    // TODO:  Will association_complete be called before this?
     send_participant_crypto_tokens(src_participant);
     sedp_.send_builtin_crypto_tokens(dp.pdata_);
+    sedp_.send_datawriter_crypto_tokens(src_participant);
+    sedp_.send_datareader_crypto_tokens(src_participant);
     sedp_.resend_user_crypto_tokens(src_participant);
   }
 }
@@ -3460,6 +3461,12 @@ bool Spdp::remote_is_requester(const DCPS::RepoId& guid) const
     return iter->second.is_requester_;
   }
   return false;
+}
+
+const ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid) const
+{
+  DiscoveredParticipantConstIter iter = participants_.find(make_id(guid, DCPS::ENTITYID_PARTICIPANT));
+  return iter->second.pdata_;
 }
 
 #endif

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1760,6 +1760,18 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
     DDS::Security::SecurityException se = {"", 0, 0};
     DDS::Security::Authentication_var auth = security_config_->get_authentication();
 
+    if (iter->second.identity_handle_ != DDS::HANDLE_NIL) {
+      if (!auth->return_identity_handle(iter->second.identity_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("DiscoveryBase::remove_discovered_participant() - ")
+                     ACE_TEXT("Unable to return identity handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+      }
+    }
+
     if (iter->second.handshake_handle_ != DDS::HANDLE_NIL) {
       if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
         if (DCPS::security_debug.auth_warn) {
@@ -1787,6 +1799,7 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
 
   // TODO:  What other security related clean up needs to be performed? (is every register unregistered)
   // TODO:  Is a local participant that is destroyed being cleaned up?
+  // TODO:  How should this be split between here and DiscoveryBase?
 #endif
 }
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1761,29 +1761,31 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
   ACE_UNUSED_ARG(iter);
 
 #ifdef OPENDDS_SECURITY
-  DDS::Security::SecurityException se = {"", 0, 0};
-  DDS::Security::Authentication_var auth = security_config_->get_authentication();
+  if (security_config_) {
+    DDS::Security::SecurityException se = {"", 0, 0};
+    DDS::Security::Authentication_var auth = security_config_->get_authentication();
 
-  if (iter->second.handshake_handle_ != DDS::HANDLE_NIL) {
-    if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
-      if (DCPS::security_debug.auth_warn) {
-        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                   ACE_TEXT("DiscoveryBase::remove_discovered_participant() - ")
-                   ACE_TEXT("Unable to return handshake handle. ")
-                   ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                   se.code, se.minor_code, se.message.in()));
+    if (iter->second.handshake_handle_ != DDS::HANDLE_NIL) {
+      if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("DiscoveryBase::remove_discovered_participant() - ")
+                     ACE_TEXT("Unable to return handshake handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
       }
     }
-  }
 
-  if (iter->second.shared_secret_handle_ != 0) {
-    if (!auth->return_sharedsecret_handle(iter->second.shared_secret_handle_, se)) {
-      if (DCPS::security_debug.auth_warn) {
-        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                   ACE_TEXT("Spdp::match_authenticated() - ")
-                   ACE_TEXT("Unable to return sharedsecret handle. ")
-                   ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                   se.code, se.minor_code, se.message.in()));
+    if (iter->second.shared_secret_handle_ != 0) {
+      if (!auth->return_sharedsecret_handle(iter->second.shared_secret_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::match_authenticated() - ")
+                     ACE_TEXT("Unable to return sharedsecret handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
       }
     }
   }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1597,17 +1597,15 @@ Spdp::attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp
     tport_->auth_deadline_processor_->schedule(config_->max_auth_time());
   }
 
-  bool start_from_auth_request = false;
   PendingRemoteAuthTokenMap::iterator token_iter = pending_remote_auth_tokens_.find(guid);
   if (token_iter == pending_remote_auth_tokens_.end()) {
     dp.remote_auth_request_token_ = DDS::Security::Token();
   } else {
-    start_from_auth_request = true;
     dp.remote_auth_request_token_ = token_iter->second;
     pending_remote_auth_tokens_.erase(token_iter);
   }
 
-  if (dp.auth_state_ == DCPS::AUTH_STATE_VALIDATING_REMOTE || start_from_auth_request) {
+  if (dp.auth_state_ == DCPS::AUTH_STATE_VALIDATING_REMOTE) {
     const DDS::Security::ValidationResult_t vr = auth->validate_remote_identity(dp.identity_handle_,
       dp.local_auth_request_token_, dp.remote_auth_request_token_, identity_handle_, dp.identity_token_, guid, se);
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1582,12 +1582,24 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
   sedp_.associate_volatile(iter->second.pdata_);
   sedp_.associate_secure_writers_to_readers(iter->second.pdata_);
   sedp_.associate_secure_readers_to_writers(iter->second.pdata_);
+  iter->second.security_builtins_associated_ = true;
 
   iter->second.bit_ih_ = bit_instance_handle;
 #ifndef DDS_HAS_MINIMUM_BIT
   process_location_updates_i(iter);
 #endif
   return true;
+}
+
+bool Spdp::security_builtins_associated(const DCPS::RepoId& remoteParticipant) const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
+  if (!security_enabled_) {
+    return false;
+  }
+
+  const DiscoveredParticipantConstIter iter = participants_.find(remoteParticipant);
+  return iter == participants_.end() ? false : iter->second.security_builtins_associated_;
 }
 
 void

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -917,7 +917,7 @@ DDS::OctetSeq Spdp::local_participant_data_as_octets() const
                ACE_TEXT("Failed to serialize parameter list.\n")));
     return DDS::OctetSeq();
   }
- 
+
   DDS::OctetSeq seq(static_cast<unsigned int>(temp_buff.length()));
   seq.length(seq.maximum());
   std::memcpy(seq.get_buffer(), temp_buff.rd_ptr(), temp_buff.length());

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1084,11 +1084,13 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
                        OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
           }
         }
+        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REQUEST;
         return;
       case DDS::Security::VALIDATION_OK:
         dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
         purge_auth_deadlines(iter);
         match_authenticated(src_participant, iter);
+        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REQUEST;
         return;
       }
     }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1408,7 +1408,7 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
     // TODO:  Will association_complete be called before this?
     send_participant_crypto_tokens(src_participant);
     sedp_.send_builtin_crypto_tokens(dp.pdata_);
-    // TODO: Send keys for the non-builtin readers and writers.
+    sedp_.resend_user_crypto_tokens(src_participant);
   }
 }
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -109,6 +109,7 @@ public:
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
   bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
                                         bool& remote_is_replier);
+  DDS::OctetSeq local_participant_data_as_octets() const;
 #endif
 
   void handle_participant_data(DCPS::MessageId id,

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -132,6 +132,7 @@ public:
   void write_secure_updates();
   void write_secure_disposes();
   bool is_security_enabled() const { return security_enabled_; }
+  bool security_builtins_associated(const DCPS::RepoId& remoteParticipant) const;
 #endif
 
   bool is_expectant_opendds(const GUID_t& participant) const;

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -105,6 +105,7 @@ public:
   DDS::Security::ParticipantCryptoHandle remote_crypto_handle(const DCPS::RepoId& remote_participant) const;
 
   void handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg);
+  void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
   void handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
 #endif
@@ -203,7 +204,11 @@ private:
   void match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
 
 #ifdef OPENDDS_SECURITY
-  bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
+  DDS::ReturnCode_t send_stateless_message(const DCPS::RepoId& guid,
+                                           DiscoveredParticipant& dp,
+                                           DDS::Security::ParticipantStatelessMessage& msg,
+                                           bool resend);
+  bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& iter);
   void attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);
 #endif

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -202,7 +202,7 @@ private:
   void match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
 
 #ifdef OPENDDS_SECURITY
-  bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
+  bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter, bool already_authenticated);
   void attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);
 #endif

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -107,7 +107,8 @@ public:
   void handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg);
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
-  bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
+  bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
+                                        bool& remote_is_replier);
 #endif
 
   void handle_participant_data(DCPS::MessageId id,
@@ -208,10 +209,11 @@ private:
   void match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
 
 #ifdef OPENDDS_SECURITY
-  DDS::ReturnCode_t send_stateless_message(const DCPS::RepoId& guid,
+  DDS::ReturnCode_t send_handshake_message(const DCPS::RepoId& guid,
                                            DiscoveredParticipant& dp,
                                            DDS::Security::ParticipantStatelessMessage& msg,
                                            bool resend);
+  DCPS::MonotonicTimePoint schedule_auth_resend(const DCPS::TimeDuration& time, const DCPS::RepoId& guid);
   bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& iter);
   void attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -149,6 +149,8 @@ public:
                                const DCPS::RepoId& guid);
 
   bool remote_is_requester(const DCPS::RepoId& guid) const;
+  const ParticipantData_t& get_participant_data(const DCPS::RepoId& guid) const;
+
 #endif
 
   DCPS::RcHandle<DCPS::JobQueue> job_queue() const { return tport_->job_queue_; }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -147,6 +147,8 @@ public:
   void process_participant_ice(const ParameterList& plist,
                                const ParticipantData_t& pdata,
                                const DCPS::RepoId& guid);
+
+  bool remote_is_requester(const DCPS::RepoId& guid) const;
 #endif
 
   DCPS::RcHandle<DCPS::JobQueue> job_queue() const { return tport_->job_queue_; }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -107,7 +107,7 @@ public:
   void handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg);
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
-  void handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
+  bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
 #endif
 
   void handle_participant_data(DCPS::MessageId id,

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -108,7 +108,8 @@ public:
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
   bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                        bool& remote_is_replier);
+                                        bool& send_our_tokens);
+  bool seen_crypto_tokens_from(const DCPS::RepoId& sender);
   DDS::OctetSeq local_participant_data_as_octets() const;
 #endif
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -175,6 +175,7 @@ public:
                                       );
 protected:
   Sedp& endpoint_manager() { return sedp_; }
+  void remove_discovered_participant_i(DiscoveredParticipantIter iter);
 
 #ifndef DDS_HAS_MINIMUM_BIT
   void enqueue_location_update_i(DiscoveredParticipantIter iter, DCPS::ParticipantLocation mask, const ACE_INET_Addr& from);
@@ -202,7 +203,7 @@ private:
   void match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
 
 #ifdef OPENDDS_SECURITY
-  bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter, bool already_authenticated);
+  bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& dp_iter);
   void attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);
 #endif

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -754,6 +754,8 @@ RecorderImpl::remove_all_associations()
 
   } catch (const CORBA::Exception&) {
   }
+
+  transport_stop();
 }
 
 void

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -779,6 +779,8 @@ void ReplayerImpl::remove_all_associations()
 
   } catch (const CORBA::Exception&) {
   }
+
+  transport_stop();
 }
 
 void

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -138,6 +138,8 @@ public:
   virtual void remove_associations(const ReaderIdSeq& readers,
                                    CORBA::Boolean     callback);
 
+  virtual void replay_durable_data_for(const RepoId&) {}
+
   virtual void update_incompatible_qos(const IncompatibleQosStatus& status);
 
   virtual void update_subscription_params(const RepoId&         readerId,

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -634,6 +634,7 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
   } else {
 
     if (max_durable_per_instance_) {
+      const_cast<DataSampleElement*>(sample)->get_header().historic_sample_ = true;
       DataSampleHeader::set_flag(HISTORIC_SAMPLE_FLAG, sample->get_sample());
       sent_data_.enqueue_tail(sample);
 

--- a/dds/DCPS/debug.cpp
+++ b/dds/DCPS/debug.cpp
@@ -31,6 +31,7 @@ OpenDDS_Dcps_Export void set_DCPS_debug_level(unsigned int lvl)
 #ifdef OPENDDS_SECURITY
 SecurityDebug::SecurityDebug()
   : fake_encryption(false)
+  , force_auth_role(FORCE_AUTH_ROLE_NORMAL)
 {
   set_all_flags_to(false);
 }

--- a/dds/DCPS/debug.h
+++ b/dds/DCPS/debug.h
@@ -86,6 +86,16 @@ public:
 
   /// Disable all encryption for security, even the required builtin encryption.
   bool fake_encryption;
+
+  /**
+   * Force role in authentication handshake. Like fake encryption this will
+   * break everything if applied inconsistently.
+   */
+  enum ForceAuthRole {
+    FORCE_AUTH_ROLE_NORMAL,
+    FORCE_AUTH_ROLE_LEADER,
+    FORCE_AUTH_ROLE_FOLLOWER
+  } force_auth_role;
 };
 extern OpenDDS_Dcps_Export SecurityDebug security_debug;
 #endif

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -898,7 +898,7 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
 {
   ::CORBA::Boolean results = false;
 
-  if (NULL == listener) {
+  if (!listener) {
     set_security_error(ex, -1, 0, "Null listener provided");
   } else {
     results = true;
@@ -1322,10 +1322,16 @@ AuthenticationBuiltInImpl::make_handshake_pair(DDS::Security::IdentityHandle h1,
   return HandshakeDataPair();
 }
 
-bool AuthenticationBuiltInImpl::is_handshake_initiator(const OpenDDS::DCPS::GUID_t& local, const OpenDDS::DCPS::GUID_t& remote)
+bool AuthenticationBuiltInImpl::is_handshake_initiator(
+  const OpenDDS::DCPS::GUID_t& local, const OpenDDS::DCPS::GUID_t& remote)
 {
   const unsigned char* local_ = reinterpret_cast<const unsigned char*>(&local);
   const unsigned char* remote_ = reinterpret_cast<const unsigned char*>(&remote);
+
+  using DCPS::SecurityDebug;
+  if (DCPS::security_debug.force_auth_role != SecurityDebug::FORCE_AUTH_ROLE_NORMAL) {
+    return DCPS::security_debug.force_auth_role == SecurityDebug::FORCE_AUTH_ROLE_LEADER;
+  }
 
   /* if remote > local, pending request; else pending handshake message */
   return std::lexicographical_compare(local_, local_ + sizeof(local),
@@ -1335,9 +1341,9 @@ bool AuthenticationBuiltInImpl::is_handshake_initiator(const OpenDDS::DCPS::GUID
 
 bool AuthenticationBuiltInImpl::check_class_versions(const char* remote_class_id)
 {
-  if (NULL == remote_class_id) {
+  if (!remote_class_id) {
     return false;
-    }
+  }
   bool class_matches = false;
 
   // Slow, but this is just for the stub

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -419,6 +419,8 @@ DatareaderCryptoHandle CryptoBuiltInImpl::register_matched_remote_datareader(
     }
     keys_[h] = dr_keys;
     if (existing_handle_iter != derived_key_handles_.end()) {
+      static const unsigned int SUBMSG_KEY_IDX = 0;
+      sessions_.erase(std::make_pair(h, SUBMSG_KEY_IDX));
       return h;
     }
     derived_key_handles_[input_handles] = h;
@@ -532,6 +534,8 @@ DatawriterCryptoHandle CryptoBuiltInImpl::register_matched_remote_datawriter(
     }
     keys_[h] = dw_keys;
     if (existing_handle_iter != derived_key_handles_.end()) {
+      static const unsigned int SUBMSG_KEY_IDX = 0;
+      sessions_.erase(std::make_pair(h, SUBMSG_KEY_IDX));
       return h;
     }
     derived_key_handles_[input_handles] = h;

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -399,11 +399,13 @@ DatareaderCryptoHandle CryptoBuiltInImpl::register_matched_remote_datareader(
       return DDS::HANDLE_NIL;
     }
     if (security_debug.bookkeeping && !security_debug.showkeys) {
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} CryptoBuiltInImpl::register_remote_datareader ")
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+        ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader ")
         ACE_TEXT("created volatile key for RDRCH %d\n"), h));
     }
     if (security_debug.showkeys) {
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {showkeys} CryptoBuiltInImpl::register_remote_datareader ")
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {showkeys} ")
+        ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader ")
         ACE_TEXT("created volatile key for RDRCH %d:\n%C"), h,
         to_dds_string(dr_keys[0]).c_str()));
     }
@@ -548,11 +550,13 @@ DatawriterCryptoHandle CryptoBuiltInImpl::register_matched_remote_datawriter(
       return DDS::HANDLE_NIL;
     }
     if (security_debug.bookkeeping && !security_debug.showkeys) {
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} CryptoBuiltInImpl::register_remote_datawriter ")
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+        ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter ")
         ACE_TEXT("created volatile key for RDWCH %d\n"), h));
     }
     if (security_debug.showkeys) {
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {showkeys} CryptoBuiltInImpl::register_remote_datawriter ")
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {showkeys} ")
+        ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter ")
         ACE_TEXT("created volatile key for RDWCH %d:\n%C"), h,
         to_dds_string(dw_keys[0]).c_str()));
     }

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -73,6 +73,11 @@ bool CryptoBuiltInImpl::marshal(TAO_OutputCDR&)
 NativeCryptoHandle CryptoBuiltInImpl::generate_handle()
 {
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  return generate_handle_i();
+}
+
+NativeCryptoHandle CryptoBuiltInImpl::generate_handle_i()
+{
   return CommonUtilities::increment_handle(next_handle_);
 }
 
@@ -393,7 +398,7 @@ DatareaderCryptoHandle CryptoBuiltInImpl::register_matched_remote_datareader(
     use_derived_key ? derived_key_handles_.find(input_handles) : derived_key_handles_.end();
   const DatareaderCryptoHandle h =
     (existing_handle_iter == derived_key_handles_.end())
-    ? generate_handle() : existing_handle_iter->second;
+    ? generate_handle_i() : existing_handle_iter->second;
 
   if (use_derived_key) {
     // Create a key from SharedSecret and track it as if Key Exchange happened
@@ -507,7 +512,7 @@ DatawriterCryptoHandle CryptoBuiltInImpl::register_matched_remote_datawriter(
     use_derived_key ? derived_key_handles_.find(input_handles) : derived_key_handles_.end();
   const DatareaderCryptoHandle h =
     (existing_handle_iter == derived_key_handles_.end())
-    ? generate_handle() : existing_handle_iter->second;
+    ? generate_handle_i() : existing_handle_iter->second;
 
   if (use_derived_key) {
     // Create a key from SharedSecret and track it as if Key Exchange happened

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -138,9 +138,7 @@ ParticipantCryptoHandle CryptoBuiltInImpl::register_local_participant(
     return DDS::HANDLE_NIL;
   }
 
-  if (!participant_security_attributes.is_rtps_protected) {
-    return DDS::HANDLE_NIL;
-  }
+  // unconditionally generate key so that key exchange has at least one thing to send
 
   const NativeCryptoHandle h = generate_handle();
   const KeyMaterial key = make_key(h,
@@ -750,13 +748,11 @@ bool CryptoBuiltInImpl::create_local_participant_crypto_tokens(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   const KeyTable_t::const_iterator iter = keys_.find(local_participant_crypto);
-  if (iter != keys_.end()) {
-    local_participant_crypto_tokens = keys_to_tokens(iter->second);
-  } else {
-    // There may not be any keys_ for this participant (depends on config)
-    local_participant_crypto_tokens.length(0);
+  if (iter == keys_.end()) {
+    return CommonUtilities::set_security_error(ex, -1, 1, "Local participant handle not registered");
   }
 
+  local_participant_crypto_tokens = keys_to_tokens(iter->second);
   return true;
 }
 

--- a/dds/DCPS/security/CryptoBuiltInImpl.h
+++ b/dds/DCPS/security/CryptoBuiltInImpl.h
@@ -77,11 +77,6 @@ private:
     bool relay_only,
     DDS::Security::SecurityException& ex);
 
-  virtual bool rekey_remote_datareader(
-    DDS::Security::DatareaderCryptoHandle remote_datawriter_crypto_handle,
-    DDS::Security::SharedSecretHandle* shared_secret,
-    DDS::Security::SecurityException& ex);
-
   virtual DDS::Security::DatareaderCryptoHandle register_local_datareader(
     DDS::Security::ParticipantCryptoHandle participant_crypto,
     const DDS::PropertySeq& datareader_properties,
@@ -91,11 +86,6 @@ private:
   virtual DDS::Security::DatawriterCryptoHandle register_matched_remote_datawriter(
     DDS::Security::DatareaderCryptoHandle local_datareader_crypto_handle,
     DDS::Security::ParticipantCryptoHandle remote_participant_crypt,
-    DDS::Security::SharedSecretHandle* shared_secret,
-    DDS::Security::SecurityException& ex);
-
-  virtual bool rekey_remote_datawriter(
-    DDS::Security::DatawriterCryptoHandle remote_datawriter_crypto_handle,
     DDS::Security::SharedSecretHandle* shared_secret,
     DDS::Security::SecurityException& ex);
 
@@ -261,6 +251,10 @@ private:
   };
   std::multimap<DDS::Security::ParticipantCryptoHandle,
                 EntityInfo> participant_to_entity_;
+
+  typedef std::pair<DDS::Security::NativeCryptoHandle, DDS::Security::NativeCryptoHandle> HandlePair_t;
+  typedef std::map<HandlePair_t, DDS::Security::NativeCryptoHandle> DerivedKeyIndex_t;
+  DerivedKeyIndex_t derived_key_handles_;
 
   struct Session {
     SessionIdType id_;

--- a/dds/DCPS/security/CryptoBuiltInImpl.h
+++ b/dds/DCPS/security/CryptoBuiltInImpl.h
@@ -219,6 +219,7 @@ private:
   CryptoBuiltInImpl& operator=(const CryptoBuiltInImpl&);
 
   DDS::Security::NativeCryptoHandle generate_handle();
+  DDS::Security::NativeCryptoHandle generate_handle_i();
 
   ACE_Thread_Mutex mutex_;
   int next_handle_;

--- a/dds/DCPS/security/CryptoBuiltInImpl.h
+++ b/dds/DCPS/security/CryptoBuiltInImpl.h
@@ -77,6 +77,11 @@ private:
     bool relay_only,
     DDS::Security::SecurityException& ex);
 
+  virtual bool rekey_remote_datareader(
+    DDS::Security::DatareaderCryptoHandle remote_datawriter_crypto_handle,
+    DDS::Security::SharedSecretHandle* shared_secret,
+    DDS::Security::SecurityException& ex);
+
   virtual DDS::Security::DatareaderCryptoHandle register_local_datareader(
     DDS::Security::ParticipantCryptoHandle participant_crypto,
     const DDS::PropertySeq& datareader_properties,
@@ -86,6 +91,11 @@ private:
   virtual DDS::Security::DatawriterCryptoHandle register_matched_remote_datawriter(
     DDS::Security::DatareaderCryptoHandle local_datareader_crypto_handle,
     DDS::Security::ParticipantCryptoHandle remote_participant_crypt,
+    DDS::Security::SharedSecretHandle* shared_secret,
+    DDS::Security::SecurityException& ex);
+
+  virtual bool rekey_remote_datawriter(
+    DDS::Security::DatawriterCryptoHandle remote_datawriter_crypto_handle,
     DDS::Security::SharedSecretHandle* shared_secret,
     DDS::Security::SecurityException& ex);
 

--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -1173,6 +1173,21 @@ DataLink::network_change() const
   }
 }
 
+void
+DataLink::replay_durable_data(const RepoId& local_pub_id, const RepoId& remote_sub_id) const
+{
+  GuidConverter local(local_pub_id);
+  GuidConverter remote(remote_sub_id);
+  ACE_DEBUG((LM_DEBUG, "Replay durable data %C -> %C\n", OPENDDS_STRING(local).c_str(), OPENDDS_STRING(remote).c_str()));
+  TransportSendListener_rch send_listener = send_listener_for(local_pub_id);
+  if (send_listener) {
+    ACE_DEBUG((LM_DEBUG, "Replay durable data %C -> %C\n", OPENDDS_STRING(local).c_str(), OPENDDS_STRING(remote).c_str()));
+    send_listener->replay_durable_data_for(remote_sub_id);
+  } else {
+    ACE_DEBUG((LM_DEBUG, "Replay durable data %C -> %C no send_listener\n", OPENDDS_STRING(local).c_str(), OPENDDS_STRING(remote).c_str()));
+  }
+}
+
 #ifndef OPENDDS_SAFETY_PROFILE
 std::ostream&
 operator<<(std::ostream& str, const DataLink& value)

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -336,6 +336,8 @@ protected:
 
   void network_change() const;
 
+  void replay_durable_data(const RepoId& local_pub_id, const RepoId& remote_sub_id) const;
+
 private:
 
   /// Helper function to output the enum as a string to help debugging.

--- a/dds/DCPS/transport/framework/SendResponseListener.h
+++ b/dds/DCPS/transport/framework/SendResponseListener.h
@@ -45,6 +45,7 @@ public:
   void notify_publication_reconnected(const ReaderIdSeq&) {}
   void notify_publication_lost(const ReaderIdSeq&) {}
   void remove_associations(const ReaderIdSeq&, bool) {}
+  void replay_durable_data_for(const RepoId&) {}
 
   void track_message();
 

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -707,6 +707,21 @@ TransportClient::disassociate(const RepoId& peerId)
   }
 }
 
+void TransportClient::transport_stop()
+{
+  ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
+  const ImplsType impls = impls_;
+  const RepoId repo_id = repo_id_;
+  guard.release();
+
+  for (size_t i = 0; i < impls.size(); ++i) {
+    const RcHandle<TransportImpl> impl = impls[i].lock();
+    if (impl) {
+      impl->client_stop(repo_id);
+    }
+  }
+}
+
 void
 TransportClient::register_for_reader(const RepoId& participant,
                                      const RepoId& writerid,

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -80,6 +80,7 @@ public:
   void stop_associating();
   void stop_associating(const GUID_t* repos, CORBA::ULong length);
   void send_final_acks();
+  void transport_stop();
 
   // Discovery:
   void register_for_reader(const RepoId& participant,

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -236,6 +236,8 @@ private:
   /// any other threads while we perform this release.
   virtual void release_datalink(DataLink* link) = 0;
 
+  virtual void client_stop(const RepoId&) {}
+
   DataLink* find_connect_i(const RepoId& local_id,
                            const AssociationData& remote_association,
                            const ConnectionAttribs& attribs,

--- a/dds/DCPS/transport/framework/TransportSendListener.h
+++ b/dds/DCPS/transport/framework/TransportSendListener.h
@@ -55,6 +55,8 @@ public:
 
   virtual void remove_associations(const ReaderIdSeq& subids, bool notify) = 0;
 
+  virtual void replay_durable_data_for(const RepoId& remote_sub_id) = 0;
+
   /// Hook for the listener to override a normal control message with
   /// customized messages to different DataLinks.
   virtual SendControlStatus send_control_customized(

--- a/dds/DCPS/transport/framework/TransportSendListener.h
+++ b/dds/DCPS/transport/framework/TransportSendListener.h
@@ -55,7 +55,7 @@ public:
 
   virtual void remove_associations(const ReaderIdSeq& subids, bool notify) = 0;
 
-  virtual void replay_durable_data_for(const RepoId& remote_sub_id) = 0;
+  virtual void replay_durable_data_for(const RepoId&) {}
 
   /// Hook for the listener to override a normal control message with
   /// customized messages to different DataLinks.

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -896,15 +896,6 @@ RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
 
       reader->remove_writer(remote_id);
 
-      if (reader->writer_count() == 0) {
-        {
-          ACE_GUARD(ACE_Thread_Mutex, h, readers_lock_);
-          rr = readers_.find(local_id);
-          if (rr != readers_.end()) {
-            readers_.erase(rr);
-          }
-        }
-      }
     } else {
       WriterToSeqReadersMap::iterator w = writer_to_seq_best_effort_readers_.find(remote_id);
       if (w != writer_to_seq_best_effort_readers_.end()) {
@@ -2916,6 +2907,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       // Count increased but ack decreased.  Replay durable data for the reader.
       ACE_DEBUG((LM_DEBUG, "Enqueuing ReplayDurableData\n"));
       link->job_queue_->enqueue(make_rch<ReplayDurableData>(link_, id_, remote));
+      ri->second.durable_timestamp_ = MonotonicTimePoint::zero_value;
     }
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2903,7 +2903,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   if (ack != SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
     if (ack >= ri->second.cur_cumulative_ack_) {
       ri->second.cur_cumulative_ack_ = ack;
-    } else {
+    } else if (ri->second.durable_ && !ri->second.expecting_durable_data()) {
       // Count increased but ack decreased.  Replay durable data for the reader.
       ACE_DEBUG((LM_DEBUG, "Enqueuing ReplayDurableData\n"));
       link->job_queue_->enqueue(make_rch<ReplayDurableData>(link_, id_, remote));

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -663,7 +663,7 @@ private:
 
   typedef OPENDDS_MAP_CMP(RepoId, CORBA::Long, DCPS::GUID_tKeyLessThan) HeartBeatCountMapType;
   HeartBeatCountMapType heartbeat_counts_;
-  
+
   struct InterestingAckNack {
     RepoId writerid;
     RepoId readerid;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -363,7 +363,8 @@ private:
     void send_nackfrag_replies_i(DisjointSequence& gaps, AddrSet& gap_recipients);
 
   public:
-    RtpsWriter(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable, size_t capacity);
+    RtpsWriter(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable,
+               int heartbeat_count, size_t capacity);
     ~RtpsWriter();
     SequenceNumber heartbeat_high(const ReaderInfo&) const;
     void add_elem_awaiting_ack(TransportQueueElement* element);
@@ -490,7 +491,7 @@ private:
   /// What was once a single lock for the whole datalink is now split between three (four including ch_lock_):
   /// - readers_lock_ protects readers_, readers_of_writer_, pending_reliable_readers_, interesting_writers_, and
   ///   writer_to_seq_best_effort_readers_ along with anything else that fits the 'reader side activity' of the datalink
-  /// - writers_lock_ protects writers_, best_effort_heartbeat_count_, and interesting_readers_
+  /// - writers_lock_ protects writers_, heartbeat_counts_ best_effort_heartbeat_count_, and interesting_readers_
   ///   along with anything else that fits the 'writers side activity' of the datalink
   /// - locators_lock_ protects locators_ (and therefore calls to get_addresses_i())
   ///   for both remote writers and remote readers
@@ -660,6 +661,9 @@ private:
   void send_heartbeats_manual_i(const TransportSendControlElement* tsce,
                                 MetaSubmessageVec& meta_submessages);
 
+  typedef OPENDDS_MAP_CMP(RepoId, CORBA::Long, DCPS::GUID_tKeyLessThan) HeartBeatCountMapType;
+  HeartBeatCountMapType heartbeat_counts_;
+  
   struct InterestingAckNack {
     RepoId writerid;
     RepoId readerid;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -582,8 +582,8 @@ RtpsUdpReceiveStrategy::deliver_from_secure(const RTPS::Submessage& submessage)
   } else {
     if (security_debug.encdec_warn) {
       ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy: ")
-                 ACE_TEXT("preprocess_secure_submsg failed RPCH %d, [%d.%d]: %C\n"),
-                 peer_pch, ex.code, ex.minor_code, ex.message.in()));
+                 ACE_TEXT("preprocess_secure_submsg failed remote %C RPCH %d, [%d.%d]: %C\n"),
+                 OPENDDS_STRING(GuidConverter(peer)).c_str(), peer_pch, ex.code, ex.minor_code, ex.message.in()));
     }
     return;
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -115,13 +115,14 @@ RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
 
 #ifdef OPENDDS_SECURITY
 namespace {
-  ssize_t recv_err(const char* msg, const ACE_INET_Addr& remote, bool& stop)
+  ssize_t recv_err(const char* msg, const ACE_INET_Addr& remote, const DCPS::RepoId& peer, bool& stop)
   {
     if (security_debug.encdec_error) {
       ACE_TCHAR addr_buff[256] = {};
       remote.addr_to_string(addr_buff, 256);
+      GuidConverter gc(peer);
       ACE_ERROR((LM_ERROR, "(%P|%t) {encdec_error} RtpsUdpReceiveStrategy::receive_bytes - "
-                 "from %s secure RTPS processing failed: %C\n", addr_buff, msg));
+                 "from %s %C secure RTPS processing failed: %C\n", addr_buff, OPENDDS_STRING(gc).c_str(), msg));
     }
     stop = true;
     return 0;
@@ -182,13 +183,15 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
   if (ret > 0 && receiver != DDS::HANDLE_NIL) {
     encoded_rtps_ = false;
 
+    GUID_t peer = GUID_UNKNOWN;
+
     const CryptoTransform_var crypto = link_->security_config()->get_crypto_transform();
     if (!crypto) {
-      return recv_err("no crypto plugin", remote_address, stop);
+      return recv_err("no crypto plugin", remote_address, peer, stop);
     }
 
     if (ret < RTPS::RTPSHDR_SZ + RTPS::SMHDR_SZ) {
-      return recv_err("message too short", remote_address, stop);
+      return recv_err("message too short", remote_address, peer, stop);
     }
 
     const unsigned int encLen = static_cast<unsigned int>(ret);
@@ -204,14 +207,13 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
     }
 
     if (copied != encLen) {
-      return recv_err("received bytes didn't fit in iovec array", remote_address, stop);
+      return recv_err("received bytes didn't fit in iovec array", remote_address, peer, stop);
     }
 
     if (encoded[RTPS::RTPSHDR_SZ] != RTPS::SRTPS_PREFIX) {
       return ret;
     }
 
-    GUID_t peer;
     static const int GuidPrefixOffset = 8; // "RTPS", Version(2), Vendor(2)
     std::memcpy(peer.guidPrefix, encBuf + GuidPrefixOffset, sizeof peer.guidPrefix);
     peer.entityId = RTPS::ENTITYID_PARTICIPANT;
@@ -241,7 +243,7 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
         stop = true;
         return ret;
       }
-      return recv_err("decode_rtps_message failed", remote_address, stop);
+      return recv_err("decode_rtps_message failed", remote_address, peer, stop);
     }
 
     copied = 0;
@@ -255,7 +257,7 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
     }
 
     if (copied != plainLen) {
-      return recv_err("plaintext doesn't fit in iovec array", remote_address, stop);
+      return recv_err("plaintext doesn't fit in iovec array", remote_address, peer, stop);
     }
 
     encoded_rtps_ = true;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -472,6 +472,16 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
   return true;
 }
 
+void RtpsUdpTransport::client_stop(const RepoId& localId)
+{
+  GuardThreadType guard_links(links_lock_);
+  const RtpsUdpDataLink_rch link = link_;
+  guard_links.release();
+  if (link) {
+    link->client_stop(localId);
+  }
+}
+
 void
 RtpsUdpTransport::shutdown_i()
 {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -52,6 +52,8 @@ private:
 
   bool configure_i(RtpsUdpInst& config);
 
+  void client_stop(const RepoId& localId);
+
   virtual void shutdown_i();
 
   virtual void register_for_reader(const RepoId& participant,

--- a/dds/DdsSecurityCore.idl
+++ b/dds/DdsSecurityCore.idl
@@ -600,10 +600,16 @@ module DDS {
 
       DatareaderCryptoHandle
       register_matched_remote_datareader(
-        in    DatawriterCryptoHandle   local_datawritert_crypto_handle,
+        in    DatawriterCryptoHandle   local_datawriter_crypto_handle,
         in    ParticipantCryptoHandle  remote_participant_crypto,
         in    SharedSecretHandle       shared_secret,
         in    boolean                  relay_only,
+        inout SecurityException        ex);
+
+      boolean
+      rekey_remote_datareader(
+        in    DatareaderCryptoHandle   remote_datareader_crypto_handle,
+        in    SharedSecretHandle       shared_secret,
         inout SecurityException        ex);
 
       DatareaderCryptoHandle
@@ -617,6 +623,12 @@ module DDS {
       register_matched_remote_datawriter(
         in    DatareaderCryptoHandle   local_datareader_crypto_handle,
         in    ParticipantCryptoHandle  remote_participant_crypt,
+        in    SharedSecretHandle       shared_secret,
+        inout SecurityException        ex );
+
+      boolean
+      rekey_remote_datawriter(
+        in    DatawriterCryptoHandle   remote_datawriter_crypto_handle,
         in    SharedSecretHandle       shared_secret,
         inout SecurityException        ex );
 

--- a/dds/DdsSecurityCore.idl
+++ b/dds/DdsSecurityCore.idl
@@ -606,12 +606,6 @@ module DDS {
         in    boolean                  relay_only,
         inout SecurityException        ex);
 
-      boolean
-      rekey_remote_datareader(
-        in    DatareaderCryptoHandle   remote_datareader_crypto_handle,
-        in    SharedSecretHandle       shared_secret,
-        inout SecurityException        ex);
-
       DatareaderCryptoHandle
       register_local_datareader(
         in    ParticipantCryptoHandle     participant_crypto,
@@ -623,12 +617,6 @@ module DDS {
       register_matched_remote_datawriter(
         in    DatareaderCryptoHandle   local_datareader_crypto_handle,
         in    ParticipantCryptoHandle  remote_participant_crypt,
-        in    SharedSecretHandle       shared_secret,
-        inout SecurityException        ex );
-
-      boolean
-      rekey_remote_datawriter(
-        in    DatawriterCryptoHandle   remote_datawriter_crypto_handle,
         in    SharedSecretHandle       shared_secret,
         inout SecurityException        ex );
 

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -33,6 +33,9 @@ three-way handshake using the "builtin SDP participant" readers and writers.
   - Finally the leader will verify the follower and send a "final" message
     back, signaling that association can continue.
 
+The role taken in the authentication handshake can be overriden using
+`OpenDDS::DCPS::security_debug.force_auth_role`.
+
 <!-- TODO: List OMG authentication states and what they actually mean -->
 
 ## Key Exchange

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -33,7 +33,7 @@ three-way handshake using the "builtin SDP participant" readers and writers.
   - Finally the leader will verify the follower and send a "final" message
     back, signaling that association can continue.
 
-The role taken in the authentication handshake can be overriden using
+The role taken in the authentication handshake can be overridden using
 `OpenDDS::DCPS::security_debug.force_auth_role`.
 
 <!-- TODO: List OMG authentication states and what they actually mean -->

--- a/tests/transport/rtps/publisher.cpp
+++ b/tests/transport/rtps/publisher.cpp
@@ -537,6 +537,7 @@ int DDS_TEST::test(ACE_TString host, u_short port)
   // 3. cleanup
 
   sdw.disassociate(subscription.remote_id_);
+  sdw.transport_stop();
 
   TheServiceParticipant->shutdown();
   ACE_Thread_Manager::instance()->wait();

--- a/tests/transport/rtps/subscriber.cpp
+++ b/tests/transport/rtps/subscriber.cpp
@@ -293,6 +293,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     }
 
     sdr.disassociate(publication.remote_id_);
+    sdr.transport_stop();
 
     TheServiceParticipant->shutdown();
     ACE_Thread_Manager::instance()->wait();

--- a/tests/transport/rtps_reliability/rtps_reliability.cpp
+++ b/tests/transport/rtps_reliability/rtps_reliability.cpp
@@ -992,6 +992,8 @@ bool run_test()
   // cleanup
   sdw2.disassociate(reader1);
   sdr2.disassociate(writer1);
+  sdw2.transport_stop();
+  sdr2.transport_stop();
   return true;
 }
 


### PR DESCRIPTION
Suppose participant A has a lease time of 100 seconds and participant
B has a lease time of 50 seconds.  Participant B is suspended for 50+
seconds so that it expires in Participant A.  Participant B is then
resumed.  This will cause Participant A to rediscover Participant
B.  (Participant B does not need to rediscover Participant A because
it has not expired.)  Participant A must reauthenticate with
Participant B.

If Participant A is the requester, then Participant B must restart
authentication when it receives the handshake request.  If Participant
B is the requester, then Participant A must send an auth request and
Participant B must restart the authentication processes.

Solution: Add support for both reauthentication scenarios.