### PR TITLE
Improve Coordination Between Bench's Test & Node Controllers

### DIFF
--- a/performance-tests/bench_2/builder/Common.cpp
+++ b/performance-tests/bench_2/builder/Common.cpp
@@ -7,7 +7,16 @@ namespace Builder {
 
 const TimeStamp ZERO = {0, 0};
 
-TimeStamp get_time()
+TimeStamp get_sys_time()
+{
+  auto now = std::chrono::system_clock::now();
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
+  auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>((now - seconds).time_since_epoch());
+  TimeStamp result = {static_cast<CORBA::Long>(seconds.count()), static_cast<CORBA::ULong>(nanoseconds.count())};
+  return result;
+}
+
+TimeStamp get_hr_time()
 {
   auto now = std::chrono::high_resolution_clock::now();
   auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());

--- a/performance-tests/bench_2/builder/Common.h
+++ b/performance-tests/bench_2/builder/Common.h
@@ -16,7 +16,9 @@ namespace Builder {
 
 Bench_Builder_Export extern const TimeStamp ZERO;
 
-Bench_Builder_Export TimeStamp get_time();
+Bench_Builder_Export TimeStamp get_sys_time();
+
+Bench_Builder_Export TimeStamp get_hr_time();
 
 Bench_Builder_Export TimeStamp from_seconds(int32_t sec);
 

--- a/performance-tests/bench_2/builder/DataReader.cpp
+++ b/performance-tests/bench_2/builder/DataReader.cpp
@@ -83,7 +83,7 @@ DataReader::DataReader(const DataReaderConfig& config, DataReaderReport& report,
   enable_time_->value.time_prop(ZERO);
   last_discovery_time_->value.time_prop(Builder::ZERO);
 
-  create_time_->value.time_prop(get_time());
+  create_time_->value.time_prop(get_hr_time());
   datareader_ = subscriber_->create_datareader(topic_, qos_, listener_, listener_status_mask_);
   if (CORBA::is_nil(datareader_.in())) {
     throw std::runtime_error("datareader creation failed");
@@ -111,7 +111,7 @@ DataReader::~DataReader() {
 
 void DataReader::enable() {
   if (enable_time_->value.time_prop() == ZERO) {
-    enable_time_->value.time_prop(get_time());
+    enable_time_->value.time_prop(get_hr_time());
     datareader_->enable();
   }
 }

--- a/performance-tests/bench_2/builder/DataWriter.cpp
+++ b/performance-tests/bench_2/builder/DataWriter.cpp
@@ -94,7 +94,7 @@ DataWriter::DataWriter(const DataWriterConfig& config, DataWriterReport& report,
   enable_time_->value.time_prop(ZERO);
   last_discovery_time_->value.time_prop(Builder::ZERO);
 
-  create_time_->value.time_prop(get_time());
+  create_time_->value.time_prop(get_hr_time());
   datawriter_ = publisher_->create_datawriter(topic_, qos, listener_, listener_status_mask_);
   if (CORBA::is_nil(datawriter_.in())) {
     throw std::runtime_error("datawriter creation failed");
@@ -122,7 +122,7 @@ DataWriter::~DataWriter() {
 
 void DataWriter::enable() {
   if (enable_time_->value.time_prop() == ZERO) {
-    enable_time_->value.time_prop(get_time());
+    enable_time_->value.time_prop(get_hr_time());
     datawriter_->enable();
   }
 }

--- a/performance-tests/bench_2/common/util.cpp
+++ b/performance-tests/bench_2/common/util.cpp
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <exception>
 #include <sstream>
-#include <chrono> // For std::chrono::system_clock
 #include <ctime>
 
 #include <ace/Lib_Find.h> // For ACE::get_temp_dir

--- a/performance-tests/bench_2/common/util.cpp
+++ b/performance-tests/bench_2/common/util.cpp
@@ -76,12 +76,12 @@ std::string create_temp_dir(const std::string& prefix)
   return ACE_TEXT_ALWAYS_CHAR(buffer);
 }
 
-std::string iso8601()
+std::string iso8601(const std::chrono::system_clock::time_point& tp)
 {
   using namespace std::chrono;
   std::stringstream ss;
-  const std::time_t now = system_clock::to_time_t(system_clock::now());
-  char buf[sizeof "2011-10-08T07:07:09Z"];
+  const std::time_t now = system_clock::to_time_t(tp);
+  char buf[sizeof "2011-10-08T07:07:09Z"]; // longest possible for UTC times (other zones add offset suffix)
   std::strftime(buf, sizeof buf, "%FT%TZ", std::gmtime(&now));
   ss << buf;
   return ss.str();

--- a/performance-tests/bench_2/common/util.h
+++ b/performance-tests/bench_2/common/util.h
@@ -1,6 +1,7 @@
 #ifndef BENCH_UTIL_HEADER
 #define BENCH_UTIL_HEADER
 
+#include <chrono>
 #include <string>
 #include <vector>
 

--- a/performance-tests/bench_2/common/util.h
+++ b/performance-tests/bench_2/common/util.h
@@ -31,7 +31,7 @@ bool Bench_Common_Export file_exists(const std::string& path);
 /**
  * Get Current UTC Time in ISO8601
  */
-std::string Bench_Common_Export iso8601();
+std::string Bench_Common_Export iso8601(const std::chrono::system_clock::time_point& tp = std::chrono::system_clock::now());
 
 }
 

--- a/performance-tests/bench_2/idl/Bench.idl
+++ b/performance-tests/bench_2/idl/Bench.idl
@@ -213,9 +213,11 @@ module Bench {
     // Result of Applying a Scenario Prototype to a List of Discovered Nodes
     @topic
     struct AllocatedScenario {
+      string scenario_id;
       NodeController::Configs configs;
       unsigned long expected_reports;
       unsigned long timeout;
+      Builder::TimeStamp launch_time;
     };
   };
 };

--- a/performance-tests/bench_2/idl/Bench.idl
+++ b/performance-tests/bench_2/idl/Bench.idl
@@ -158,7 +158,7 @@ module Bench {
       unsigned long timeout;
       WorkerConfigs workers;
     };
-    const string config_topic_name = "Node_Controller_Config";
+    const string allocated_scenario_topic_name = "Allocated_Scenario_Config";
     typedef sequence<Config> Configs;
 
     @topic

--- a/performance-tests/bench_2/idl/Bench.idl
+++ b/performance-tests/bench_2/idl/Bench.idl
@@ -14,11 +14,9 @@ module Bench {
 // Data Section
 // ---
 
-#pragma DCPS_DATA_TYPE "Bench::Data"
-#pragma DCPS_DATA_KEY  "Bench::Data id.high"
-#pragma DCPS_DATA_KEY  "Bench::Data id.low"
+  @topic
   struct Data {
-    UniqueId id;
+    @key UniqueId id;
     unsigned long msg_count;
     unsigned long total_hops;
     unsigned long hop_count;
@@ -132,25 +130,9 @@ module Bench {
       BUSY
     };
 
-#pragma DCPS_DATA_TYPE "Bench::NodeController::Status"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[11]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[10]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[9]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[8]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[7]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[6]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[5]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[4]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[3]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[2]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[1]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.guidPrefix[0]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.entityId.entityKey[2]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.entityId.entityKey[1]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.entityId.entityKey[0]"
-#pragma DCPS_DATA_KEY "Bench::NodeController::Status node_id.entityId.entityKind"
+    @topic
     struct Status {
-      NodeId node_id;
+      @key NodeId node_id;
       StateEnum state;
       // Optional Human Friendly Name
       string name;
@@ -167,7 +149,6 @@ module Bench {
     };
     typedef sequence<WorkerConfig> WorkerConfigs;
 
-#pragma DCPS_DATA_TYPE "Bench::NodeController::Config"
     struct Config {
       NodeId node_id;
       /*
@@ -180,7 +161,7 @@ module Bench {
     const string config_topic_name = "Node_Controller_Config";
     typedef sequence<Config> Configs;
 
-#pragma DCPS_DATA_TYPE "Bench::NodeController::Report"
+    @topic
     struct Report {
       NodeId node_id;
       WorkerId worker_id;
@@ -230,6 +211,7 @@ module Bench {
     };
 
     // Result of Applying a Scenario Prototype to a List of Discovered Nodes
+    @topic
     struct AllocatedScenario {
       NodeController::Configs configs;
       unsigned long expected_reports;

--- a/performance-tests/bench_2/node_controller/main.cpp
+++ b/performance-tests/bench_2/node_controller/main.cpp
@@ -582,7 +582,7 @@ bool wait_for_scenario_data(AllocatedScenarioDataReader_var config_reader_impl) 
 
   while (!read_condition->get_trigger_value()) {
     DDS::ConditionSeq active;
-    const DDS::Duration_t wake_interval = { 3, 0 };
+    const DDS::Duration_t wake_interval = { 0, 500000000 };
     DDS::ReturnCode_t rc = ws->wait(active, wake_interval);
     if (rc != DDS::RETCODE_OK && rc != DDS::RETCODE_TIMEOUT) {
       std::cerr << "Wait for node config failed" << std::endl;
@@ -719,7 +719,7 @@ int run_cycle(
     return 1;
   }
 
-  std::this_thread::sleep_for(std::chrono::seconds(10));
+  std::this_thread::sleep_for(std::chrono::seconds(3));
 
   return 0;
 }

--- a/performance-tests/bench_2/node_controller/main.cpp
+++ b/performance-tests/bench_2/node_controller/main.cpp
@@ -704,11 +704,11 @@ int run_cycle(
 
   using Builder::ZERO;
 
-  std::chrono::time_point<std::chrono::high_resolution_clock> timeout_time;
+  std::chrono::time_point<std::chrono::system_clock> timeout_time;
   if (scenario.launch_time < ZERO) {
-    timeout_time = std::chrono::high_resolution_clock::now() - get_duration(scenario.launch_time);
+    timeout_time = std::chrono::system_clock::now() - get_duration(scenario.launch_time);
   } else {
-    timeout_time = std::chrono::high_resolution_clock::time_point(get_duration(scenario.launch_time));
+    timeout_time = std::chrono::system_clock::time_point(get_duration(scenario.launch_time));
   }
   std::this_thread::sleep_until(timeout_time);
 

--- a/performance-tests/bench_2/test_controller/DdsEntities.cpp
+++ b/performance-tests/bench_2/test_controller/DdsEntities.cpp
@@ -33,7 +33,7 @@ DdsEntities::DdsEntities(
     throw std::runtime_error("create_topic status failed");
   }
   delete [] status_type_name;
-  config_ts_ = new ConfigTypeSupportImpl;
+  config_ts_ = new Bench::TestController::AllocatedScenarioTypeSupportImpl;
   if (config_ts_->register_type(participant_, "")) {
     throw std::runtime_error("register_type failed for Config");
   }
@@ -75,8 +75,8 @@ DdsEntities::DdsEntities(
   if (!config_writer_) {
     throw std::runtime_error("create_datawriter config failed");
   }
-  config_writer_impl_ = ConfigDataWriter::_narrow(config_writer_);
-  if (!config_writer_impl_) {
+  scenario_writer_impl_ = Bench::TestController::AllocatedScenarioDataWriter::_narrow(config_writer_);
+  if (!scenario_writer_impl_) {
     throw std::runtime_error("narrow writer config failed");
   }
 

--- a/performance-tests/bench_2/test_controller/DdsEntities.cpp
+++ b/performance-tests/bench_2/test_controller/DdsEntities.cpp
@@ -88,8 +88,10 @@ DdsEntities::DdsEntities(
   }
   DDS::DataReaderQos dr_qos;
   subscriber_->get_default_datareader_qos(dr_qos);
-  dr_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+  dr_qos.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
+  dr_qos.history.depth = 1;
   dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+  dr_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
   status_reader_ = subscriber_->create_datareader(
     status_topic_, dr_qos, &status_listener_,
     OpenDDS::DCPS::DEFAULT_STATUS_MASK);
@@ -100,6 +102,9 @@ DdsEntities::DdsEntities(
   if (!status_reader_impl_) {
     throw std::runtime_error("narrow status reader failed");
   }
+  subscriber_->get_default_datareader_qos(dr_qos);
+  dr_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+  dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
   report_reader_ = subscriber_->create_datareader(
     report_topic_, dr_qos, nullptr,
     OpenDDS::DCPS::DEFAULT_STATUS_MASK);

--- a/performance-tests/bench_2/test_controller/DdsEntities.cpp
+++ b/performance-tests/bench_2/test_controller/DdsEntities.cpp
@@ -33,18 +33,18 @@ DdsEntities::DdsEntities(
     throw std::runtime_error("create_topic status failed");
   }
   delete [] status_type_name;
-  config_ts_ = new Bench::TestController::AllocatedScenarioTypeSupportImpl;
-  if (config_ts_->register_type(participant_, "")) {
+  allocated_scenario_ts_ = new Bench::TestController::AllocatedScenarioTypeSupportImpl;
+  if (allocated_scenario_ts_->register_type(participant_, "")) {
     throw std::runtime_error("register_type failed for Config");
   }
-  char* config_type_name = config_ts_->get_type_name();
-  config_topic_ = participant_->create_topic(
-    config_topic_name, config_type_name, TOPIC_QOS_DEFAULT, nullptr,
+  char* allocated_scenario_type_name = allocated_scenario_ts_->get_type_name();
+  allocated_scenario_topic_ = participant_->create_topic(
+    allocated_scenario_topic_name, allocated_scenario_type_name, TOPIC_QOS_DEFAULT, nullptr,
     OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-  if (!config_topic_) {
+  if (!allocated_scenario_topic_) {
     throw std::runtime_error("create_topic config failed");
   }
-  delete [] config_type_name;
+  delete [] allocated_scenario_type_name;
   report_ts_ = new ReportTypeSupportImpl;
   if (report_ts_->register_type(participant_, "")) {
     throw std::runtime_error("register_type failed for Report");
@@ -69,13 +69,13 @@ DdsEntities::DdsEntities(
   dw_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
   dw_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
   dw_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
-  config_writer_ = publisher_->create_datawriter(
-    config_topic_, dw_qos, nullptr,
+  allocated_scenario_writer_ = publisher_->create_datawriter(
+    allocated_scenario_topic_, dw_qos, nullptr,
     OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-  if (!config_writer_) {
+  if (!allocated_scenario_writer_) {
     throw std::runtime_error("create_datawriter config failed");
   }
-  scenario_writer_impl_ = Bench::TestController::AllocatedScenarioDataWriter::_narrow(config_writer_);
+  scenario_writer_impl_ = Bench::TestController::AllocatedScenarioDataWriter::_narrow(allocated_scenario_writer_);
   if (!scenario_writer_impl_) {
     throw std::runtime_error("narrow writer config failed");
   }

--- a/performance-tests/bench_2/test_controller/DdsEntities.h
+++ b/performance-tests/bench_2/test_controller/DdsEntities.h
@@ -28,13 +28,13 @@ public:
 
   Bench::NodeController::StatusTypeSupport_var status_ts_;
   DDS::Topic_var status_topic_;
-  Bench::TestController::AllocatedScenarioTypeSupport_var config_ts_;
-  DDS::Topic_var config_topic_;
+  Bench::TestController::AllocatedScenarioTypeSupport_var allocated_scenario_ts_;
+  DDS::Topic_var allocated_scenario_topic_;
   Bench::NodeController::ReportTypeSupport_var report_ts_;
   DDS::Topic_var report_topic_;
 
   DDS::Publisher_var publisher_;
-  DDS::DataWriter_var config_writer_;
+  DDS::DataWriter_var allocated_scenario_writer_;
   Bench::TestController::AllocatedScenarioDataWriter_var scenario_writer_impl_;
 
   DDS::Subscriber_var subscriber_;

--- a/performance-tests/bench_2/test_controller/DdsEntities.h
+++ b/performance-tests/bench_2/test_controller/DdsEntities.h
@@ -28,14 +28,14 @@ public:
 
   Bench::NodeController::StatusTypeSupport_var status_ts_;
   DDS::Topic_var status_topic_;
-  Bench::NodeController::ConfigTypeSupport_var config_ts_;
+  Bench::TestController::AllocatedScenarioTypeSupport_var config_ts_;
   DDS::Topic_var config_topic_;
   Bench::NodeController::ReportTypeSupport_var report_ts_;
   DDS::Topic_var report_topic_;
 
   DDS::Publisher_var publisher_;
   DDS::DataWriter_var config_writer_;
-  Bench::NodeController::ConfigDataWriter_var config_writer_impl_;
+  Bench::TestController::AllocatedScenarioDataWriter_var scenario_writer_impl_;
 
   DDS::Subscriber_var subscriber_;
   DDS::DataReader_var status_reader_;

--- a/performance-tests/bench_2/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench_2/test_controller/ScenarioManager.cpp
@@ -287,10 +287,8 @@ AllocatedScenario ScenarioManager::allocate_scenario(
 std::vector<WorkerReport> ScenarioManager::execute(const AllocatedScenario& allocated_scenario)
 {
   // Write Configs
-  for (unsigned i = 0; i < allocated_scenario.configs.length(); i++) {
-    if (dds_entities_.config_writer_impl_->write(allocated_scenario.configs[i], DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
-      throw std::runtime_error("Config write failed!");
-    }
+  if (dds_entities_.scenario_writer_impl_->write(allocated_scenario, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+    throw std::runtime_error("Config write failed!");
   }
 
   // Set up Waiting for Reading Reports or the Scenario Timeout

--- a/performance-tests/bench_2/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench_2/test_controller/ScenarioManager.cpp
@@ -389,10 +389,7 @@ std::vector<WorkerReport> ScenarioManager::execute(const AllocatedScenario& allo
             if (timeout_thread) {
               timeout_thread->join();
             }
-            std::stringstream ss;
-            ss << "Timedout waiting for the scenario to complete";
-            throw std::runtime_error(ss.str());
-          } else {
+            throw std::runtime_error("Timedout waiting for the scenario to complete");
           }
         }
       }

--- a/performance-tests/bench_2/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench_2/test_controller/ScenarioManager.cpp
@@ -116,7 +116,7 @@ namespace {
 }
 
 void ScenarioManager::customize_configs(std::map<std::string, std::string>& worker_configs) {
-  Builder::TimeStamp now = Builder::get_time();
+  Builder::TimeStamp now = Builder::get_sys_time();
 
   for (auto it = worker_configs.begin(); it != worker_configs.end(); ++it) {
 
@@ -281,6 +281,13 @@ AllocatedScenario ScenarioManager::allocate_scenario(
     }
   }
 
+  char host[256];
+  ACE_OS::hostname(host, sizeof(host));
+  pid_t pid = ACE_OS::getpid();
+  std::stringstream ss;
+  ss << host << "_" << pid << std::flush;
+  allocated_scenario.scenario_id = ss.str().c_str();
+
   return allocated_scenario;
 }
 
@@ -298,7 +305,7 @@ std::vector<WorkerReport> ScenarioManager::execute(const AllocatedScenario& allo
 
   AllocatedScenario temp = allocated_scenario;
   temp.configs.length(0);
-  temp.launch_time = Builder::get_time() + Builder::from_seconds(3);
+  temp.launch_time = Builder::get_sys_time() + Builder::from_seconds(3);
 
   // Write Configs
   if (dds_entities_.scenario_writer_impl_->write(temp, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {

--- a/performance-tests/bench_2/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench_2/test_controller/ScenarioManager.cpp
@@ -288,6 +288,8 @@ AllocatedScenario ScenarioManager::allocate_scenario(
   ss << host << "_" << pid << std::flush;
   allocated_scenario.scenario_id = ss.str().c_str();
 
+  allocated_scenario.launch_time = Builder::ZERO;
+
   return allocated_scenario;
 }
 

--- a/performance-tests/bench_2/worker/ForwardAction.cpp
+++ b/performance-tests/bench_2/worker/ForwardAction.cpp
@@ -123,7 +123,7 @@ void ForwardAction::on_data(const Data& data) {
 
         // Temporarily break const promises to modify data for resending
         Data& dangerous_data = const_cast<Data&>(data);
-        dangerous_data.sent_time = Builder::get_time();
+        dangerous_data.sent_time = Builder::get_sys_time();
         dangerous_data.hop_count = old_hop_count + 1;
 
         (*it)->write(data, 0);
@@ -142,7 +142,7 @@ void ForwardAction::do_writes() {
     Data& data = data_queue_[queue_first_];
     data.hop_count += 1;
     for (auto it = data_dws_.begin(); it != data_dws_.end(); ++it) {
-      data.sent_time = Builder::get_time();
+      data.sent_time = Builder::get_sys_time();
       (*it)->write(data, 0);
     }
     queue_first_ = (queue_first_ + 1) % data_queue_.size();

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
@@ -96,7 +96,7 @@ WorkerDataReaderListener::on_data_available(DDS::DataReader_ptr reader)
     if (status == DDS::RETCODE_OK && si.valid_data) {
 
       // Calculate the stateless stuff
-      const Builder::TimeStamp& now = Builder::get_time();
+      const Builder::TimeStamp& now = Builder::get_sys_time();
       double latency = Builder::to_seconds_double(now - data.sent_time);
       double jitter = -1.0;
       double round_trip_latency = -1.0;
@@ -192,13 +192,13 @@ WorkerDataReaderListener::on_subscription_matched(
     if (static_cast<size_t>(status.current_count) == expected_match_count_) {
       //std::cout << "WorkerDataReaderListener reached expected count!" << std::endl;
       if (datareader_) {
-        last_discovery_time_->value.time_prop(Builder::get_time());
+        last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }
     }
   } else {
     if (static_cast<size_t>(status.current_count) > match_count_) {
       if (datareader_) {
-        last_discovery_time_->value.time_prop(Builder::get_time());
+        last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }
     }
   }

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
@@ -51,13 +51,13 @@ WorkerDataWriterListener::on_publication_matched(
     if (static_cast<size_t>(status.current_count) == expected_match_count_) {
       //std::cout << "WorkerDataWriterListener reached expected count!" << std::endl;
       if (datawriter_) {
-        last_discovery_time_->value.time_prop(Builder::get_time());
+        last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }
     }
   } else {
     if (static_cast<size_t>(status.current_count) > match_count_) {
       if (datawriter_) {
-        last_discovery_time_->value.time_prop(Builder::get_time());
+        last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }
     }
   }

--- a/performance-tests/bench_2/worker/WriteAction.cpp
+++ b/performance-tests/bench_2/worker/WriteAction.cpp
@@ -161,7 +161,7 @@ void WriteAction::do_write() {
         data_.id.high = mt_();
         data_.id.low = mt_();
       }
-      data_.created_time = data_.sent_time = Builder::get_time();
+      data_.created_time = data_.sent_time = Builder::get_sys_time();
       DDS::ReturnCode_t result = data_dw_->write(data_, 0);
       if (result != DDS::RETCODE_OK) {
         --(data_.msg_count);

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -228,9 +228,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
     Log::log() << "Beginning process construction / entity creation." << std::endl;
 
-    process_construction_begin_time = Builder::get_time();
+    process_construction_begin_time = Builder::get_hr_time();
     Builder::BuilderProcess process(config.process);
-    process_construction_end_time = Builder::get_time();
+    process_construction_end_time = Builder::get_hr_time();
 
     Log::log() << std::endl << "Process construction / entity creation complete." << std::endl << std::endl;
 
@@ -255,9 +255,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
     Log::log() << "Enabling DDS entities (if not already enabled)." << std::endl;
 
-    process_enable_begin_time = Builder::get_time();
+    process_enable_begin_time = Builder::get_hr_time();
     process.enable_dds_entities();
-    process_enable_end_time = Builder::get_time();
+    process_enable_end_time = Builder::get_hr_time();
 
     Log::log() << "DDS entities enabled." << std::endl << std::endl;
 
@@ -276,9 +276,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
     Log::log() << "Starting process tests." << std::endl;
 
-    process_start_begin_time = Builder::get_time();
+    process_start_begin_time = Builder::get_hr_time();
     am.start();
-    process_start_end_time = Builder::get_time();
+    process_start_end_time = Builder::get_hr_time();
 
     Log::log() << "Process tests started." << std::endl << std::endl;
 
@@ -297,9 +297,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
     Log::log() << "Stopping process tests." << std::endl;
 
-    process_stop_begin_time = Builder::get_time();
+    process_stop_begin_time = Builder::get_hr_time();
     am.stop();
-    process_stop_end_time = Builder::get_time();
+    process_stop_end_time = Builder::get_hr_time();
 
     Log::log() << "Process tests stopped." << std::endl << std::endl;
 
@@ -328,7 +328,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
     Log::log() << "Beginning process destruction / entity deletion." << std::endl;
 
-    process_destruction_begin_time = Builder::get_time();
+    process_destruction_begin_time = Builder::get_hr_time();
   } catch (const std::exception& e) {
     std::cerr << "Exception caught trying to build process object: " << e.what() << std::endl;
     proactor.proactor_end_event_loop();
@@ -348,7 +348,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
     TheServiceParticipant->shutdown();
     return 1;
   }
-  process_destruction_end_time = Builder::get_time();
+  process_destruction_end_time = Builder::get_hr_time();
 
   Log::log() << "Process destruction / entity deletion complete." << std::endl << std::endl;
 


### PR DESCRIPTION
Currently, delays in propagating configuration between the test controller and node controllers can cause different node controllers to launch their worker processes at different times. Improve this by sending the whole scenario at once to improve flow control issues and then wait for acknowledgement before sending a launch time.