### PR TITLE
Handle SpdpLocalAddress formatted as defined in Dev Guide properly

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -281,7 +281,7 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
         } else if (name == "SpdpLocalAddress") {
           ACE_INET_Addr addr;
           if (addr.set(u_short(0), it->second.c_str())) {
-              ACE_ERROR_RETURN((LM_ERROR,
+            ACE_ERROR_RETURN((LM_ERROR,
                               ACE_TEXT("(%P|%t) ERROR: RtpsDiscovery::Config::discovery_config(): ")
                               ACE_TEXT("failed to parse SpdpLocalAddress %C\n"),
                               it->second.c_str()),

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -280,8 +280,8 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
           config->sedp_local_address(addr);
         } else if (name == "SpdpLocalAddress") {
           ACE_INET_Addr addr;
-          if (addr.set(it->second.c_str())) {
-            ACE_ERROR_RETURN((LM_ERROR,
+          if (addr.set(u_short(0), it->second.c_str())) {
+              ACE_ERROR_RETURN((LM_ERROR,
                               ACE_TEXT("(%P|%t) ERROR: RtpsDiscovery::Config::discovery_config(): ")
                               ACE_TEXT("failed to parse SpdpLocalAddress %C\n"),
                               it->second.c_str()),

--- a/tests/DCPS/ConfigFile/test1.ini
+++ b/tests/DCPS/ConfigFile/test1.ini
@@ -100,6 +100,7 @@ D0=1
 D1=9
 DX=15
 SpdpSendAddrs=host1:10001
+SpdpLocalAddress=192.168.1.1
 
 [domain/98]
 DiscoveryConfig=MultiSendAddr


### PR DESCRIPTION
Fixes #1738 
This changes the code in RtpsDiscovery::Config::discovery_config(), specifically for the SpdpLocalAddress case, to use a version of the ACE_INET_Addr::set() functions that allows for an IP address without a port number (as is required for SpdpLocalAddress according to the OpenDDS Developers' Guide). This change follows the example of "InteropMulticastOverride".

Note: I've assumed the actual port used will overwrite the 0 it's set to .

In addition an SpdpLocalAddress is specified, in the correct format, in the test1.ini file in the tests/DCPS/ConfigFile directory is updated to exercise this code.