### PR TITLE
Protect Listeners in DataLink::network_change()

### DIFF
--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -1156,16 +1156,23 @@ DataLink::ImmediateStart::execute() {
 void
 DataLink::network_change() const
 {
-  for (IdToSendListenerMap::const_iterator itr = send_listeners_.begin();
-       itr != send_listeners_.end(); ++itr) {
+  IdToSendListenerMap send_listeners;
+  IdToRecvListenerMap recv_listeners;
+  {
+    GuardType guard(pub_sub_maps_lock_);
+    send_listeners = send_listeners_;
+    recv_listeners = recv_listeners_;
+  }
+  for (IdToSendListenerMap::const_iterator itr = send_listeners.begin();
+       itr != send_listeners.end(); ++itr) {
     TransportSendListener_rch tsl = itr->second.lock();
     if (tsl) {
       tsl->transport_discovery_change();
     }
   }
 
-  for (IdToRecvListenerMap::const_iterator itr = recv_listeners_.begin();
-       itr != recv_listeners_.end(); ++itr) {
+  for (IdToRecvListenerMap::const_iterator itr = recv_listeners.begin();
+       itr != recv_listeners.end(); ++itr) {
     TransportReceiveListener_rch trl = itr->second.lock();
     if (trl) {
       trl->transport_discovery_change();


### PR DESCRIPTION
Fixes RestartTest from a SEGV when accessing recently-deleted listener maps.