### PR TITLE
Added type support draft code for TypeLookup_getTypeDependencies_In

### DIFF
--- a/dds/DCPS/TypeLookup_getTypeDependencies_InC.h
+++ b/dds/DCPS/TypeLookup_getTypeDependencies_InC.h
@@ -339,8 +339,8 @@ TAO_BEGIN_VERSIONED_NAMESPACE_DECL
 TAO_END_VERSIONED_NAMESPACE_DECL
 
 
-#if defined (__ACE_INLINE__)
-#include "i3C.inl"
-#endif /* defined INLINE */
+//#if defined (__ACE_INLINE__)
+//#include "i3C.inl"
+//#endif /* defined INLINE */
 
 #endif /* ifndef _TYPE_LOOKUP_GET_DEPENDENCIES_IN_H_ */

--- a/dds/DCPS/TypeLookup_getTypeDependencies_InC.h
+++ b/dds/DCPS/TypeLookup_getTypeDependencies_InC.h
@@ -1,0 +1,344 @@
+#ifndef _TYPE_LOOKUP_GET_DEPENDENCIES_IN_H_
+#define _TYPE_LOOKUP_GET_DEPENDENCIES_IN_H_
+
+
+#include /**/ "ace/config-all.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+# pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+
+#include "tao/AnyTypeCode/AnyTypeCode_methods.h"
+#include "tao/AnyTypeCode/Any.h"
+#include "tao/ORB.h"
+#include "tao/Basic_Types.h"
+#include "tao/String_Manager_T.h"
+#include "tao/Sequence_T.h"
+#include "tao/Seq_Var_T.h"
+#include "tao/Seq_Out_T.h"
+#include "tao/VarOut_T.h"
+#include "tao/Arg_Traits_T.h"
+#include "tao/Basic_Arguments.h"
+#include "tao/Special_Basic_Arguments.h"
+#include "tao/Any_Insert_Policy_T.h"
+#include "tao/Fixed_Size_Argument_T.h"
+#include "tao/Var_Size_Argument_T.h"
+#include /**/ "tao/Version.h"
+#include /**/ "tao/Versioned_Namespace.h"
+
+#include "TypeObject.h"
+
+namespace OpenDDS
+{
+namespace XTypes
+{
+#if !defined (_XTYPES_TYPEIDENTIFIERSEQ_CH_)
+#define _XTYPES_TYPEIDENTIFIERSEQ_CH_
+
+  //class TypeIdentifierSeq;
+
+  typedef
+    ::TAO_VarSeq_Var_T<
+        TypeIdentifierSeq
+      >
+    TypeIdentifierSeq_var;
+
+  typedef
+    ::TAO_Seq_Out_T<
+        TypeIdentifierSeq
+      >
+    TypeIdentifierSeq_out;
+
+//  class  TypeIdentifierSeq
+//    : public
+//        ::TAO::unbounded_value_sequence<
+//            TypeIdentifier
+//          >
+//  {
+//  public:
+//    TypeIdentifierSeq (void);
+//    TypeIdentifierSeq ( ::CORBA::ULong max);
+//    TypeIdentifierSeq (
+//      ::CORBA::ULong max,
+//      ::CORBA::ULong length,
+//      TypeIdentifier* buffer,
+//      ::CORBA::Boolean release = false);
+//#if defined (ACE_HAS_CPP11)
+//    TypeIdentifierSeq (const TypeIdentifierSeq &) = default;
+//    TypeIdentifierSeq (TypeIdentifierSeq &&) = default;
+//    TypeIdentifierSeq& operator= (const TypeIdentifierSeq &) = default;
+//    TypeIdentifierSeq& operator= (TypeIdentifierSeq &&) = default;
+//#endif /* ACE_HAS_CPP11 */
+//    virtual ~TypeIdentifierSeq (void);
+//    
+//    typedef TypeIdentifierSeq_var _var_type;
+//    typedef TypeIdentifierSeq_out _out_type;
+//
+//    static void _tao_any_destructor (void *);
+//  };
+
+#endif /* end #if !defined */
+
+  extern  ::CORBA::TypeCode_ptr const _tc_TypeIdentifierSeq;
+
+#if !defined (_XTYPES_CONTINUATION_POINT_SEQ_CH_)
+#define _XTYPES_CONTINUATION_POINT_SEQ_CH_
+
+  class continuation_point_Seq;
+
+  typedef
+    ::TAO_FixedSeq_Var_T<
+        continuation_point_Seq
+      >
+    continuation_point_Seq_var;
+
+  typedef
+    ::TAO_Seq_Out_T<
+        continuation_point_Seq
+      >
+    continuation_point_Seq_out;
+
+  // TODO: do we need to add 'generated' *C.cpp file with implementation of serialization methods, or remove their declarations from the header?
+  class  continuation_point_Seq
+    : public
+        ::TAO::bounded_value_sequence<
+            ::CORBA::Octet,
+            32
+          >
+  {
+  public:
+    continuation_point_Seq(void) {}
+    // TODO: do we need to add 'generated' *C.cpp file with implementation?
+    //continuation_point_Seq (
+    //  ::CORBA::ULong length,
+    //  ::CORBA::Octet* buffer,
+    //  ::CORBA::Boolean release = false);
+#if defined (ACE_HAS_CPP11)
+    continuation_point_Seq (const continuation_point_Seq &) = default;
+    continuation_point_Seq (continuation_point_Seq &&) = default;
+    continuation_point_Seq& operator= (const continuation_point_Seq &) = default;
+    continuation_point_Seq& operator= (continuation_point_Seq &&) = default;
+#endif /* ACE_HAS_CPP11 */
+    virtual ~continuation_point_Seq(void) {}
+    
+    typedef continuation_point_Seq_var _var_type;
+    typedef continuation_point_Seq_out _out_type;
+
+    // TODO: do we need to add 'generated' *C.cpp file with implementation?
+    //static void _tao_any_destructor (void *);
+  };
+
+#endif /* end #if !defined */
+
+  extern  ::CORBA::TypeCode_ptr const _tc_continuation_point_Seq;
+
+  struct TypeLookup_getTypeDependencies_In;
+
+  typedef
+    ::TAO_Var_Var_T<
+        TypeLookup_getTypeDependencies_In
+      >
+    TypeLookup_getTypeDependencies_In_var;
+
+  typedef
+    ::TAO_Out_T<
+        TypeLookup_getTypeDependencies_In
+      >
+    TypeLookup_getTypeDependencies_In_out;
+
+  struct  TypeLookup_getTypeDependencies_In
+  {   
+    typedef TypeLookup_getTypeDependencies_In_var _var_type;
+    typedef TypeLookup_getTypeDependencies_In_out _out_type;
+
+    static void _tao_any_destructor (void *);
+    
+    XTypes::TypeIdentifierSeq type_ids;
+    XTypes::continuation_point_Seq continuation_point;
+  };
+
+  extern  ::CORBA::TypeCode_ptr const _tc_TypeLookup_getTypeDependencies_In;
+
+} // module XTypes
+}
+
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+
+// Arg traits specializations.
+namespace TAO
+{
+  template<>
+  class Arg_Traits< OpenDDS::XTypes::TypeIdentifierSeq>
+    : public
+        Var_Size_Arg_Traits_T<
+            OpenDDS::XTypes::TypeIdentifierSeq,
+            TAO::Any_Insert_Policy_Stream
+          >
+  {
+  };
+
+  template<>
+  class Arg_Traits< OpenDDS::XTypes::continuation_point_Seq>
+    : public
+        Var_Size_Arg_Traits_T<
+            OpenDDS::XTypes::continuation_point_Seq,
+            TAO::Any_Insert_Policy_Stream
+          >
+  {
+  };
+
+  template<>
+  class Arg_Traits< OpenDDS::XTypes::TypeLookup_getTypeDependencies_In>
+    : public
+        Var_Size_Arg_Traits_T<
+            OpenDDS::XTypes::TypeLookup_getTypeDependencies_In,
+            TAO::Any_Insert_Policy_Stream
+          >
+  {
+  };
+}
+
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+// Traits specializations.
+namespace TAO
+{
+}
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+#if defined (ACE_ANY_OPS_USE_NAMESPACE)
+
+namespace XTypes
+{
+   void operator<<= ( ::CORBA::Any &, const ::XTypes::TypeIdentifierSeq &); // copying version
+   void operator<<= ( ::CORBA::Any &, ::XTypes::TypeIdentifierSeq*); // noncopying version
+   ::CORBA::Boolean operator>>= (const ::CORBA::Any &, ::XTypes::TypeIdentifierSeq *&); // deprecated
+   ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::XTypes::TypeIdentifierSeq *&);
+}
+
+#else
+
+
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+ void operator<<= ( ::CORBA::Any &, const OpenDDS::XTypes::TypeIdentifierSeq &); // copying version
+ void operator<<= ( ::CORBA::Any &, OpenDDS::XTypes::TypeIdentifierSeq*); // noncopying version
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, OpenDDS::XTypes::TypeIdentifierSeq *&); // deprecated
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const OpenDDS::XTypes::TypeIdentifierSeq *&);
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+
+#endif
+
+
+#if defined (ACE_ANY_OPS_USE_NAMESPACE)
+
+namespace XTypes
+{
+   void operator<<= ( ::CORBA::Any &, const ::XTypes::continuation_point_Seq &); // copying version
+   void operator<<= ( ::CORBA::Any &, ::XTypes::continuation_point_Seq*); // noncopying version
+   ::CORBA::Boolean operator>>= (const ::CORBA::Any &, ::XTypes::continuation_point_Seq *&); // deprecated
+   ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::XTypes::continuation_point_Seq *&);
+}
+
+#else
+
+
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+ void operator<<= ( ::CORBA::Any &, const OpenDDS::XTypes::continuation_point_Seq &); // copying version
+ void operator<<= ( ::CORBA::Any &, OpenDDS::XTypes::continuation_point_Seq*); // noncopying version
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, OpenDDS::XTypes::continuation_point_Seq *&); // deprecated
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const OpenDDS::XTypes::continuation_point_Seq *&);
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+
+#endif
+
+
+#if defined (ACE_ANY_OPS_USE_NAMESPACE)
+
+namespace XTypes
+{
+   void operator<<= (::CORBA::Any &, const ::XTypes::TypeLookup_getTypeDependencies_In &); // copying version
+   void operator<<= (::CORBA::Any &, ::XTypes::TypeLookup_getTypeDependencies_In*); // noncopying version
+   ::CORBA::Boolean operator>>= (const ::CORBA::Any &, ::XTypes::TypeLookup_getTypeDependencies_In *&); // deprecated
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const ::XTypes::TypeLookup_getTypeDependencies_In *&);
+}
+
+#else
+
+
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+ void operator<<= (::CORBA::Any &, const OpenDDS::XTypes::TypeLookup_getTypeDependencies_In &); // copying version
+ void operator<<= (::CORBA::Any &, OpenDDS::XTypes::TypeLookup_getTypeDependencies_In*); // noncopying version
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, OpenDDS::XTypes::TypeLookup_getTypeDependencies_In *&); // deprecated
+ ::CORBA::Boolean operator>>= (const ::CORBA::Any &, const OpenDDS::XTypes::TypeLookup_getTypeDependencies_In *&);
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+
+#endif
+
+
+#if !defined _TAO_CDR_OP_XTypes_TypeIdentifierSeq_H_
+#define _TAO_CDR_OP_XTypes_TypeIdentifierSeq_H_
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+
+ ::CORBA::Boolean operator<< (
+    TAO_OutputCDR &strm,
+    const OpenDDS::XTypes::TypeIdentifierSeq &_tao_sequence);
+ ::CORBA::Boolean operator>> (
+    TAO_InputCDR &strm,
+    OpenDDS::XTypes::TypeIdentifierSeq &_tao_sequence);
+
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+
+#endif /* _TAO_CDR_OP_XTypes_TypeIdentifierSeq_H_ */
+
+
+#if !defined _TAO_CDR_OP_XTypes_continuation_point_Seq_H_
+#define _TAO_CDR_OP_XTypes_continuation_point_Seq_H_
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+
+ ::CORBA::Boolean operator<< (
+    TAO_OutputCDR &strm,
+    const OpenDDS::XTypes::continuation_point_Seq &_tao_sequence);
+ ::CORBA::Boolean operator>> (
+    TAO_InputCDR &strm,
+    OpenDDS::XTypes::continuation_point_Seq &_tao_sequence);
+
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+
+#endif /* _TAO_CDR_OP_XTypes_continuation_point_Seq_H_ */
+
+
+TAO_BEGIN_VERSIONED_NAMESPACE_DECL
+
+ ::CORBA::Boolean operator<< (TAO_OutputCDR &, const OpenDDS::XTypes::TypeLookup_getTypeDependencies_In &);
+ ::CORBA::Boolean operator>> (TAO_InputCDR &, OpenDDS::XTypes::TypeLookup_getTypeDependencies_In &);
+
+TAO_END_VERSIONED_NAMESPACE_DECL
+
+
+#if defined (__ACE_INLINE__)
+#include "i3C.inl"
+#endif /* defined INLINE */
+
+#endif /* ifndef _TYPE_LOOKUP_GET_DEPENDENCIES_IN_H_ */

--- a/dds/DCPS/TypeLookup_getTypeDependencies_InC.h
+++ b/dds/DCPS/TypeLookup_getTypeDependencies_InC.h
@@ -36,7 +36,7 @@ namespace XTypes
 #if !defined (_XTYPES_TYPEIDENTIFIERSEQ_CH_)
 #define _XTYPES_TYPEIDENTIFIERSEQ_CH_
 
-  //class TypeIdentifierSeq;
+  class TypeIdentifierSeq;
 
   typedef
     ::TAO_VarSeq_Var_T<
@@ -50,33 +50,35 @@ namespace XTypes
       >
     TypeIdentifierSeq_out;
 
-//  class  TypeIdentifierSeq
-//    : public
-//        ::TAO::unbounded_value_sequence<
-//            TypeIdentifier
-//          >
-//  {
-//  public:
-//    TypeIdentifierSeq (void);
-//    TypeIdentifierSeq ( ::CORBA::ULong max);
-//    TypeIdentifierSeq (
-//      ::CORBA::ULong max,
-//      ::CORBA::ULong length,
-//      TypeIdentifier* buffer,
-//      ::CORBA::Boolean release = false);
-//#if defined (ACE_HAS_CPP11)
-//    TypeIdentifierSeq (const TypeIdentifierSeq &) = default;
-//    TypeIdentifierSeq (TypeIdentifierSeq &&) = default;
-//    TypeIdentifierSeq& operator= (const TypeIdentifierSeq &) = default;
-//    TypeIdentifierSeq& operator= (TypeIdentifierSeq &&) = default;
-//#endif /* ACE_HAS_CPP11 */
-//    virtual ~TypeIdentifierSeq (void);
-//    
-//    typedef TypeIdentifierSeq_var _var_type;
-//    typedef TypeIdentifierSeq_out _out_type;
-//
-//    static void _tao_any_destructor (void *);
-//  };
+  class  TypeIdentifierSeq
+    : public
+        ::TAO::unbounded_value_sequence<
+            TypeIdentifier
+          >
+  {
+  public:
+    TypeIdentifierSeq(void) {}
+    // TODO: is implementation needed (from *C.cpp)?
+    //TypeIdentifierSeq ( ::CORBA::ULong max);
+    //TypeIdentifierSeq (
+    //  ::CORBA::ULong max,
+    //  ::CORBA::ULong length,
+    //  TypeIdentifier* buffer,
+    //  ::CORBA::Boolean release = false);
+#if defined (ACE_HAS_CPP11)
+    TypeIdentifierSeq (const TypeIdentifierSeq &) = default;
+    TypeIdentifierSeq (TypeIdentifierSeq &&) = default;
+    TypeIdentifierSeq& operator= (const TypeIdentifierSeq &) = default;
+    TypeIdentifierSeq& operator= (TypeIdentifierSeq &&) = default;
+#endif /* ACE_HAS_CPP11 */
+    virtual ~TypeIdentifierSeq(void) {}
+
+    typedef TypeIdentifierSeq_var _var_type;
+    typedef TypeIdentifierSeq_out _out_type;
+
+    // TODO: is implementation needed (from *C.cpp)?
+    //static void _tao_any_destructor (void *);
+  };
 
 #endif /* end #if !defined */
 
@@ -121,7 +123,7 @@ namespace XTypes
     continuation_point_Seq& operator= (continuation_point_Seq &&) = default;
 #endif /* ACE_HAS_CPP11 */
     virtual ~continuation_point_Seq(void) {}
-    
+
     typedef continuation_point_Seq_var _var_type;
     typedef continuation_point_Seq_out _out_type;
 
@@ -148,12 +150,12 @@ namespace XTypes
     TypeLookup_getTypeDependencies_In_out;
 
   struct  TypeLookup_getTypeDependencies_In
-  {   
+  {
     typedef TypeLookup_getTypeDependencies_In_var _var_type;
     typedef TypeLookup_getTypeDependencies_In_out _out_type;
 
     static void _tao_any_destructor (void *);
-    
+
     XTypes::TypeIdentifierSeq type_ids;
     XTypes::continuation_point_Seq continuation_point;
   };

--- a/dds/DCPS/TypeLookup_getTypeDependencies_InTypeSupportImpl.cpp
+++ b/dds/DCPS/TypeLookup_getTypeDependencies_InTypeSupportImpl.cpp
@@ -1,0 +1,424 @@
+#include "DCPS/DdsDcps_pch.h"
+#include "TypeLookup_getTypeDependencies_InTypeSupportImpl.h"
+#include <cstring>
+#include <stdexcept>
+#include "dds/CorbaSeq/OctetSeqTypeSupportImpl.h"
+#include "dds/DCPS/FilterEvaluator.h"
+#include "dds/DCPS/PoolAllocator.h"
+
+
+/* Begin TYPEDEF: TypeIdentifierSeq */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+void serialized_size(const Encoding& encoding, size_t& size, const XTypes::TypeIdentifierSeq& seq)
+{
+  ACE_UNUSED_ARG(encoding);
+  ACE_UNUSED_ARG(size);
+  ACE_UNUSED_ARG(seq);
+  OpenDDS::DCPS::serialized_size_ulong(encoding, size);
+  if (seq.length() == 0) {
+    return;
+  }
+  for (CORBA::ULong i = 0; i < seq.length(); ++i) {
+    serialized_size(encoding, size, seq[i]);
+  }
+}
+
+bool operator<<(Serializer& strm, const XTypes::TypeIdentifierSeq& seq)
+{
+  ACE_UNUSED_ARG(strm);
+  ACE_UNUSED_ARG(seq);
+  const CORBA::ULong length = seq.length();
+  if (!(strm << length)) {
+    return false;
+  }
+  if (length == 0) {
+    return true;
+  }
+  for (CORBA::ULong i = 0; i < length; ++i) {
+    if (!(strm << seq[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool operator>>(Serializer& strm, XTypes::TypeIdentifierSeq& seq)
+{
+  ACE_UNUSED_ARG(strm);
+  ACE_UNUSED_ARG(seq);
+  CORBA::ULong length;
+  if (!(strm >> length)) {
+    return false;
+  }
+  seq.length(length);
+  for (CORBA::ULong i = 0; i < length; ++i) {
+    if (!(strm >> seq[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+bool gen_skip_over(Serializer& ser, XTypes::TypeIdentifierSeq*)
+{
+  ACE_UNUSED_ARG(ser);
+  ACE_CDR::ULong length;
+  if (!(ser >> length)) return false;
+  for (ACE_CDR::ULong i = 0; i < length; ++i) {
+    if (!gen_skip_over(ser, static_cast<XTypes::TypeIdentifier*>(0))) return false;
+  }
+  return true;
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_TypeIdentifierSeq_xtag>()
+{
+  static const XTypes::TypeObject to = XTypes::TypeObject(
+    XTypes::MinimalTypeObject(
+      XTypes::MinimalAliasType(
+        XTypes::AliasTypeFlag(0),
+        XTypes::MinimalAliasHeader(),
+        XTypes::MinimalAliasBody(
+          XTypes::CommonAliasBody(
+            XTypes::AliasMemberFlag(),
+            XTypes::TypeIdentifier::makePlainSequence(getMinimalTypeIdentifier<XTypes_TypeIdentifier_xtag>(), XTypes::SBound(0))
+          )
+        )
+      )
+    )
+  );
+  return to;
+}
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_TypeIdentifierSeq_xtag>()
+{
+  static const XTypes::TypeIdentifier ti = XTypes::makeTypeIdentifier(getMinimalTypeObject<XTypes_TypeIdentifierSeq_xtag>());
+  return ti;
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+
+/* End TYPEDEF: TypeIdentifierSeq */
+
+
+/* Begin TYPEDEF: continuation_point_Seq */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+void serialized_size(const Encoding& encoding, size_t& size, const XTypes::continuation_point_Seq& seq)
+{
+  ACE_UNUSED_ARG(encoding);
+  ACE_UNUSED_ARG(size);
+  ACE_UNUSED_ARG(seq);
+  OpenDDS::DCPS::serialized_size_ulong(encoding, size);
+  if (seq.length() == 0) {
+    return;
+  }
+  max_serialized_size_octet(encoding, size, seq.length());
+}
+
+bool operator<<(Serializer& strm, const XTypes::continuation_point_Seq& seq)
+{
+  ACE_UNUSED_ARG(strm);
+  ACE_UNUSED_ARG(seq);
+  const CORBA::ULong length = seq.length();
+  if (length > 32) {
+    return false;
+  }
+  if (!(strm << length)) {
+    return false;
+  }
+  if (length == 0) {
+    return true;
+  }
+  return strm.write_octet_array(seq.get_buffer(), length);
+}
+
+bool operator>>(Serializer& strm, XTypes::continuation_point_Seq& seq)
+{
+  ACE_UNUSED_ARG(strm);
+  ACE_UNUSED_ARG(seq);
+  CORBA::ULong length;
+  if (!(strm >> length)) {
+    return false;
+  }
+  if (length > seq.maximum()) {
+    return false;
+  }
+  seq.length(length);
+  if (length == 0) {
+    return true;
+  }
+  return strm.read_octet_array(seq.get_buffer(), length);
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+bool gen_skip_over(Serializer& ser, XTypes::continuation_point_Seq*)
+{
+  ACE_UNUSED_ARG(ser);
+  ACE_CDR::ULong length;
+  if (!(ser >> length)) return false;
+  return ser.skip(static_cast<ACE_UINT16>(length), 1);
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_continuation_point_Seq_xtag>()
+{
+  static const XTypes::TypeObject to = XTypes::TypeObject(
+    XTypes::MinimalTypeObject(
+      XTypes::MinimalAliasType(
+        XTypes::AliasTypeFlag(0),
+        XTypes::MinimalAliasHeader(),
+        XTypes::MinimalAliasBody(
+          XTypes::CommonAliasBody(
+            XTypes::AliasMemberFlag(),
+            XTypes::TypeIdentifier::makePlainSequence(getMinimalTypeIdentifier<CORBA::Octet>(), XTypes::SBound(32))
+          )
+        )
+      )
+    )
+  );
+  return to;
+}
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_continuation_point_Seq_xtag>()
+{
+  static const XTypes::TypeIdentifier ti = XTypes::makeTypeIdentifier(getMinimalTypeObject<XTypes_continuation_point_Seq_xtag>());
+  return ti;
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+
+/* End TYPEDEF: continuation_point_Seq */
+
+
+/* Begin STRUCT: TypeLookup_getTypeDependencies_In */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+void serialized_size(const Encoding& encoding, size_t& size, const XTypes::TypeLookup_getTypeDependencies_In& stru)
+{
+  ACE_UNUSED_ARG(encoding);
+  ACE_UNUSED_ARG(size);
+  ACE_UNUSED_ARG(stru);
+  serialized_size(encoding, size, stru.type_ids);
+  serialized_size(encoding, size, stru.continuation_point);
+}
+
+bool operator<<(Serializer& strm, const XTypes::TypeLookup_getTypeDependencies_In& stru)
+{
+  ACE_UNUSED_ARG(strm);
+  ACE_UNUSED_ARG(stru);
+  return (strm << stru.type_ids)
+    && (strm << stru.continuation_point);
+}
+
+bool operator>>(Serializer& strm, XTypes::TypeLookup_getTypeDependencies_In& stru)
+{
+  ACE_UNUSED_ARG(strm);
+  ACE_UNUSED_ARG(stru);
+  return (strm >> stru.type_ids)
+    && (strm >> stru.continuation_point);
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+template<>
+struct MetaStructImpl<XTypes::TypeLookup_getTypeDependencies_In> : MetaStruct {
+  typedef XTypes::TypeLookup_getTypeDependencies_In T;
+
+#ifndef OPENDDS_NO_MULTI_TOPIC
+  void* allocate() const { return new T; }
+
+  void deallocate(void* stru) const { delete static_cast<T*>(stru); }
+
+  size_t numDcpsKeys() const { return 0; }
+
+#endif /* OPENDDS_NO_MULTI_TOPIC */
+
+  bool isDcpsKey(const char* field) const
+  {
+    ACE_UNUSED_ARG(field);
+    return false;
+  }
+
+  Value getValue(const void* stru, const char* field) const
+  {
+    const XTypes::TypeLookup_getTypeDependencies_In& typed = *static_cast<const XTypes::TypeLookup_getTypeDependencies_In*>(stru);
+    ACE_UNUSED_ARG(typed);
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeLookup_getTypeDependencies_In)");
+  }
+
+  Value getValue(Serializer& ser, const char* field) const
+  {
+    if (!gen_skip_over(ser, static_cast<XTypes::TypeIdentifierSeq*>(0))) {
+      throw std::runtime_error("Field " + OPENDDS_STRING(field) + " could not be skipped");
+    }
+    if (!gen_skip_over(ser, static_cast<XTypes::continuation_point_Seq*>(0))) {
+      throw std::runtime_error("Field " + OPENDDS_STRING(field) + " could not be skipped");
+    }
+    if (!field[0]) {
+      return 0;
+    }
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not valid for struct XTypes::TypeLookup_getTypeDependencies_In");
+  }
+
+  ComparatorBase::Ptr create_qc_comparator(const char* field, ComparatorBase::Ptr next) const
+  {
+    ACE_UNUSED_ARG(next);
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeLookup_getTypeDependencies_In)");
+  }
+
+#ifndef OPENDDS_NO_MULTI_TOPIC
+  const char** getFieldNames() const
+  {
+    static const char* names[] = {"type_ids", "continuation_point", 0};
+    return names;
+  }
+
+  const void* getRawField(const void* stru, const char* field) const
+  {
+    if (std::strcmp(field, "type_ids") == 0) {
+      return &static_cast<const T*>(stru)->type_ids;
+    }
+    if (std::strcmp(field, "continuation_point") == 0) {
+      return &static_cast<const T*>(stru)->continuation_point;
+    }
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeLookup_getTypeDependencies_In)");
+  }
+
+  void assign(void* lhs, const char* field, const void* rhs,
+    const char* rhsFieldSpec, const MetaStruct& rhsMeta) const
+  {
+    ACE_UNUSED_ARG(lhs);
+    ACE_UNUSED_ARG(field);
+    ACE_UNUSED_ARG(rhs);
+    ACE_UNUSED_ARG(rhsFieldSpec);
+    ACE_UNUSED_ARG(rhsMeta);
+    if (std::strcmp(field, "type_ids") == 0) {
+      static_cast<T*>(lhs)->type_ids = *static_cast<const XTypes::TypeIdentifierSeq*>(rhsMeta.getRawField(rhs, rhsFieldSpec));
+      return;
+    }
+    if (std::strcmp(field, "continuation_point") == 0) {
+      static_cast<T*>(lhs)->continuation_point = *static_cast<const XTypes::continuation_point_Seq*>(rhsMeta.getRawField(rhs, rhsFieldSpec));
+      return;
+    }
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeLookup_getTypeDependencies_In)");
+  }
+#endif /* OPENDDS_NO_MULTI_TOPIC */
+
+  bool compare(const void* lhs, const void* rhs, const char* field) const
+  {
+    ACE_UNUSED_ARG(lhs);
+    ACE_UNUSED_ARG(field);
+    ACE_UNUSED_ARG(rhs);
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeLookup_getTypeDependencies_In)");
+  }
+};
+
+template<>
+const MetaStruct& getMetaStruct<XTypes::TypeLookup_getTypeDependencies_In>()
+{
+  static MetaStructImpl<XTypes::TypeLookup_getTypeDependencies_In> msi;
+  return msi;
+}
+
+bool gen_skip_over(Serializer& ser, XTypes::TypeLookup_getTypeDependencies_In*)
+{
+  ACE_UNUSED_ARG(ser);
+  MetaStructImpl<XTypes::TypeLookup_getTypeDependencies_In>().getValue(ser, "");
+  return true;
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_TypeLookup_getTypeDependencies_In_xtag>()
+{
+  static const XTypes::TypeObject to = XTypes::TypeObject(
+    XTypes::MinimalTypeObject(
+      XTypes::MinimalStructType(
+        XTypes::StructTypeFlag( XTypes::IS_APPENDABLE | XTypes::IS_NESTED ),
+        XTypes::MinimalStructHeader(
+          getMinimalTypeIdentifier<void>(),
+          XTypes::MinimalTypeDetail()
+        ),
+        XTypes::MinimalStructMemberSeq()
+        .append(
+          XTypes::MinimalStructMember(
+            XTypes::CommonStructMember(
+              0,
+              XTypes::StructMemberFlag( 0 ),
+              getMinimalTypeIdentifier<XTypes_TypeIdentifierSeq_xtag>()
+            ),
+            XTypes::MinimalMemberDetail("type_ids")
+          )
+        )
+        .append(
+          XTypes::MinimalStructMember(
+            XTypes::CommonStructMember(
+              1,
+              XTypes::StructMemberFlag( 0 ),
+              getMinimalTypeIdentifier<XTypes_continuation_point_Seq_xtag>()
+            ),
+            XTypes::MinimalMemberDetail("continuation_point")
+          )
+        )
+        .sort()
+        )
+      )
+    );
+  return to;
+}
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_TypeLookup_getTypeDependencies_In_xtag>()
+{
+  static const XTypes::TypeIdentifier ti = XTypes::makeTypeIdentifier(getMinimalTypeObject<XTypes_TypeLookup_getTypeDependencies_In_xtag>());
+  return ti;
+}
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/TypeLookup_getTypeDependencies_InTypeSupportImpl.h
+++ b/dds/DCPS/TypeLookup_getTypeDependencies_InTypeSupportImpl.h
@@ -1,0 +1,118 @@
+#ifndef _TYPE_LOOKUP_GET_DEPENDENCIES_IN_IMPL_H_
+#define _TYPE_LOOKUP_GET_DEPENDENCIES_IN_IMPL_H_
+#include "TypeLookup_getTypeDependencies_InC.h"
+#include "dds/DCPS/Definitions.h"
+#include "dds/DdsDcpsC.h"
+#include "dds/DCPS/Serializer.h"
+#include "dds/DCPS/TypeObject.h"
+
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+void serialized_size(const Encoding& encoding, size_t& size, const XTypes::TypeIdentifierSeq& seq);
+
+bool operator<<(Serializer& strm, const XTypes::TypeIdentifierSeq& seq);
+
+bool operator>>(Serializer& strm, XTypes::TypeIdentifierSeq& seq);
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+bool gen_skip_over(Serializer& ser, XTypes::TypeIdentifierSeq*);
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+struct XTypes_TypeIdentifierSeq_xtag {};
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_TypeIdentifierSeq_xtag>();
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_TypeIdentifierSeq_xtag>();
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+void serialized_size(const Encoding& encoding, size_t& size, const XTypes::continuation_point_Seq& seq);
+
+bool operator<<(Serializer& strm, const XTypes::continuation_point_Seq& seq);
+
+bool operator>>(Serializer& strm, XTypes::continuation_point_Seq& seq);
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+bool gen_skip_over(Serializer& ser, XTypes::continuation_point_Seq*);
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+struct XTypes_continuation_point_Seq_xtag {};
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_continuation_point_Seq_xtag>();
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_continuation_point_Seq_xtag>();
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+void serialized_size(const Encoding& encoding, size_t& size, const XTypes::TypeLookup_getTypeDependencies_In& stru);
+
+bool operator<<(Serializer& strm, const XTypes::TypeLookup_getTypeDependencies_In& stru);
+
+bool operator>>(Serializer& strm, XTypes::TypeLookup_getTypeDependencies_In& stru);
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+class MetaStruct;
+
+template<typename T>
+const MetaStruct& getMetaStruct();
+
+template<>
+const MetaStruct& getMetaStruct<XTypes::TypeLookup_getTypeDependencies_In>();
+bool gen_skip_over(Serializer& ser, XTypes::TypeLookup_getTypeDependencies_In*);
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS { namespace DCPS {
+
+struct XTypes_TypeLookup_getTypeDependencies_In_xtag {};
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_TypeLookup_getTypeDependencies_In_xtag>();
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_TypeLookup_getTypeDependencies_In_xtag>();
+
+}  }
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* _TYPE_LOOKUP_GET_DEPENDENCIES_IN_IMPL_H_ */

--- a/dds/DCPS/TypeObject.cpp
+++ b/dds/DCPS/TypeObject.cpp
@@ -2865,43 +2865,45 @@ struct MetaStructImpl<XTypes::TypeIdentifier> : MetaStruct {
     //if (std::strcmp(field, "count") == 0) {
     //  return typed.count;
     //}
-    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    //throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    return 0;
   }
 
   Value getValue(Serializer& ser, const char* field) const
   {
-    if (std::strcmp(field, "from") == 0) {
-      TAO::String_Manager val;
-      if (!(ser >> val.out())) {
-        throw std::runtime_error("Field 'from' could not be deserialized");
-      }
-      return val;
-    }
-    else {
-      ACE_CDR::ULong len;
-      if (!(ser >> len)) {
-        throw std::runtime_error("String 'from' length could not be deserialized");
-      }
-      if (!ser.skip(static_cast<ACE_UINT16>(len))) {
-        throw std::runtime_error("String 'from' contents could not be skipped");
-      }
-    }
-    if (std::strcmp(field, "count") == 0) {
-      ACE_CDR::Long val;
-      if (!(ser >> val)) {
-        throw std::runtime_error("Field 'count' could not be deserialized");
-      }
-      return val;
-    }
-    else {
-      if (!ser.skip(1, 4)) {
-        throw std::runtime_error("Field 'count' could not be skipped");
-      }
-    }
-    if (!field[0]) {
-      return 0;
-    }
-    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not valid for struct XTypes::TypeIdentifier");
+    //if (std::strcmp(field, "from") == 0) {
+    //  TAO::String_Manager val;
+    //  if (!(ser >> val.out())) {
+    //    throw std::runtime_error("Field 'from' could not be deserialized");
+    //  }
+    //  return val;
+    //}
+    //else {
+    //  ACE_CDR::ULong len;
+    //  if (!(ser >> len)) {
+    //    throw std::runtime_error("String 'from' length could not be deserialized");
+    //  }
+    //  if (!ser.skip(static_cast<ACE_UINT16>(len))) {
+    //    throw std::runtime_error("String 'from' contents could not be skipped");
+    //  }
+    //}
+    //if (std::strcmp(field, "count") == 0) {
+    //  ACE_CDR::Long val;
+    //  if (!(ser >> val)) {
+    //    throw std::runtime_error("Field 'count' could not be deserialized");
+    //  }
+    //  return val;
+    //}
+    //else {
+    //  if (!ser.skip(1, 4)) {
+    //    throw std::runtime_error("Field 'count' could not be skipped");
+    //  }
+    //}
+    //if (!field[0]) {
+    //  return 0;
+    //}
+    //throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not valid for struct XTypes::TypeIdentifier");
+    return 0;
   }
 
   ComparatorBase::Ptr create_qc_comparator(const char* field, ComparatorBase::Ptr next) const
@@ -2913,7 +2915,8 @@ struct MetaStructImpl<XTypes::TypeIdentifier> : MetaStruct {
     //if (std::strcmp(field, "count") == 0) {
     //  return make_field_cmp(&T::count, next);
     //}
-    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    //throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    return *(new OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::ComparatorBase>);
   }
 
 #ifndef OPENDDS_NO_MULTI_TOPIC
@@ -2931,7 +2934,8 @@ struct MetaStructImpl<XTypes::TypeIdentifier> : MetaStruct {
     //if (std::strcmp(field, "count") == 0) {
     //  return &static_cast<const T*>(stru)->count;
     //}
-    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    //throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    return 0;
   }
 
   void assign(void* lhs, const char* field, const void* rhs,
@@ -2950,7 +2954,8 @@ struct MetaStructImpl<XTypes::TypeIdentifier> : MetaStruct {
     //  static_cast<T*>(lhs)->count = *static_cast<const CORBA::Long*>(rhsMeta.getRawField(rhs, rhsFieldSpec));
     //  return;
     //}
-    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    //throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    return;
   }
 #endif /* OPENDDS_NO_MULTI_TOPIC */
 
@@ -2965,7 +2970,8 @@ struct MetaStructImpl<XTypes::TypeIdentifier> : MetaStruct {
     //if (std::strcmp(field, "count") == 0) {
     //  return static_cast<const T*>(lhs)->count == static_cast<const T*>(rhs)->count;
     //}
-    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    //throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+    return false;
   }
 };
 

--- a/dds/DCPS/TypeObject.cpp
+++ b/dds/DCPS/TypeObject.cpp
@@ -5,6 +5,8 @@
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
 
+#include "dds/DCPS/FilterEvaluator.h"
+
 #include "TypeObject.h"
 
 #include "Hash.h"
@@ -2824,6 +2826,204 @@ template<>
 XTypes::TypeIdentifier getMinimalTypeIdentifier<ACE_CDR::WChar*>()
 {
   static const XTypes::TypeIdentifier ti = XTypes::TypeIdentifier::makeString(true, XTypes::StringSTypeDefn(XTypes::INVALID_SBOUND));
+  return ti;
+}
+
+///
+//
+// TODO: Functions below are stubs for TypeIdentifier type support
+// Implement
+//
+///
+
+template<>
+struct MetaStructImpl<XTypes::TypeIdentifier> : MetaStruct {
+  typedef XTypes::TypeIdentifier T;
+
+#ifndef OPENDDS_NO_MULTI_TOPIC
+  void* allocate() const { return new T; }
+
+  void deallocate(void* stru) const { delete static_cast<T*>(stru); }
+
+  size_t numDcpsKeys() const { return 0; }
+
+#endif /* OPENDDS_NO_MULTI_TOPIC */
+
+  bool isDcpsKey(const char* field) const
+  {
+    ACE_UNUSED_ARG(field);
+    return false;
+  }
+
+  Value getValue(const void* stru, const char* field) const
+  {
+    const XTypes::TypeIdentifier& typed = *static_cast<const XTypes::TypeIdentifier*>(stru);
+    ACE_UNUSED_ARG(typed);
+    //if (std::strcmp(field, "from") == 0) {
+    //  return typed.from.in();
+    //}
+    //if (std::strcmp(field, "count") == 0) {
+    //  return typed.count;
+    //}
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+  }
+
+  Value getValue(Serializer& ser, const char* field) const
+  {
+    if (std::strcmp(field, "from") == 0) {
+      TAO::String_Manager val;
+      if (!(ser >> val.out())) {
+        throw std::runtime_error("Field 'from' could not be deserialized");
+      }
+      return val;
+    }
+    else {
+      ACE_CDR::ULong len;
+      if (!(ser >> len)) {
+        throw std::runtime_error("String 'from' length could not be deserialized");
+      }
+      if (!ser.skip(static_cast<ACE_UINT16>(len))) {
+        throw std::runtime_error("String 'from' contents could not be skipped");
+      }
+    }
+    if (std::strcmp(field, "count") == 0) {
+      ACE_CDR::Long val;
+      if (!(ser >> val)) {
+        throw std::runtime_error("Field 'count' could not be deserialized");
+      }
+      return val;
+    }
+    else {
+      if (!ser.skip(1, 4)) {
+        throw std::runtime_error("Field 'count' could not be skipped");
+      }
+    }
+    if (!field[0]) {
+      return 0;
+    }
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not valid for struct XTypes::TypeIdentifier");
+  }
+
+  ComparatorBase::Ptr create_qc_comparator(const char* field, ComparatorBase::Ptr next) const
+  {
+    ACE_UNUSED_ARG(next);
+    //if (std::strcmp(field, "from") == 0) {
+    //  return make_field_cmp(&T::from, next);
+    //}
+    //if (std::strcmp(field, "count") == 0) {
+    //  return make_field_cmp(&T::count, next);
+    //}
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+  }
+
+#ifndef OPENDDS_NO_MULTI_TOPIC
+  const char** getFieldNames() const
+  {
+    static const char* names[] = { "from", "count", 0 };
+    return names;
+  }
+
+  const void* getRawField(const void* stru, const char* field) const
+  {
+    //if (std::strcmp(field, "from") == 0) {
+    //  return &static_cast<const T*>(stru)->from;
+    //}
+    //if (std::strcmp(field, "count") == 0) {
+    //  return &static_cast<const T*>(stru)->count;
+    //}
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+  }
+
+  void assign(void* lhs, const char* field, const void* rhs,
+    const char* rhsFieldSpec, const MetaStruct& rhsMeta) const
+  {
+    ACE_UNUSED_ARG(lhs);
+    ACE_UNUSED_ARG(field);
+    ACE_UNUSED_ARG(rhs);
+    ACE_UNUSED_ARG(rhsFieldSpec);
+    ACE_UNUSED_ARG(rhsMeta);
+    //if (std::strcmp(field, "from") == 0) {
+    //  static_cast<T*>(lhs)->from = *static_cast<const TAO::String_Manager*>(rhsMeta.getRawField(rhs, rhsFieldSpec));
+    //  return;
+    //}
+    //if (std::strcmp(field, "count") == 0) {
+    //  static_cast<T*>(lhs)->count = *static_cast<const CORBA::Long*>(rhsMeta.getRawField(rhs, rhsFieldSpec));
+    //  return;
+    //}
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+  }
+#endif /* OPENDDS_NO_MULTI_TOPIC */
+
+  bool compare(const void* lhs, const void* rhs, const char* field) const
+  {
+    ACE_UNUSED_ARG(lhs);
+    ACE_UNUSED_ARG(field);
+    ACE_UNUSED_ARG(rhs);
+    //if (std::strcmp(field, "from") == 0) {
+    //  return 0 == ACE_OS::strcmp(static_cast<const T*>(lhs)->from.in(), static_cast<const T*>(rhs)->from.in());
+    //}
+    //if (std::strcmp(field, "count") == 0) {
+    //  return static_cast<const T*>(lhs)->count == static_cast<const T*>(rhs)->count;
+    //}
+    throw std::runtime_error("Field " + OPENDDS_STRING(field) + " not found or its type is not supported (in struct XTypes::TypeIdentifier)");
+  }
+};
+
+template<>
+const MetaStruct& getMetaStruct<XTypes::TypeIdentifier>()
+{
+  static MetaStructImpl<XTypes::TypeIdentifier> msi;
+  return msi;
+}
+
+bool gen_skip_over(Serializer& ser, XTypes::TypeIdentifier*)
+{
+  ACE_UNUSED_ARG(ser);
+  MetaStructImpl<XTypes::TypeIdentifier>().getValue(ser, "");
+  return true;
+}
+
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_TypeIdentifier_xtag>()
+{
+  static const XTypes::TypeObject to = XTypes::TypeObject(
+    XTypes::MinimalTypeObject(
+      XTypes::MinimalStructType(
+        XTypes::StructTypeFlag(XTypes::IS_APPENDABLE | XTypes::IS_NESTED),
+        XTypes::MinimalStructHeader(
+          getMinimalTypeIdentifier<void>(),
+          XTypes::MinimalTypeDetail()
+        ),
+        XTypes::MinimalStructMemberSeq()
+        .append(
+          XTypes::MinimalStructMember(
+            XTypes::CommonStructMember(
+              0,
+              XTypes::StructMemberFlag(0),
+              getMinimalTypeIdentifier<char*>()
+            ),
+            XTypes::MinimalMemberDetail("from")
+          )
+        )
+        .append(
+          XTypes::MinimalStructMember(
+            XTypes::CommonStructMember(
+              1,
+              XTypes::StructMemberFlag(0),
+              getMinimalTypeIdentifier<CORBA::Long>()
+            ),
+            XTypes::MinimalMemberDetail("count")
+          )
+        )
+        .sort()
+      )
+    )
+  );
+  return to;
+}
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_TypeIdentifier_xtag>()
+{
+  static const XTypes::TypeIdentifier ti = XTypes::makeTypeIdentifier(getMinimalTypeObject<XTypes_TypeIdentifier_xtag>());
   return ti;
 }
 

--- a/dds/DCPS/TypeObject.h
+++ b/dds/DCPS/TypeObject.h
@@ -2271,7 +2271,22 @@ void serialized_size(const Encoding& encoding, size_t& size,
 bool operator<<(Serializer& strm, const XTypes::TypeObjectHashId& stru);
 bool operator>>(Serializer& strm, XTypes::TypeObjectHashId& stru);
 
+///
+// TypeIdentifier type support
+///
+class MetaStruct;
 
+template<typename T>
+const MetaStruct& getMetaStruct();
+
+template<>
+const MetaStruct& getMetaStruct<XTypes::TypeIdentifier>();
+bool gen_skip_over(Serializer& ser, XTypes::TypeIdentifier*);
+
+struct XTypes_TypeIdentifier_xtag {};
+template<> const XTypes::TypeObject& getMinimalTypeObject<XTypes_TypeIdentifier_xtag>();
+
+template<> XTypes::TypeIdentifier getMinimalTypeIdentifier<XTypes_TypeIdentifier_xtag>();
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/TypeObject.h
+++ b/dds/DCPS/TypeObject.h
@@ -674,7 +674,7 @@ namespace XTypes {
     void reset();
   };
 
-  typedef Sequence<TypeIdentifier> TypeIdentifierSeq;
+  // typedef Sequence<TypeIdentifier> TypeIdentifierSeq;
 
   // --- Annotation usage: -----------------------------------------------
 


### PR DESCRIPTION
Type support 'skeleton' files are generated with idl compilers and then manually modified.