### PR TITLE
Authentication does handle resends

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -54,19 +54,26 @@ namespace OpenDDS {
       EndpointSecurityAttributesMap;
 
     enum AuthState {
-      AUTH_STATE_UNKNOWN,
-      AUTH_STATE_VALIDATING_REMOTE,
       AUTH_STATE_HANDSHAKE,
       AUTH_STATE_AUTHENTICATED,
       AUTH_STATE_UNAUTHENTICATED
     };
 
     enum HandshakeState {
-      // State of Requester waiting for reply and Replier waiting for final
-      HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL,
+      // Requester should call begin_handshake_request
+      HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST,
 
-      // State of Replier waiting for request
-      HANDSHAKE_STATE_EXPECTING_REQUEST
+      // Replier should call begin_handshake_reply
+      HANDSHAKE_STATE_BEGIN_HANDSHAKE_REPLY,
+
+      // Requester and replier should call process handshake
+      HANDSHAKE_STATE_PROCESS_HANDSHAKE,
+
+      // Requester is waiting to see a token from replier.
+      HANDSHAKE_STATE_WAITING_FOR_TOKEN,
+
+      // Handshake concluded or timed out
+      HANDSHAKE_STATE_DONE
     };
 #endif
 
@@ -1592,9 +1599,10 @@ namespace OpenDDS {
 #ifdef OPENDDS_SECURITY
         , have_auth_req_msg_(false)
         , have_handshake_msg_(false)
-        , auth_state_(AUTH_STATE_UNKNOWN)
-        , handshake_state_(HANDSHAKE_STATE_EXPECTING_REQUEST)
+        , auth_state_(AUTH_STATE_HANDSHAKE)
+        , handshake_state_(HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST)
         , is_requester_(false)
+        , stateless_sequence_number_(0)
         , security_builtins_associated_(false)
         , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
@@ -1622,9 +1630,10 @@ namespace OpenDDS {
 #ifdef OPENDDS_SECURITY
         , have_auth_req_msg_(false)
         , have_handshake_msg_(false)
-        , auth_state_(AUTH_STATE_UNKNOWN)
-        , handshake_state_(HANDSHAKE_STATE_EXPECTING_REQUEST)
+        , auth_state_(AUTH_STATE_HANDSHAKE)
+        , handshake_state_(HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST)
         , is_requester_(false)
+        , stateless_sequence_number_(0)
         , security_builtins_associated_(false)
         , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
@@ -1684,10 +1693,11 @@ namespace OpenDDS {
         DDS::Security::ParticipantStatelessMessage handshake_msg_;
         MonotonicTimePoint stateless_msg_deadline_;
 
-        MonotonicTimePoint auth_deadline_;
+        MonotonicTimePoint handshake_deadline_;
         AuthState auth_state_;
         HandshakeState handshake_state_;
         bool is_requester_;
+        CORBA::LongLong stateless_sequence_number_;
         bool security_builtins_associated_;
         bool seen_some_crypto_tokens_;
 

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1602,7 +1602,8 @@ namespace OpenDDS {
         , auth_state_(AUTH_STATE_HANDSHAKE)
         , handshake_state_(HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST)
         , is_requester_(false)
-        , stateless_sequence_number_(0)
+        , auth_req_sequence_number_(0)
+        , handshake_sequence_number_(0)
         , security_builtins_associated_(false)
         , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
@@ -1633,7 +1634,8 @@ namespace OpenDDS {
         , auth_state_(AUTH_STATE_HANDSHAKE)
         , handshake_state_(HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST)
         , is_requester_(false)
-        , stateless_sequence_number_(0)
+        , auth_req_sequence_number_(0)
+        , handshake_sequence_number_(0)
         , security_builtins_associated_(false)
         , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
@@ -1697,7 +1699,8 @@ namespace OpenDDS {
         AuthState auth_state_;
         HandshakeState handshake_state_;
         bool is_requester_;
-        CORBA::LongLong stateless_sequence_number_;
+        CORBA::LongLong auth_req_sequence_number_;
+        CORBA::LongLong handshake_sequence_number_;
         bool security_builtins_associated_;
         bool seen_some_crypto_tokens_;
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2796,10 +2796,6 @@ bool Sedp::should_drop_stateless_message(const DDS::Security::ParticipantGeneric
     return true;
   }
 
-  if (!spdp_.new_stateless_message(msg)) {
-    return true;
-  }
-
   return false;
 }
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2778,11 +2778,11 @@ bool Sedp::should_drop_stateless_message(const DDS::Security::ParticipantGeneric
 
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, true);
 
-  const GUID_t src_endpoint = msg.source_endpoint_guid;
-  const GUID_t dst_endpoint = msg.destination_endpoint_guid;
-  const GUID_t this_endpoint = participant_stateless_message_reader_->get_repo_id();
-  const GUID_t dst_participant = msg.destination_participant_guid;
-  const GUID_t this_participant = participant_id_;
+  const GUID_t& src_endpoint = msg.source_endpoint_guid;
+  const GUID_t& dst_endpoint = msg.destination_endpoint_guid;
+  const GUID_t& this_endpoint = participant_stateless_message_reader_->get_repo_id();
+  const GUID_t& dst_participant = msg.destination_participant_guid;
+  const GUID_t& this_participant = participant_id_;
 
   if (ignoring(src_endpoint)) {
     return true;
@@ -2793,6 +2793,10 @@ bool Sedp::should_drop_stateless_message(const DDS::Security::ParticipantGeneric
   }
 
   if (dst_endpoint != GUID_UNKNOWN && dst_endpoint != this_endpoint) {
+    return true;
+  }
+
+  if (!spdp_.new_stateless_message(msg)) {
     return true;
   }
 
@@ -3969,10 +3973,9 @@ Sedp::write_durable_participant_message_data(const RepoId& reader)
 
 #ifdef OPENDDS_SECURITY
 DDS::ReturnCode_t
-Sedp::write_stateless_message(DDS::Security::ParticipantStatelessMessage& msg,
+Sedp::write_stateless_message(const DDS::Security::ParticipantStatelessMessage& msg,
                               const RepoId& reader)
 {
-  msg.message_identity.sequence_number = static_cast<unsigned long>(participant_stateless_message_writer_->get_seq().getValue());
   DCPS::SequenceNumber sequence = DCPS::SequenceNumber::SEQUENCENUMBER_UNKNOWN();
   return participant_stateless_message_writer_->write_stateless_message(msg, reader, sequence);
 }

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -126,7 +126,7 @@ public:
   void update_locators(const ParticipantData_t& pdata);
 
 #ifdef OPENDDS_SECURITY
-  DDS::ReturnCode_t write_stateless_message(DDS::Security::ParticipantStatelessMessage& msg,
+  DDS::ReturnCode_t write_stateless_message(const DDS::Security::ParticipantStatelessMessage& msg,
                                             const DCPS::RepoId& reader);
 
   DDS::ReturnCode_t write_volatile_message(DDS::Security::ParticipantVolatileMessageSecure& msg,

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -345,7 +345,7 @@ Spdp::~Spdp()
         if (spdp_endpoint) {
           ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, part->first);
         }
-        purge_auth_deadlines(part);
+        purge_handshake_deadlines(part);
 #endif
         remove_discovered_participant(part);
       }
@@ -635,7 +635,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         iter->second.property_qos_ = pdata.ddsParticipantDataSecure.base.property;
         iter->second.security_info_ = pdata.ddsParticipantDataSecure.base.security_info;
 
-        attempt_authentication(guid, iter->second);
+        attempt_authentication(iter, true);
         if (iter->second.auth_state_ == DCPS::AUTH_STATE_UNAUTHENTICATED) {
           if (participant_sec_attr_.allow_unauthenticated_participants == false) {
             if (DCPS::security_debug.auth_debug) {
@@ -691,7 +691,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       if (spdp_endpoint) {
         ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, iter->first);
       }
-      purge_auth_deadlines(iter);
+      purge_handshake_deadlines(iter);
 #endif
       remove_discovered_participant(iter);
       return;
@@ -737,7 +737,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     // Else a reset has occured and check if we should remove the participant
     } else if (iter->second.seq_reset_count_ >= config_->max_spdp_sequence_msg_reset_check()) {
 #ifdef OPENDDS_SECURITY
-      purge_auth_deadlines(iter);
+      purge_handshake_deadlines(iter);
 #endif
       remove_discovered_participant(iter);
     }
@@ -833,6 +833,24 @@ Spdp::match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter&
 }
 
 #ifdef OPENDDS_SECURITY
+
+bool
+Spdp::new_stateless_message(const DDS::Security::ParticipantStatelessMessage& msg)
+{
+  const RepoId guid = make_id(msg.message_identity.source_guid, DCPS::ENTITYID_PARTICIPANT);
+  ACE_Guard<ACE_Thread_Mutex> g(lock_, false);
+
+  DiscoveredParticipantMap::iterator iter = participants_.find(guid);
+
+  if (iter != participants_.end()) {
+    bool retval = msg.message_identity.sequence_number > iter->second.stateless_sequence_number_;
+    iter->second.stateless_sequence_number_ = std::max(msg.message_identity.sequence_number, iter->second.stateless_sequence_number_);
+    return retval;
+  }
+
+  return true;
+}
+
 void
 Spdp::handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg)
 {
@@ -855,7 +873,7 @@ Spdp::handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg)
   DiscoveredParticipantMap::iterator iter = participants_.find(guid);
 
   if (iter != participants_.end()) {
-    attempt_authentication(iter->first, iter->second);
+    attempt_authentication(iter, false);
   }
 }
 
@@ -927,7 +945,7 @@ DDS::OctetSeq Spdp::local_participant_data_as_octets() const
 void
 Spdp::send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp)
 {
-  dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL;
+  OPENDDS_ASSERT(dp.handshake_state_ == DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST);
 
   Security::Authentication_var auth = security_config_->get_authentication();
   DDS::Security::SecurityException se = {"", 0, 0};
@@ -961,6 +979,8 @@ Spdp::send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp
     return;
   }
 
+  dp.handshake_state_ = DCPS::HANDSHAKE_STATE_PROCESS_HANDSHAKE;
+
   DDS::Security::ParticipantStatelessMessage msg;
   msg.message_identity.source_guid = guid_;
   msg.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_HANDSHAKE;
@@ -972,7 +992,7 @@ Spdp::send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp
   msg.message_data.length(1);
   msg.message_data[0] = hs_mt;
 
-  if (send_handshake_message(guid, dp, msg, true) != DDS::RETCODE_OK) {
+  if (send_handshake_message(guid, dp, msg) != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::send_handshake_request() - ")
                ACE_TEXT("Unable to write stateless message (handshake).\n")));
     return;
@@ -980,6 +1000,123 @@ Spdp::send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::send_handshake_request() - ")
                ACE_TEXT("Sent handshake request message for participant: %C\n"),
                OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+  }
+}
+
+void
+Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery)
+{
+  const DCPS::RepoId& guid = iter->first;
+  DiscoveredParticipant& dp = iter->second;
+
+  PendingRemoteAuthTokenMap::iterator token_iter = pending_remote_auth_tokens_.find(guid);
+  if (token_iter == pending_remote_auth_tokens_.end()) {
+    dp.remote_auth_request_token_ = DDS::Security::Token();
+  } else {
+    dp.remote_auth_request_token_ = token_iter->second;
+    pending_remote_auth_tokens_.erase(token_iter);
+  }
+
+  if (DCPS::security_debug.auth_debug) {
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication for %C have_remote_token=%d auth_state=%d handshake_state=%d\n", OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str(), !(dp.remote_auth_request_token_ == DDS::Security::Token()), dp.auth_state_, dp.handshake_state_));
+  }
+
+  if (!from_discovery && dp.handshake_state_ != DCPS::HANDSHAKE_STATE_DONE) {
+    // Ignore auth reqs when already in progress.
+    return;
+  }
+
+  // Reset.
+  purge_handshake_deadlines(iter);
+  dp.handshake_deadline_ = DCPS::MonotonicTimePoint::now() + config_->max_auth_time();
+  handshake_deadlines_.insert(std::make_pair(dp.handshake_deadline_, guid));
+  tport_->handshake_deadline_processor_->schedule(config_->max_auth_time());
+
+  DDS::Security::Authentication_var auth = security_config_->get_authentication();
+  DDS::Security::SecurityException se = {"", 0, 0};
+
+  const DDS::Security::ValidationResult_t vr = auth->validate_remote_identity(dp.identity_handle_,
+                                                                              dp.local_auth_request_token_, dp.remote_auth_request_token_, identity_handle_, dp.identity_token_, guid, se);
+
+  dp.have_auth_req_msg_ = !(dp.local_auth_request_token_ == DDS::Security::Token());
+  if (dp.have_auth_req_msg_) {
+    dp.auth_req_msg_.message_identity.source_guid = guid_;
+    dp.auth_req_msg_.message_identity.sequence_number = static_cast<CORBA::LongLong>((++stateless_sequence_number_).getValue());
+    dp.auth_req_msg_.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_REQUEST;
+    dp.auth_req_msg_.destination_participant_guid = guid;
+    dp.auth_req_msg_.destination_endpoint_guid = GUID_UNKNOWN;
+    dp.auth_req_msg_.source_endpoint_guid = GUID_UNKNOWN;
+    dp.auth_req_msg_.related_message_identity.source_guid = GUID_UNKNOWN;
+    dp.auth_req_msg_.related_message_identity.sequence_number = 0;
+    dp.auth_req_msg_.message_data.length(1);
+    dp.auth_req_msg_.message_data[0] = dp.local_auth_request_token_;
+    // Send the auth req immediately to reset the remote if they are
+    // still authenticated with us.
+    if (sedp_.write_stateless_message(dp.auth_req_msg_, make_id(guid, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER)) != DDS::RETCODE_OK) {
+      if (DCPS::security_debug.auth_debug) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::attempt_authentication() - ")
+                   ACE_TEXT("Unable to write auth req message retry.\n")));
+      }
+    } else {
+      if (DCPS::security_debug.auth_debug) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
+                   ACE_TEXT("Sent auth req message for participant: %C\n"),
+                   OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+      }
+    }
+    // Schedule resend.
+    schedule_handshake_resend(config_->auth_resend_period(), guid);
+  }
+
+  switch (vr) {
+  case DDS::Security::VALIDATION_OK: {
+    dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+    purge_handshake_deadlines(participants_.find(guid));
+    return;
+  }
+  case DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE: {
+    if (DCPS::security_debug.auth_debug) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
+                 ACE_TEXT("Attempting authentication (expecting request) for participant: %C\n"),
+                 OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+    }
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REPLY;
+    dp.is_requester_ = true;
+    return; // We'll need to wait for an inbound handshake request from the remote participant
+  }
+  case DDS::Security::VALIDATION_PENDING_HANDSHAKE_REQUEST: {
+    if (DCPS::security_debug.auth_debug) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
+                 ACE_TEXT("Attempting authentication (sending request/expecting reply) for participant: %C\n"),
+                 OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+    }
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST;
+    send_handshake_request(guid, dp);
+    return;
+  }
+  case DDS::Security::VALIDATION_FAILED: {
+    if (DCPS::security_debug.auth_debug) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
+                 ACE_TEXT("Remote participant identity is invalid. Security Exception[%d.%d]: %C\n"),
+                 se.code, se.minor_code, se.message.in()));
+    }
+    dp.auth_state_ = DCPS::AUTH_STATE_UNAUTHENTICATED;
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+    purge_handshake_deadlines(participants_.find(guid));
+    return;
+  }
+  default: {
+    if (DCPS::security_debug.auth_debug) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
+                 ACE_TEXT("Unexpected return value while validating remote identity. Security Exception[%d.%d]: %C\n"),
+                 se.code, se.minor_code, se.message.in()));
+    }
+    dp.auth_state_ = DCPS::AUTH_STATE_UNAUTHENTICATED;
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+    purge_handshake_deadlines(participants_.find(guid));
+    return;
+  }
   }
 }
 
@@ -1012,248 +1149,234 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
 
   DiscoveredParticipant& dp = iter->second;
 
-  switch (dp.auth_state_) {
-  case DCPS::AUTH_STATE_AUTHENTICATED:
-    dp.auth_state_ = DCPS::AUTH_STATE_UNKNOWN;
-    attempt_authentication(src_participant, dp);
-    break;
-  case DCPS::AUTH_STATE_HANDSHAKE:
-    break;
-  default:
-    if (DCPS::security_debug.auth_warn) {
-      ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
-                 ACE_TEXT("Dropping handshake message from %C, auth_state_ %d not expected\n"),
-                 OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str(),
-                 dp.auth_state_));
+  if (DCPS::security_debug.auth_debug) {
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message for %C auth_state=%d handshake_state=%d\n", OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str(), dp.auth_state_, dp.handshake_state_));
+  }
+
+  // We have received a handshake message from the remote which means
+  // we don't need to send the auth req.
+  dp.have_auth_req_msg_ = false;
+
+  switch (dp.handshake_state_) {
+  case DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST:
+  case DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN:
+  case DCPS::HANDSHAKE_STATE_DONE: {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
+               ACE_TEXT("Invalid handshake state\n")));
+    return;
+  }
+
+  case DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REPLY: {
+    DDS::Security::ParticipantStatelessMessage reply;
+    reply.message_identity.source_guid = guid_;
+    reply.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_HANDSHAKE;
+    reply.related_message_identity = msg.message_identity;
+    reply.destination_participant_guid = src_participant;
+    reply.destination_endpoint_guid = GUID_UNKNOWN;
+    reply.source_endpoint_guid = GUID_UNKNOWN;
+    reply.message_data.length(1);
+    reply.message_data[0] = msg.message_data[0];
+
+    if (dp.handshake_handle_ != DDS::HANDLE_NIL) {
+      // Return the handle for reauth.
+      if (!auth->return_handshake_handle(dp.handshake_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::handke_handshake_message() - ")
+                     ACE_TEXT("Unable to return handshake handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+        return;
+      }
+      dp.handshake_handle_ = DDS::HANDLE_NIL;
+    }
+
+    const DDS::OctetSeq local_participant = local_participant_data_as_octets();
+    if (!local_participant.length()) {
+      return; // already logged in local_participant_data_as_octets()
+    }
+    const DDS::Security::ValidationResult_t vr =
+      auth->begin_handshake_reply(dp.handshake_handle_, reply.message_data[0], dp.identity_handle_,
+                                  identity_handle_, local_participant, se);
+
+    switch (vr) {
+    case DDS::Security::VALIDATION_OK: {
+      // Theoretically, this shouldn't happen unless handshakes can involve fewer than 3 messages
+      dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
+      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+      purge_handshake_deadlines(iter);
+      match_authenticated(src_participant, iter);
+      return;
+    }
+    case DDS::Security::VALIDATION_FAILED: {
+      if (DCPS::security_debug.auth_warn) {
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Failed to reply to incoming handshake message. Security Exception[%d.%d]: %C\n"),
+                   se.code, se.minor_code, se.message.in()));
+      }
+      return;
+    }
+    case DDS::Security::VALIDATION_PENDING_RETRY: {
+      if (DCPS::security_debug.auth_warn) {
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Unexpected validation pending retry\n")));
+      }
+      return;
+    }
+    case DDS::Security::VALIDATION_PENDING_HANDSHAKE_REQUEST: {
+      if (DCPS::security_debug.auth_warn) {
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Unexpected validation pending handshake request\n")));
+      }
+      return;
+    }
+    case DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE: {
+      if (send_handshake_message(src_participant, dp, reply) != DDS::RETCODE_OK) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Unable to write stateless message for handshake reply.\n")));
+        }
+        return;
+      } else {
+        if (DCPS::security_debug.auth_debug) {
+          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Sent handshake reply for participant: %C\n"),
+                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        }
+      }
+      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_PROCESS_HANDSHAKE;
+      return;
+    }
+    case DDS::Security::VALIDATION_OK_FINAL_MESSAGE: {
+      // Theoretically, this shouldn't happen unless handshakes can involve fewer than 3 messages
+      if (send_handshake_message(src_participant, dp, reply) != DDS::RETCODE_OK) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Unable to write stateless message for final message.\n")));
+        }
+        return;
+      } else {
+        if (DCPS::security_debug.auth_debug) {
+          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Sent handshake final for participant: %C\n"),
+                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        }
+      }
+      dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
+      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_PROCESS_HANDSHAKE;
+      purge_handshake_deadlines(iter);
+      match_authenticated(src_participant, iter);
+      return;
+    }
     }
     return;
   }
 
-  switch (dp.handshake_state_) {
-  case DCPS::HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL:
-    if (msg.related_message_identity.source_guid != guid_) {
+  case DCPS::HANDSHAKE_STATE_PROCESS_HANDSHAKE: {
+    DDS::Security::ParticipantStatelessMessage reply;
+    reply.message_identity.source_guid = guid_;
+    reply.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_HANDSHAKE;
+    reply.related_message_identity = msg.message_identity;
+    reply.destination_participant_guid = src_participant;
+    reply.destination_endpoint_guid = GUID_UNKNOWN;
+    reply.source_endpoint_guid = GUID_UNKNOWN;
+    reply.message_data.length(1);
+
+    DDS::Security::ValidationResult_t vr = auth->process_handshake(reply.message_data[0], msg.message_data[0],
+                                                                   dp.handshake_handle_, se);
+    switch (vr) {
+    case DDS::Security::VALIDATION_FAILED: {
       if (DCPS::security_debug.auth_warn) {
-        ACE_DEBUG((LM_WARNING,
-                   ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
-                   ACE_TEXT("Dropping handshake message from %C, incorrect related message identity source guid\n"),
-                   OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: ")
+                   ACE_TEXT("Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Failed to process incoming handshake message when ")
+                   ACE_TEXT("expecting %C from %C. Security Exception[%d.%d]: %C\n"),
+                   dp.is_requester_ ? "final" : "reply",
+                   OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str(),
+                   se.code, se.minor_code, se.message.in()));
       }
       return;
     }
-
-    {
-      DDS::Security::ParticipantStatelessMessage reply;
-      reply.message_identity.source_guid = guid_;
-      reply.message_identity.sequence_number = 0;
-      reply.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_HANDSHAKE;
-      reply.related_message_identity = msg.message_identity;
-      reply.destination_participant_guid = src_participant;
-      reply.destination_endpoint_guid = GUID_UNKNOWN;
-      reply.source_endpoint_guid = GUID_UNKNOWN;
-      reply.message_data.length(1);
-
-      DDS::Security::ValidationResult_t vr = auth->process_handshake(reply.message_data[0], msg.message_data[0],
-                                                                     dp.handshake_handle_, se);
-      switch (vr) {
-      case DDS::Security::VALIDATION_FAILED:
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: ")
-                     ACE_TEXT("Spdp::handle_handshake_message() - ")
-                     ACE_TEXT("Failed to process incoming handshake message when ")
-                     ACE_TEXT("expecting %C from %C. Security Exception[%d.%d]: %C\n"),
-                     dp.is_requester_ ? "final" : "reply",
-                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str(),
-                     se.code, se.minor_code, se.message.in()));
-        }
-        return;
-      case DDS::Security::VALIDATION_PENDING_RETRY:
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
-                     ACE_TEXT("Unexpected validation pending retry\n")));
-        }
-        return;
-      case DDS::Security::VALIDATION_PENDING_HANDSHAKE_REQUEST:
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
-                     ACE_TEXT("Unexpected validation pending handshake request\n")));
-        }
-        return;
-      case DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE:
-        // Theoretically, this shouldn't happen unless handshakes can involve more than 3 messages
-        if (send_handshake_message(src_participant, dp, reply, false) != DDS::RETCODE_OK) {
-          if (DCPS::security_debug.auth_warn) {
-            ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Unable to write stateless message for handshake reply.\n")));
-          }
-          return;
-        } else {
-          if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Sent hanshake unknown message for participant: %C\n"),
-                       OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
-          }
-        }
-        return;
-      case DDS::Security::VALIDATION_OK_FINAL_MESSAGE:
-        dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
-        purge_auth_deadlines(iter);
-        // Install the shared secret before sending the final so that
-        // we are prepared to receive the crypto tokens from the
-        // replier.
-        dp.seen_some_crypto_tokens_ = false;
-        match_authenticated(src_participant, iter);
-        if (send_handshake_message(src_participant, dp, reply, false) != DDS::RETCODE_OK) {
-          if (DCPS::security_debug.auth_warn) {
-            ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Unable to write stateless message for final message.\n")));
-          }
-          return;
-        } else {
-          if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Sent handshake final for participant: %C\n"),
-                       OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
-          }
-        }
-        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REQUEST;
-        return;
-      case DDS::Security::VALIDATION_OK:
-        dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
-        purge_auth_deadlines(iter);
-        match_authenticated(src_participant, iter);
-        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REQUEST;
-        return;
-      }
-    }
-    return;
-
-  case DCPS::HANDSHAKE_STATE_EXPECTING_REQUEST:
-    if (msg.related_message_identity.source_guid != GUID_UNKNOWN) {
+    case DDS::Security::VALIDATION_PENDING_RETRY: {
       if (DCPS::security_debug.auth_warn) {
-        ACE_DEBUG((LM_WARNING,
-                   ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
-                   ACE_TEXT("Dropping handshake message from %C, incorrect related message identity source guid\n"),
-                   OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Unexpected validation pending retry\n")));
       }
       return;
     }
-
-    {
-      DDS::Security::ParticipantStatelessMessage reply;
-      reply.message_identity.source_guid = guid_;
-      reply.message_identity.sequence_number = 0;
-      reply.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_HANDSHAKE;
-      reply.related_message_identity = msg.message_identity;
-      reply.destination_participant_guid = src_participant;
-      reply.destination_endpoint_guid = GUID_UNKNOWN;
-      reply.source_endpoint_guid = GUID_UNKNOWN;
-      reply.message_data.length(1);
-      reply.message_data[0] = msg.message_data[0];
-
-      if (dp.handshake_handle_ != DDS::HANDLE_NIL) {
-        // Return the handle for reauth.
-        if (!auth->return_handshake_handle(dp.handshake_handle_, se)) {
-          if (DCPS::security_debug.auth_warn) {
-            ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                       ACE_TEXT("Spdp::handke_handshake_message() - ")
-                       ACE_TEXT("Unable to return handshake handle. ")
-                       ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                       se.code, se.minor_code, se.message.in()));
-          }
-          return;
-        }
-        dp.handshake_handle_ = DDS::HANDLE_NIL;
+    case DDS::Security::VALIDATION_PENDING_HANDSHAKE_REQUEST: {
+      if (DCPS::security_debug.auth_warn) {
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Unexpected validation pending handshake request\n")));
       }
-
-      const DDS::OctetSeq local_participant = local_participant_data_as_octets();
-      if (!local_participant.length()) {
-        return; // already logged in local_participant_data_as_octets()
-      }
-      const DDS::Security::ValidationResult_t vr =
-        auth->begin_handshake_reply(dp.handshake_handle_, reply.message_data[0], dp.identity_handle_,
-                                    identity_handle_, local_participant, se);
-
-      switch (vr) {
-      case DDS::Security::VALIDATION_OK:
-        // Theoretically, this shouldn't happen unless handshakes can involve fewer than 3 messages
-        dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
-        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL;
-        purge_auth_deadlines(iter);
-        match_authenticated(src_participant, iter);
-        return;
-      case DDS::Security::VALIDATION_FAILED:
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
-                     ACE_TEXT("Failed to reply to incoming handshake message. Security Exception[%d.%d]: %C\n"),
-                     se.code, se.minor_code, se.message.in()));
-        }
-        return;
-      case DDS::Security::VALIDATION_PENDING_RETRY:
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
-                     ACE_TEXT("Unexpected validation pending retry\n")));
-        }
-        return;
-      case DDS::Security::VALIDATION_PENDING_HANDSHAKE_REQUEST:
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
-                     ACE_TEXT("Unexpected validation pending handshake request\n")));
-        }
-        return;
-      case DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE:
-        if (send_handshake_message(src_participant, dp, reply, true) != DDS::RETCODE_OK) {
-          if (DCPS::security_debug.auth_warn) {
-            ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Unable to write stateless message for handshake reply.\n")));
-          }
-          return;
-        } else {
-          if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Sent handshake reply for participant: %C\n"),
-                       OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
-          }
-        }
-        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL;
-        return;
-      case DDS::Security::VALIDATION_OK_FINAL_MESSAGE:
-        // Theoretically, this shouldn't happen unless handshakes can involve fewer than 3 messages
-        if (send_handshake_message(src_participant, dp, reply, false) != DDS::RETCODE_OK) {
-          if (DCPS::security_debug.auth_warn) {
-            ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Unable to write stateless message for final message.\n")));
-          }
-          return;
-        } else {
-          if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
-                       ACE_TEXT("Sent handshake final for participant: %C\n"),
-                       OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
-          }
-        }
-        dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
-        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REPLY_OR_FINAL;
-        purge_auth_deadlines(iter);
-        match_authenticated(src_participant, iter);
-        return;
-      }
+      return;
     }
-    return;
+    case DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE: {
+      // Theoretically, this shouldn't happen unless handshakes can involve more than 3 messages
+      if (send_handshake_message(src_participant, dp, reply) != DDS::RETCODE_OK) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Unable to write stateless message for handshake reply.\n")));
+        }
+        return;
+      } else {
+        if (DCPS::security_debug.auth_debug) {
+          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Sent hanshake unknown message for participant: %C\n"),
+                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        }
+      }
+      return;
+    }
+    case DDS::Security::VALIDATION_OK_FINAL_MESSAGE: {
+      dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
+      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN;
+      // Install the shared secret before sending the final so that
+      // we are prepared to receive the crypto tokens from the
+      // replier.
+      dp.seen_some_crypto_tokens_ = false;
+      match_authenticated(src_participant, iter);
+      if (send_handshake_message(src_participant, dp, reply) != DDS::RETCODE_OK) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Unable to write stateless message for final message.\n")));
+        }
+        return;
+      } else {
+        if (DCPS::security_debug.auth_debug) {
+          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
+                     ACE_TEXT("Sent handshake final for participant: %C\n"),
+                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        }
+      }
+      return;
+    }
+    case DDS::Security::VALIDATION_OK: {
+      dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
+      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+      purge_handshake_deadlines(iter);
+      match_authenticated(src_participant, iter);
+      return;
+    }
+    }
+  }
   }
 }
 
 void
-Spdp::process_auth_deadlines(const DCPS::MonotonicTimePoint& now)
+Spdp::process_handshake_deadlines(const DCPS::MonotonicTimePoint& now)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, lock_);
 
-  for (TimeQueue::iterator pos = auth_deadlines_.begin(),
-        limit = auth_deadlines_.upper_bound(now); pos != limit;) {
+  for (TimeQueue::iterator pos = handshake_deadlines_.begin(),
+        limit = handshake_deadlines_.upper_bound(now); pos != limit;) {
 
     DiscoveredParticipantIter pit = participants_.find(pos->second);
     if (pit != participants_.end()) {
       if (DCPS::security_debug.auth_debug) {
-        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_auth_deadlines() - ")
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_handshake_deadlines() - ")
                    ACE_TEXT("Removing discovered participant due to authentication timeout: %C\n"),
                    OPENDDS_STRING(DCPS::GuidConverter(pos->second)).c_str()));
       }
@@ -1268,32 +1391,33 @@ Spdp::process_auth_deadlines(const DCPS::MonotonicTimePoint& now)
         if (spdp_endpoint) {
           ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, pit->first);
         }
-        auth_deadlines_.erase(pos);
+        handshake_deadlines_.erase(pos);
         remove_discovered_participant(pit);
       } else {
-        purge_auth_resends(pit);
+        purge_handshake_resends(pit);
         pit->second.auth_state_ = DCPS::AUTH_STATE_UNAUTHENTICATED;
-        auth_deadlines_.erase(pos);
+        pit->second.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+        handshake_deadlines_.erase(pos);
         match_unauthenticated(part_id, pit);
       }
-      pos = auth_deadlines_.lower_bound(ptime);
-      limit = auth_deadlines_.upper_bound(now);
+      pos = handshake_deadlines_.lower_bound(ptime);
+      limit = handshake_deadlines_.upper_bound(now);
     } else {
-      auth_deadlines_.erase(pos++);
+      handshake_deadlines_.erase(pos++);
     }
   }
 
-  if (!auth_deadlines_.empty()) {
-    tport_->auth_deadline_processor_->schedule(auth_deadlines_.begin()->first - now);
+  if (!handshake_deadlines_.empty()) {
+    tport_->handshake_deadline_processor_->schedule(handshake_deadlines_.begin()->first - now);
   }
 }
 
 void
-Spdp::process_auth_resends(const DCPS::MonotonicTimePoint& now)
+Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, lock_);
 
-  for (TimeQueue::iterator pos = auth_resends_.begin(), limit = auth_resends_.end();
+  for (TimeQueue::iterator pos = handshake_resends_.begin(), limit = handshake_resends_.end();
        pos != limit && pos->first <= now;) {
 
     DiscoveredParticipantIter pit = participants_.find(pos->second);
@@ -1305,12 +1429,12 @@ Spdp::process_auth_resends(const DCPS::MonotonicTimePoint& now)
       if (pit->second.have_handshake_msg_) {
         if (sedp_.write_stateless_message(pit->second.handshake_msg_, reader) != DDS::RETCODE_OK) {
           if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_auth_resends() - ")
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_handshake_resends() - ")
                        ACE_TEXT("Unable to write handshake message retry.\n")));
           }
         } else {
           if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::process_auth_resends() - ")
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::process_handshake_resends() - ")
                        ACE_TEXT("Sent handshake message for participant: %C\n"),
                        OPENDDS_STRING(DCPS::GuidConverter(pit->first)).c_str()));
           }
@@ -1318,26 +1442,26 @@ Spdp::process_auth_resends(const DCPS::MonotonicTimePoint& now)
       } else if (pit->second.have_auth_req_msg_) {
         if (sedp_.write_stateless_message(pit->second.auth_req_msg_, reader) != DDS::RETCODE_OK) {
           if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_auth_resends() - ")
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_handshake_resends() - ")
                        ACE_TEXT("Unable to write auth req message retry.\n")));
           }
         } else {
           if (DCPS::security_debug.auth_debug) {
-            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::process_auth_resends() - ")
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::process_handshake_resends() - ")
                        ACE_TEXT("Sent auth req message for participant: %C\n"),
                        OPENDDS_STRING(DCPS::GuidConverter(pit->first)).c_str()));
           }
         }
       }
 
-      auth_resends_.insert(std::make_pair(pit->second.stateless_msg_deadline_, pit->first));
+      handshake_resends_.insert(std::make_pair(pit->second.stateless_msg_deadline_, pit->first));
     }
 
-    auth_resends_.erase(pos++);
+    handshake_resends_.erase(pos++);
   }
 
-  if (!auth_resends_.empty()) {
-    tport_->auth_resend_processor_->schedule(auth_resends_.begin()->first - now);
+  if (!handshake_resends_.empty()) {
+    tport_->handshake_resend_processor_->schedule(handshake_resends_.begin()->first - now);
   }
 }
 
@@ -1388,6 +1512,11 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
 
   send_our_tokens = !dp.is_requester_ && !dp.seen_some_crypto_tokens_;
   dp.seen_some_crypto_tokens_ = true;
+  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN) {
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+    purge_handshake_deadlines(iter);
+  }
+
   return true;
 }
 
@@ -1401,30 +1530,34 @@ bool Spdp::seen_crypto_tokens_from(const RepoId& sender)
   DiscoveredParticipant& dp = iter->second;
   const bool send_our_tokens = !dp.is_requester_ && !dp.seen_some_crypto_tokens_;
   dp.seen_some_crypto_tokens_ = true;
+  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN) {
+    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
+    purge_handshake_deadlines(iter);
+  }
+
   return send_our_tokens;
 }
 
 DDS::ReturnCode_t
 Spdp::send_handshake_message(const DCPS::RepoId& guid,
                              DiscoveredParticipant& dp,
-                             DDS::Security::ParticipantStatelessMessage& msg,
-                             bool resend)
+                             const DDS::Security::ParticipantStatelessMessage& msg)
 {
+  dp.handshake_msg_ = msg;
+  dp.handshake_msg_.message_identity.sequence_number = static_cast<CORBA::LongLong>((++stateless_sequence_number_).getValue());
+
   const DCPS::RepoId reader = make_id(guid, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER);
-  const DDS::ReturnCode_t retval = sedp_.write_stateless_message(msg, reader);
-  if (resend) {
-    dp.have_handshake_msg_ = true;
-    dp.handshake_msg_ = msg;
-    dp.stateless_msg_deadline_ = schedule_auth_resend(config_->auth_resend_period(), guid);
-  }
+  const DDS::ReturnCode_t retval = sedp_.write_stateless_message(dp.handshake_msg_, reader);
+  dp.have_handshake_msg_ = true;
+  dp.stateless_msg_deadline_ = schedule_handshake_resend(config_->auth_resend_period(), guid);
   return retval;
 }
 
-MonotonicTimePoint Spdp::schedule_auth_resend(const TimeDuration& time, const RepoId& guid)
+MonotonicTimePoint Spdp::schedule_handshake_resend(const TimeDuration& time, const RepoId& guid)
 {
   const MonotonicTimePoint deadline = MonotonicTimePoint::now() + time;
-  auth_resends_.insert(std::make_pair(deadline, guid));
-  tport_->auth_resend_processor_->schedule(time);
+  handshake_resends_.insert(std::make_pair(deadline, guid));
+  tport_->handshake_resend_processor_->schedule(time);
   return deadline;
 }
 
@@ -1509,7 +1642,7 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
   iter->second.permissions_handle_ = access->validate_remote_permissions(
     auth, identity_handle_, iter->second.identity_handle_,
     iter->second.permissions_token_, iter->second.authenticated_peer_credential_token_, se);
-  if (participant_sec_attr_.is_access_protected == true &&
+  if (participant_sec_attr_.is_access_protected &&
       iter->second.permissions_handle_ == DDS::HANDLE_NIL) {
     if (DCPS::security_debug.auth_warn) {
       ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
@@ -1617,107 +1750,6 @@ bool Spdp::security_builtins_associated(const DCPS::RepoId& remoteParticipant) c
   return iter == participants_.end() ? false : iter->second.security_builtins_associated_;
 }
 
-void
-Spdp::attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp)
-{
-  DDS::Security::Authentication_var auth = security_config_->get_authentication();
-  DDS::Security::SecurityException se = {"", 0, 0};
-
-  ACE_DEBUG((LM_DEBUG, "attempt_authentication starting auth_state %d\n", dp.auth_state_));
-
-  PendingRemoteAuthTokenMap::iterator token_iter = pending_remote_auth_tokens_.find(guid);
-  bool started_from_discovery = false;
-  if (token_iter == pending_remote_auth_tokens_.end()) {
-    dp.remote_auth_request_token_ = DDS::Security::Token();
-    started_from_discovery = true;
-  } else {
-    dp.remote_auth_request_token_ = token_iter->second;
-    pending_remote_auth_tokens_.erase(token_iter);
-  }
-
-  if (dp.auth_state_ == DCPS::AUTH_STATE_UNKNOWN ||
-      (dp.auth_state_ != DCPS::AUTH_STATE_HANDSHAKE && !started_from_discovery)) {
-    dp.auth_deadline_ = DCPS::MonotonicTimePoint::now() + config_->max_auth_time();
-    dp.auth_state_ = DCPS::AUTH_STATE_VALIDATING_REMOTE;
-    auth_deadlines_.insert(std::make_pair(dp.auth_deadline_, guid));
-    tport_->auth_deadline_processor_->schedule(config_->max_auth_time());
-  }
-
-  if (dp.auth_state_ == DCPS::AUTH_STATE_VALIDATING_REMOTE) {
-    const DDS::Security::ValidationResult_t vr = auth->validate_remote_identity(dp.identity_handle_,
-      dp.local_auth_request_token_, dp.remote_auth_request_token_, identity_handle_, dp.identity_token_, guid, se);
-
-    ACE_DEBUG((LM_DEBUG, "post validate sfd=%d vr=%d\n", started_from_discovery, vr));
-    dp.have_auth_req_msg_ = !(dp.local_auth_request_token_ == DDS::Security::Token());
-    if (dp.have_auth_req_msg_) {
-      dp.auth_req_msg_.message_identity.source_guid = guid_;
-      dp.auth_req_msg_.message_class_id = DDS::Security::GMCLASSID_SECURITY_AUTH_REQUEST;
-      dp.auth_req_msg_.destination_participant_guid = guid;
-      dp.auth_req_msg_.destination_endpoint_guid = GUID_UNKNOWN;
-      dp.auth_req_msg_.source_endpoint_guid = GUID_UNKNOWN;
-      dp.auth_req_msg_.related_message_identity.source_guid = GUID_UNKNOWN;
-      dp.auth_req_msg_.related_message_identity.sequence_number = 0;
-      dp.auth_req_msg_.message_data.length(1);
-      dp.auth_req_msg_.message_data[0] = dp.local_auth_request_token_;
-      const TimeDuration auth_req_delay =
-        (vr == DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE && started_from_discovery)
-        ? TimeDuration::zero_value : config_->auth_resend_period();
-      schedule_auth_resend(auth_req_delay, guid);
-    }
-
-    switch (vr) {
-      case DDS::Security::VALIDATION_OK: {
-        dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
-        purge_auth_deadlines(participants_.find(guid));
-        return;
-      }
-      case DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE: {
-        if (DCPS::security_debug.auth_debug) {
-          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
-                     ACE_TEXT("Attempting authentication (expecting request) for participant: %C\n"),
-                     OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
-        }
-        dp.auth_state_ = DCPS::AUTH_STATE_HANDSHAKE;
-        dp.handshake_state_ = DCPS::HANDSHAKE_STATE_EXPECTING_REQUEST;
-        dp.is_requester_ = true;
-        return; // We'll need to wait for an inbound handshake request from the remote participant
-      }
-      case DDS::Security::VALIDATION_PENDING_HANDSHAKE_REQUEST: {
-        if (DCPS::security_debug.auth_debug) {
-          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
-            ACE_TEXT("Attempting authentication (sending request/expecting reply) for participant: %C\n"),
-            OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
-        }
-        dp.auth_state_ = DCPS::AUTH_STATE_HANDSHAKE;
-        send_handshake_request(guid, dp);
-        return;
-      }
-      case DDS::Security::VALIDATION_FAILED: {
-        if (DCPS::security_debug.auth_debug) {
-          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
-            ACE_TEXT("Remote participant identity is invalid. Security Exception[%d.%d]: %C\n"),
-            se.code, se.minor_code, se.message.in()));
-        }
-        dp.auth_state_ = DCPS::AUTH_STATE_UNAUTHENTICATED;
-        purge_auth_deadlines(participants_.find(guid));
-        return;
-      }
-      default: {
-        if (DCPS::security_debug.auth_debug) {
-          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
-            ACE_TEXT("Unexpected return value while validating remote identity. Security Exception[%d.%d]: %C\n"),
-            se.code, se.minor_code, se.message.in()));
-        }
-        dp.auth_state_ = DCPS::AUTH_STATE_UNAUTHENTICATED;
-        purge_auth_deadlines(participants_.find(guid));
-        return;
-      }
-    }
-  }
-
-  return;
-}
-
 void Spdp::update_agent_info(const DCPS::RepoId&, const ICE::AgentInfo&)
 {
   if (is_security_enabled()) {
@@ -1766,7 +1798,7 @@ Spdp::remove_expired_participants()
         if (spdp_endpoint) {
           ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, part->first);
         }
-        purge_auth_deadlines(part);
+        purge_handshake_deadlines(part);
 #endif
         remove_discovered_participant(part);
       }
@@ -2092,8 +2124,8 @@ Spdp::SpdpTransport::open()
   local_sender_->enable(outer_->config_->resend_period());
 
 #ifdef OPENDDS_SECURITY
-  auth_deadline_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::process_auth_deadlines);
-  auth_resend_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::process_auth_resends);
+  handshake_deadline_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::process_handshake_deadlines);
+  handshake_resend_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::process_handshake_resends);
 #endif
 
   relay_sender_ = DCPS::make_rch<SpdpPeriodic>(reactor_task_.interceptor(), ref(*this), &SpdpTransport::send_relay);
@@ -2201,11 +2233,11 @@ Spdp::SpdpTransport::close()
     ice_endpoint_added_ = false;
   }
 
-  if (auth_deadline_processor_) {
-    auth_deadline_processor_->cancel_and_wait();
+  if (handshake_deadline_processor_) {
+    handshake_deadline_processor_->cancel_and_wait();
   }
-  if (auth_resend_processor_) {
-    auth_resend_processor_->cancel_and_wait();
+  if (handshake_resend_processor_) {
+    handshake_resend_processor_->cancel_and_wait();
   }
 #endif
   if (relay_sender_) {
@@ -3115,14 +3147,12 @@ Spdp::lookup_participant_permissions(const DCPS::RepoId& id) const
 DCPS::AuthState
 Spdp::lookup_participant_auth_state(const DCPS::RepoId& id) const
 {
-  DCPS::AuthState result = DCPS::AUTH_STATE_UNKNOWN;
-
   ACE_Guard<ACE_Thread_Mutex> g(lock_, false);
   DiscoveredParticipantConstIter pi = participants_.find(id);
   if (pi != participants_.end()) {
-    result = pi->second.auth_state_;
+    return pi->second.auth_state_;
   }
-  return result;
+  return DCPS::AUTH_STATE_HANDSHAKE;
 }
 #endif
 
@@ -3388,34 +3418,34 @@ void Spdp::SpdpTransport::send_local(const DCPS::MonotonicTimePoint& /*now*/)
 }
 
 #ifdef OPENDDS_SECURITY
-void Spdp::SpdpTransport::process_auth_deadlines(const DCPS::MonotonicTimePoint& now)
+void Spdp::SpdpTransport::process_handshake_deadlines(const DCPS::MonotonicTimePoint& now)
 {
-  outer_->process_auth_deadlines(now);
+  outer_->process_handshake_deadlines(now);
 }
 
-void Spdp::SpdpTransport::process_auth_resends(const DCPS::MonotonicTimePoint& now)
+void Spdp::SpdpTransport::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
 {
-  outer_->process_auth_resends(now);
+  outer_->process_handshake_resends(now);
 }
 
-void Spdp::purge_auth_deadlines(DiscoveredParticipantIter iter)
+void Spdp::purge_handshake_deadlines(DiscoveredParticipantIter iter)
 {
   if (iter == participants_.end()) {
     return;
   }
 
-  purge_auth_resends(iter);
+  purge_handshake_resends(iter);
 
-  std::pair<TimeQueue::iterator, TimeQueue::iterator> range = auth_deadlines_.equal_range(iter->second.auth_deadline_);
+  std::pair<TimeQueue::iterator, TimeQueue::iterator> range = handshake_deadlines_.equal_range(iter->second.handshake_deadline_);
   for (; range.first != range.second; ++range.first) {
     if (range.first->second == iter->first) {
-      auth_deadlines_.erase(range.first);
+      handshake_deadlines_.erase(range.first);
       break;
     }
   }
 }
 
-void Spdp::purge_auth_resends(DiscoveredParticipantIter iter)
+void Spdp::purge_handshake_resends(DiscoveredParticipantIter iter)
 {
   if (iter == participants_.end()) {
     return;
@@ -3424,10 +3454,10 @@ void Spdp::purge_auth_resends(DiscoveredParticipantIter iter)
   iter->second.have_auth_req_msg_ = false;
   iter->second.have_handshake_msg_ = false;
 
-  std::pair<TimeQueue::iterator, TimeQueue::iterator> range = auth_resends_.equal_range(iter->second.stateless_msg_deadline_);
+  std::pair<TimeQueue::iterator, TimeQueue::iterator> range = handshake_resends_.equal_range(iter->second.stateless_msg_deadline_);
   for (; range.first != range.second; ++range.first) {
     if (range.first->second == iter->first) {
-      auth_resends_.erase(range.first);
+      handshake_resends_.erase(range.first);
       break;
     }
   }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -104,7 +104,6 @@ public:
   DDS::Security::ParticipantCryptoHandle crypto_handle() const { return crypto_handle_; }
   DDS::Security::ParticipantCryptoHandle remote_crypto_handle(const DCPS::RepoId& remote_participant) const;
 
-  bool new_stateless_message(const DDS::Security::ParticipantStatelessMessage& msg);
   void handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg);
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -104,6 +104,7 @@ public:
   DDS::Security::ParticipantCryptoHandle crypto_handle() const { return crypto_handle_; }
   DDS::Security::ParticipantCryptoHandle remote_crypto_handle(const DCPS::RepoId& remote_participant) const;
 
+  bool new_stateless_message(const DDS::Security::ParticipantStatelessMessage& msg);
   void handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg);
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
@@ -122,8 +123,8 @@ public:
   static bool validateSequenceNumber(const DCPS::SequenceNumber& seq, DiscoveredParticipantIter& iter);
 
 #ifdef OPENDDS_SECURITY
-  void process_auth_deadlines(const DCPS::MonotonicTimePoint& tv);
-  void process_auth_resends(const DCPS::MonotonicTimePoint& tv);
+  void process_handshake_deadlines(const DCPS::MonotonicTimePoint& tv);
+  void process_handshake_resends(const DCPS::MonotonicTimePoint& tv);
 
   /**
    * Write Secured Updated DP QOS
@@ -214,11 +215,10 @@ private:
 #ifdef OPENDDS_SECURITY
   DDS::ReturnCode_t send_handshake_message(const DCPS::RepoId& guid,
                                            DiscoveredParticipant& dp,
-                                           DDS::Security::ParticipantStatelessMessage& msg,
-                                           bool resend);
-  DCPS::MonotonicTimePoint schedule_auth_resend(const DCPS::TimeDuration& time, const DCPS::RepoId& guid);
+                                           const DDS::Security::ParticipantStatelessMessage& msg);
+  DCPS::MonotonicTimePoint schedule_handshake_resend(const DCPS::TimeDuration& time, const DCPS::RepoId& guid);
   bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& iter);
-  void attempt_authentication(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
+  void attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery);
   void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);
 #endif
 
@@ -305,10 +305,10 @@ private:
     void send_local(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpMulti> local_sender_;
 #ifdef OPENDDS_SECURITY
-    void process_auth_deadlines(const DCPS::MonotonicTimePoint& now);
-    DCPS::RcHandle<SpdpSporadic> auth_deadline_processor_;
-    void process_auth_resends(const DCPS::MonotonicTimePoint& now);
-    DCPS::RcHandle<SpdpSporadic> auth_resend_processor_;
+    void process_handshake_deadlines(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpSporadic> handshake_deadline_processor_;
+    void process_handshake_resends(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpSporadic> handshake_resend_processor_;
 #endif
     void send_relay(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpPeriodic> relay_sender_;
@@ -375,6 +375,8 @@ private:
   Security::SecurityConfig_rch security_config_;
   bool security_enabled_;
 
+  DCPS::SequenceNumber stateless_sequence_number_;
+
   DDS::Security::IdentityHandle identity_handle_;
   DDS::Security::PermissionsHandle permissions_handle_;
   DDS::Security::ParticipantCryptoHandle crypto_handle_;
@@ -387,14 +389,15 @@ private:
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
 
   typedef std::multimap<DCPS::MonotonicTimePoint, DCPS::RepoId> TimeQueue;
-  TimeQueue auth_deadlines_;
-  TimeQueue auth_resends_;
+  TimeQueue handshake_deadlines_;
+  TimeQueue handshake_resends_;
 
   void start_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail, const ICE::AgentInfo& agent_info);
   void stop_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail);
 
-  void purge_auth_deadlines(DiscoveredParticipantIter iter);
-  void purge_auth_resends(DiscoveredParticipantIter iter);
+  void purge_handshake_deadlines(DiscoveredParticipantIter iter);
+  void purge_handshake_resends(DiscoveredParticipantIter iter);
+
 #endif
 
   friend class ::DDS_TEST;


### PR DESCRIPTION
An auth resend can cause the authentication process to get into a bad
state (stall and/or livelock).

Solution: Rework the state machine with the following objectives
1. Use sequence numbers for the stateless endpoints for at-most-once
   processing.
2. Resend all handshake messages (request, reply, final) according to
   the resend timer.  Finals are resent until a token is received from
   the replier.
3. Resend auth reqs until a handshake message is received from the remote.
4. Further separate auth state from handshake state.  So that a
   participant remains authenticated through a reauth scenario.