### PR TITLE
Remove dcpslib from opendds_security.mpb

### DIFF
--- a/MPC/config/opendds_security.mpb
+++ b/MPC/config/opendds_security.mpb
@@ -1,4 +1,4 @@
-project: dcpslib, dcps_rtps, dds_openssl, ace_xml_utils {
+project: dcps_rtps, dds_openssl, ace_xml_utils {
   after += OpenDDS_Security
   libs  += OpenDDS_Security
   avoids += no_opendds_security


### PR DESCRIPTION
`dcpslib` installs libraries to `$DDS_ROOT/lib`, which I'm certain is not the intention here.