### PR TITLE
By default, omit optional properties from Authentication's handshake tokens

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3112,24 +3112,6 @@ Sedp::Endpoint::~Endpoint()
 Sedp::Writer::Writer(const RepoId& pub_id, Sedp& sedp, ACE_INT64 seq_init)
   : Endpoint(pub_id, sedp), seq_(seq_init)
 {
-  header_.prefix[0] = 'R';
-  header_.prefix[1] = 'T';
-  header_.prefix[2] = 'P';
-  header_.prefix[3] = 'S';
-  header_.version = PROTOCOLVERSION;
-  header_.vendorId = VENDORID_OPENDDS;
-  header_.guidPrefix[0] = pub_id.guidPrefix[0];
-  header_.guidPrefix[1] = pub_id.guidPrefix[1],
-  header_.guidPrefix[2] = pub_id.guidPrefix[2];
-  header_.guidPrefix[3] = pub_id.guidPrefix[3];
-  header_.guidPrefix[4] = pub_id.guidPrefix[4];
-  header_.guidPrefix[5] = pub_id.guidPrefix[5];
-  header_.guidPrefix[6] = pub_id.guidPrefix[6];
-  header_.guidPrefix[7] = pub_id.guidPrefix[7];
-  header_.guidPrefix[8] = pub_id.guidPrefix[8];
-  header_.guidPrefix[9] = pub_id.guidPrefix[9];
-  header_.guidPrefix[10] = pub_id.guidPrefix[10];
-  header_.guidPrefix[11] = pub_id.guidPrefix[11];
 }
 
 Sedp::Writer::~Writer()

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -395,7 +395,6 @@ private:
 
 
   private:
-    Header header_;
     DCPS::SequenceNumber seq_;
 
     void write_control_msg(DCPS::Message_Block_Ptr payload,

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -53,6 +53,8 @@ const std::string Handshake_Request_Class_Ext("Req");
 const std::string Handshake_Reply_Class_Ext("Reply");
 const std::string Handshake_Final_Class_Ext("Final");
 
+const char* AuthenticationBuiltInImpl::PROPERTY_HANDSHAKE_DEBUG = "opendds.sec.auth.handshake_debug";
+
 struct SharedSecret : DCPS::LocalObject<DDS::Security::SharedSecretHandle> {
 
   SharedSecret(DDS::OctetSeq challenge1,
@@ -111,6 +113,12 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
         LocalParticipantData::shared_ptr local_participant = DCPS::make_rch<LocalParticipantData>();
         local_participant->participant_guid = adjusted_participant_guid;
         local_participant->credentials = credentials;
+        for (unsigned i = 0; i < participant_qos.property.value.length(); ++i) {
+          if (std::strcmp(PROPERTY_HANDSHAKE_DEBUG,
+                          participant_qos.property.value[i].name.in()) == 0) {
+            local_participant->handshake_debug = true;
+          }
+        }
 
         {
           ACE_Guard<ACE_Thread_Mutex> identity_data_guard(identity_mutex_);
@@ -345,7 +353,9 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
   message_out.add_bin_property("c.pdata", serialized_local_participant_data);
   message_out.add_bin_property("c.dsign_algo", local_credential_data.get_participant_cert().dsign_algo());
   message_out.add_bin_property("c.kagree_algo", diffie_hellman->kagree_algo());
-  message_out.add_bin_property("hash_c1", hash_c1);
+  if (local_data.handshake_debug) {
+    message_out.add_bin_property("hash_c1", hash_c1);
+  }
 
   DDS::OctetSeq dhpub;
   diffie_hellman->pub_key(dhpub);
@@ -715,12 +725,19 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
   message_out.add_bin_property("c.pdata", serialized_local_participant_data);
   message_out.add_bin_property("c.dsign_algo", local_credential_data.get_participant_cert().dsign_algo());
   message_out.add_bin_property("c.kagree_algo", diffie_hellman->kagree_algo());
-  message_out.add_bin_property("hash_c2", hash_c2);
+
+  if (local_data.handshake_debug) {
+    message_out.add_bin_property("hash_c2", hash_c2);
+  }
 
   diffie_hellman->pub_key(dh2);
   message_out.add_bin_property("dh2", dh2);
-  message_out.add_bin_property("hash_c1", hash_c1);
-  message_out.add_bin_property("dh1", dh1);
+
+  if (local_data.handshake_debug) {
+    message_out.add_bin_property("hash_c1", hash_c1);
+    message_out.add_bin_property("dh1", dh1);
+  }
+
   message_out.add_bin_property("challenge1", challenge1);
 
   TokenReader initiator_local_auth_request(remote_data.local_auth_request);
@@ -1114,10 +1131,13 @@ DDS::Security::ValidationResult_t AuthenticationBuiltInImpl::process_handshake_r
 
   OpenDDS::Security::TokenWriter final_msg(handshake_message_out, build_class_id(Handshake_Final_Class_Ext));
 
-  final_msg.add_bin_property("hash_c1", remote_data.hash_c1);
-  final_msg.add_bin_property("hash_c2", hash_c2);
-  final_msg.add_bin_property("dh1", dh1);
-  final_msg.add_bin_property("dh2", dh2);
+  if (local_data.handshake_debug) {
+    final_msg.add_bin_property("hash_c1", remote_data.hash_c1);
+    final_msg.add_bin_property("hash_c2", hash_c2);
+    final_msg.add_bin_property("dh1", dh1);
+    final_msg.add_bin_property("dh2", dh2);
+  }
+
   final_msg.add_bin_property("challenge1", challenge1);
   final_msg.add_bin_property("challenge2", challenge2);
 

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.h
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.h
@@ -49,6 +49,10 @@ class DdsSecurity_Export  AuthenticationBuiltInImpl
   : public virtual DDS::Security::Authentication
 {
 public:
+
+  /// include in PropertyQosPolicy to add optional properties to Handshake tokens
+  static const char* PROPERTY_HANDSHAKE_DEBUG;
+
   AuthenticationBuiltInImpl();
   virtual ~AuthenticationBuiltInImpl();
 
@@ -187,13 +191,14 @@ private:
     DCPS::GUID_t participant_guid;
     LocalAuthCredentialData::shared_ptr credentials;
     RemoteParticipantMap validated_remotes;
+    bool handshake_debug;
 
     LocalParticipantData()
-      : participant_guid(DCPS::GUID_UNKNOWN),
-        credentials(),
-        validated_remotes()
+      : participant_guid(DCPS::GUID_UNKNOWN)
+      , credentials()
+      , validated_remotes()
+      , handshake_debug(false)
     {
-
     }
   };
   typedef std::map<DDS::Security::IdentityHandle, LocalParticipantData::shared_ptr> LocalParticipantMap;

--- a/tests/security/Authentication/AuthenticationTest.cpp
+++ b/tests/security/Authentication/AuthenticationTest.cpp
@@ -430,7 +430,7 @@ TEST_F(AuthenticationTest, BeginHandshakeRequest_UsingLocalAuthRequestToken_Succ
   // practical to check the lengths of the resultant parameters
   const DDS::BinaryPropertySeq& bprops = request_token.binary_properties;
   const DDS::PropertySeq& props = request_token.properties;
-  ASSERT_EQ(8u, bprops.length());
+  ASSERT_EQ(7u, bprops.length());
   ASSERT_EQ(0u, props.length());
   ASSERT_EQ(65u, value_of("dh1", bprops).length());
   {


### PR DESCRIPTION
Use a DomainParticipantQos Property_t to include them again