### PR TITLE
Allow skipping of packets with bad transport headers 

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -157,7 +157,10 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
   receive_transport_header_ = *cur_rb;
   if (!receive_transport_header_.valid()) {
     cur_rb->reset();
-    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: TransportHeader invalid.\n")), 0);
+    if (DCPS::DCPS_debug_level > 0) {
+      ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: TransportHeader invalid.\n")));
+    }
+    return 0;
   }
 
   bytes_remaining = receive_transport_header_.length_;

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -156,9 +156,9 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
 
   receive_transport_header_ = *cur_rb;
   if (!receive_transport_header_.valid()) {
-    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: TransportHeader invalid.\n")), -1);
+    cur_rb->reset();
+    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: TransportHeader invalid.\n")), 0);
   }
-
 
   bytes_remaining = receive_transport_header_.length_;
   if (!check_header(receive_transport_header_)) {

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -157,7 +157,7 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
   receive_transport_header_ = *cur_rb;
   if (!receive_transport_header_.valid()) {
     cur_rb->reset();
-    if (DCPS::DCPS_debug_level > 0) {
+    if (DCPS_debug_level > 0) {
       ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: TransportHeader invalid.\n")));
     }
     return 0;


### PR DESCRIPTION
Specifically, in TransportReceiveStrategy::handle_simple_dds_input() which is used by RtpsUdp transport instances.