### PR TITLE
Prefer Unicast For INFO_DST Submessages

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -557,7 +557,7 @@ RtpsUdpDataLink::add_locators(const RepoId& remote_id,
     narrow_address.addr_to_string(narrow_addr_buff, 256);
     ACE_TCHAR wide_addr_buff[256] = {};
     wide_address.addr_to_string(wide_addr_buff, 256);
-    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) RtpsUdpDataLink::add_locators %C is now at %s or %s\n"), LogGuid(remote_id).c_str(), narrow_addr_buff, wide_addr_buff));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) RtpsUdpDataLink::add_locators %C is now at %s and %s\n"), LogGuid(remote_id).c_str(), narrow_addr_buff, wide_addr_buff));
   }
 }
 
@@ -2202,14 +2202,14 @@ RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVec& meta_submessages, 
   AddrSet addrs;
   // Sort meta_submessages by address set and destination
   for (MetaSubmessageVec::iterator it = meta_submessages.begin(); it != meta_submessages.end(); ++it) {
-    const bool undirected = it->dst_guid_ == GUID_UNKNOWN;
-    if (undirected) {
-      addrs = get_addresses_i(it->from_guid_); // This will overwrite, but addrs should always be empty here
-    } else {
+    const bool directed = it->dst_guid_ != GUID_UNKNOWN;
+    if (directed) {
       accumulate_addresses(it->from_guid_, it->dst_guid_, addrs, true);
+    } else {
+      addrs = get_addresses_i(it->from_guid_); // This will overwrite, but addrs should always be empty here
     }
     for (RepoIdSet::iterator it2 = it->to_guids_.begin(); it2 != it->to_guids_.end(); ++it2) {
-      accumulate_addresses(it->from_guid_, *it2, addrs, !undirected);
+      accumulate_addresses(it->from_guid_, *it2, addrs, directed);
     }
     if (addrs.empty()) {
       continue;
@@ -4009,7 +4009,7 @@ RtpsUdpDataLink::get_addresses_i(const RepoId& local) const {
 
 void
 RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
-                                      AddrSet& addresses, bool narrow) const {
+                                      AddrSet& addresses, bool prefer_narrow) const {
   ACE_UNUSED_ARG(local);
   OPENDDS_ASSERT(local != GUID_UNKNOWN);
   OPENDDS_ASSERT(remote != GUID_UNKNOWN);
@@ -4021,7 +4021,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   typedef OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter_t;
   iter_t pos = locators_.find(remote);
   if (pos != locators_.end()) {
-    normal_addr = narrow ? pos->second.narrow_addr_ : pos->second.wide_addr_;
+    normal_addr = prefer_narrow ? pos->second.narrow_addr_ : pos->second.wide_addr_;
   } else {
     const GuidConverter conv(remote);
     if (conv.isReader()) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3988,7 +3988,7 @@ RtpsUdpDataLink::AddrSet
 RtpsUdpDataLink::get_addresses_i(const RepoId& local, const RepoId& remote) const {
   AddrSet retval;
 
-  accumulate_addresses(local, remote, retval);
+  accumulate_addresses(local, remote, retval, true);
 
   return retval;
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -544,17 +544,20 @@ RtpsUdpDataLink::leave_multicast_group(const DCPS::NetworkInterface& nic)
 }
 
 void
-RtpsUdpDataLink::add_locator(const RepoId& remote_id,
-                             const ACE_INET_Addr& address,
-                             bool requires_inline_qos)
+RtpsUdpDataLink::add_locators(const RepoId& remote_id,
+                              const ACE_INET_Addr& narrow_address,
+                              const ACE_INET_Addr& wide_address,
+                              bool requires_inline_qos)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
-  locators_[remote_id] = RemoteInfo(address, requires_inline_qos);
+  locators_[remote_id] = RemoteInfo(narrow_address, wide_address, requires_inline_qos);
 
   if (DCPS::DCPS_debug_level > 3) {
-    ACE_TCHAR addr_buff[256] = {};
-    address.addr_to_string(addr_buff, 256);
-    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) RtpsUdpDataLink::add_locator %C is now at %s\n"), LogGuid(remote_id).c_str(), addr_buff));
+    ACE_TCHAR narrow_addr_buff[256] = {};
+    narrow_address.addr_to_string(narrow_addr_buff, 256);
+    ACE_TCHAR wide_addr_buff[256] = {};
+    wide_address.addr_to_string(wide_addr_buff, 256);
+    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) RtpsUdpDataLink::add_locators %C is now at %s or %s\n"), LogGuid(remote_id).c_str(), narrow_addr_buff, wide_addr_buff));
   }
 }
 
@@ -2199,13 +2202,14 @@ RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVec& meta_submessages, 
   AddrSet addrs;
   // Sort meta_submessages by address set and destination
   for (MetaSubmessageVec::iterator it = meta_submessages.begin(); it != meta_submessages.end(); ++it) {
-    if (it->dst_guid_ == GUID_UNKNOWN) {
+    const bool undirected = it->dst_guid_ == GUID_UNKNOWN;
+    if (undirected) {
       addrs = get_addresses_i(it->from_guid_); // This will overwrite, but addrs should always be empty here
     } else {
-      accumulate_addresses(it->from_guid_, it->dst_guid_, addrs);
+      accumulate_addresses(it->from_guid_, it->dst_guid_, addrs, true);
     }
     for (RepoIdSet::iterator it2 = it->to_guids_.begin(); it2 != it->to_guids_.end(); ++it2) {
-      accumulate_addresses(it->from_guid_, *it2, addrs);
+      accumulate_addresses(it->from_guid_, *it2, addrs, !undirected);
     }
     if (addrs.empty()) {
       continue;
@@ -4005,7 +4009,7 @@ RtpsUdpDataLink::get_addresses_i(const RepoId& local) const {
 
 void
 RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
-                                                     AddrSet& addresses) const {
+                                      AddrSet& addresses, bool narrow) const {
   ACE_UNUSED_ARG(local);
   OPENDDS_ASSERT(local != GUID_UNKNOWN);
   OPENDDS_ASSERT(remote != GUID_UNKNOWN);
@@ -4017,7 +4021,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   typedef OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter_t;
   iter_t pos = locators_.find(remote);
   if (pos != locators_.end()) {
-    normal_addr = pos->second.addr_;
+    normal_addr = narrow ? pos->second.narrow_addr_ : pos->second.wide_addr_;
   } else {
     const GuidConverter conv(remote);
     if (conv.isReader()) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -729,7 +729,7 @@ private:
   EndpointSecurityAttributesMap endpoint_security_attributes_;
 #endif
 
-  void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses, bool narrow = false) const;
+  void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses, bool prefer_narrow = false) const;
 
   struct ChangeMulticastGroup : public JobQueue::Job {
     enum CmgAction {CMG_JOIN, CMG_LEAVE};

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -120,8 +120,8 @@ public:
 
   const GuidPrefix_t& local_prefix() const { return local_prefix_; }
 
-  void add_locator(const RepoId& remote_id, const ACE_INET_Addr& address,
-                   bool requires_inline_qos);
+  void add_locators(const RepoId& remote_id, const ACE_INET_Addr& narrow_address,
+                    const ACE_INET_Addr& wide_address, bool requires_inline_qos);
 
   typedef OPENDDS_SET(ACE_INET_Addr) AddrSet;
 
@@ -231,10 +231,11 @@ private:
   GuidPrefix_t local_prefix_;
 
   struct RemoteInfo {
-    RemoteInfo() : addr_(), requires_inline_qos_(false) {}
-    RemoteInfo(const ACE_INET_Addr& addr, bool iqos)
-      : addr_(addr), requires_inline_qos_(iqos) {}
-    ACE_INET_Addr addr_;
+    RemoteInfo() : narrow_addr_(), wide_addr_(), requires_inline_qos_(false) {}
+    RemoteInfo(const ACE_INET_Addr& narrow_addr, const ACE_INET_Addr& wide_addr, bool iqos)
+      : narrow_addr_(narrow_addr), wide_addr_(wide_addr), requires_inline_qos_(iqos) {}
+    ACE_INET_Addr narrow_addr_;
+    ACE_INET_Addr wide_addr_;
     bool requires_inline_qos_;
   };
 
@@ -728,7 +729,7 @@ private:
   EndpointSecurityAttributesMap endpoint_security_attributes_;
 #endif
 
-  void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses) const;
+  void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses, bool narrow = false) const;
 
   struct ChangeMulticastGroup : public JobQueue::Job {
     enum CmgAction {CMG_JOIN, CMG_LEAVE};

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -265,16 +265,15 @@ RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
     ACE_INET_Addr addr;
     // If conversion was successful
     if (locator_to_address(addr, locators[i], false) == 0) {
-      // if this is a unicast address, or if we are allowing multicast
-      if (!addr.is_multicast()) {
-        if (uc_addr == ACE_INET_Addr()) {
-          uc_addr = addr;
-          uc_addr_valid = true;
-        }
-      } else {
+      if (addr.is_multicast()) {
         if (mc_addr == ACE_INET_Addr()) {
           mc_addr = addr;
           mc_addr_valid = true;
+        }
+      } else {
+        if (uc_addr == ACE_INET_Addr()) {
+          uc_addr = addr;
+          uc_addr_valid = true;
         }
       }
       if (uc_addr_valid && (!config().use_multicast_ || mc_addr_valid)) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -267,11 +267,15 @@ RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
     if (locator_to_address(addr, locators[i], false) == 0) {
       // if this is a unicast address, or if we are allowing multicast
       if (!addr.is_multicast()) {
-        uc_addr = addr;
-        uc_addr_valid = true;
+        if (uc_addr == ACE_INET_Addr()) {
+          uc_addr = addr;
+          uc_addr_valid = true;
+        }
       } else {
-        mc_addr = addr;
-        mc_addr_valid = true;
+        if (mc_addr == ACE_INET_Addr()) {
+          mc_addr = addr;
+          mc_addr_valid = true;
+        }
       }
       if (uc_addr_valid && (!config().use_multicast_ || mc_addr_valid)) {
         return std::make_pair(uc_addr, config().use_multicast_ ? mc_addr : uc_addr);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -225,11 +225,11 @@ RtpsUdpTransport::use_datalink(const RepoId& local_id,
 {
   bool requires_inline_qos;
   unsigned int blob_bytes_read;
-  ACE_INET_Addr addr = get_connection_addr(remote_data, &requires_inline_qos,
-                                           &blob_bytes_read);
+  std::pair<ACE_INET_Addr, ACE_INET_Addr> addrs = get_connection_addrs(remote_data, &requires_inline_qos,
+                                                                       &blob_bytes_read);
 
   if (link_) {
-    link_->add_locator(remote_id, addr, requires_inline_qos);
+    link_->add_locators(remote_id, addrs.first, addrs.second, requires_inline_qos);
 
 #if defined(OPENDDS_SECURITY)
     if (remote_data.length() > blob_bytes_read) {
@@ -244,32 +244,50 @@ RtpsUdpTransport::use_datalink(const RepoId& local_id,
   }
 }
 
-ACE_INET_Addr
-RtpsUdpTransport::get_connection_addr(const TransportBLOB& remote,
-                                      bool* requires_inline_qos,
-                                      unsigned int* blob_bytes_read) const
+std::pair<ACE_INET_Addr, ACE_INET_Addr>
+RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
+                                       bool* requires_inline_qos,
+                                       unsigned int* blob_bytes_read) const
 {
   using namespace OpenDDS::RTPS;
   LocatorSeq locators;
   DDS::ReturnCode_t result =
     blob_to_locators(remote, locators, requires_inline_qos, blob_bytes_read);
   if (result != DDS::RETCODE_OK) {
-    return ACE_INET_Addr();
+    return std::make_pair(ACE_INET_Addr(), ACE_INET_Addr());
   }
 
+  ACE_INET_Addr uc_addr;
+  ACE_INET_Addr mc_addr;
+  bool uc_addr_valid = false;
+  bool mc_addr_valid = false;
   for (CORBA::ULong i = 0; i < locators.length(); ++i) {
     ACE_INET_Addr addr;
     // If conversion was successful
     if (locator_to_address(addr, locators[i], false) == 0) {
       // if this is a unicast address, or if we are allowing multicast
-      if (!addr.is_multicast() || config().use_multicast_) {
-        return addr;
+      if (!addr.is_multicast()) {
+        uc_addr = addr;
+        uc_addr_valid = true;
+      } else {
+        mc_addr = addr;
+        mc_addr_valid = true;
+      }
+      if (uc_addr_valid && (!config().use_multicast_ || mc_addr_valid)) {
+        return std::make_pair(uc_addr, config().use_multicast_ ? mc_addr : uc_addr);
       }
     }
   }
 
-  // Return default address
-  return ACE_INET_Addr();
+  // If we didn't return early, something was 'missing'
+  if (uc_addr == ACE_INET_Addr() && !(mc_addr == ACE_INET_Addr())) {
+    uc_addr = mc_addr;
+  }
+  if (mc_addr == ACE_INET_Addr() && !(uc_addr == ACE_INET_Addr())) {
+    mc_addr = uc_addr;
+  }
+
+  return std::make_pair(uc_addr, config().use_multicast_ ? mc_addr : uc_addr);
 }
 
 bool
@@ -297,7 +315,7 @@ RtpsUdpTransport::register_for_reader(const RepoId& participant,
     link_ = make_datalink(participant.guidPrefix);
   }
 
-  link_->register_for_reader(writerid, readerid, get_connection_addr(*blob),
+  link_->register_for_reader(writerid, readerid, get_connection_addrs(*blob).second,
                              listener);
 }
 
@@ -329,7 +347,7 @@ RtpsUdpTransport::register_for_writer(const RepoId& participant,
     link_ = make_datalink(participant.guidPrefix);
   }
 
-  link_->register_for_writer(readerid, writerid, get_connection_addr(*blob),
+  link_->register_for_writer(readerid, writerid, get_connection_addrs(*blob).first,
                              listener);
 }
 
@@ -357,9 +375,9 @@ RtpsUdpTransport::update_locators(const RepoId& remote,
   if (link_) {
     bool requires_inline_qos;
     unsigned int blob_bytes_read;
-    ACE_INET_Addr addr = get_connection_addr(*blob, &requires_inline_qos,
-                                             &blob_bytes_read);
-    link_->add_locator(remote, addr, requires_inline_qos);
+    std::pair<ACE_INET_Addr, ACE_INET_Addr> addrs = get_connection_addrs(*blob, &requires_inline_qos,
+                                                                         &blob_bytes_read);
+    link_->add_locators(remote, addrs.first, addrs.second, requires_inline_qos);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -77,9 +77,9 @@ private:
                                      const RepoId& /*writerid*/);
 
   virtual bool connection_info_i(TransportLocator& info, ConnectionInfoFlags flags) const;
-  ACE_INET_Addr get_connection_addr(const TransportBLOB& data,
-                                    bool* requires_inline_qos = 0,
-                                    unsigned int* blob_bytes_read = 0) const;
+  std::pair<ACE_INET_Addr, ACE_INET_Addr> get_connection_addrs(const TransportBLOB& data,
+                                                               bool* requires_inline_qos = 0,
+                                                               unsigned int* blob_bytes_read = 0) const;
 
   virtual void release_datalink(DataLink* link);
 


### PR DESCRIPTION
As I mentioned previously, this seems to be a pretty straightforward change and has performance improvements in the test environment for small & medium scale tests. However, at larger test scales it also seemed slightly less stable. I can't think of any good reasons why that would be the case, unless it's simply a matter of tying up the reactor thread with a larger number of individual writes. I'm hopeful that one of you might spot something obvious that I'm missing.