### PR TITLE
XTypes: WChar Support in Metaclass Generator

### DIFF
--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -132,7 +132,6 @@ namespace {
       return "ACE_CDR::ULong";
     }
     if (cls & CL_STRING) {
-      size = 4; // encoding of str length is 4 bytes
       return string_type(cls);
     }
     if (cls & CL_PRIMITIVE) {

--- a/tests/DCPS/MetaStruct/MetaStructTest.cpp
+++ b/tests/DCPS/MetaStruct/MetaStructTest.cpp
@@ -2,6 +2,7 @@
 #include <ace/OS_NS_string.h>
 #include <tao/SystemException.h>
 #include <dds/DCPS/FilterEvaluator.h>
+#include <dds/DCPS/Serializer.h>
 
 #include "MetaStructTestTypeSupportImpl.h"
 
@@ -12,8 +13,8 @@
 
 using namespace OpenDDS::DCPS;
 
-int check(const TAO::String_Manager& lhs, const TAO::String_Manager& rhs,
-          const char* name)
+int checkVal(const TAO::String_Manager& lhs, const TAO::String_Manager& rhs,
+             const char* name)
 {
   if (std::strcmp(lhs, rhs)) {
     std::cout << "ERROR: target's " << name << " " << lhs << " != "
@@ -23,7 +24,7 @@ int check(const TAO::String_Manager& lhs, const TAO::String_Manager& rhs,
   return 0;
 }
 
-int check(const float& lhs, const float& rhs, const char* name)
+int checkVal(const float& lhs, const float& rhs, const char* name)
 {
   if (std::fabs((lhs - rhs) / lhs) > .001) {
     std::cout << "ERROR: target's " << name << " " << lhs << " != "
@@ -49,11 +50,35 @@ int check_array(short (&lhs)[N][M], short (&rhs)[N][M], const char* name)
 }
 
 template<typename T>
-int check(const T& lhs, const T& rhs, const char* name)
+int checkVal(const T& lhs, const T& rhs, const char* name)
 {
   if (lhs != rhs) {
     std::cout << "ERROR: target's " << name << " " << lhs << " != "
               << rhs << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+template<typename T, typename T2>
+int check(const T& lhs, const T& rhs, const char* name, ACE_Message_Block* amb, Value::Type type,
+          const MetaStruct& ms, T2 Value::*ptrmbr)
+{
+  if (checkVal(lhs, rhs, name)) return 1;
+
+  Message_Block_Ptr mb (amb->duplicate());
+  const Encoding encoding(OpenDDS::DCPS::Encoding::KIND_UNALIGNED_CDR, OpenDDS::DCPS::ENDIAN_NATIVE);
+  OpenDDS::DCPS::Serializer ser(mb.get(), encoding);
+  std::string rhs_name = name;
+  rhs_name[0] = 'r';
+  Value val = ms.getValue(ser, rhs_name.c_str());
+  if (val.type_ == type) {
+    std::string ser_name = std::string("Serialized ") + name;
+    if (checkVal(rhs, val.*ptrmbr, ser_name.c_str())) return 1;
+  } else {
+    std::cout << "ERROR: Serialized type of " << name
+              << " does not match. expected " << type
+              << " received " << val.type_ << std::endl;
     return 1;
   }
   return 0;
@@ -75,6 +100,8 @@ int run_test(int, ACE_TCHAR*[])
   Source src;
   src.rhs_a.s = "hello";
   src.rhs_a.l = 42;
+  src.rhs_a.w = 0xdead;
+  src.rhs_a.c = 'j';
   src.rhs_sa[0] = 23;
   src.rhs_sa[1] = -16536;
   src.rhs_sa[2] = 16535;
@@ -96,21 +123,30 @@ int run_test(int, ACE_TCHAR*[])
     tgtField[0] = 'l';
     targetMeta.assign(&tgt, tgtField.c_str(), &src, *fields, sourceMeta);
   }
-
-  return check(tgt.lhs_a.s, src.rhs_a.s, "lhs_a.s")
-    + check(tgt.lhs_a.l, src.rhs_a.l, "lhs_a.l")
-    + check(tgt.lhs_sa[0], src.rhs_sa[0], "lhs_sa[0]")
-    + check(tgt.lhs_sa[1], src.rhs_sa[1], "lhs_sa[1]")
-    + check(tgt.lhs_sa[2], src.rhs_sa[2], "lhs_sa[2]")
+  const Encoding encoding(OpenDDS::DCPS::Encoding::KIND_UNALIGNED_CDR, OpenDDS::DCPS::ENDIAN_NATIVE);
+  OpenDDS::DCPS::Message_Block_Ptr data(new ACE_Message_Block(OpenDDS::DCPS::serialized_size(encoding, src)));
+  OpenDDS::DCPS::Serializer ser(data.get(), encoding);
+  if(!(ser<<src)) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Tests::MetaStructTest::run_test: ")
+      ACE_TEXT("Failed to serialize source.\n")));
+  }
+  // Use checkVal for types that aren't supported in MetaStruct::getValue(), such as arrays and unions
+  return check(tgt.lhs_a.s, src.rhs_a.s, "lhs_a.s", data.get(), Value::VAL_STRING, sourceMeta, &Value::s_)
+    + check(tgt.lhs_a.l, src.rhs_a.l, "lhs_a.l", data.get(), Value::VAL_INT, sourceMeta, &Value::i_)
+    + check(tgt.lhs_a.w, src.rhs_a.w, "lhs_a.w", data.get(), Value::VAL_INT, sourceMeta, &Value::i_)
+    + check(tgt.lhs_a.c, src.rhs_a.c, "lhs_a.c", data.get(), Value::VAL_CHAR, sourceMeta, &Value::c_)
+    + checkVal(tgt.lhs_sa[0], src.rhs_sa[0], "lhs_sa[0]")
+    + checkVal(tgt.lhs_sa[1], src.rhs_sa[1], "lhs_sa[1]")
+    + checkVal(tgt.lhs_sa[2], src.rhs_sa[2], "lhs_sa[2]")
     + check_array(tgt.lhs_asa, src.rhs_asa, "lhs_asa")
-    + check(tgt.lhs_ss.length(), src.rhs_ss.length(), "lhs_ss.length()")
-    + check(tgt.lhs_ss[0].s, src.rhs_ss[0].s, "lhs_ss[0].s")
-    + check(tgt.lhs_ss[0].l, src.rhs_ss[0].l, "lhs_ss[0].l")
-    + check(tgt.lhs_ss[1].s, src.rhs_ss[1].s, "lhs_ss[1].s")
-    + check(tgt.lhs_ss[1].l, src.rhs_ss[1].l, "lhs_ss[1].l")
-    + check(tgt.lhs_e, src.rhs_e, "lhs_e")
-    + check(tgt.lhs_u._d(), src.rhs_u._d(), "lhs_u._d()")
-    + check(tgt.lhs_u.u_f(), src.rhs_u.u_f(), "lhs_u.u_f()");
+    + checkVal(tgt.lhs_ss.length(), src.rhs_ss.length(), "lhs_ss.length()")
+    + checkVal(tgt.lhs_ss[0].s, src.rhs_ss[0].s, "lhs_ss[0].s")
+    + checkVal(tgt.lhs_ss[0].l, src.rhs_ss[0].l, "lhs_ss[0].l")
+    + checkVal(tgt.lhs_ss[1].s, src.rhs_ss[1].s, "lhs_ss[1].s")
+    + checkVal(tgt.lhs_ss[1].l, src.rhs_ss[1].l, "lhs_ss[1].l")
+    + check(tgt.lhs_e, src.rhs_e, "lhs_e", data.get(), Value::VAL_UINT, sourceMeta, &Value::u_)
+    + checkVal(tgt.lhs_u._d(), src.rhs_u._d(), "lhs_u._d()")
+    + checkVal(tgt.lhs_u.u_f(), src.rhs_u.u_f(), "lhs_u.u_f()");
 }
 
 int ACE_TMAIN(int argc, ACE_TCHAR* argv[])

--- a/tests/DCPS/MetaStruct/MetaStructTest.cpp
+++ b/tests/DCPS/MetaStruct/MetaStructTest.cpp
@@ -67,8 +67,8 @@ int check(const T& lhs, const T& rhs, const char* name, ACE_Message_Block* amb, 
   if (checkVal(lhs, rhs, name)) return 1;
 
   Message_Block_Ptr mb (amb->duplicate());
-  const Encoding encoding(OpenDDS::DCPS::Encoding::KIND_UNALIGNED_CDR, OpenDDS::DCPS::ENDIAN_NATIVE);
-  OpenDDS::DCPS::Serializer ser(mb.get(), encoding);
+  const Encoding encoding(Encoding::KIND_UNALIGNED_CDR);
+  Serializer ser(mb.get(), encoding);
   std::string rhs_name = name;
   rhs_name[0] = 'r';
   Value val = ms.getValue(ser, rhs_name.c_str());
@@ -100,7 +100,7 @@ int run_test(int, ACE_TCHAR*[])
   Source src;
   src.rhs_a.s = "hello";
   src.rhs_a.l = 42;
-  src.rhs_a.w = 0xdead;
+  src.rhs_a.w = L'☺';
   src.rhs_a.c = 'j';
   src.rhs_sa[0] = 23;
   src.rhs_sa[1] = -16536;
@@ -123,12 +123,13 @@ int run_test(int, ACE_TCHAR*[])
     tgtField[0] = 'l';
     targetMeta.assign(&tgt, tgtField.c_str(), &src, *fields, sourceMeta);
   }
-  const Encoding encoding(OpenDDS::DCPS::Encoding::KIND_UNALIGNED_CDR, OpenDDS::DCPS::ENDIAN_NATIVE);
-  OpenDDS::DCPS::Message_Block_Ptr data(new ACE_Message_Block(OpenDDS::DCPS::serialized_size(encoding, src)));
-  OpenDDS::DCPS::Serializer ser(data.get(), encoding);
-  if(!(ser<<src)) {
+  const Encoding encoding(Encoding::KIND_UNALIGNED_CDR);
+  Message_Block_Ptr data(new ACE_Message_Block(serialized_size(encoding, src)));
+  Serializer ser(data.get(), encoding);
+  if (!(ser<<src)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Tests::MetaStructTest::run_test: ")
       ACE_TEXT("Failed to serialize source.\n")));
+    return 1;
   }
   // Use checkVal for types that aren't supported in MetaStruct::getValue(), such as arrays and unions
   return check(tgt.lhs_a.s, src.rhs_a.s, "lhs_a.s", data.get(), Value::VAL_STRING, sourceMeta, &Value::s_)

--- a/tests/DCPS/MetaStruct/MetaStructTest.idl
+++ b/tests/DCPS/MetaStruct/MetaStructTest.idl
@@ -1,6 +1,8 @@
 struct A {
   string s;
   long l;
+  wchar w;
+  char c;
 };
 
 typedef short ShortArray[3];


### PR DESCRIPTION
I did a check by moving the new test files to an old build of OpenDDS and running the test. As expected, it fails because it is not certain the length of a wchar. 

 The new build of OpenDDS with the metastruct changes passes because a wchar is always 16bits.