### PR TITLE
XTypes: IDL portion of TryConstruct

### DIFF
--- a/dds/DCPS/XTypes/TypeObject.h
+++ b/dds/DCPS/XTypes/TypeObject.h
@@ -239,6 +239,10 @@ namespace XTypes {
   typedef MemberFlag BitflagFlag;             // Unused. No flags apply
   typedef MemberFlag BitsetMemberFlag;        // Unused. No flags apply
 
+  const MemberFlag TryConstructDiscardValue    = TRY_CONSTRUCT1;
+  const MemberFlag TryConstructUseDefaultValue = TRY_CONSTRUCT2;
+  const MemberFlag TryConstructTrimValue       = TRY_CONSTRUCT1 | TRY_CONSTRUCT2;
+
   // Mask used to remove the flags that do not affect assignability
   // Selects  T1, T2, O, M, K, D
   const MemberFlag MemberFlagMinimalMask = 0x003f;

--- a/dds/idl/annotations.cpp
+++ b/dds/idl/annotations.cpp
@@ -21,6 +21,7 @@ void Annotations::register_all()
   register_one<FinalAnnotation>();
   register_one<AppendableAnnotation>();
   register_one<MutableAnnotation>();
+  register_one<TryConstructAnnotation>();
   register_one<OpenDDS::DataRepresentationAnnotation>();
 }
 
@@ -356,6 +357,25 @@ std::string MutableAnnotation::definition() const
 std::string MutableAnnotation::name() const
 {
   return "mutable";
+}
+
+// @tryconstruct ============================================================
+
+std::string TryConstructAnnotation::definition() const
+{
+  return
+    "@annotation try_construct {\n"
+    "  enum TryConstructFailAction {\n"
+    "    DISCARD,\n"
+    "    USE_DEFAULT,\n"
+    "    TRIM\n"
+    "  };\n"
+    "  TryConstructFailAction value default USE_DEFAULT;\n"
+    "};\n";
+}
+std::string TryConstructAnnotation::name() const
+{
+  return "try_construct";
 }
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/dds/idl/annotations.cpp
+++ b/dds/idl/annotations.cpp
@@ -359,7 +359,7 @@ std::string MutableAnnotation::name() const
   return "mutable";
 }
 
-// @tryconstruct ============================================================
+// @try_construct ============================================================
 
 std::string TryConstructAnnotation::definition() const
 {
@@ -373,6 +373,7 @@ std::string TryConstructAnnotation::definition() const
     "  TryConstructFailAction value default USE_DEFAULT;\n"
     "};\n";
 }
+
 std::string TryConstructAnnotation::name() const
 {
   return "try_construct";

--- a/dds/idl/annotations.h
+++ b/dds/idl/annotations.h
@@ -262,6 +262,20 @@ public:
   std::string name() const;
 };
 
+// @tryconstruct ==================================================================
+
+enum TryConstructFailAction {
+  tryconstructfailaction_discard,
+  tryconstructfailaction_use_default,
+  tryconstructfailaction_trim,
+};
+
+class TryConstructAnnotation : public AnnotationWithEnumValue<TryConstructFailAction> {
+public:
+  std::string definition() const;
+  std::string name() const;
+};
+
 // OpenDDS Specific Annotations
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {

--- a/dds/idl/annotations.h
+++ b/dds/idl/annotations.h
@@ -274,6 +274,10 @@ class TryConstructAnnotation : public AnnotationWithEnumValue<TryConstructFailAc
 public:
   std::string definition() const;
   std::string name() const;
+  virtual TryConstructFailAction default_value() const
+  {
+    return tryconstructfailaction_discard;
+  }
 };
 
 // OpenDDS Specific Annotations

--- a/dds/idl/annotations.h
+++ b/dds/idl/annotations.h
@@ -262,7 +262,7 @@ public:
   std::string name() const;
 };
 
-// @tryconstruct ==================================================================
+// @try_construct ============================================================
 
 enum TryConstructFailAction {
   tryconstructfailaction_discard,

--- a/dds/idl/be_global.cpp
+++ b/dds/idl/be_global.cpp
@@ -753,11 +753,7 @@ TryConstructFailAction BE_GlobalData::try_construct(AST_Decl* node) const
   TryConstructAnnotation* try_construct_annotation =
     dynamic_cast<TryConstructAnnotation*>(
       builtin_annotations_["::@try_construct"]);
-  TryConstructFailAction value;
-  if (!try_construct_annotation->node_value_exists(node, value)) {
-    value = tryconstructfailaction_discard;
-  }
-  return value;
+  return try_construct_annotation->node_value(node);
 }
 
 OpenDDS::DataRepresentation BE_GlobalData::data_representations(

--- a/dds/idl/be_global.cpp
+++ b/dds/idl/be_global.cpp
@@ -748,6 +748,18 @@ ExtensibilityKind BE_GlobalData::extensibility(AST_Decl* node) const
   return value;
 }
 
+TryConstructFailAction BE_GlobalData::try_construct(AST_Decl* node) const
+{
+  TryConstructAnnotation* try_construct_annotation =
+    dynamic_cast<TryConstructAnnotation*>(
+      builtin_annotations_["::@try_construct"]);
+  TryConstructFailAction value;
+  if (!try_construct_annotation->node_value_exists(node, value)) {
+    value = tryconstructfailaction_discard;
+  }
+  return value;
+}
+
 OpenDDS::DataRepresentation BE_GlobalData::data_representations(
   AST_Decl* node) const
 {

--- a/dds/idl/be_global.h
+++ b/dds/idl/be_global.h
@@ -210,6 +210,8 @@ public:
 
   ExtensibilityKind extensibility(AST_Decl* node) const;
 
+  TryConstructFailAction try_construct(AST_Decl* node) const;
+
   OpenDDS::DataRepresentation data_representations(AST_Decl* node) const;
 
   unsigned get_id(

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -463,24 +463,24 @@ void typeobject_generator::gen_type_flag_str(std::string& type_flag_str,
                                              AST_Decl* node)
 {
   switch (exten) {
-    case extensibilitykind_final:
-      type_flag_str = "XTypes::IS_FINAL";
-      break;
-    case extensibilitykind_appendable:
-      type_flag_str = "XTypes::IS_APPENDABLE";
-      break;
-    case extensibilitykind_mutable:
-      if (can_be_mutable) {
-        type_flag_str = "XTypes::IS_MUTABLE";
-      } else {
-        idl_global->err()->misc_error(
-          "Unexpected extensibility while setting flags: type cannot be mutable", node);
-      }
-      break;
-    default:
+  case extensibilitykind_final:
+    type_flag_str = "XTypes::IS_FINAL";
+    break;
+  case extensibilitykind_appendable:
+    type_flag_str = "XTypes::IS_APPENDABLE";
+    break;
+  case extensibilitykind_mutable:
+    if (can_be_mutable) {
+      type_flag_str = "XTypes::IS_MUTABLE";
+    } else {
       idl_global->err()->misc_error(
-        "Unexpected extensibility while setting flags", node);
+        "Unexpected extensibility while setting flags: type cannot be mutable", node);
     }
+    break;
+  default:
+    idl_global->err()->misc_error(
+      "Unexpected extensibility while setting flags", node);
+  }
 }
 
 void typeobject_generator::gen_member_flag_str(std::string& member_flag_str,
@@ -488,17 +488,17 @@ void typeobject_generator::gen_member_flag_str(std::string& member_flag_str,
                                                AST_Decl* node)
 {
   switch (trycon) {
-    case tryconstructfailaction_discard:
-      member_flag_str = "XTypes::TryConstructDiscardValue";
-      break;
-    case tryconstructfailaction_use_default:
-      member_flag_str = "XTypes::TryConstructUseDefaultValue";
-      break;
-    case tryconstructfailaction_trim:
-      member_flag_str = "XTypes::TryConstructTrimValue";
-      break;
-    default:
-      idl_global->err()->misc_error(
-        "Unexpected try_construct value while setting flags", node);
+  case tryconstructfailaction_discard:
+    member_flag_str = "XTypes::TryConstructDiscardValue";
+    break;
+  case tryconstructfailaction_use_default:
+    member_flag_str = "XTypes::TryConstructUseDefaultValue";
+    break;
+  case tryconstructfailaction_trim:
+    member_flag_str = "XTypes::TryConstructTrimValue";
+    break;
+  default:
+    idl_global->err()->misc_error(
+      "Unexpected try_construct value while setting flags", node);
   }
 }

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -500,5 +500,5 @@ void typeobject_generator::gen_member_flag_str(std::string& member_flag_str,
     default:
       idl_global->err()->misc_error(
         "Unexpected try_construct value while setting flags", node);
-    }
+  }
 }

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -398,7 +398,6 @@ typeobject_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
       string member_string;
       const TryConstructFailAction trycon = be_global->try_construct(*pos);
       gen_member_flag_str(member_string, trycon, *pos);
-
       be_global->impl_ <<
         "        .append(\n"
         "          XTypes::MinimalUnionMember(\n"

--- a/dds/idl/typeobject_generator.h
+++ b/dds/idl/typeobject_generator.h
@@ -27,6 +27,8 @@ public:
 
   void gen_type_flag_str(std::string& type_flag_str, ExtensibilityKind exten, bool can_be_mutable, AST_Decl* node);
 
+  void gen_member_flag_str(std::string& member_flag_str, TryConstructFailAction trycon, AST_Decl* node);
+
   static std::string tag_type(UTL_ScopedName* name);
 };
 


### PR DESCRIPTION
This is the IDL portion of the try construct card.  It consists of defining the annotation(s) and setting the member flags.  Also contains a bugfix where key was on wrong part of union member.