### PR TITLE
RTPS durability nacks gapped or answered from send buffer

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2892,6 +2892,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       }
     }
   }
+
   SequenceNumber ack;
   ack.setValue(acknack.readerSNState.bitmapBase.high,
                acknack.readerSNState.bitmapBase.low);
@@ -2909,7 +2910,12 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   // If this ACKNACK was final, the DR doesn't expect a reply, and therefore
   // we don't need to do anything further.
   if (!is_final || bitmapNonEmpty(acknack.readerSNState)) {
-    ri->second.requested_changes_.push_back(acknack.readerSNState);
+    // Don't add the request if the reader is expecting durable data.
+    // Otherwise, send_and_gather_nack_replies will either answer from
+    // the send buffer or send a gap.
+    if (!ri->second.expecting_durable_data()) {
+      ri->second.requested_changes_.push_back(acknack.readerSNState);
+    }
     // Determine if the reader needs a heartbeat.
     DisjointSequence reqs;
     process_requested_changes_i(reqs, ri->second);
@@ -2937,6 +2943,9 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
     ++deliver_iter;
   }
 
+  // TODO(jrw972): Move this earlier so the acknack can actually send
+  // the durability data.  Until then, the reader must send at least two
+  // acknacks before it will get any data.
   if (first_ack) {
     link->invoke_on_start_callbacks(id_, remote, true);
   }


### PR DESCRIPTION
The first nack from a durable reader can result in a call to
send_and_gather_nack_replies that uses data in the send buffer to
process the nack or sends a gap instead.

Solution: Only process the nack if the reader is not expecting
durability data.