### PR TITLE
Fix Windows Bench Scoreboard Failures

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -422,3 +422,4 @@ performance-tests/bench_2/run_test.pl fan: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNE
 performance-tests/bench_2/run_test.pl fan_frag: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl echo: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl echo_frag: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench_2/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON

--- a/performance-tests/bench_2/node_controller/main.cpp
+++ b/performance-tests/bench_2/node_controller/main.cpp
@@ -721,13 +721,18 @@ int run_cycle(
 
   using Builder::ZERO;
 
-  std::chrono::time_point<std::chrono::system_clock> timeout_time;
   if (scenario.launch_time < ZERO) {
-    timeout_time = std::chrono::system_clock::now() - get_duration(scenario.launch_time);
+    auto duration = -1 * get_duration(scenario.launch_time);
+    if (duration > std::chrono::seconds::zero()) {
+      std::this_thread::sleep_for(duration);
+    }
   } else {
-    timeout_time = std::chrono::system_clock::time_point(get_duration(scenario.launch_time));
+    auto now = std::chrono::system_clock::now();
+    auto duration = std::chrono::system_clock::time_point(get_duration(scenario.launch_time)) - now;
+    if (duration > std::chrono::seconds::zero()) {
+      std::this_thread::sleep_for(duration);
+    }
   }
-  std::this_thread::sleep_until(timeout_time);
 
   // Run Workers and Wait for Them to Finish
   worker_manager.run_workers(report_writer_impl);

--- a/performance-tests/bench_2/node_controller/main.cpp
+++ b/performance-tests/bench_2/node_controller/main.cpp
@@ -723,14 +723,14 @@ int run_cycle(
 
   if (scenario.launch_time < ZERO) {
     auto duration = -1 * get_duration(scenario.launch_time);
-    if (duration > std::chrono::seconds::zero()) {
-      std::this_thread::sleep_for(duration);
+    if (duration > std::chrono::milliseconds(100)) {
+      std::this_thread::sleep_until(std::chrono::steady_clock::now() + duration);
     }
   } else {
     auto now = std::chrono::system_clock::now();
     auto duration = std::chrono::system_clock::time_point(get_duration(scenario.launch_time)) - now;
-    if (duration > std::chrono::seconds::zero()) {
-      std::this_thread::sleep_for(duration);
+    if (duration > std::chrono::milliseconds(100)) {
+      std::this_thread::sleep_until(std::chrono::steady_clock::now() + duration);
     }
   }
 

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -223,7 +223,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       } else {
         timeout_time = std::chrono::system_clock::time_point(get_duration(config.create_time));
       }
-      std::this_thread::sleep_until(timeout_time);
+      if (std::chrono::system_clock::now() < timeout_time) {
+        std::this_thread::sleep_until(timeout_time);
+      }
     }
 
     Log::log() << "Beginning process construction / entity creation." << std::endl;
@@ -250,7 +252,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       } else {
         timeout_time = std::chrono::system_clock::time_point(get_duration(config.enable_time));
       }
-      std::this_thread::sleep_until(timeout_time);
+      if (std::chrono::system_clock::now() < timeout_time) {
+        std::this_thread::sleep_until(timeout_time);
+      }
     }
 
     Log::log() << "Enabling DDS entities (if not already enabled)." << std::endl;
@@ -271,7 +275,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       } else {
         timeout_time = std::chrono::system_clock::time_point(get_duration(config.start_time));
       }
-      std::this_thread::sleep_until(timeout_time);
+      if (std::chrono::system_clock::now() < timeout_time) {
+        std::this_thread::sleep_until(timeout_time);
+      }
     }
 
     Log::log() << "Starting process tests." << std::endl;
@@ -292,7 +298,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       } else {
         timeout_time = std::chrono::system_clock::time_point(get_duration(config.stop_time));
       }
-      std::this_thread::sleep_until(timeout_time);
+      if (std::chrono::system_clock::now() < timeout_time) {
+        std::this_thread::sleep_until(timeout_time);
+      }
     }
 
     Log::log() << "Stopping process tests." << std::endl;
@@ -319,7 +327,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       } else {
         timeout_time = std::chrono::system_clock::time_point(get_duration(config.destruction_time));
       }
-      std::this_thread::sleep_until(timeout_time);
+      if (std::chrono::system_clock::now() < timeout_time) {
+        std::this_thread::sleep_until(timeout_time);
+      }
     }
 
     process.detach_listeners();

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -217,11 +217,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
     std::mutex cv_mutex;
 
     if (!(config.create_time == ZERO)) {
-      std::chrono::time_point<std::chrono::high_resolution_clock> timeout_time;
+      std::chrono::time_point<std::chrono::system_clock> timeout_time;
       if (config.create_time < ZERO) {
-        timeout_time = std::chrono::high_resolution_clock::now() - get_duration(config.create_time);
+        timeout_time = std::chrono::system_clock::now() - get_duration(config.create_time);
       } else {
-        timeout_time = std::chrono::high_resolution_clock::time_point(get_duration(config.create_time));
+        timeout_time = std::chrono::system_clock::time_point(get_duration(config.create_time));
       }
       std::this_thread::sleep_until(timeout_time);
     }
@@ -244,11 +244,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       std::cerr << "No test enable time specified. Press any key to enable process entities." << std::endl;
       std::getline(std::cin, line);
     } else {
-      std::chrono::time_point<std::chrono::high_resolution_clock> timeout_time;
+      std::chrono::time_point<std::chrono::system_clock> timeout_time;
       if (config.enable_time < ZERO) {
-        timeout_time = std::chrono::high_resolution_clock::now() - get_duration(config.enable_time);
+        timeout_time = std::chrono::system_clock::now() - get_duration(config.enable_time);
       } else {
-        timeout_time = std::chrono::high_resolution_clock::time_point(get_duration(config.enable_time));
+        timeout_time = std::chrono::system_clock::time_point(get_duration(config.enable_time));
       }
       std::this_thread::sleep_until(timeout_time);
     }
@@ -265,11 +265,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       std::cerr << "No test start time specified. Press any key to start process testing." << std::endl;
       std::getline(std::cin, line);
     } else {
-      std::chrono::time_point<std::chrono::high_resolution_clock> timeout_time;
+      std::chrono::time_point<std::chrono::system_clock> timeout_time;
       if (config.start_time < ZERO) {
-        timeout_time = std::chrono::high_resolution_clock::now() - get_duration(config.start_time);
+        timeout_time = std::chrono::system_clock::now() - get_duration(config.start_time);
       } else {
-        timeout_time = std::chrono::high_resolution_clock::time_point(get_duration(config.start_time));
+        timeout_time = std::chrono::system_clock::time_point(get_duration(config.start_time));
       }
       std::this_thread::sleep_until(timeout_time);
     }
@@ -286,11 +286,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       std::cerr << "No stop time specified. Press any key to stop process testing." << std::endl;
       std::getline(std::cin, line);
     } else {
-      std::chrono::time_point<std::chrono::high_resolution_clock> timeout_time;
+      std::chrono::time_point<std::chrono::system_clock> timeout_time;
       if (config.stop_time < ZERO) {
-        timeout_time = std::chrono::high_resolution_clock::now() - get_duration(config.stop_time);
+        timeout_time = std::chrono::system_clock::now() - get_duration(config.stop_time);
       } else {
-        timeout_time = std::chrono::high_resolution_clock::time_point(get_duration(config.stop_time));
+        timeout_time = std::chrono::system_clock::time_point(get_duration(config.stop_time));
       }
       std::this_thread::sleep_until(timeout_time);
     }
@@ -313,11 +313,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       std::cerr << "No destruction time specified. Press any key to destroy process entities." << std::endl;
       std::getline(std::cin, line);
     } else {
-      std::chrono::time_point<std::chrono::high_resolution_clock> timeout_time;
+      std::chrono::time_point<std::chrono::system_clock> timeout_time;
       if (config.destruction_time < ZERO) {
-        timeout_time = std::chrono::high_resolution_clock::now() - get_duration(config.destruction_time);
+        timeout_time = std::chrono::system_clock::now() - get_duration(config.destruction_time);
       } else {
-        timeout_time = std::chrono::high_resolution_clock::time_point(get_duration(config.destruction_time));
+        timeout_time = std::chrono::system_clock::time_point(get_duration(config.destruction_time));
       }
       std::this_thread::sleep_until(timeout_time);
     }

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -83,7 +83,7 @@ double weighted_median(std::vector<double> medians, std::vector<size_t> weights,
 void do_wait(const Builder::TimeStamp& ts, const std::string& ts_name, bool zero_equals_key_press = true) {
   if (zero_equals_key_press && ts == ZERO) {
     std::stringstream ss;
-    ss << "No " << ts_name << " time specified. Press any key to continue." << std::endl;
+    ss << "No " << ts_name << " time specified. Press enter to continue." << std::endl;
     std::cerr << ss.str() << std::flush;
     std::string line;
     std::getline(std::cin, line);

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -90,14 +90,14 @@ void do_wait(const Builder::TimeStamp& ts, const std::string& ts_name, bool zero
   } else {
     if (ts < ZERO) {
       auto duration = -1 * get_duration(ts);
-      if (duration > std::chrono::seconds::zero()) {
-        std::this_thread::sleep_for(duration);
+      if (duration > std::chrono::milliseconds(100)) {
+        std::this_thread::sleep_until(std::chrono::steady_clock::now() + duration);
       }
     } else {
       auto now = std::chrono::system_clock::now();
       auto duration = std::chrono::system_clock::time_point(get_duration(ts)) - now;
-      if (duration > std::chrono::seconds::zero()) {
-        std::this_thread::sleep_for(duration);
+      if (duration > std::chrono::milliseconds(100)) {
+        std::this_thread::sleep_until(std::chrono::steady_clock::now() + duration);
       }
     }
   }


### PR DESCRIPTION
Bench's worker was still using high_resolution_clock timer to generate absolute times, which causes issues on machines where high_resolution clock doesn't have a predictable epoch (windows). Switch these over to system_clock and enable the small "mixed" test while we're at it to stress test simultaneous reliable / durable messaging during discovery.