### PR TITLE
Prevent invalid access in TransportClient::PendingAssocTimer::ScheduleCommand during shutdown

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -311,7 +311,7 @@ TransportClient::associate(const AssociationData& data, bool active)
           if (res.success_) {
             if (res.link_.is_nil()) {
                 // In this case, it may be waiting for the TCP connection to be established.  Just wait without trying other transports.
-                pending_assoc_timer_->schedule_timer(this, iter->second);
+                pending_assoc_timer_->schedule_timer(rchandle_from(this), iter->second);
             } else {
               use_datalink_i(data.remote_id_, res.link_, guard);
               return true;
@@ -321,7 +321,7 @@ TransportClient::associate(const AssociationData& data, bool active)
       }
     }
 
-    pending_assoc_timer_->schedule_timer(this, iter->second);
+    pending_assoc_timer_->schedule_timer(rchandle_from(this), iter->second);
   }
 
   return true;
@@ -571,7 +571,7 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
   }
 
   iter->second->reset_client();
-  pending_assoc_timer_->cancel_timer(this, pend);
+  pending_assoc_timer_->cancel_timer(pend);
   prev_pending_.insert(std::make_pair(iter->first, iter->second));
   pending_.erase(iter);
 
@@ -602,7 +602,7 @@ TransportClient::stop_associating()
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
   for (PendingMap::iterator it = pending_.begin(); it != pending_.end(); ++it) {
     it->second->reset_client();
-    pending_assoc_timer_->cancel_timer(this, it->second);
+    pending_assoc_timer_->cancel_timer(it->second);
     prev_pending_.insert(std::make_pair(it->first, it->second));
   }
   pending_.clear();
@@ -620,7 +620,7 @@ TransportClient::stop_associating(const GUID_t* repos, CORBA::ULong length)
       PendingMap::iterator iter = pending_.find(repos[i]);
       if (iter != pending_.end()) {
         iter->second->reset_client();
-        pending_assoc_timer_->cancel_timer(this, iter->second);
+        pending_assoc_timer_->cancel_timer(iter->second);
         prev_pending_.insert(std::make_pair(iter->first, iter->second));
         pending_.erase(iter);
       }
@@ -648,7 +648,7 @@ TransportClient::disassociate(const RepoId& peerId)
   PendingMap::iterator iter = pending_.find(peerId);
   if (iter != pending_.end()) {
     iter->second->reset_client();
-    pending_assoc_timer_->cancel_timer(this, iter->second);
+    pending_assoc_timer_->cancel_timer(iter->second);
     prev_pending_.insert(std::make_pair(iter->first, iter->second));
     pending_.erase(iter);
     return;

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -215,14 +215,14 @@ private:
       : ReactorInterceptor(reactor, owner)
     { }
 
-    void schedule_timer(TransportClient* transport_client, const PendingAssoc_rch& pend)
+    void schedule_timer(TransportClient_rch transport_client, const PendingAssoc_rch& pend)
     {
       execute_or_enqueue(new ScheduleCommand(this, transport_client, pend));
     }
 
-    ReactorInterceptor::CommandPtr cancel_timer(TransportClient* transport_client, const PendingAssoc_rch& pend)
+    ReactorInterceptor::CommandPtr cancel_timer(const PendingAssoc_rch& pend)
     {
-      return execute_or_enqueue(new CancelCommand(this, transport_client, pend));
+      return execute_or_enqueue(new CancelCommand(this, pend));
     }
 
     virtual bool reactor_is_shut_down() const
@@ -237,39 +237,40 @@ private:
     class CommandBase : public Command {
     public:
       CommandBase(PendingAssocTimer* timer,
-                  TransportClient* transport_client,
                   const PendingAssoc_rch& assoc)
         : timer_ (timer)
-        , transport_client_ (transport_client)
         , assoc_ (assoc)
       { }
     protected:
       PendingAssocTimer* timer_;
-      TransportClient* transport_client_;
       PendingAssoc_rch assoc_;
     };
     struct ScheduleCommand : public CommandBase {
       ScheduleCommand(PendingAssocTimer* timer,
-                      TransportClient* transport_client,
+                      TransportClient_rch transport_client,
                       const PendingAssoc_rch& assoc)
-        : CommandBase (timer, transport_client, assoc)
+        : CommandBase (timer, assoc)
+        , transport_client_ (transport_client)
       { }
       virtual void execute()
       {
         if (timer_->reactor()) {
-          ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
-          assoc_->scheduled_ = true;
-          timer_->reactor()->schedule_timer(assoc_.in(),
-                                            transport_client_,
-                                            transport_client_->passive_connect_duration_.value());
+          TransportClient_rch client = transport_client_.lock();
+          if (client) {
+            ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
+            assoc_->scheduled_ = true;
+            timer_->reactor()->schedule_timer(assoc_.in(),
+                                              client.in(),
+                                              client->passive_connect_duration_.value());
+          }
         }
       }
+      WeakRcHandle<TransportClient> transport_client_;
     };
     struct CancelCommand : public CommandBase {
       CancelCommand(PendingAssocTimer* timer,
-                    TransportClient* transport_client,
                     const PendingAssoc_rch& assoc)
-        : CommandBase (timer, transport_client, assoc)
+        : CommandBase (timer, assoc)
       { }
       virtual void execute()
       {


### PR DESCRIPTION
CommandBase was storing TransportClient pointers, which may be invalid by the time the Reactor executes the command. Instead, store WeakRcHandle to TransportClient and lock / check before use.