### PR TITLE
Remove visited link css state

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -120,10 +120,6 @@ h1, h2, h3, h4, h5, h6 {
     color: $brand-color;
     text-decoration: none;
 
-    &:visited {
-        color: darken($brand-color, 15%);
-    }
-
     &:hover {
         color: $text-color;
         text-decoration: underline;


### PR DESCRIPTION
The color scheme for visited links darkens the brand color and eliminates the contrast between the link and text. Keeping links the original color resolves this issue while not impacting the user.

Current visited state
<img width="348" alt="Screen Shot 2020-07-31 at 11 14 57 AM" src="https://user-images.githubusercontent.com/3648874/89054886-27004f00-d31f-11ea-92c5-0abaf5d657fb.png">

Change
<img width="344" alt="Screen Shot 2020-07-31 at 11 15 04 AM" src="https://user-images.githubusercontent.com/3648874/89054903-2cf63000-d31f-11ea-9a52-f9588ebf45f1.png">
