### PR TITLE
Improve Efficiency of Waiting on Pending Writes

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -2528,6 +2528,19 @@ DataWriterImpl::prepare_to_delete()
   this->set_deleted(true);
   this->stop_associating();
   this->terminate_send_if_suspended();
+
+#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+  // Trigger data to be persisted, i.e. made durable, if so
+  // configured. This needs be called before unregister_instances
+  // because unregister_instances may cause instance dispose.
+  if (!persist_data() && DCPS_debug_level >= 2) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::prepare_to_delete: ")
+      ACE_TEXT("failed to make data durable.\n")));
+  }
+#endif
+
+  // Unregister all registered instances prior to deletion.
+  unregister_instances(SystemTimePoint::now().to_dds_time());
 }
 
 PublicationInstance_rch
@@ -2679,20 +2692,12 @@ DataWriterImpl::persist_data()
 }
 #endif
 
-void
-DataWriterImpl::wait_control_pending()
+void DataWriterImpl::wait_pending()
 {
   if (!TransportRegistry::instance()->released()) {
-    OPENDDS_STRING caller_string("DataWriterImpl::wait_control_pending");
-    controlTracker.wait_messages_pending(caller_string);
-  }
-}
-
-void
-DataWriterImpl::wait_pending()
-{
-  if (!TransportRegistry::instance()->released()) {
-    data_container_->wait_pending();
+    data_container_->wait_pending(wait_pending_deadline_);
+    controlTracker.wait_messages_pending(
+      "DataWriterImpl::wait_control_pending", wait_pending_deadline_);
   }
 }
 
@@ -2769,9 +2774,12 @@ DataWriterImpl::get_ice_endpoint()
   return TransportClient::get_ice_endpoint();
 }
 
-int
-LivenessTimer::handle_timeout(const ACE_Time_Value &tv,
-                             const void *arg)
+void DataWriterImpl::set_wait_pending_deadline(const MonotonicTimePoint& deadline)
+{
+  wait_pending_deadline_ = deadline;
+}
+
+int LivenessTimer::handle_timeout(const ACE_Time_Value& tv, const void* arg)
 {
   DataWriterImpl_rch writer = this->writer_.lock();
   if (writer) {

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -2696,8 +2696,7 @@ void DataWriterImpl::wait_pending()
 {
   if (!TransportRegistry::instance()->released()) {
     data_container_->wait_pending(wait_pending_deadline_);
-    controlTracker.wait_messages_pending(
-      "DataWriterImpl::wait_control_pending", wait_pending_deadline_);
+    controlTracker.wait_messages_pending("DataWriterImpl::wait_pending", wait_pending_deadline_);
   }
 }
 

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -427,8 +427,14 @@ public:
   bool persist_data();
 #endif
 
-  /// Wait for pending samples to drain.
+  /// Wait for pending data and control messages to drain.
   void wait_pending();
+
+  /**
+   * Set deadline to complete wait_pending by. If 0, then wait_pending will
+   * wait indefinately if needed.
+   */
+  void set_wait_pending_deadline(const MonotonicTimePoint& deadline);
 
   /**
    * Get an instance handle for a new instance.
@@ -443,12 +449,6 @@ public:
                   const FilterEvaluator& evaluator,
                   const DDS::StringSeq& expression_params) const;
 #endif
-
-  /**
-   * Wait until pending control elements have either been delivered
-   * or dropped.
-   */
-  void wait_control_pending();
 
   DataBlockLockPool::DataBlockLock* get_db_lock() {
     return db_lock_pool_->get_lock();
@@ -681,6 +681,8 @@ private:
   // and unregister_instances during deletion of datawriter from application
   ACE_Thread_Mutex sync_unreg_rem_assocs_lock_;
   RcHandle<LivenessTimer> liveness_timer_;
+
+  MonotonicTimePoint wait_pending_deadline_;
 };
 
 typedef RcHandle<DataWriterImpl> DataWriterImpl_rch;
@@ -695,8 +697,7 @@ public:
   }
 
   /// Handle the assert liveliness timeout.
-  virtual int handle_timeout(const ACE_Time_Value &tv,
-                             const void *arg);
+  virtual int handle_timeout(const ACE_Time_Value& tv, const void* arg);
 
 private:
   WeakRcHandle<DataWriterImpl> writer_;

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -6,15 +6,17 @@
  */
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+
 #include "DomainParticipantFactoryImpl.h"
+
 #include "DomainParticipantImpl.h"
 #include "Marked_Default_Qos.h"
-#include "dds/DdsDcpsInfoUtilsC.h"
 #include "GuidConverter.h"
 #include "Service_Participant.h"
 #include "Qos_Helper.h"
 #include "Util.h"
-#include "tao/debug.h"
+
+#include <dds/DdsDcpsInfoUtilsC.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -103,9 +105,7 @@ DomainParticipantFactoryImpl::delete_participant(
 
   // The servant's ref count should be 2 at this point, one referenced
   // by the poa and the other referenced by the map.
-  DomainParticipantImpl* the_servant
-  = dynamic_cast<DomainParticipantImpl*>(a_participant);
-
+  DomainParticipantImpl* the_servant = dynamic_cast<DomainParticipantImpl*>(a_participant);
   if (!the_servant) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
       ACE_TEXT("DomainParticipantFactoryImpl::delete_participant: ")
@@ -151,9 +151,7 @@ DomainParticipantFactoryImpl::delete_participant(
                         OPENDDS_STRING(converter).c_str()), DDS::RETCODE_ERROR);
 
     } else {
-      DDS::ReturnCode_t result
-      = the_servant->delete_contained_entities();
-
+      DDS::ReturnCode_t result = the_servant->delete_contained_entities();
       if (result != DDS::RETCODE_OK) {
         return result;
       }

--- a/dds/DCPS/DomainParticipantFactoryImpl.h
+++ b/dds/DCPS/DomainParticipantFactoryImpl.h
@@ -9,10 +9,12 @@
 #define OPENDDS_DCPS_DOMAIN_PARTICIPANT_FACTORY_IMPL_H
 
 #include "Definitions.h"
-#include "dds/DdsDcpsDomainC.h"
-#include "ace/Recursive_Thread_Mutex.h"
-#include "dds/DCPS/LocalObject.h"
-#include "dds/DCPS/PoolAllocator.h"
+#include "LocalObject.h"
+#include "PoolAllocator.h"
+
+#include <dds/DdsDcpsDomainC.h>
+
+#include <ace/Recursive_Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -380,6 +380,9 @@ public:
   }
 #endif
 
+  bool prepare_to_delete_datawriters();
+  bool set_wait_pending_deadline(const MonotonicTimePoint& deadline);
+
 private:
 
   bool validate_publisher_qos(DDS::PublisherQos & publisher_qos);

--- a/dds/DCPS/MessageTracker.h
+++ b/dds/DCPS/MessageTracker.h
@@ -8,10 +8,12 @@
 #ifndef OPENDDS_DCPS_MESSAGETRACKER_H
 #define OPENDDS_DCPS_MESSAGETRACKER_H
 
-#include "dds/DCPS/dcps_export.h"
-#include "dds/DCPS/PoolAllocator.h"
-#include "ace/Thread_Mutex.h"
-#include "ace/Condition_Thread_Mutex.h"
+#include "dcps_export.h"
+#include "PoolAllocator.h"
+#include "TimeTypes.h"
+
+#include <ace/Thread_Mutex.h>
+#include <ace/Condition_Thread_Mutex.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -47,9 +49,16 @@ namespace DCPS {
     bool pending_messages();
 
     /**
-     * Block until all messages have been account for.
+     * Block until all messages have been accounted for or timeouts out based
+     * on PendingTimeout.
      */
-    void wait_messages_pending(OPENDDS_STRING& caller_message);
+    void wait_messages_pending(const char* caller);
+
+    /**
+     * Block until all messages have been accounted for or the deadline supplied
+     * has passed. Blocks indefinitely if deadline is zero.
+     */
+    void wait_messages_pending(const char* caller, const MonotonicTimePoint& deadline);
 
     /**
      * For testing.

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -321,10 +321,11 @@ bool PublisherImpl::prepare_to_delete_datawriters()
   const DataWriterMap::iterator end = datawriter_map_.end();
   for (DataWriterMap::iterator i = datawriter_map_.begin(); i != end; ++i) {
     DataWriterImpl* const writer = dynamic_cast<DataWriterImpl*>(i->second.in());
-    if (!writer) {
+    if (writer) {
+      writer->prepare_to_delete();
+    } else {
       result = false;
     }
-    writer->prepare_to_delete();
   }
 
   return result;

--- a/dds/DCPS/PublisherImpl.h
+++ b/dds/DCPS/PublisherImpl.h
@@ -146,9 +146,13 @@ public:
 
   virtual RcHandle<EntityImpl> parent() const;
   static bool validate_datawriter_qos(const DDS::DataWriterQos& qos,
-                                         const DDS::DataWriterQos& default_qos,
-                                         DDS::Topic_ptr a_topic,
-                                         DDS::DataWriterQos& dw_qos);
+                                      const DDS::DataWriterQos& default_qos,
+                                      DDS::Topic_ptr a_topic,
+                                      DDS::DataWriterQos& dw_qos);
+
+  bool prepare_to_delete_datawriters();
+  bool set_wait_pending_deadline(const MonotonicTimePoint& deadline);
+
 private:
   typedef OPENDDS_MULTIMAP(OPENDDS_STRING, DataWriterImpl_rch) DataWriterMap;
 

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -269,6 +269,9 @@ public:
   void pending_timeout(const TimeDuration& value);
   //@}
 
+  /// Get a new pending timeout deadline
+  MonotonicTimePoint new_pending_timeout_deadline() const;
+
   /// Accessors for priority extremums for the current scheduler.
   //@{
   int priority_min() const;

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -320,6 +320,13 @@ void Service_Participant::pending_timeout(const TimeDuration& value)
 }
 
 ACE_INLINE
+MonotonicTimePoint Service_Participant::new_pending_timeout_deadline() const
+{
+  return pending_timeout_.is_zero() ?
+    MonotonicTimePoint() : MonotonicTimePoint::now() + pending_timeout_;
+}
+
+ACE_INLINE
 int
 Service_Participant::priority_min() const
 {

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -8,8 +8,6 @@
 #ifndef OPENDDS_DCPS_WRITE_DATA_CONTAINER_H
 #define OPENDDS_DCPS_WRITE_DATA_CONTAINER_H
 
-#include "dds/DdsDcpsInfrastructureC.h"
-#include "dds/DdsDcpsCoreC.h"
 #include "DataSampleElement.h"
 #include "SendStateDataSampleList.h"
 #include "WriterDataSampleList.h"
@@ -20,12 +18,14 @@
 #include "TimeTypes.h"
 #include "SporadicTask.h"
 
+#include <dds/DdsDcpsInfrastructureC.h>
+#include <dds/DdsDcpsCoreC.h>
 
-#include "ace/Synch_Traits.h"
-#include "ace/Condition_T.h"
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
-#include "ace/Reverse_Lock_T.h"
+#include <ace/Synch_Traits.h>
+#include <ace/Condition_T.h>
+#include <ace/Condition_Thread_Mutex.h>
+#include <ace/Condition_Recursive_Thread_Mutex.h>
+#include <ace/Reverse_Lock_T.h>
 
 #include <memory>
 
@@ -327,10 +327,10 @@ public:
 #endif
 
   /**
-   * Block until pending samples have either been delivered
-   * or dropped.
+   * Block until pending samples have either been delivered, dropped, or the
+   * deadline has passed. Blocks indefinitely if deadline is zero.
    */
-  void wait_pending();
+  void wait_pending(const MonotonicTimePoint& deadline);
 
   /**
    * Returns a vector of handles for the instances registered for this

--- a/dds/DCPS/transport/framework/SendResponseListener.cpp
+++ b/dds/DCPS/transport/framework/SendResponseListener.cpp
@@ -22,8 +22,7 @@ SendResponseListener::SendResponseListener(const OPENDDS_STRING& msg_src)
 
 SendResponseListener::~SendResponseListener()
 {
-  OPENDDS_STRING caller_string("SendResponseListener::~SendResponseListener");
-  tracker_.wait_messages_pending(caller_string);
+  tracker_.wait_messages_pending("SendResponseListener::~SendResponseListener");
 }
 
 void


### PR DESCRIPTION
If multiple `DataWriter`s are being deleted in a `DomainParticipant` or `Publisher`, use PendingTimeout for a single deadline to finish pending data and control writes for all the writers, instead of waiting for at least a separate data and control deadline for every single writer. Also start instance unregisters for all writers before setting and waiting on the deadline.

These changes should dramatically reduce the amount of time `Publisher::delete_contained_entities` and `DomainParticipant::delete_contained_entities` block for multiple writers, especially when there are a large amount of them.