### PR TITLE
Allow Fragmentation in RTPS Durability Resends

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -112,6 +112,7 @@ tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/TransientLocalTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalTest/run_test.pl rtps: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/DelayedDurable/run_test.pl: !DCPS_MIN RTPS
+tests/DCPS/DelayedDurable/run_test.pl --large-samples: !DCPS_MIN RTPS
 tests/DCPS/MultiRepoTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/MultiRepoTest/run_test.pl fileconfig: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Presentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/dds/DCPS/DisjointSequence.cpp
+++ b/dds/DCPS/DisjointSequence.cpp
@@ -328,6 +328,13 @@ DisjointSequence::contains(SequenceNumber value) const
   return iter != sequences_.end() && iter->first <= value;
 }
 
+bool DisjointSequence::contains_any(const SequenceRange& range) const
+{
+  const SequenceRange search(0 /*ignored*/, range.first);
+  const RangeSet::const_iterator iter = sequences_.lower_bound(search);
+  return iter != sequences_.end() && iter->first <= range.second;
+}
+
 void
 DisjointSequence::validate(const SequenceRange& range)
 {

--- a/dds/DCPS/DisjointSequence.h
+++ b/dds/DCPS/DisjointSequence.h
@@ -57,6 +57,8 @@ public:
 
   bool contains(SequenceNumber value) const;
 
+  bool contains_any(const SequenceRange& range) const;
+
   /// All insert() methods return true upon modifying the set and false if
   /// the set already contained the SequenceNumber(s) that were to be inserted.
   /// This is the general form of insert() whereby the caller receives a list of
@@ -82,6 +84,9 @@ public:
   bool insert(SequenceNumber value,
               CORBA::ULong num_bits,
               const CORBA::Long bits[]);
+
+  /// Insert the intersection of range and filter
+  bool insert_filtered(const SequenceRange& range, const DisjointSequence& filter);
 
   /// Inverse of insert(value, num_bits, bits).  Populates array of
   /// bitmap[length] with the bitmap of ranges above the cumulative_ack() value.

--- a/dds/DCPS/DisjointSequence.inl
+++ b/dds/DCPS/DisjointSequence.inl
@@ -81,6 +81,19 @@ DisjointSequence::insert(const SequenceRange& range,
   return insert_i(range, &gaps);
 }
 
+ACE_INLINE bool
+DisjointSequence::insert_filtered(const SequenceRange& range, const DisjointSequence& filter)
+{
+  for (SequenceNumber i = range.first; i < range.second; ++i) {
+    if (filter.contains(i)) {
+      if (!insert(i)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/SequenceNumber.cpp
+++ b/dds/DCPS/SequenceNumber.cpp
@@ -1,0 +1,20 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "SequenceNumber.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+const SequenceRange unknown_sequence_range(
+  SequenceNumber::SEQUENCENUMBER_UNKNOWN(),
+  SequenceNumber::SEQUENCENUMBER_UNKNOWN());
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/SequenceNumber.cpp
+++ b/dds/DCPS/SequenceNumber.cpp
@@ -3,6 +3,8 @@
  * See: http://www.opendds.org/license.html
  */
 
+#include <DCPS/DdsDcps_pch.h>
+
 #include "SequenceNumber.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/SequenceNumber.h
+++ b/dds/DCPS/SequenceNumber.h
@@ -8,15 +8,15 @@
 #ifndef OPENDDS_DCPS_SEQUENCENUMBER_H
 #define OPENDDS_DCPS_SEQUENCENUMBER_H
 
-#include "ace/Global_Macros.h"
+#include "Serializer.h"
 
-#include <utility>
+#include <ace/Global_Macros.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "dds/DCPS/Serializer.h"
+#include <utility>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -200,6 +200,7 @@ gen_find_size(const SequenceNumber& /*sn*/, size_t& size, size_t& padding) {
 }
 
 typedef std::pair<SequenceNumber, SequenceNumber> SequenceRange;
+extern OpenDDS_Dcps_Export const SequenceRange unknown_sequence_range;
 
 } // namespace OpenDDS
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/DataLinkSet.inl
+++ b/dds/DCPS/transport/framework/DataLinkSet.inl
@@ -52,8 +52,7 @@ OpenDDS::DCPS::DataLinkSet::send(DataSampleElement* sample)
 
       DataSampleHeader::add_cfentries(guids, mb.get());
 
-      TransportCustomizedElement* tce =
-        new TransportCustomizedElement(send_element, false);
+      TransportCustomizedElement* tce = new TransportCustomizedElement(send_element);
       tce->set_msg(move(mb)); // tce now owns ACE_Message_Block chain
 
       itr->second->send(tce);

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
@@ -40,28 +40,6 @@ TransportCustomizedElement::release_element(bool dropped_by_transport)
   }
 }
 
-RepoId
-TransportCustomizedElement::publication_id() const
-{
-  DBG_ENTRY_LVL("TransportCustomizedElement", "publication_id", 6);
-  return publication_id_;
-}
-
-RepoId
-TransportCustomizedElement::subscription_id() const
-{
-  DBG_ENTRY_LVL("TransportCustomizedElement", "subscription_id", 6);
-  const TransportSendElement* ose = original_send_element();
-  return ose ? ose->subscription_id() : GUID_UNKNOWN;
-}
-
-void
-TransportCustomizedElement::set_publication_id(const RepoId& id)
-{
-  DBG_ENTRY_LVL("TransportCustomizedElement", "set_msg", 6);
-  publication_id_ = id;
-}
-
 const ACE_Message_Block*
 TransportCustomizedElement::msg() const
 {

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.h
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.h
@@ -23,18 +23,23 @@ class OpenDDS_Dcps_Export TransportCustomizedElement
   : public TransportQueueElement {
 
 public:
-  TransportCustomizedElement(TransportQueueElement* orig,
-                             bool fragment);
+  TransportCustomizedElement(TransportQueueElement* orig);
+
+  void set_fragment(TransportQueueElement* orig);
 
   virtual RepoId publication_id() const;
   void set_publication_id(const RepoId& id);
+
+  RepoId subscription_id() const;
+  void set_subscription_id(const RepoId& id);
+
+  SequenceNumber sequence() const;
+  void set_sequence(const SequenceNumber& value);
 
   virtual const ACE_Message_Block* msg() const;
   void set_msg(Message_Block_Ptr m);
 
   virtual const ACE_Message_Block* msg_payload() const;
-
-  virtual SequenceNumber sequence() const;
 
   virtual bool owned_by_transport() { return false; }
 
@@ -48,18 +53,14 @@ protected:
   virtual bool requires_exclusive_packet() const { return exclusive_; }
   void set_requires_exclusive() { exclusive_ = true; }
 
-  void set_fragment() { fragment_ = true; }
-
-
   virtual ~TransportCustomizedElement();
 
-
 private:
-  RepoId subscription_id() const;
-
   TransportQueueElement* orig_;
   Message_Block_Ptr msg_;
   RepoId publication_id_;
+  RepoId subscription_id_;
+  SequenceNumber sequence_;
   bool fragment_, exclusive_;
 };
 

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.h
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.h
@@ -23,7 +23,7 @@ class OpenDDS_Dcps_Export TransportCustomizedElement
   : public TransportQueueElement {
 
 public:
-  TransportCustomizedElement(TransportQueueElement* orig);
+  explicit TransportCustomizedElement(TransportQueueElement* orig);
 
   void set_fragment(TransportQueueElement* orig);
 

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.inl
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.inl
@@ -6,6 +6,7 @@
  */
 
 #include "EntryExit.h"
+#include "TransportSendElement.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -14,23 +15,72 @@ namespace DCPS {
 
 ACE_INLINE
 TransportCustomizedElement::TransportCustomizedElement(
-  TransportQueueElement* orig, bool fragment)
+  TransportQueueElement* orig)
   : TransportQueueElement(1),
     orig_(orig),
     publication_id_(orig ? orig->publication_id() : GUID_UNKNOWN),
-    fragment_(fragment),
+    subscription_id_(GUID_UNKNOWN),
+    sequence_(SequenceNumber::SEQUENCENUMBER_UNKNOWN()),
+    fragment_(false),
     exclusive_(false)
 {
   DBG_ENTRY_LVL("TransportCustomizedElement", "TransportCustomizedElement", 6);
 }
 
+ACE_INLINE
+RepoId TransportCustomizedElement::publication_id() const
+{
+  DBG_ENTRY_LVL("TransportCustomizedElement", "publication_id", 6);
+  return publication_id_;
+}
+
+ACE_INLINE
+void TransportCustomizedElement::set_publication_id(const RepoId& id)
+{
+  publication_id_ = id;
+}
+
+ACE_INLINE
+RepoId TransportCustomizedElement::subscription_id() const
+{
+  if (subscription_id_ != GUID_UNKNOWN) {
+    return subscription_id_;
+  }
+  DBG_ENTRY_LVL("TransportCustomizedElement", "subscription_id", 6);
+  const TransportSendElement* ose = original_send_element();
+  return ose ? ose->subscription_id() : GUID_UNKNOWN;
+}
+
+ACE_INLINE
+void TransportCustomizedElement::set_subscription_id(const RepoId& id)
+{
+  subscription_id_ = id;
+}
 
 ACE_INLINE
 SequenceNumber
 TransportCustomizedElement::sequence() const
 {
+  if (sequence_ != SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
+    return sequence_;
+  }
   return this->orig_ ? this->orig_->sequence()
     : SequenceNumber::SEQUENCENUMBER_UNKNOWN();
+}
+
+ACE_INLINE
+void TransportCustomizedElement::set_sequence(const SequenceNumber& value)
+{
+  sequence_ = value;
+}
+
+ACE_INLINE
+void TransportCustomizedElement::set_fragment(TransportQueueElement* orig)
+{
+  fragment_ = true;
+  set_publication_id(orig->publication_id());
+  set_subscription_id(orig->subscription_id());
+  set_sequence(orig->sequence());
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/TransportQueueElement.cpp
+++ b/dds/DCPS/transport/framework/TransportQueueElement.cpp
@@ -20,6 +20,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+const TqePair null_tqe_pair(0, 0);
+
 TransportQueueElement::~TransportQueueElement()
 {
   DBG_ENTRY_LVL("TransportQueueElement", "~TransportQueueElement", 6);

--- a/dds/DCPS/transport/framework/TransportQueueElement.cpp
+++ b/dds/DCPS/transport/framework/TransportQueueElement.cpp
@@ -47,12 +47,12 @@ TqePair TransportQueueElement::fragment(size_t size)
   Message_Block_Ptr tail;
   DataSampleHeader::split(*msg(), size, head, tail);
 
-  TransportCustomizedElement* frag = new TransportCustomizedElement(0, true);
-  frag->set_publication_id(publication_id());
+  TransportCustomizedElement* frag = new TransportCustomizedElement(0);
+  frag->set_fragment(this);
   frag->set_msg(move(head));
 
-  TransportCustomizedElement* rest =
-    new TransportCustomizedElement(this, true);
+  TransportCustomizedElement* rest = new TransportCustomizedElement(this);
+  frag->set_fragment(this);
   rest->set_msg(move(tail));
 
   return TqePair(frag, rest);

--- a/dds/DCPS/transport/framework/TransportQueueElement.cpp
+++ b/dds/DCPS/transport/framework/TransportQueueElement.cpp
@@ -39,8 +39,7 @@ TransportQueueElement::is_control(RepoId /*pub_id*/) const
   return false;
 }
 
-ElementPair
-TransportQueueElement::fragment(size_t size)
+TqePair TransportQueueElement::fragment(size_t size)
 {
   Message_Block_Ptr head;
   Message_Block_Ptr tail;
@@ -54,7 +53,7 @@ TransportQueueElement::fragment(size_t size)
     new TransportCustomizedElement(this, true);
   rest->set_msg(move(tail));
 
-  return ElementPair(frag, rest);
+  return TqePair(frag, rest);
 }
 
 ACE_Message_Block*

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -27,7 +27,7 @@ namespace DCPS {
 
 class TransportQueueElement;
 typedef std::pair<TransportQueueElement*, TransportQueueElement*> TqePair;
-extern const TqePair null_tqe_pair;
+extern OpenDDS_Dcps_Export const TqePair null_tqe_pair;
 typedef OPENDDS_VECTOR(TransportQueueElement*) TqeVector;
 
 /**

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -25,10 +25,9 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class DataSampleElement;
-
 class TransportQueueElement;
-typedef std::pair<TransportQueueElement*, TransportQueueElement*> ElementPair;
+typedef std::pair<TransportQueueElement*, TransportQueueElement*> TqePair;
+typedef OPENDDS_VECTOR(TransportQueueElement*) TqeVector;
 
 /**
  * @class TransportQueueElement
@@ -141,7 +140,7 @@ public:
   /// the newly-created elements will need to invoke non-const methods on it).
   /// Each element in the pair will contain its own serialized modified
   /// DataSampleHeader.
-  virtual ElementPair fragment(size_t size);
+  virtual TqePair fragment(size_t size);
 
   /// Is this QueueElement the result of fragmentation?
   virtual bool is_fragment() const { return false; }

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -27,6 +27,7 @@ namespace DCPS {
 
 class TransportQueueElement;
 typedef std::pair<TransportQueueElement*, TransportQueueElement*> TqePair;
+extern const TqePair null_tqe_pair;
 typedef OPENDDS_VECTOR(TransportQueueElement*) TqeVector;
 
 /**
@@ -140,6 +141,8 @@ public:
   /// the newly-created elements will need to invoke non-const methods on it).
   /// Each element in the pair will contain its own serialized modified
   /// DataSampleHeader.
+  ///
+  /// If the fragmentation fails, a copy of null_tqe_pair is returned.
   virtual TqePair fragment(size_t size);
 
   /// Is this QueueElement the result of fragmentation?

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -97,6 +97,10 @@ public:
   /// The return value indicates if this element is released.
   bool data_delivered();
 
+  /// Delay releasing the element by one decision (either a data_dropped or
+  /// data_delivered).
+  void increment_loan() { sub_loan_count_++; }
+
   /// Does the sample require an exclusive transport packet?
   virtual bool requires_exclusive_packet() const;
 

--- a/dds/DCPS/transport/framework/TransportSendControlElement.cpp
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.cpp
@@ -6,9 +6,12 @@
  */
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+
 #include "TransportSendControlElement.h"
 #include "TransportSendListener.h"
-#include "dds/DCPS/transport/framework/EntryExit.h"
+#include "EntryExit.h"
+
+#include <dds/DCPS/DataSampleElement.h>
 
 #if !defined (__ACE_INLINE__)
 #include "TransportSendControlElement.inl"

--- a/dds/DCPS/transport/framework/TransportSendControlElement.h
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.h
@@ -25,8 +25,8 @@ namespace OpenDDS {
 namespace DCPS {
 
 class TransportSendListener;
-
 class TransportSendControlElement;
+class DataSampleElement;
 
 typedef Cached_Allocator_With_Overflow<TransportSendControlElement, ACE_SYNCH_NULL_MUTEX>
 TransportSendControlElementAllocator;

--- a/dds/DCPS/transport/framework/TransportSendControlElement.inl
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.inl
@@ -5,9 +5,6 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "EntryExit.h"
-#include "dds/DCPS/DataSampleElement.h"
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+
 #include "TransportSendStrategy.h"
+
 #include "RemoveAllVisitor.h"
 #include "TransportInst.h"
 #include "ThreadSynchStrategy.h"
@@ -19,12 +21,13 @@
 #include "PacketRemoveVisitor.h"
 #include "TransportDefs.h"
 #include "DirectPriorityMapper.h"
-#include "dds/DCPS/DataSampleHeader.h"
-#include "dds/DCPS/DataSampleElement.h"
-#include "dds/DCPS/Service_Participant.h"
 #include "EntryExit.h"
 
-#include "ace/Reverse_Lock_T.h"
+#include <dds/DCPS/DataSampleHeader.h>
+#include <dds/DCPS/DataSampleElement.h>
+#include <dds/DCPS/Service_Participant.h>
+
+#include <ace/Reverse_Lock_T.h>
 
 #if !defined (__ACE_INLINE__)
 #include "TransportSendStrategy.inl"
@@ -1937,21 +1940,18 @@ bool TransportSendStrategy::fragmentation_helper(
 {
   const size_t space = space_available();
   const bool fragmentation_allowed = max_message_size();
-  ACE_DEBUG((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
-    "max_message_size: %B\n", max_message_size()));
   for (TransportQueueElement* e = original_element; e;) {
     const size_t esize = e->msg()->total_length();
     if (esize > space) {
       if (!fragmentation_allowed) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: TransportSendStrategy::fragmentation_helper: "
           "message size, %B, is greater than space available, %B, but can't "
-          "fragment because max_message_size is 0",
-          esize, space));
+          "fragment because max_message_size is 0\n", esize, space));
         return false;
       }
 
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
-        "message size %B > space %B: Fragmenting\n", esize, space));
+      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
+          "message size %B > space %B: Fragmenting\n", esize, space), 0);
       const TqePair pair = e->fragment(space);
       if (pair == null_tqe_pair) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: TransportSendStrategy::fragmentation_helper: "
@@ -1960,10 +1960,10 @@ bool TransportSendStrategy::fragmentation_helper(
       }
       elements_to_send.push_back(pair.first);
       e = pair.second;
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
-        "Fragment %B\n", elements_to_send.back()->msg()->total_length()));
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
-        "Left %B\n", e->msg()->total_length()));
+      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
+        "Fragment %B\n", elements_to_send.back()->msg()->total_length()), 0);
+      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
+        "Left %B\n", e->msg()->total_length()), 0);
     } else {
       elements_to_send.push_back(e);
       e = 0;
@@ -1972,8 +1972,7 @@ bool TransportSendStrategy::fragmentation_helper(
   return true;
 }
 
-// close namespaces
-}
-}
+} // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -1939,17 +1939,9 @@ bool TransportSendStrategy::fragmentation_helper(
   TransportQueueElement* original_element, TqeVector& elements_to_send)
 {
   const size_t space = space_available();
-  const bool fragmentation_allowed = max_message_size();
   for (TransportQueueElement* e = original_element; e;) {
     const size_t esize = e->msg()->total_length();
     if (esize > space) {
-      if (!fragmentation_allowed) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: TransportSendStrategy::fragmentation_helper: "
-          "message size, %B, is greater than space available, %B, but can't "
-          "fragment because max_message_size is 0\n", esize, space));
-        return false;
-      }
-
       VDBG_LVL((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
           "message size %B > space %B: Fragmenting\n", esize, space), 0);
       const TqePair pair = e->fragment(space);
@@ -1960,10 +1952,6 @@ bool TransportSendStrategy::fragmentation_helper(
       }
       elements_to_send.push_back(pair.first);
       e = pair.second;
-      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
-        "Fragment %B\n", elements_to_send.back()->msg()->total_length()), 0);
-      VDBG_LVL((LM_DEBUG, "(%P|%t) TransportSendStrategy::fragmentation_helper: "
-        "Left %B\n", e->msg()->total_length()), 0);
     } else {
       elements_to_send.push_back(e);
       e = 0;

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -266,11 +266,17 @@ private:
   /// the entire packet was not sent.
   int adjust_packet_after_send(ssize_t num_bytes_sent);
 
+  /**
+   * How much space is available in packet with a given used space before we
+   * reach one of the limits: max_message_size() [transport's inherent
+   * limitation] or max_size_ [user's configured limit]
+   */
+  size_t space_available(size_t already_used = 0) const;
 
-  /// How much space is available in the current packet before we reach one
-  /// of the limits: max_message_size() [transport's inherent limitation]
-  /// or max_size_ [user's configured limit]
-  size_t space_available() const;
+  /**
+   * Like above, but use the current packet.
+   */
+  size_t current_space_available() const;
 
   typedef ACE_SYNCH_MUTEX     LockType;
   typedef ACE_Guard<LockType> GuardType;

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -149,6 +149,8 @@ public:
   /**
    * This is a simpler alternative to TransportSendStrategy::send for achieving
    * fragmentation.
+   *
+   * Return false if the operation failed.
    */
   bool fragmentation_helper(
     TransportQueueElement* original_element, TqeVector& elements_to_send);

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -146,6 +146,13 @@ public:
   /// actually be a little larger.
   static const size_t UDP_MAX_MESSAGE_SIZE = 65466;
 
+  /**
+   * This is a simpler alternative to TransportSendStrategy::send for achieving
+   * fragmentation.
+   */
+  bool fragmentation_helper(
+    TransportQueueElement* original_element, TqeVector& elements_to_send);
+
 protected:
 
   TransportSendStrategy(std::size_t id,

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -146,12 +146,14 @@ public:
   /// actually be a little larger.
   static const size_t UDP_MAX_MESSAGE_SIZE = 65466;
 
-  /**
-   * This is a simpler alternative to TransportSendStrategy::send for achieving
-   * fragmentation.
-   *
-   * Return false if the operation failed.
-   */
+  /// Alternative to TransportSendStrategy::send for fragmentation
+  ///
+  /// @param original_element data sample to send, may be larger than max msg size
+  /// @param elements_to_send populated by this method with either original_element
+  ///                         or fragments created from it.  Elements which are not
+  ///                         the original_element need to be cleaned up by the
+  ///                         caller using data_delivered or data_dropped.
+  /// @return operation succeeded
   bool fragmentation_helper(
     TransportQueueElement* original_element, TqeVector& elements_to_send);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.cpp
@@ -20,8 +20,7 @@ namespace DCPS {
 RtpsCustomizedElement::~RtpsCustomizedElement()
 {}
 
-ElementPair
-RtpsCustomizedElement::fragment(size_t size)
+TqePair RtpsCustomizedElement::fragment(size_t size)
 {
   Message_Block_Ptr head;
   Message_Block_Ptr tail;
@@ -40,7 +39,7 @@ RtpsCustomizedElement::fragment(size_t size)
   rest->set_fragment();
   rest->last_frag_ = fragNumbers.second;
 
-  return ElementPair(frag, rest);
+  return TqePair(frag, rest);
 }
 
 const ACE_Message_Block*

--- a/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.cpp
@@ -26,6 +26,9 @@ TqePair RtpsCustomizedElement::fragment(size_t size)
   Message_Block_Ptr tail;
   const SequenceRange fragNumbers =
     RtpsSampleHeader::split(*msg(), size, head, tail);
+  if (fragNumbers == unknown_sequence_range) {
+    return TqePair(0, 0);
+  }
 
   RtpsCustomizedElement* frag =
     new RtpsCustomizedElement(0, move(head));

--- a/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.cpp
@@ -27,19 +27,15 @@ TqePair RtpsCustomizedElement::fragment(size_t size)
   const SequenceRange fragNumbers =
     RtpsSampleHeader::split(*msg(), size, head, tail);
   if (fragNumbers == unknown_sequence_range) {
-    return TqePair(0, 0);
+    return null_tqe_pair;
   }
 
-  RtpsCustomizedElement* frag =
-    new RtpsCustomizedElement(0, move(head));
-  frag->set_publication_id(publication_id());
-  frag->seq_ = sequence();
-  frag->set_fragment();
+  RtpsCustomizedElement* frag = new RtpsCustomizedElement(0, move(head));
+  frag->set_fragment(this);
   frag->last_frag_ = fragNumbers.first;
 
-  RtpsCustomizedElement* rest =
-    new RtpsCustomizedElement(this, move(tail));
-  rest->set_fragment();
+  RtpsCustomizedElement* rest = new RtpsCustomizedElement(this, move(tail));
+  rest->set_fragment(this);
   rest->last_frag_ = fragNumbers.second;
 
   return TqePair(frag, rest);

--- a/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.h
@@ -34,7 +34,7 @@ private:
 
   virtual ~RtpsCustomizedElement();
 
-  ElementPair fragment(size_t size);
+  TqePair fragment(size_t size);
   const ACE_Message_Block* msg_payload() const;
 
   SequenceNumber seq_, last_frag_;

--- a/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.h
@@ -27,7 +27,6 @@ public:
   RtpsCustomizedElement(TransportQueueElement* orig,
                         Message_Block_Ptr msg);
 
-  SequenceNumber sequence() const;
   SequenceNumber last_fragment() const;
 
 private:
@@ -37,7 +36,7 @@ private:
   TqePair fragment(size_t size);
   const ACE_Message_Block* msg_payload() const;
 
-  SequenceNumber seq_, last_frag_;
+  SequenceNumber last_frag_;
 };
 
 typedef Dynamic_Cached_Allocator_With_Overflow<ACE_Thread_Mutex>

--- a/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.inl
+++ b/dds/DCPS/transport/rtps_udp/RtpsCustomizedElement.inl
@@ -13,20 +13,10 @@ namespace DCPS {
 ACE_INLINE
 RtpsCustomizedElement::RtpsCustomizedElement(TransportQueueElement* orig,
                                              Message_Block_Ptr msg)
-  : TransportCustomizedElement(orig, false)
-  , seq_(SequenceNumber::SEQUENCENUMBER_UNKNOWN())
+  : TransportCustomizedElement(orig)
 {
   set_requires_exclusive();
   set_msg(move(msg));
-}
-
-
-ACE_INLINE
-SequenceNumber
-RtpsCustomizedElement::sequence() const
-{
-  return (seq_ == SequenceNumber::SEQUENCENUMBER_UNKNOWN()) ?
-    TransportCustomizedElement::sequence() : seq_;
 }
 
 ACE_INLINE

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -622,8 +622,6 @@ RtpsSampleHeader::split(const ACE_Message_Block& orig, size_t size,
                         Message_Block_Ptr& head, Message_Block_Ptr& tail)
 {
   using namespace RTPS;
-  static const SequenceRange unknown_range(SequenceNumber::SEQUENCENUMBER_UNKNOWN(),
-                                           SequenceNumber::SEQUENCENUMBER_UNKNOWN());
   size_t data_offset = 0;
   const char* rd = orig.rd_ptr();
   ACE_CDR::ULong starting_frag, sample_size;
@@ -645,7 +643,7 @@ RtpsSampleHeader::split(const ACE_Message_Block& orig, size_t size,
           ACE_ERROR((LM_ERROR, "(%P|%t) RtpsSampleHeader::split() ERROR - "
             "attempting to fragment a Data submessage with no payload.\n"));
         }
-        return unknown_range;
+        return unknown_sequence_range;
       }
       found_data = true;
       starting_frag = 1;
@@ -672,7 +670,7 @@ RtpsSampleHeader::split(const ACE_Message_Block& orig, size_t size,
         ACE_ERROR((LM_ERROR, "(%P|%t) RtpsSampleHeader::split() ERROR - "
           "invalid octetsToNextHeader encountered while fragmenting.\n"));
       }
-      return unknown_range;
+      return unknown_sequence_range;
     }
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -6,26 +6,26 @@
  */
 
 #include "RtpsSampleHeader.h"
+
 #include "RtpsUdpSendStrategy.h"
 
-#include "dds/DCPS/Serializer.h"
-#include "dds/DCPS/DataSampleElement.h"
-#include "dds/DCPS/Marked_Default_Qos.h"
-#include "dds/DCPS/Qos_Helper.h"
-#include "dds/DCPS/Service_Participant.h"
-#include "dds/DCPS/DisjointSequence.h"
-
-#include "dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h"
-#include "dds/DCPS/RTPS/MessageTypes.h"
-#include "dds/DCPS/RTPS/BaseMessageTypes.h"
-
-#include "dds/DCPS/transport/framework/ReceivedDataSample.h"
-#include "dds/DCPS/transport/framework/TransportSendListener.h"
+#include <dds/DCPS/SequenceNumber.h>
+#include <dds/DCPS/Serializer.h>
+#include <dds/DCPS/DataSampleElement.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/Qos_Helper.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/DisjointSequence.h>
+#include <dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h>
+#include <dds/DCPS/RTPS/MessageTypes.h>
+#include <dds/DCPS/RTPS/BaseMessageTypes.h>
+#include <dds/DCPS/transport/framework/ReceivedDataSample.h>
+#include <dds/DCPS/transport/framework/TransportSendListener.h>
 
 #include <cstring>
 
 #ifndef __ACE_INLINE__
-#include "RtpsSampleHeader.inl"
+#  include "RtpsSampleHeader.inl"
 #endif
 
 namespace {
@@ -709,6 +709,12 @@ RtpsSampleHeader::split(const ACE_Message_Block& orig, size_t size,
   const size_t max_data = size - sz, orig_payload = orig.cont()->total_length();
   const ACE_CDR::UShort frags =
     static_cast<ACE_CDR::UShort>(std::min(max_data, orig_payload) / FRAG_SIZE);
+  if (frags == 0) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsSampleHeader::split: "
+      "Number of Fragments is Zero: min(%B, %B) / FRAG_SIZE\n",
+      max_data, orig_payload));
+    return unknown_sequence_range;
+  }
   write(head, frags, swap_bytes);
   write(head, FRAG_SIZE, swap_bytes);
   write(head, sample_size, swap_bytes);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3347,15 +3347,15 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
 void
 RtpsUdpDataLink::durability_resend(TransportQueueElement* element)
 {
-  ACE_Message_Block* msg = const_cast<ACE_Message_Block*>(element->msg());
-  AddrSet addrs = get_addresses(element->publication_id(), element->subscription_id());
+  const AddrSet addrs = get_addresses(element->publication_id(), element->subscription_id());
   if (addrs.empty()) {
     const GuidConverter conv(element->subscription_id());
     ACE_ERROR((LM_ERROR,
                "(%P|%t) RtpsUdpDataLink::durability_resend() - "
                "no locator for remote %C\n", OPENDDS_STRING(conv).c_str()));
   } else {
-    send_strategy()->send_rtps_control(*msg, addrs);
+    const RtpsUdpSendStrategy::OverrideToken ot = send_strategy()->override_destinations(addrs);
+    send_strategy()->send(element);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3377,6 +3377,9 @@ void RtpsUdpDataLink::durability_resend(TransportQueueElement* element,
     return;
   }
 
+  // Sending will decrement loan, and we need to keep it because it's durable.
+  element->increment_loan();
+
   TqeVector to_send;
   if (!send_strategy()->fragmentation_helper(element, to_send)) {
     return;
@@ -3393,9 +3396,7 @@ void RtpsUdpDataLink::durability_resend(TransportQueueElement* element,
       send_strategy()->send_rtps_control(*const_cast<ACE_Message_Block*>((*i)->msg()), addrs);
     }
 
-    //if (*i != element) {
-    //  (*i)->data_delivered();
-    //}
+    (*i)->data_delivered();
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2806,7 +2806,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   if (!ri->second.durable_data_.empty()) {
     if (Transport_debug_level > 5) {
       const GuidConverter local_conv(id_), remote_conv(remote);
-      ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                  "local %C has durable for remote %C\n",
                  OPENDDS_STRING(local_conv).c_str(),
                  OPENDDS_STRING(remote_conv).c_str()));
@@ -2816,7 +2816,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
                  acknack.readerSNState.bitmapBase.low);
     const SequenceNumber& dd_last = ri->second.durable_data_.rbegin()->first;
     if (Transport_debug_level > 5) {
-      ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                  "check ack %q against last durable %q\n",
                  ack.getValue(), dd_last.getValue()));
     }
@@ -2824,7 +2824,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       // Reader acknowledges durable data, we no longer need to store it
       ri->second.durable_data_.swap(pendingCallbacks);
       if (Transport_debug_level > 5) {
-        ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                    "durable data acked\n"));
       }
     } else {
@@ -2853,7 +2853,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
         for (; it != ri->second.durable_data_.end()
              && it->first <= psr[i].second; ++it) {
           if (Transport_debug_level > 5) {
-            ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+            ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                        "durable resend %d\n", int(it->first.getValue())));
           }
           link->durability_resend(it->second);
@@ -2873,7 +2873,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       }
       if (!gaps.empty()) {
         if (Transport_debug_level > 5) {
-          ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+          ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                      "sending durability gaps:\n"));
           gaps.dump();
         }
@@ -2887,7 +2887,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
         // All nacks were below the start of the durable data.
           requests.insert(SequenceRange(requests.high(), dd_first.previous()));
         if (Transport_debug_level > 5) {
-          ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+          ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                      "sending durability gaps for all requests:\n"));
           requests.dump();
         }
@@ -2904,7 +2904,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
                                     std::min(psr[i].second, dd_first)));
         }
         if (Transport_debug_level > 5) {
-          ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::received(ACKNACK) "
+          ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
                      "sending durability gaps for some requests:\n"));
           gaps.dump();
         }
@@ -2922,7 +2922,9 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       ri->second.cur_cumulative_ack_ = ack;
     } else if (ri->second.durable_ && !ri->second.expecting_durable_data()) {
       // Count increased but ack decreased.  Replay durable data for the reader.
-      ACE_DEBUG((LM_DEBUG, "Enqueuing ReplayDurableData\n"));
+      if (Transport_debug_level > 5) {
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received: Enqueuing ReplayDurableData\n"));
+      }
       link->job_queue_->enqueue(make_rch<ReplayDurableData>(link_, id_, remote));
       ri->second.durable_timestamp_ = MonotonicTimePoint::zero_value;
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -510,6 +510,11 @@ private:
                                   CORBA::ULong extent);
 
   void durability_resend(TransportQueueElement* element);
+  void durability_resend(TransportQueueElement* element, const RTPS::FragmentNumberSet& fragmentSet);
+
+  static bool include_fragment(const TransportQueueElement& element,
+                               const DisjointSequence& fragments,
+                               SequenceNumber& lastFragment);
 
   template<typename T, typename FN>
   void datawriter_dispatch(const T& submessage, const GuidPrefix_t& src_prefix,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -722,12 +722,12 @@ RtpsUdpSendStrategy::stop_i()
 size_t RtpsUdpSendStrategy::max_message_size() const
 {
   // TODO: Make this conditional on if the message actually needs to do this.
-  return max_message_size_ ? max_message_size_
+  return max_message_size_
 #ifdef OPENDDS_SECURITY
     // Worst case scenario is full message encryption plus one submessage encryption.
     - MaxSecureSubmessageAdditionalSize - MaxSecureFullMessageAdditionalSize
 #endif
-    : 0;
+    ;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -568,7 +568,7 @@ namespace {
     char *iter = buffer;
     for (int i = 0; i < n; ++i) {
       if (size_t(iter - buffer + iov[i].iov_len) > UDP_MAX_MESSAGE_SIZE) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "
+        ACE_ERROR((LM_ERROR, "(%P|%t) RtpsUdpTransport.cpp send_single_i() - "
                    "message too large at index %d size %d\n", i, iov[i].iov_len));
         return -1;
       }
@@ -585,7 +585,7 @@ namespace {
       addr.addr_to_string(addr_buff, 256);
       errno = err;
       const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
-      ACE_ERROR((prio, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "
+      ACE_ERROR((prio, "(%P|%t) RtpsUdpTransport.cpp send_single_i() - "
                  "destination %s failed %p\n", addr_buff, ACE_TEXT("send")));
     }
     return result;

--- a/tests/DCPS/DelayedDurable/DelayedDurable.cpp
+++ b/tests/DCPS/DelayedDurable/DelayedDurable.cpp
@@ -17,7 +17,6 @@ using OpenDDS::DCPS::DEFAULT_STATUS_MASK;
 const unsigned large_sample_seq_size =
  static_cast<unsigned>(
     OpenDDS::DCPS::TransportSendStrategy::UDP_MAX_MESSAGE_SIZE);
-const unsigned minimum_sample_count = 981;
 
 int scale(int value, bool large_samples)
 {
@@ -97,6 +96,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     }
 
   } else if (reader) {
+    ACE_DEBUG((LM_DEBUG, "Reader starting at %T\n"));
+
     Subscriber_var sub = dp->create_subscriber(SUBSCRIBER_QOS_DEFAULT, 0,
                                                DEFAULT_STATUS_MASK);
     DataReaderQos dr_qos;
@@ -112,7 +113,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     WaitSet_var ws = new WaitSet;
     ws->attach_condition(dr_rc);
     unsigned counter = 0;
-    ACE_DEBUG((LM_DEBUG, "Reader starting at %T\n"));
+    const unsigned minimum_sample_count = large_samples ? 95 : 981;
     std::set<int> instances;
     while (true) {
       ConditionSeq active;

--- a/tests/DCPS/DelayedDurable/DelayedDurable.idl
+++ b/tests/DCPS/DelayedDurable/DelayedDurable.idl
@@ -1,6 +1,8 @@
-#pragma DCPS_DATA_TYPE "Property"
-#pragma DCPS_DATA_KEY "Property key"
+#include <tao/OctetSeq.pidl>
+
+@topic
 struct Property {
-  long key;
+  @key long key;
   long value;
+  sequence<octet> extra;
 };

--- a/tests/DCPS/DelayedDurable/rtps_disc.ini
+++ b/tests/DCPS/DelayedDurable/rtps_disc.ini
@@ -12,3 +12,4 @@ ResendPeriod=2
 [transport/the_rtps_transport]
 transport_type=rtps_udp
 use_multicast=0
+max_message_size=500

--- a/tests/DCPS/DelayedDurable/rtps_disc.ini
+++ b/tests/DCPS/DelayedDurable/rtps_disc.ini
@@ -12,4 +12,3 @@ ResendPeriod=2
 [transport/the_rtps_transport]
 transport_type=rtps_udp
 use_multicast=0
-max_message_size=500

--- a/tests/DCPS/DelayedDurable/rtps_disc.ini
+++ b/tests/DCPS/DelayedDurable/rtps_disc.ini
@@ -12,3 +12,6 @@ ResendPeriod=2
 [transport/the_rtps_transport]
 transport_type=rtps_udp
 use_multicast=0
+heartbeat_period=500
+nak_response_delay=100
+heartbeat_response_delay=100

--- a/tests/DCPS/DelayedDurable/run_test.pl
+++ b/tests/DCPS/DelayedDurable/run_test.pl
@@ -5,19 +5,33 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 use lib "$ENV{ACE_ROOT}/bin";
 use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
+use Getopt::Long;
 use strict;
-
-my $cfg = '-DCPSConfigFile rtps_disc.ini';
 
 my $test = new PerlDDS::TestFramework();
 $test->enable_console_logging();
 
-$test->process('writer', 'DelayedDurable', "$cfg -writer");
+my $verbose = 0;
+my $large_samples= 0;
+GetOptions(
+  "large-samples" => \$large_samples,
+  "verbose" => \$verbose,
+);
+
+my @common_args = ('-DCPSConfigFile', 'rtps_disc.ini');
+push(@common_args, "--verbose") if ($verbose);
+push(@common_args, "--large-samples") if ($large_samples);
+
+my @writer_args = ('--writer');
+push(@writer_args, @common_args);
+$test->process('writer', 'DelayedDurable', join(' ', @writer_args));
 $test->start_process('writer');
 
 sleep 15;
 
-$test->process('reader', 'DelayedDurable', "$cfg -reader");
+my @reader_args = ('--reader');
+push(@reader_args, @common_args);
+$test->process('reader', 'DelayedDurable', join(' ', @reader_args));
 $test->start_process('reader');
 
 exit $test->finish(60);


### PR DESCRIPTION
Fixes issue with durable samples bigger than the max UDP message size failing because they were not being fragmented.

Also correct error logs in `RtpsUdpTransport.cpp`.