### PR TITLE
Implement Wait-for-Discovery-Complete for Bench Worker

### DIFF
--- a/performance-tests/bench_2/example/config/scenario/ci_disco_flag.json
+++ b/performance-tests/bench_2/example/config/scenario/ci_disco_flag.json
@@ -1,0 +1,11 @@
+{
+  "name": "Continuous Integration Wait for Discovery Test",
+  "desc": "This is a small quick test which waits up to x seconds for (quiet) discovery capability with many participant processes",
+  "any_node": [
+    {
+      "config": "ci_disco_flag.json",
+      "count": 20
+    }
+  ],
+  "timeout": 120
+}

--- a/performance-tests/bench_2/example/config/worker/ci_disco_flag.json
+++ b/performance-tests/bench_2/example/config/worker/ci_disco_flag.json
@@ -1,0 +1,111 @@
+{
+  "enable_time": { "sec": -1, "nsec": 0 },
+  "start_time": { "sec": -3, "nsec": 0 },
+  "stop_time": { "sec": -10, "nsec": 0 },
+  "destruction_time": { "sec": -1, "nsec": 0 },
+  "wait_for_discovery":true,
+  "wait_for_discovery_seconds":30,
+
+  "process": {
+    "config_sections": [
+      { "name": "common",
+        "properties": [
+          { "name": "DCPSSecurity",
+            "value": "0"
+          },
+          { "name": "DCPSDebugLevel",
+            "value": "0"
+          }
+        ]
+      }
+    ],
+    "discoveries": [
+      { "name": "bench_test_rtps",
+        "type": "rtps",
+        "domain": 7
+      }
+    ],
+    "instances": [
+      { "name": "rtps_instance_01",
+        "type": "rtps_udp",
+        "domain": 7
+      }
+    ],
+    "participants": [
+      { "name": "participant_01",
+        "domain": 7,
+        "transport_config_name": "rtps_instance_01",
+
+        "qos": { "entity_factory": { "autoenable_created_entities": false } },
+        "qos_mask": { "entity_factory": { "has_autoenable_created_entities": false } },
+
+        "topics": [
+          { "name": "topic_01",
+            "type_name": "Bench::Data"
+          },
+          { "name": "topic_02",
+            "type_name": "Bench::Data"
+          }
+        ],
+        "subscribers": [
+          { "name": "subscriber_01",
+            "datareaders": [
+              { "name": "datareader_01",
+                "topic_name": "topic_01",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 10 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              },
+              { "name": "datareader_02",
+                "topic_name": "topic_02",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              }
+            ]
+          }
+        ],
+        "publishers": [
+          { "name": "publisher_01",
+            "datawriters": [
+              { "name": "datawriter_01",
+                "topic_name": "topic_01",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 10 }
+                  }
+                ]
+              },
+              { "name": "datawriter_02",
+                "topic_name": "topic_02",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/performance-tests/bench_2/idl/Bench.idl
+++ b/performance-tests/bench_2/idl/Bench.idl
@@ -59,6 +59,8 @@ module Bench {
     Builder::ProcessConfig process;
     ActionConfigSeq actions;
     ActionReportSeq action_reports;
+	boolean wait_for_discovery;
+    unsigned long wait_for_discovery_seconds;
   };
 
   struct WorkerReport {

--- a/performance-tests/bench_2/idl/Bench.idl
+++ b/performance-tests/bench_2/idl/Bench.idl
@@ -59,7 +59,7 @@ module Bench {
     Builder::ProcessConfig process;
     ActionConfigSeq actions;
     ActionReportSeq action_reports;
-	boolean wait_for_discovery;
+    boolean wait_for_discovery;
     unsigned long wait_for_discovery_seconds;
   };
 

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
@@ -191,7 +191,7 @@ WorkerDataReaderListener::on_subscription_matched(
   if (expected_match_count_ != 0) {
     if (static_cast<size_t>(status.current_count) == expected_match_count_) {
       //std::cout << "WorkerDataReaderListener reached expected count!" << std::endl;
-      dr_expected_match_cv.notify_all();
+      expected_match_cv.notify_all();
       if (datareader_) {
         last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }
@@ -371,6 +371,18 @@ WorkerDataReaderListener::unset_datareader(Builder::DataReader& datareader)
 
     datareader_ = nullptr;
   }
+}
+
+bool WorkerDataReaderListener::wait_for_expected_match(const std::chrono::system_clock::time_point& deadline) const
+{
+  std::unique_lock<std::mutex> expected_lock(mutex_);
+
+  while (expected_match_count_ != match_count_) {
+    if (expected_match_cv.wait_until(expected_lock, deadline) == std::cv_status::timeout) {
+      return match_count_ == expected_match_count_;
+    }
+  }
+  return true;
 }
 
 }

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
@@ -191,6 +191,7 @@ WorkerDataReaderListener::on_subscription_matched(
   if (expected_match_count_ != 0) {
     if (static_cast<size_t>(status.current_count) == expected_match_count_) {
       //std::cout << "WorkerDataReaderListener reached expected count!" << std::endl;
+      dr_expected_match_cv.notify_all();
       if (datareader_) {
         last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.h
@@ -8,6 +8,7 @@
 #include "dds/DCPS/DisjointSequence.h"
 
 #include <unordered_map>
+#include <condition_variable>
 
 namespace Bench {
 

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.h
@@ -36,14 +36,10 @@ public:
   void set_datareader(Builder::DataReader& datareader) override;
   void unset_datareader(Builder::DataReader& datareader) override;
 
-  size_t get_match_count() { return match_count_; }
-  size_t get_expected_match_count() { return expected_match_count_; }
-
-  std::condition_variable dr_expected_match_cv;
-  std::mutex dr_expected_match_cv_mutex;
+  bool wait_for_expected_match(const std::chrono::system_clock::time_point& deadline) const;
 
 protected:
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   bool durable_{false};
   bool reliable_{false};
   bool history_keep_all_{false};
@@ -55,6 +51,7 @@ protected:
   Builder::DataReader* datareader_{0};
   DataDataReader_var data_dr_;
   std::vector<DataHandler*> handlers_;
+  mutable std::condition_variable expected_match_cv;
 
   Builder::PropertyIndex last_discovery_time_;
   Builder::PropertyIndex lost_sample_count_;

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.h
@@ -35,7 +35,7 @@ public:
 
   void set_datareader(Builder::DataReader& datareader) override;
   void unset_datareader(Builder::DataReader& datareader) override;
-  
+
   size_t get_match_count() { return match_count_; }
   size_t get_expected_match_count() { return expected_match_count_; }
 

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.h
@@ -35,6 +35,12 @@ public:
 
   void set_datareader(Builder::DataReader& datareader) override;
   void unset_datareader(Builder::DataReader& datareader) override;
+  
+  size_t get_match_count() { return match_count_; }
+  size_t get_expected_match_count() { return expected_match_count_; }
+
+  std::condition_variable dr_expected_match_cv;
+  std::mutex dr_expected_match_cv_mutex;
 
 protected:
   std::mutex mutex_;

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
@@ -50,6 +50,7 @@ WorkerDataWriterListener::on_publication_matched(
   if (expected_match_count_ != 0) {
     if (static_cast<size_t>(status.current_count) == expected_match_count_) {
       //std::cout << "WorkerDataWriterListener reached expected count!" << std::endl;
+      wr_expected_match_cv.notify_all();
       if (datawriter_) {
         last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
@@ -50,7 +50,7 @@ WorkerDataWriterListener::on_publication_matched(
   if (expected_match_count_ != 0) {
     if (static_cast<size_t>(status.current_count) == expected_match_count_) {
       //std::cout << "WorkerDataWriterListener reached expected count!" << std::endl;
-      wr_expected_match_cv.notify_all();
+      expected_match_cv.notify_all();
       if (datawriter_) {
         last_discovery_time_->value.time_prop(Builder::get_hr_time());
       }
@@ -79,6 +79,18 @@ WorkerDataWriterListener::unset_datawriter(Builder::DataWriter& datawriter)
   if (datawriter_ == &datawriter) {
     datawriter_ = nullptr;
   }
+}
+
+bool WorkerDataWriterListener::wait_for_expected_match(const std::chrono::system_clock::time_point& deadline) const
+{
+  std::unique_lock<std::mutex> expected_lock(mutex_);
+
+  while (expected_match_count_ != match_count_) {
+    if (expected_match_cv.wait_until(expected_lock, deadline) == std::cv_status::timeout) {
+      return match_count_ == expected_match_count_;
+    }
+  }
+  return true;
 }
 
 }

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "DataWriterListener.h"
+#include <condition_variable>
 
 namespace Bench {
 

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.h
@@ -22,7 +22,7 @@ public:
 
   void set_datawriter(Builder::DataWriter& datawriter) override;
   void unset_datawriter(Builder::DataWriter& datawriter) override;
-  
+
   size_t get_match_count() { return match_count_; }
   size_t get_expected_match_count() { return expected_match_count_; }
 

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.h
@@ -23,18 +23,15 @@ public:
   void set_datawriter(Builder::DataWriter& datawriter) override;
   void unset_datawriter(Builder::DataWriter& datawriter) override;
 
-  size_t get_match_count() { return match_count_; }
-  size_t get_expected_match_count() { return expected_match_count_; }
-
-  std::condition_variable wr_expected_match_cv;
-  std::mutex wr_expected_match_cv_mutex;
+  bool wait_for_expected_match(const std::chrono::system_clock::time_point& deadline) const;
 
 protected:
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   size_t expected_match_count_{0};
   size_t match_count_{0};
   Builder::DataWriter* datawriter_{0};
   Builder::PropertyIndex last_discovery_time_;
+  mutable std::condition_variable expected_match_cv;
 };
 
 }

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.h
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.h
@@ -22,6 +22,12 @@ public:
 
   void set_datawriter(Builder::DataWriter& datawriter) override;
   void unset_datawriter(Builder::DataWriter& datawriter) override;
+  
+  size_t get_match_count() { return match_count_; }
+  size_t get_expected_match_count() { return expected_match_count_; }
+
+  std::condition_variable wr_expected_match_cv;
+  std::mutex wr_expected_match_cv_mutex;
 
 protected:
   std::mutex mutex_;

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -306,7 +306,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
             }
           }
         }
-               
+
         auto writeMap = process.get_writer_map();
         if (writeMap.size() > 0) {
           typedef std::map<std::string, std::shared_ptr<Builder::DataWriter>>::iterator WriteMapIt;

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -43,15 +43,15 @@
 #include "WorkerPublisherListener.h"
 #include "WorkerParticipantListener.h"
 #include "WriteAction.h"
+#include "DataReader.h"
+#include "DataWriter.h"
 
 #include <cmath>
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <mutex>
 #include <thread>
 #include <iomanip>
-#include <condition_variable>
 
 #include <util.h>
 #include <json_conversion.h>
@@ -170,6 +170,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   config.enable_time = ZERO;
   config.start_time = ZERO;
   config.stop_time = ZERO;
+  config.wait_for_discovery = false;
+  config.wait_for_discovery_seconds = 0;
 
   if (!json_2_idl(config_file, config)) {
     std::cerr << "Unable to parse configuration" << std::endl;
@@ -223,6 +225,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   Builder::TimeStamp process_start_begin_time = ZERO, process_start_end_time = ZERO;
   Builder::TimeStamp process_stop_begin_time = ZERO, process_stop_end_time = ZERO;
   Builder::TimeStamp process_destruction_begin_time = ZERO, process_destruction_end_time = ZERO;
+  Builder::TimeStamp process_start_discovery_time = ZERO, process_stop_discovery_time = ZERO;
 
   set_global_properties(config.properties);
 
@@ -237,8 +240,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
   try {
     std::string line;
-    std::condition_variable cv;
-    std::mutex cv_mutex;
 
     do_wait(config.create_time, "create", false);
 
@@ -267,6 +268,79 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
     Log::log() << "DDS entities enabled." << std::endl << std::endl;
 
     do_wait(config.start_time, "start");
+
+    Log::log() << "Starting Discovery Check." << std::endl;
+
+    process_start_discovery_time = Builder::get_time();
+
+    if (config.wait_for_discovery) {
+      if (config.wait_for_discovery_seconds > 0) {
+
+        std::chrono::seconds timeoutPeriod(config.wait_for_discovery_seconds);
+        std::chrono::system_clock::time_point timeout_time;
+
+        auto readMap = process.get_reader_map();
+        if (readMap.size() > 0) {
+          typedef std::map<std::string, std::shared_ptr<Builder::DataReader>>::iterator ReadMapIt;
+          std::shared_ptr<Builder::DataReader> dtRdrPtr(nullptr);
+          size_t dr_expected_match_count;
+          size_t dr_match_count;
+
+          for (ReadMapIt it = readMap.begin(); it != readMap.end(); ++it) {
+            dtRdrPtr = it->second;
+            Bench::WorkerDataReaderListener* wdrl = dynamic_cast<Bench::WorkerDataReaderListener*>(dtRdrPtr->get_dds_datareaderlistener().in());
+            std::unique_lock<std::mutex> expected_lock(wdrl->dr_expected_match_cv_mutex);
+            dr_expected_match_count = wdrl->get_expected_match_count();
+            dr_match_count = wdrl->get_match_count();
+            timeout_time = std::chrono::system_clock::now() + timeoutPeriod;
+            if (dr_match_count != dr_expected_match_count) {
+              wdrl->dr_expected_match_cv.wait_until(expected_lock, timeout_time);
+              if (wdrl->get_expected_match_count() == wdrl->get_match_count()) {
+                Log::log() << it->first << "Found " << wdrl->get_match_count() << " expected readers" << std::endl << std::endl;
+              }
+              else {
+                Log::log() << it->first << " Expected readers " << wdrl->get_expected_match_count() << " not found. Found " << wdrl->get_match_count() << std::endl << std::endl;
+              }
+            } else {
+               Log::log() << it->first << "Found " << wdrl->get_match_count() << " expected readers" << std::endl << std::endl;
+            }
+          }
+        }
+               
+        auto writeMap = process.get_writer_map();
+        if (writeMap.size() > 0) {
+          typedef std::map<std::string, std::shared_ptr<Builder::DataWriter>>::iterator WriteMapIt;
+          std::shared_ptr<Builder::DataWriter> dtWtrPtr(nullptr);
+          size_t dw_expected_match_count;
+          size_t dw_match_count;
+
+          for (WriteMapIt it = writeMap.begin(); it != writeMap.end(); ++it) {
+            dtWtrPtr = it->second;
+            Bench::WorkerDataWriterListener* wdwl = dynamic_cast<Bench::WorkerDataWriterListener*>(dtWtrPtr->get_dds_datawriterlistener().in());
+            std::unique_lock<std::mutex> expected_lock(wdwl->wr_expected_match_cv_mutex);
+            dw_expected_match_count = wdwl->get_expected_match_count();
+            dw_match_count = wdwl->get_match_count();
+            timeout_time = std::chrono::system_clock::now() + timeoutPeriod;
+            if (dw_match_count != dw_expected_match_count) {
+              wdwl->wr_expected_match_cv.wait_until(expected_lock, timeout_time);
+              if (wdwl->get_expected_match_count() == wdwl->get_match_count()) {
+                Log::log() << it->first << "Found " << wdwl->get_match_count() << " expected writers" << std::endl << std::endl;
+              }
+              else {
+                Log::log() << it->first << " Expected writers " << wdwl->get_expected_match_count() << " not found. Found " << wdwl->get_match_count() << std::endl << std::endl;
+              }
+            }
+            else {
+              Log::log() << it->first << "Found " << wdwl->get_match_count() << " expected writers" << std::endl << std::endl;
+            }
+          }
+        }
+      }
+    }
+
+    process_stop_discovery_time = Builder::get_time();
+
+    Log::log() << "Discovery Time Check." << process_stop_discovery_time - process_start_discovery_time << std::endl << std::endl;
 
     Log::log() << "Starting process tests." << std::endl;
 

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -275,7 +275,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
       if (config.wait_for_discovery_seconds > 0) {
 
         const std::chrono::seconds timeoutPeriod(config.wait_for_discovery_seconds);
-        std::chrono::system_clock::time_point timeout_time;
+        const std::chrono::system_clock::time_point timeout_time = std::chrono::system_clock::now() + timeoutPeriod;
 
         auto readMap = process.get_reader_map();
         if (readMap.size() > 0) {
@@ -285,7 +285,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
           for (ReadMapIt it = readMap.begin(); it != readMap.end(); ++it) {
             dtRdrPtr = it->second;
             Bench::WorkerDataReaderListener* wdrl = dynamic_cast<Bench::WorkerDataReaderListener*>(dtRdrPtr->get_dds_datareaderlistener().in());
-            timeout_time = std::chrono::system_clock::now() + timeoutPeriod;
 
             if (wdrl->wait_for_expected_match(timeout_time)) {
               Log::log() << it->first << "Found expected writers." << std::endl << std::endl;
@@ -304,7 +303,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
           for (WriteMapIt it = writeMap.begin(); it != writeMap.end(); ++it) {
             dtWtrPtr = it->second;
             Bench::WorkerDataWriterListener* wdwl = dynamic_cast<Bench::WorkerDataWriterListener*>(dtWtrPtr->get_dds_datawriterlistener().in());
-            timeout_time = std::chrono::system_clock::now() + timeoutPeriod;
 
             if (wdwl->wait_for_expected_match(timeout_time)) {
               Log::log() << it->first << "Found expected writers." << std::endl << std::endl;


### PR DESCRIPTION
Adds a delay to Bench 2 worker until all readers and writers are discovered or times out.