### PR TITLE
XTypes: Fix Default Allowed Data Representation and Other Misc Fixes

### DIFF
--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -62,7 +62,7 @@ ACE_END_VERSIONED_NAMESPACE_DECL
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace DDS {
-  struct OctetSeq;
+  class OctetSeq;
 }
 
 namespace OpenDDS {

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -826,28 +826,30 @@ bool Serializer::align_w(size_t al)
 ACE_INLINE void
 Serializer::align_cont_r()
 {
+  const size_t max_align = encoding().max_align();
   const size_t thisblock =
-    (ptrdiff_t(current_->rd_ptr()) - align_rshift_) % encoding().max_align();
+    max_align ? (ptrdiff_t(current_->rd_ptr()) - align_rshift_) % max_align : 0;
 
-  this->current_ = this->current_->cont();
+  current_ = current_->cont();
 
-  if (this->current_) {
-    this->align_rshift_ =
-      (ptrdiff_t(current_->rd_ptr()) - thisblock) % encoding().max_align();
+  if (current_ && max_align) {
+    align_rshift_ =
+      (ptrdiff_t(current_->rd_ptr()) - thisblock) % max_align;
   }
 }
 
 ACE_INLINE void
 Serializer::align_cont_w()
 {
+  const size_t max_align = encoding().max_align();
   const size_t thisblock =
-    (ptrdiff_t(current_->wr_ptr()) - align_wshift_) % encoding().max_align();
+    max_align ? (ptrdiff_t(current_->wr_ptr()) - align_wshift_) % max_align : 0;
 
-  this->current_ = this->current_->cont();
+  current_ = current_->cont();
 
-  if (this->current_) {
-    this->align_wshift_ =
-      (ptrdiff_t(current_->wr_ptr()) - thisblock) % encoding().max_align();
+  if (current_ && max_align) {
+    align_wshift_ =
+      (ptrdiff_t(current_->wr_ptr()) - thisblock) % max_align;
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2342,8 +2342,6 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(
 
     prev_dst = GUID_UNKNOWN;
 
-    size_t submessage_length = 0;
-
     for (DestMetaSubmessageMap::iterator dest_it = addr_it->second.begin(); dest_it != addr_it->second.end(); ++dest_it) {
       for (MetaSubmessageIterVec::iterator resp_it = dest_it->second.begin(); resp_it != dest_it->second.end(); ++resp_it) {
         // Check before every meta_submessage to see if we need to prefix a INFO_DST

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -77,28 +77,33 @@ module DDS {
     };
     typedef sequence<BinaryProperty_t> BinaryPropertySeq;
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct PropertyQosPolicy {
         PropertySeq        value;
         BinaryPropertySeq  binary_value;
     };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct UserDataQosPolicy {
                 OctetSeq value;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct GroupDataQosPolicy {
                 OctetSeq value;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct TopicDataQosPolicy {
                 OctetSeq value;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct PartitionQosPolicy {
                 StringSeq name;
                 };
@@ -115,7 +120,8 @@ module DDS {
                 PERSISTENT_DURABILITY_QOS
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct DurabilityQosPolicy {
                 DurabilityQosPolicyKind kind;
                 };
@@ -129,12 +135,14 @@ module DDS {
         long                    max_samples_per_instance;
     };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct DeadlineQosPolicy {
                 Duration_t period;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct LatencyBudgetQosPolicy {
                 Duration_t duration;
                 };
@@ -145,7 +153,8 @@ module DDS {
                 MANUAL_BY_TOPIC_LIVELINESS_QOS
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct LivelinessQosPolicy {
                 LivelinessQosPolicyKind kind;
                 Duration_t lease_duration;
@@ -156,13 +165,15 @@ module DDS {
                 RELIABLE_RELIABILITY_QOS
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct ReliabilityQosPolicy {
                 ReliabilityQosPolicyKind kind;
                 Duration_t max_blocking_time;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     enum DestinationOrderQosPolicyKind {
                 BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS,
                 BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
@@ -172,25 +183,29 @@ module DDS {
                 DestinationOrderQosPolicyKind kind;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct HistoryQosPolicy {
                 HistoryQosPolicyKind kind;
                 long depth;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct ResourceLimitsQosPolicy {
                 long max_samples;
                 long max_instances;
                 long max_samples_per_instance;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct TransportPriorityQosPolicy {
                 long value;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct LifespanQosPolicy {
                 Duration_t duration;
                 };
@@ -200,12 +215,14 @@ module DDS {
                 EXCLUSIVE_OWNERSHIP_QOS
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct OwnershipQosPolicy {
                 OwnershipQosPolicyKind kind;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct OwnershipStrengthQosPolicy {
                 long value;
                 };
@@ -216,14 +233,16 @@ module DDS {
                 GROUP_PRESENTATION_QOS
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct PresentationQosPolicy {
                 PresentationQosPolicyAccessScopeKind access_scope;
                 boolean coherent_access;
                 boolean ordered_access;
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct TimeBasedFilterQosPolicy {
                 Duration_t minimum_separation;
                 };
@@ -238,7 +257,9 @@ module DDS {
     const DataRepresentationId_t XCDR2_DATA_REPRESENTATION = 2;
 
     typedef sequence<DataRepresentationId_t> DataRepresentationIdSeq;
-    //@appendable
+
+    // This is for when we support XCDR1.
+    // @appendable
     struct DataRepresentationQosPolicy {
       DataRepresentationIdSeq value;
     };
@@ -256,7 +277,8 @@ module DDS {
     const string TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_NAME =
       "TypeConsistencyEnforcement";
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct TypeConsistencyEnforcementQosPolicy {
       TypeConsistencyKind kind;
       boolean ignore_sequence_bounds;
@@ -267,7 +289,8 @@ module DDS {
     };
     */
 
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct TopicQos {
       TopicDataQosPolicy topic_data;
       DurabilityQosPolicy durability;
@@ -289,7 +312,8 @@ module DDS {
                 boolean autodispose_unregistered_instances;
                 };
 
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct DataWriterQos {
       DurabilityQosPolicy durability;
       DurabilityServiceQosPolicy durability_service;
@@ -325,7 +349,8 @@ module DDS {
                 Duration_t autopurge_disposed_samples_delay;
                 };
 
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct DataReaderQos {
       DurabilityQosPolicy durability;
       DeadlineQosPolicy deadline;
@@ -362,7 +387,8 @@ module DDS {
                 PropertyQosPolicy property; // DDS-Security 1.1 ptc/2017-09-26
                 };
 
-    //@appendable
+    // This is for when we support XCDR1.
+    // @appendable
     struct BuiltinTopicKey_t {
                 BUILT_IN_TOPIC_KEY BuiltinTopicKeyValue value;
                 };
@@ -370,7 +396,8 @@ module DDS {
     // ----------------------------------------------------------------------
 
     BUILT_IN_TOPIC_TYPE
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct ParticipantBuiltinTopicData {
       BUILT_IN_TOPIC_KEY
       @id(0x0050) BuiltinTopicKey_t key;
@@ -378,7 +405,8 @@ module DDS {
     };
 
     BUILT_IN_TOPIC_TYPE
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct PublicationBuiltinTopicData {
       BUILT_IN_TOPIC_KEY
       @id(0x005A) BuiltinTopicKey_t key;
@@ -413,7 +441,8 @@ module DDS {
     };
 
     BUILT_IN_TOPIC_TYPE
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct SubscriptionBuiltinTopicData {
       @id(0x005A) BUILT_IN_TOPIC_KEY BuiltinTopicKey_t key;
       @id(0x0050) BuiltinTopicKey_t participant_key;
@@ -448,7 +477,8 @@ module DDS {
     };
 
     BUILT_IN_TOPIC_TYPE
-    /* @mutable */
+    // This is for when we support XCDR1.
+    // @mutable
     struct TopicBuiltinTopicData {
       BUILT_IN_TOPIC_KEY
       @id(0x005A) BuiltinTopicKey_t key;

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -77,28 +77,28 @@ module DDS {
     };
     typedef sequence<BinaryProperty_t> BinaryPropertySeq;
 
-    @appendable
+    //@appendable
     struct PropertyQosPolicy {
         PropertySeq        value;
         BinaryPropertySeq  binary_value;
     };
 
-    @appendable
+    //@appendable
     struct UserDataQosPolicy {
                 OctetSeq value;
                 };
 
-    @appendable
+    //@appendable
     struct GroupDataQosPolicy {
                 OctetSeq value;
                 };
 
-    @appendable
+    //@appendable
     struct TopicDataQosPolicy {
                 OctetSeq value;
                 };
 
-    @appendable
+    //@appendable
     struct PartitionQosPolicy {
                 StringSeq name;
                 };
@@ -115,7 +115,7 @@ module DDS {
                 PERSISTENT_DURABILITY_QOS
                 };
 
-    @appendable
+    //@appendable
     struct DurabilityQosPolicy {
                 DurabilityQosPolicyKind kind;
                 };
@@ -129,12 +129,12 @@ module DDS {
         long                    max_samples_per_instance;
     };
 
-    @appendable
+    //@appendable
     struct DeadlineQosPolicy {
                 Duration_t period;
                 };
 
-    @appendable
+    //@appendable
     struct LatencyBudgetQosPolicy {
                 Duration_t duration;
                 };
@@ -145,7 +145,7 @@ module DDS {
                 MANUAL_BY_TOPIC_LIVELINESS_QOS
                 };
 
-    @appendable
+    //@appendable
     struct LivelinessQosPolicy {
                 LivelinessQosPolicyKind kind;
                 Duration_t lease_duration;
@@ -156,13 +156,13 @@ module DDS {
                 RELIABLE_RELIABILITY_QOS
                 };
 
-    @appendable
+    //@appendable
     struct ReliabilityQosPolicy {
                 ReliabilityQosPolicyKind kind;
                 Duration_t max_blocking_time;
                 };
 
-    @appendable
+    //@appendable
     enum DestinationOrderQosPolicyKind {
                 BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS,
                 BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
@@ -172,25 +172,25 @@ module DDS {
                 DestinationOrderQosPolicyKind kind;
                 };
 
-    @appendable
+    //@appendable
     struct HistoryQosPolicy {
                 HistoryQosPolicyKind kind;
                 long depth;
                 };
 
-    @appendable
+    //@appendable
     struct ResourceLimitsQosPolicy {
                 long max_samples;
                 long max_instances;
                 long max_samples_per_instance;
                 };
 
-    @appendable
+    //@appendable
     struct TransportPriorityQosPolicy {
                 long value;
                 };
 
-    @appendable
+    //@appendable
     struct LifespanQosPolicy {
                 Duration_t duration;
                 };
@@ -200,12 +200,12 @@ module DDS {
                 EXCLUSIVE_OWNERSHIP_QOS
                 };
 
-    @appendable
+    //@appendable
     struct OwnershipQosPolicy {
                 OwnershipQosPolicyKind kind;
                 };
 
-    @appendable
+    //@appendable
     struct OwnershipStrengthQosPolicy {
                 long value;
                 };
@@ -216,14 +216,14 @@ module DDS {
                 GROUP_PRESENTATION_QOS
                 };
 
-    @appendable
+    //@appendable
     struct PresentationQosPolicy {
                 PresentationQosPolicyAccessScopeKind access_scope;
                 boolean coherent_access;
                 boolean ordered_access;
                 };
 
-    @appendable
+    //@appendable
     struct TimeBasedFilterQosPolicy {
                 Duration_t minimum_separation;
                 };
@@ -238,7 +238,7 @@ module DDS {
     const DataRepresentationId_t XCDR2_DATA_REPRESENTATION = 2;
 
     typedef sequence<DataRepresentationId_t> DataRepresentationIdSeq;
-    @appendable
+    //@appendable
     struct DataRepresentationQosPolicy {
       DataRepresentationIdSeq value;
     };
@@ -256,7 +256,7 @@ module DDS {
     const string TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_NAME =
       "TypeConsistencyEnforcement";
 
-    @appendable
+    //@appendable
     struct TypeConsistencyEnforcementQosPolicy {
       TypeConsistencyKind kind;
       boolean ignore_sequence_bounds;
@@ -267,7 +267,7 @@ module DDS {
     };
     */
 
-    @mutable
+    /* @mutable */
     struct TopicQos {
       TopicDataQosPolicy topic_data;
       DurabilityQosPolicy durability;
@@ -289,7 +289,7 @@ module DDS {
                 boolean autodispose_unregistered_instances;
                 };
 
-    @mutable
+    /* @mutable */
     struct DataWriterQos {
       DurabilityQosPolicy durability;
       DurabilityServiceQosPolicy durability_service;
@@ -325,7 +325,7 @@ module DDS {
                 Duration_t autopurge_disposed_samples_delay;
                 };
 
-    @mutable
+    /* @mutable */
     struct DataReaderQos {
       DurabilityQosPolicy durability;
       DeadlineQosPolicy deadline;
@@ -362,7 +362,7 @@ module DDS {
                 PropertyQosPolicy property; // DDS-Security 1.1 ptc/2017-09-26
                 };
 
-    @appendable
+    //@appendable
     struct BuiltinTopicKey_t {
                 BUILT_IN_TOPIC_KEY BuiltinTopicKeyValue value;
                 };
@@ -370,7 +370,7 @@ module DDS {
     // ----------------------------------------------------------------------
 
     BUILT_IN_TOPIC_TYPE
-    @mutable
+    /* @mutable */
     struct ParticipantBuiltinTopicData {
       BUILT_IN_TOPIC_KEY
       @id(0x0050) BuiltinTopicKey_t key;
@@ -378,7 +378,7 @@ module DDS {
     };
 
     BUILT_IN_TOPIC_TYPE
-    @mutable
+    /* @mutable */
     struct PublicationBuiltinTopicData {
       BUILT_IN_TOPIC_KEY
       @id(0x005A) BuiltinTopicKey_t key;
@@ -413,7 +413,7 @@ module DDS {
     };
 
     BUILT_IN_TOPIC_TYPE
-    @mutable
+    /* @mutable */
     struct SubscriptionBuiltinTopicData {
       @id(0x005A) BUILT_IN_TOPIC_KEY BuiltinTopicKey_t key;
       @id(0x0050) BuiltinTopicKey_t participant_key;
@@ -448,7 +448,7 @@ module DDS {
     };
 
     BUILT_IN_TOPIC_TYPE
-    @mutable
+    /* @mutable */
     struct TopicBuiltinTopicData {
       BUILT_IN_TOPIC_KEY
       @id(0x005A) BuiltinTopicKey_t key;

--- a/dds/idl/be_global.cpp
+++ b/dds/idl/be_global.cpp
@@ -58,7 +58,7 @@ BE_GlobalData::BE_GlobalData()
   , warn_about_dcps_data_type_(true)
   , default_extensibility_(extensibilitykind_appendable)
 {
-  default_data_representation_.set_all(false);
+  default_data_representation_.set_all(true);
 }
 
 BE_GlobalData::~BE_GlobalData()

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -529,7 +529,9 @@ namespace {
       insertion.addArg(use_cxx11 ? "wrap" : "seq", const_cxx);
       insertion.endArgs();
 
-      be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+      be_global->impl_ <<
+        "  const Encoding& encoding = strm.encoding();\n"
+        "  ACE_UNUSED_ARG(encoding);\n";
       std::vector<string> code;
       code.push_back(string("serialized_size(strm.encoding(), total_size, ") + (use_cxx11 ? "wrap" : "seq") + ");");
       code.push_back("if (!strm.write_delimiter(total_size)) {");
@@ -601,7 +603,9 @@ namespace {
       extraction.addArg(use_cxx11 ? "wrap" : "seq", cxx);
       extraction.endArgs();
 
-      be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+      be_global->impl_ <<
+        "  const Encoding& encoding = strm.encoding();\n"
+        "  ACE_UNUSED_ARG(encoding);\n";
       std::vector<string> code;
       code.push_back("if (!strm.read_delimiter(total_size)) {");
       code.push_back("  return false;");
@@ -1018,7 +1022,9 @@ namespace {
       insertion.addArg(use_cxx11 ? "wrap" : "arr", const_cxx);
       insertion.endArgs();
 
-      be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+      be_global->impl_ <<
+        "  const Encoding& encoding = strm.encoding();\n"
+        "  ACE_UNUSED_ARG(encoding);\n";
       std::vector<string> code;
       code.push_back(string("serialized_size(strm.encoding(), total_size, ") + (use_cxx11 ? "wrap" : "arr") + ");");
       code.push_back("if (!strm.write_delimiter(total_size)) {");
@@ -1065,7 +1071,10 @@ namespace {
       extraction.addArg(use_cxx11 ? "wrap" : "arr", cxx);
       extraction.endArgs();
 
-      be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+      be_global->impl_ <<
+        "  const Encoding& encoding = strm.encoding();\n"
+        "  ACE_UNUSED_ARG(encoding);\n";
+      std::vector<string> code;
       std::vector<string> code;
       code.push_back("if (!strm.read_delimiter(total_size)) {");
       code.push_back("  return false;");
@@ -2306,7 +2315,9 @@ bool marshal_generator::gen_struct(AST_Structure* node,
     insertion.addArg("stru", "const " + cxx + "&");
     insertion.endArgs();
 
-    be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+    be_global->impl_ <<
+      "  const Encoding& encoding = strm.encoding();\n"
+      "  ACE_UNUSED_ARG(encoding);\n";
     std::vector<string> code;
     code.push_back("serialized_size(strm.encoding(), total_size, stru);");
     code.push_back("if (!strm.write_delimiter(total_size)) {");
@@ -2373,7 +2384,9 @@ bool marshal_generator::gen_struct(AST_Structure* node,
     extraction.endArgs();
     string intro;
 
-    be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+    be_global->impl_ <<
+      "  const Encoding& encoding = strm.encoding();\n"
+      "  ACE_UNUSED_ARG(encoding);\n";
     std::vector<string> code;
     code.push_back("if (!strm.read_delimiter(total_size)) {");
     code.push_back("  return false;");
@@ -3011,7 +3024,9 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
     insertion.addArg("uni", "const " + cxx + "&");
     insertion.endArgs();
 
-    be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+    be_global->impl_ <<
+      "  const Encoding& encoding = strm.encoding();\n"
+      "  ACE_UNUSED_ARG(encoding);\n";
     std::vector<string> code;
     code.push_back("serialized_size(encoding, total_size, uni);");
     code.push_back("if (!strm.write_delimiter(total_size)) {");
@@ -3033,7 +3048,9 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
     extraction.addArg("uni", cxx + "&");
     extraction.endArgs();
 
-    be_global->impl_ << "  const Encoding& encoding = strm.encoding();\n";
+    be_global->impl_ <<
+      "  const Encoding& encoding = strm.encoding();\n"
+      "  ACE_UNUSED_ARG(encoding);\n";
     std::vector<string> code;
     code.push_back("if (!strm.read_delimiter(total_size)) {");
     code.push_back("  return false;");

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -1075,7 +1075,6 @@ namespace {
         "  const Encoding& encoding = strm.encoding();\n"
         "  ACE_UNUSED_ARG(encoding);\n";
       std::vector<string> code;
-      std::vector<string> code;
       code.push_back("if (!strm.read_delimiter(total_size)) {");
       code.push_back("  return false;");
       code.push_back("}");

--- a/dds/idl/ts_generator.cpp
+++ b/dds/idl/ts_generator.cpp
@@ -233,7 +233,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
       "\n"
       "  void representations_allowed_by_type(::DDS::DataRepresentationIdSeq& seq);\n"
       "\n"
-      "  virtual const OpenDDS::XTypes::TypeObject& getMinimalTypeObject() const; \n"
+      "  virtual const OpenDDS::XTypes::TypeObject& getMinimalTypeObject() const;\n"
       "\n"
       "  virtual OpenDDS::DCPS::Extensibility getExtensibility() const;\n"
       "\n"


### PR DESCRIPTION
Set the allowed data representation of types without a annotation to all of them, or all true. I might have gotten mixed up with the fact that in `DataRepresentationAnnotation::node_value_exists`, when there is an annotation, the starting value has to be all false and then the annotations add values to it.

Also added some misc minor fixes, mostly cherry-picked from #1846 so that they might get merged faster.