### PR TITLE
XTypes: Improve XCDR2 tests

### DIFF
--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -2393,7 +2393,7 @@ bool marshal_generator::gen_struct(AST_Structure* node,
     generate_dheader_code(code, not_final);
     if (not_final) {
       be_global->impl_ <<
-        "  size_t start_pos = strm.pos();\n";
+        "  const size_t start_pos = strm.pos();\n";
     }
 
     if (may_be_parameter_list) {

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -1084,7 +1084,7 @@ void expect_values_equal(const MixedMutableStruct& a,
 }
 
 const unsigned char mixed_mutable_struct_xcdr2[] = {
-  0x00, 0x00, 0x00, 0xab, // +4 DHEADER = 4 (TODO: update)
+  0x00, 0x00, 0x00, 0xaf, // +4 DHEADER = 4
   //MU,LC,ID   NEXTINT
   0x40,0,0,1,  0,0,0,0x28, // +8 EMHEADER1 + NEXTINT of struct_nested = 12
   // <<<<<< Begin struct_nested

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -780,6 +780,7 @@ TEST(appendable_tests, BothAppendableStruct2)
 
 // Mutable Tests =============================================================
 
+// ---------- MutableStruct
 const unsigned char mutable_struct_expected_xcdr1[] = {
   // short_field
   0xc0, 0x04, 0x00, 0x02, // PID +4 = 4
@@ -799,7 +800,11 @@ const unsigned char mutable_struct_expected_xcdr1[] = {
   0x3f, 0x02, 0x00, 0x00 // +4 = 40
 };
 
-const unsigned char mutable_struct_expected_xcdr2[] = {
+struct MutableStructExpectedXcdr2BE {
+  STREAM_DATA
+};
+
+const unsigned char MutableStructExpectedXcdr2BE::expected[] = {
   0x00,0,0,0x24, // +4=4 Delimiter
   0x10,0,0,0x04, 0x7f,0xff,  (0),(0), // +4+2+(2)=12 short_field
   0x20,0,0,0x06, 0x7f,0xff,0xff,0xff, // +4+4    =20 long_field
@@ -807,65 +812,87 @@ const unsigned char mutable_struct_expected_xcdr2[] = {
   0x30,0,0,0x0a, 0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff // +4+8=40 long_long_field
 };
 
-// Baseline ------------------------------------------------------------------
+const unsigned MutableStructExpectedXcdr2BE::layout[] = {4,4,2,2,4,4,4,1,3,4,8};
 
-TEST(mutable_tests, baseline_xcdr1_test)
+TEST(MutableTests, BaselineXcdr1Test)
 {
   baseline_checks<MutableStruct>(xcdr1, mutable_struct_expected_xcdr1);
 }
 
-TEST(mutable_tests, baseline_xcdr2_test)
+TEST(MutableTests, BaselineXcdr2Test)
 {
-  baseline_checks<MutableStruct>(xcdr2, mutable_struct_expected_xcdr2);
+  baseline_checks<MutableStruct>(xcdr2, MutableStructExpectedXcdr2BE::expected);
 }
 
-const unsigned char mutable_union_expected_xcdr2_short[] = {
+TEST(MutableTests, BaselineXcdr2TestLE)
+{
+  test_little_endian<MutableStruct, MutableStructExpectedXcdr2BE>();
+}
+
+// ---------- MutableUnion
+struct MutableUnionExpectedXcdr2ShortBE {
+  STREAM_DATA
+};
+
+const unsigned char MutableUnionExpectedXcdr2ShortBE::expected[] = {
   // Delimiter
   0x00, 0x00, 0x00, 0x0e, // +4 = 4
-  // Discriminator EMHEADER
-  0x20, 0x00, 0x00, 0x00, // PID  +4 = 8
   // Discriminator
-  0x00, 0x00, 0x00, 0x00, // +4 = 12
+  0x20, 0x00, 0x00, 0x00, // +4 EMHEADER1 = 8
+  0x00, 0x00, 0x00, 0x00, // +4 value = 12
   // short_field
-  0x10, 0x00, 0x00, 0x04, // PID  +4 = 16
-  0x7f, 0xff // +2 = 18
+  0x10, 0x00, 0x00, 0x04, // +4 EMHEADER1 = 16
+  0x7f, 0xff // +2 value = 18
+};
+const unsigned MutableUnionExpectedXcdr2ShortBE::layout[] = {4,4,4,4,2};
+
+struct MutableUnionExpectedXcdr2LongBE {
+  STREAM_DATA
 };
 
-const unsigned char mutable_union_expected_xcdr2_long[] = {
+const unsigned char MutableUnionExpectedXcdr2LongBE::expected[] = {
   // Delimiter
   0x00, 0x00, 0x00, 0x10, // +4 = 4
-  // Discriminator EMHEADER
-  0x20, 0x00, 0x00, 0x00, // PID  +4 = 8
   // Discriminator
-  0x00, 0x00, 0x00, 0x01, // +4 = 12
+  0x20, 0x00, 0x00, 0x00, // +4 EMHEADER1 = 8
+  0x00, 0x00, 0x00, 0x01, // +4 value = 12
   // long_field
-  0x20, 0x00, 0x00, 0x06,// PID  +4 = 16
-  0x7f, 0xff, 0xff, 0xff // +4 = 20
+  0x20, 0x00, 0x00, 0x06,// +4 EMHEADER1 = 16
+  0x7f, 0xff, 0xff, 0xff // +4 value = 20
+};
+const unsigned MutableUnionExpectedXcdr2LongBE::layout[] = {4,4,4,4,4};
+
+struct MutableUnionExpectedXcdr2OctetBE {
+  STREAM_DATA
 };
 
-const unsigned char mutable_union_expected_xcdr2_octet[] = {
+const unsigned char MutableUnionExpectedXcdr2OctetBE::expected[] = {
   // Delimiter
   0x00, 0x00, 0x00, 0x0d, // +4 = 4
-  // Discriminator EMHEADER
-  0x20, 0x00, 0x00, 0x00, // PID  +4 = 8
   // Discriminator
-  0x00, 0x00, 0x00, 0x02, // +4 = 12
+  0x20, 0x00, 0x00, 0x00, // +4 EMHEADER1 = 8
+  0x00, 0x00, 0x00, 0x02, // +4 value = 12
   // octet_field
-  0x00, 0x00, 0x00, 0x08, // PID  +4 = 16
-  0x01                    // +1 = 17
+  0x00, 0x00, 0x00, 0x08, // +4 EMHEADER1 = 16
+  0x01                    // +1 value = 17
+};
+const unsigned MutableUnionExpectedXcdr2OctetBE::layout[] = {4,4,4,4,1};
+
+struct MutableUnionExpectedXcdr2LongLongBE {
+  STREAM_DATA
 };
 
-const unsigned char mutable_union_expected_xcdr2_long_long[] = {
+const unsigned char MutableUnionExpectedXcdr2LongLongBE::expected[] = {
   // Delimiter
   0x00, 0x00, 0x00, 0x14, // +4 = 4
-  // Discriminator EMHEADER
-  0x20, 0x00, 0x00, 0x00, // PID  +4 = 8
   // Discriminator
-  0x00, 0x00, 0x00, 0x03, // +4 = 12
+  0x20, 0x00, 0x00, 0x00, // +4 EMHEADER1 = 8
+  0x00, 0x00, 0x00, 0x03, // +4 value = 12
   // long_field
-  0x30, 0x00, 0x00, 0x0a, // PID  +4 = 16
-  0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +8 = 24
+  0x30, 0x00, 0x00, 0x0a, // +4 EMHEADER1 = 16
+  0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +8 value = 24
 };
+const unsigned MutableUnionExpectedXcdr2LongLongBE::layout[] = {4,4,4,4,8};
 
 template<>
 void expect_values_equal(const MutableUnion& a, const MutableUnion& b)
@@ -873,24 +900,33 @@ void expect_values_equal(const MutableUnion& a, const MutableUnion& b)
   expect_values_equal_base_union(a, b);
 }
 
-TEST(mutable_tests, baseline_xcdr2_test_union)
+TEST(MutableTests, BaselineXcdr2TestUnion)
 {
-  baseline_checks_union<MutableUnion>(xcdr2, mutable_union_expected_xcdr2_short, E_SHORT_FIELD);
-  baseline_checks_union<MutableUnion>(xcdr2, mutable_union_expected_xcdr2_long, E_LONG_FIELD);
-  baseline_checks_union<MutableUnion>(xcdr2, mutable_union_expected_xcdr2_octet, E_OCTET_FIELD);
-  baseline_checks_union<MutableUnion>(xcdr2, mutable_union_expected_xcdr2_long_long, E_LONG_LONG_FIELD);
+  baseline_checks_union<MutableUnion>(
+    xcdr2, MutableUnionExpectedXcdr2ShortBE::expected, E_SHORT_FIELD);
+  baseline_checks_union<MutableUnion>(
+    xcdr2, MutableUnionExpectedXcdr2LongBE::expected, E_LONG_FIELD);
+  baseline_checks_union<MutableUnion>(
+    xcdr2, MutableUnionExpectedXcdr2OctetBE::expected, E_OCTET_FIELD);
+  baseline_checks_union<MutableUnion>(
+    xcdr2, MutableUnionExpectedXcdr2LongLongBE::expected, E_LONG_LONG_FIELD);
 }
 
-// Reordered Tests -----------------------------------------------------------
+TEST(MutableTests, BaselineXcdr2TestUnionLE)
+{
+  // TODO (sonndinh): do this
+}
+
+// ---------- ReorderedMutableStruct
 // Test compatibility between two structures with different field orders.
 
-TEST(mutable_tests, to_reordered_xcdr1_test)
+TEST(MutableTests, ToReorderedXcdr1Test)
 {
   amalgam_serializer_test<MutableStruct, ReorderedMutableStruct>(
     xcdr1, mutable_struct_expected_xcdr1);
 }
 
-TEST(mutable_tests, from_reordered_xcdr1_test)
+TEST(MutableTests, FromReorderedXcdr1Test)
 {
   const unsigned char expected[] = {
     // long_field
@@ -913,22 +949,34 @@ TEST(mutable_tests, from_reordered_xcdr1_test)
   amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr1, expected);
 }
 
-TEST(mutable_tests, to_reordered_xcdr2_test)
+TEST(MutableTests, ToReorderedXcdr2Test)
 {
   amalgam_serializer_test<MutableStruct, ReorderedMutableStruct>(
-    xcdr2, mutable_struct_expected_xcdr2);
+    xcdr2, MutableStructExpectedXcdr2BE::expected);
 }
 
-TEST(mutable_tests, from_reordered_xcdr2_test)
+TEST(MutableTests, ToReorderedXcdr2TestLE)
 {
-  const unsigned char expected[] = {
+  test_little_endian<MutableStruct, ReorderedMutableStruct,
+                     MutableStructExpectedXcdr2BE>();
+}
+
+TEST(MutableTests, FromReorderedXcdr2Test)
+{
+  unsigned char expected[] = {
     0x00,0,0,0x22, // +4=4 Delimiter
     0x20,0,0,0x06, 0x7f,0xff,0xff,0xff, // +4+4=12 long_field
     0x30,0,0,0x0a, 0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff, // +4+8=24 long_long_field
     0x00,0,0,0x08, 0x01,   (0),(0),(0), // +4+1+(3)=32 octet_field
     0x10,0,0,0x04, 0x7f,0xff            // +4+2    =38 short_field
   };
+  const unsigned layout[] = {4,4,4,4,8,4,1,3,4,2};
+
   amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr2, expected);
+
+  // Little-endian test
+  change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
+  amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr2_le, expected);
 }
 
 // ---------- AdditionalFieldMutableStruct
@@ -942,7 +990,7 @@ void set_values<AdditionalFieldMutableStruct>(
   value.additional_field = 0x12345678;
 }
 
-TEST(mutable_tests, to_additional_field_xcdr1_test)
+TEST(MutableTests, ToAdditionalFieldXcdr1Test)
 {
   MutableStruct value;
   set_values(value);
@@ -952,7 +1000,7 @@ TEST(mutable_tests, to_additional_field_xcdr1_test)
   /// value?) if we decide on that.
 }
 
-TEST(mutable_tests, from_additional_field_xcdr1_test)
+TEST(MutableTests, FromAdditionalFieldXcdr1Test)
 {
   const unsigned char expected[] = {
     // long_field
@@ -978,19 +1026,22 @@ TEST(mutable_tests, from_additional_field_xcdr1_test)
   amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr1, expected);
 }
 
-TEST(mutable_tests, to_additional_field_xcdr2_test)
+TEST(MutableTests, ToAdditionalFieldXcdr2Test)
 {
   MutableStruct value;
   set_values(value);
   AdditionalFieldMutableStruct result;
-  amalgam_serializer_test(xcdr2, mutable_struct_expected_xcdr2, value, result);
+  amalgam_serializer_test(xcdr2, MutableStructExpectedXcdr2BE::expected, value, result);
   /// TODO(iguessthidlldo): Test for correct try construct behavior (default
   /// value?) if we decide on that.
+
+  test_little_endian<MutableStruct, AdditionalFieldMutableStruct,
+                     MutableStructExpectedXcdr2BE>();
 }
 
-TEST(mutable_tests, from_additional_field_must_understand_test)
+TEST(MutableTests, FromAdditionalFieldMustUnderstandTest)
 {
-  const unsigned char additional_field_must_understand[] = {
+  unsigned char additional_field_must_understand[] = {
     0x00,0x00,0x00,0x2a, // +4=4 Delimiter
     0x20,0x00,0x00,0x06, 0x7f,0xff,0xff,0xff, // +4+4=12 long_field
     0xa0,0x00,0x00,0x01, 0x12,0x34,0x56,0x78, // +4+4=20 additional_field @must_understand
@@ -998,6 +1049,7 @@ TEST(mutable_tests, from_additional_field_must_understand_test)
     0x00,0x00,0x00,0x08, 0x01, (0),(0),(0), // +4+1+(3)=40 octet_field
     0x10,0x00,0x00,0x04, 0x7f,0xff // +4+2=46 short_field
   };
+  unsigned layout[] = {4,4,4,4,4,4,8,4,1,3,4,2};
 
   // Deserialization should fail for unknown must_understand field
   ACE_Message_Block buffer(1024);
@@ -1010,11 +1062,16 @@ TEST(mutable_tests, from_additional_field_must_understand_test)
   AdditionalFieldMutableStruct expected;
   set_values(expected);
   deserialize_compare(xcdr2, additional_field_must_understand, expected);
+
+  // Little-endian test
+  change_endianness(additional_field_must_understand,
+                    layout, sizeof(layout)/sizeof(unsigned));
+  deserialize_compare(xcdr2_le, additional_field_must_understand, expected);
 }
 
-TEST(mutable_tests, from_additional_field_xcdr2_test)
+TEST(MutableTests, FromAdditionalFieldXcdr2Test)
 {
-  const unsigned char expected[] = {
+  unsigned char expected[] = {
     0x00,0x00,0x00,0x2a, // +4=4 Delimiter
     0x20,0x00,0x00,0x06, 0x7f,0xff,0xff,0xff, // +4+4=12 long_field
     0x20,0x00,0x00,0x01, 0x12,0x34,0x56,0x78, // +4+4=20 additional_field
@@ -1022,7 +1079,11 @@ TEST(mutable_tests, from_additional_field_xcdr2_test)
     0x00,0x00,0x00,0x08, 0x01, (0),(0),(0), // +4+1+(3)=40 octet_field
     0x10,0x00,0x00,0x04, 0x7f,0xff // +4+2=46 short_field
   };
+  unsigned layout[] = {4,4,4,4,4,4,8,4,1,3,4,2};
+
   amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr2, expected);
+  change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
+  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr2_le, expected);
 }
 
 // ---------- LengthCodeStruct
@@ -1064,7 +1125,7 @@ void expect_values_equal(const LengthCodeStruct& a, const LengthCodeStruct& b)
   EXPECT_STREQ(a.str5, b.str5);
 }
 
-TEST(mutable_tests, length_code_test)
+TEST(MutableTests, LengthCodeTest)
 {
   unsigned char expected[] = {
     0x00,0x00,0x00,0xc1, // +4 = 4  Delimiter
@@ -1150,7 +1211,7 @@ void expect_values_equal(const LC567Struct& a, const LC567Struct& b)
   EXPECT_EQ(a.ls[1], b.ls[1]);
 }
 
-TEST(mutable_tests, read_lc567_test)
+TEST(MutableTests, ReadLc567Test)
 {
   unsigned char data[] = {
     0,0,0,0x87, // Delimiter +4=4
@@ -1258,12 +1319,12 @@ const unsigned MixedMutableStructXcdr2BE::layout[] = {4,4,4,4,4,2,2,4,4,4,1,3,4,
                                                       1,1,1,1,1,1,1,1,1,1,4,1,1,1,1,1,
                                                       1,1,1,1,1,1,1,4,1,1,1,1,1,1,1,1,1,1,1};
 
-TEST(mutable_tests, BothMixedMutableStruct)
+TEST(MutableTests, BothMixedMutableStruct)
 {
   serializer_test<MixedMutableStruct>(xcdr2, MixedMutableStructXcdr2BE::expected);
 }
 
-TEST(mutable_tests, BothMixedMutableStructLE)
+TEST(MutableTests, BothMixedMutableStructLE)
 {
   test_little_endian<MixedMutableStruct, MixedMutableStructXcdr2BE>();
 }
@@ -1275,13 +1336,13 @@ void expect_values_equal(const MixedMutableStruct& a,
   expect_values_equal_base(a.struct_nested, b.struct_nested);
 }
 
-TEST(mutable_tests, FromMixedMutableStruct)
+TEST(MutableTests, FromMixedMutableStruct)
 {
   amalgam_serializer_test<MixedMutableStruct, ModifiedMixedMutableStruct>(
     xcdr2, MixedMutableStructXcdr2BE::expected);
 }
 
-TEST(mutable_tests, FromMixedMutableStructLE)
+TEST(MutableTests, FromMixedMutableStructLE)
 {
   test_little_endian<MixedMutableStruct, ModifiedMixedMutableStruct,
                      MixedMutableStructXcdr2BE>();
@@ -1341,12 +1402,12 @@ const unsigned NestingFinalStructXcdr2BE::layout[] = {4,1,1,1,1,1,1,1,1,1,1,1,1,
                                                       4,2,2,4,1,3,8,4,2,2,2,2,4,
                                                       4,2,2,4,4,4,1,3,4,8};
 
-TEST(mixed_exten_tests, NestingFinalStruct)
+TEST(MixedExtenTests, NestingFinalStruct)
 {
   serializer_test<NestingFinalStruct>(xcdr2, NestingFinalStructXcdr2BE::expected);
 }
 
-TEST(mixed_exten_tests, NestingFinalStructLE)
+TEST(MixedExtenTests, NestingFinalStructLE)
 {
   test_little_endian<NestingFinalStruct, NestingFinalStructXcdr2BE>();
 }
@@ -1405,12 +1466,12 @@ const unsigned NestingAppendableStructXcdr2BE::layout[] = {4,4,1,1,1,1,1,1,1,1,1
                                                            4,4,2,2,4,4,4,1,3,4,8,4,4,4,
                                                            4,2,2,4,1,3,8};
 
-TEST(mixed_exten_tests, NestingAppendableStruct)
+TEST(MixedExtenTests, NestingAppendableStruct)
 {
   serializer_test<NestingAppendableStruct>(xcdr2, NestingAppendableStructXcdr2BE::expected);
 }
 
-TEST(mixed_exten_tests, NestingAppendableStructLE)
+TEST(MixedExtenTests, NestingAppendableStructLE)
 {
   test_little_endian<NestingAppendableStruct, NestingAppendableStructXcdr2BE>();
 }
@@ -1471,12 +1532,12 @@ const unsigned NestingMutableStructXcdr2BE::layout[] = {4,4,4,4,1,1,1,1,1,1,1,1,
                                                         4,4,4,2,2,4,1,3,8,4,4,4,1,1,1,1,
                                                         1,1,1,1,4,4,2,2,4,1,3,8};
 
-TEST(mixed_exten_tests, NestingMutableStruct)
+TEST(MixedExtenTests, NestingMutableStruct)
 {
   serializer_test<NestingMutableStruct>(xcdr2, NestingMutableStructXcdr2BE::expected);
 }
 
-TEST(mixed_exten_tests, NestingMutableStructLE)
+TEST(MixedExtenTests, NestingMutableStructLE)
 {
   test_little_endian<NestingMutableStruct, NestingMutableStructXcdr2BE>();
 }

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -635,6 +635,25 @@ TEST(mutable_tests, read_lc567_test)
   deserialize_compare(xcdr2, data, expected);
 }
 
+TEST(mutable_tests, MixedMutableStruct)
+{
+  const unsigned char expected[] = {
+                                    0x00, 0x00, 0x00, 0x00, // +4 Delimiter = 4
+  };
+}
+
+TEST(extensibility_tests, NestingFinalStruct)
+{
+}
+
+TEST(extensibility_tests, NestingAppendableStruct)
+{
+}
+
+TEST(extensibility_tests, NestingMutableStruct)
+{
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -1054,7 +1054,7 @@ const unsigned char nesting_mutable_struct_xcdr2[] = {
   0x00, 0x00, 0x00, 0x68, // +4 DHEADER = 4
   //MU,LC,ID   NEXTINT   Value and pad(0)
   0x40,0,0,0,  0,0,0,16, 0,0,0,12,'h','e','l','l','o',' ','w','o','r','l','d','\0', // +24 string_field = 28
-  0x40,0,0,1,  0,0,0,18, // +8 EMHEADER1 + NEXTINT of appendable_nested = 36
+  0x40,0,0,1,  0,0,0,0x18, // +8 EMHEADER1 + NEXTINT of appendable_nested = 36
   // <<<<<< Begin appendable_nested
   0x00, 0x00, 0x00, 0x14, // +4 DHEADER of appendable_nested = 40
   0x7f,0xff,(0),(0),    // +4 short_field = 44
@@ -1062,8 +1062,8 @@ const unsigned char nesting_mutable_struct_xcdr2[] = {
   0x01,(0),(0),(0),     // +4 octet_field = 52
   0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff, // +8 long_long_field = 60
   // End appendable_nested >>>>>>
-  0x40,0,0,2,  0,0,0,11, 0,0,0,7,0x7f,0x7f,0x7f,0x7f,0x7f,0x7f,0x7f,(0), // +20 sequence_field = 80
-  0x40,0,0,3,  0,0,0,14, // +8 EMHEADER1 + NEXTINT of final_nested = 88
+  0x40,0,0,2,  0,0,0,0x0b, 0,0,0,7,0x7f,0x7f,0x7f,0x7f,0x7f,0x7f,0x7f,(0), // +20 sequence_field = 80
+  0x40,0,0,3,  0,0,0,0x14, // +8 EMHEADER1 + NEXTINT of final_nested = 88
   // <<<<<< Begin final_nested
   0x7f,0xff,(0),(0),    // +4 short_field = 92
   0x7f,0xff,0xff,0xff,  // +4 long_field = 96

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -324,7 +324,7 @@ default:
 
 // DHEADER is not generated for anonymous sequence of string,
 // so make a name for it here
-typedef sequence<string> StringSeq;
+typedef sequence<string> StringSequence;
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
@@ -332,14 +332,14 @@ struct MixedMutableStruct {
   @id(1) MutableStruct struct_nested;
   @id(2) sequence<short> sequence_field;
   @id(3) NestedUnion union_nested;
-  @id(4) StringSeq sequence_field2;
+  @id(4) StringSequence sequence_field2;
 };
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct ModifiedMixedMutableStruct {
   @id(3) NestedUnion union_nested;
-  @id(4) StringSeq sequence_field2;
+  @id(4) StringSequence sequence_field2;
   @id(1) MutableStruct struct_nested;
 };
 

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -2,12 +2,21 @@
 #include <tao/ShortSeq.pidl>
 #include <tao/OctetSeq.pidl>
 
-// TODO(iguessthislldo): Add more fields
 #define COMMON_FIELDS \
   short short_field; \
   long long_field; \
   octet octet_field; \
-  long long long_long_field; \
+  long long long_long_field;
+
+#define COMMON_BRANCHES \
+  case E_SHORT_FIELD: \
+    short short_field; \
+  case E_LONG_FIELD: \
+    long long_field; \
+  case E_OCTET_FIELD: \
+    octet octet_field; \
+  case E_LONG_LONG_FIELD: \
+    long long long_long_field;
 
 // Generic XCDR1 Tests =======================================================
 
@@ -83,14 +92,37 @@ enum UnionDisc {
 @OpenDDS::data_representation(XCDR1)
 @OpenDDS::data_representation(XCDR2)
 union MutableXcdr12Union switch (UnionDisc) {
-case E_SHORT_FIELD:
-  short short_field;
-case E_LONG_FIELD:
-  long long_field;
-case E_OCTET_FIELD:
-  octet octet_field;
-case E_LONG_LONG_FIELD:
-  long long long_long_field;
+  COMMON_BRANCHES
+};
+
+@final
+struct NoDataRepFinalStruct {
+  COMMON_FIELDS
+};
+
+@appendable
+struct NoDataRepAppendableStruct {
+  COMMON_FIELDS
+};
+
+@mutable
+struct NoDataRepMutableStruct {
+  COMMON_FIELDS
+};
+
+@final
+union NoDataRepFinalUnion switch(UnionDisc) {
+  COMMON_BRANCHES
+};
+
+@appendable
+union NoDataRepAppendableUnion switch(UnionDisc) {
+  COMMON_BRANCHES
+};
+
+@mutable
+union NoDataRepMutableUnion switch(UnionDisc) {
+  COMMON_BRANCHES
 };
 
 // Appendable Tests ==========================================================

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -260,7 +260,7 @@ struct NestingFinalStruct {
 struct NestingAppendableStruct {
   string string_field;
   MutableXcdr2Struct mutable_nested;
-  sequence<short> sequence_field;
+  sequence<long> sequence_field;
   FinalXcdr2Struct final_nested;
 };
 
@@ -269,6 +269,6 @@ struct NestingAppendableStruct {
 struct NestingMutableStruct {
   string string_field;
   AppendableXcdr2Struct appendable_nested;
-  sequence<short> sequence_field;
+  sequence<octet> sequence_field;
   FinalXcdr2Struct final_nested;
 };

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -85,7 +85,8 @@ enum UnionDisc {
   E_SHORT_FIELD,
   E_LONG_FIELD,
   E_OCTET_FIELD,
-  E_LONG_LONG_FIELD
+  E_LONG_LONG_FIELD,
+  E_ADDITIONAL_FIELD
 };
 
 @mutable
@@ -157,6 +158,21 @@ struct AppendableStruct2 {
   string string_field;
   NestedStruct nested;
 };
+
+@appendable
+@OpenDDS::data_representation(XCDR2)
+union AppendableUnion switch (UnionDisc) {
+  COMMON_BRANCHES
+};
+
+@appendable
+@OpenDDS::data_representation(XCDR2)
+union ModifiedAppendableUnion switch (UnionDisc) {
+  COMMON_BRANCHES
+case E_ADDITIONAL_FIELD:
+  long additional_field;
+};
+
 
 // Mutable Tests =============================================================
 
@@ -280,6 +296,17 @@ case E_OCTET_FIELD:
   @id(8) octet octet_field;
 case E_LONG_LONG_FIELD:
   @id(10) long long long_long_field;
+};
+
+@mutable
+@OpenDDS::data_representation(XCDR2)
+union ModifiedMutableUnion switch (UnionDisc) {
+case E_LONG_FIELD:
+  @id(6) long long_field;
+case E_SHORT_FIELD:
+  @id(4) short short_field;
+case E_ADDITIONAL_FIELD:
+  @id(12) long additional_field;
 };
 
 typedef sequence<long> LongSeq;

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -1,6 +1,6 @@
-//#include <tao/LongSeq.pidl>
-//#include <tao/ShortSeq.pidl>
-//#include <tao/OctetSeq.pidl>
+#include <tao/LongSeq.pidl>
+#include <tao/ShortSeq.pidl>
+#include <tao/OctetSeq.pidl>
 #include <tao/StringSeq.pidl>
 
 #define COMMON_FIELDS \
@@ -325,7 +325,7 @@ default:
 
 // DHEADER is not generated for anonymous sequence of string,
 // so make a name for it here
-//typedef sequence<string> StringSequence;
+typedef sequence<string> StringSeq;
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
@@ -333,15 +333,14 @@ struct MixedMutableStruct {
   @id(1) MutableStruct struct_nested;
   @id(2) sequence<short> sequence_field;
   @id(3) NestedUnion union_nested;
-  @id(4) CORBA::StringSeq sequence_field2;
-  
+  @id(4) StringSeq sequence_field2;
 };
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct ModifiedMixedMutableStruct {
   @id(3) NestedUnion union_nested;
-  @id(4) CORBA::StringSeq sequence_field2;
+  @id(4) StringSeq sequence_field2;
   @id(1) MutableStruct struct_nested;
 };
 

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -263,20 +263,24 @@ default:
   @id(3) string string_field;
 };
 
+// DHEADER is not generated for anonymous sequence of string,
+// so make a name for it here
+typedef sequence<string> StringSeq;
+
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct MixedMutableStruct {
   @id(1) MutableStruct struct_nested;
   @id(2) sequence<short> sequence_field;
   @id(3) NestedUnion union_nested;
-  @id(4) sequence<string> sequence_field2;
+  @id(4) StringSeq sequence_field2;
 };
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct ModifiedMixedMutableStruct {
   @id(3) NestedUnion union_nested;
-  @id(4) sequence<string> sequence_field2;
+  @id(4) StringSeq sequence_field2;
   @id(1) MutableStruct struct_nested;
 };
 

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -1,6 +1,7 @@
-#include <tao/LongSeq.pidl>
-#include <tao/ShortSeq.pidl>
-#include <tao/OctetSeq.pidl>
+//#include <tao/LongSeq.pidl>
+//#include <tao/ShortSeq.pidl>
+//#include <tao/OctetSeq.pidl>
+#include <tao/StringSeq.pidl>
 
 #define COMMON_FIELDS \
   short short_field; \
@@ -324,7 +325,7 @@ default:
 
 // DHEADER is not generated for anonymous sequence of string,
 // so make a name for it here
-typedef sequence<string> StringSequence;
+//typedef sequence<string> StringSequence;
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
@@ -332,14 +333,15 @@ struct MixedMutableStruct {
   @id(1) MutableStruct struct_nested;
   @id(2) sequence<short> sequence_field;
   @id(3) NestedUnion union_nested;
-  @id(4) StringSequence sequence_field2;
+  @id(4) CORBA::StringSeq sequence_field2;
+  
 };
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct ModifiedMixedMutableStruct {
   @id(3) NestedUnion union_nested;
-  @id(4) StringSequence sequence_field2;
+  @id(4) CORBA::StringSeq sequence_field2;
   @id(1) MutableStruct struct_nested;
 };
 

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -106,7 +106,6 @@ struct AppendableStruct2 {
 };
 
 // Mutable Tests =============================================================
-// TODO(iguessthislldo): Add more fields
 
 @mutable
 @OpenDDS::data_representation(XCDR1)
@@ -216,48 +215,60 @@ struct LC567Struct {            //LC Size
   @id(7) string<7> str7;        // 5    7
 };
 
-@mutable
-@OpenDDS::data_representation(XCDR2)
-union NestedUnion switch(octet) {
-case 1:
-  short short_field;
-case 2:
-  sequence<long> sequence_field;
-default:
-  string string_field;
-};
+//@mutable
+//@OpenDDS::data_representation(XCDR2)
+//union NestedUnion switch(short) {
+//case 1:
+//  short short_field;
+//case 2:
+//  sequence<long> sequence_field;
+//default:
+//  string string_field;
+//};
 
 typedef octet OctetArray[5];
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct MixedMutableStruct {
-  COMMON_FIELDS
-  Short3S s3_field;
-  OctetArray array_field;
-  NestedUnion union_field;
+  @id(1) MutableStruct struct_nested;
+  @id(2) sequence<short> sequence_field;
+  // TODO (sonndinh): add these fields when they're implemented.
+  //  @id(3) OctetArray array_field;
+  //  @id(4) NestedUnion union_nested;
+};
+
+@mutable
+@OpenDDS::data_representation(XCDR2)
+struct ModifiedMixedMutableStruct {
+  //  @id(3) OctetArray array_field;
+  @id(1) MutableStruct struct_nested;
+  //  @id(4) NestedUnion union_nested;
 };
 
 @final
 @OpenDDS::data_representation(XCDR2)
 struct NestingFinalStruct {
-  AppendableXcdr2Struct appendable_nested;
   string string_field;
+  AppendableXcdr2Struct appendable_nested;
+  sequence<short> sequence_field;
   MutableXcdr2Struct mutable_nested;
 };
 
 @appendable
 @OpenDDS::data_representation(XCDR2)
 struct NestingAppendableStruct {
-  MutableXcdr2Struct mutable_nested;
   string string_field;
+  MutableXcdr2Struct mutable_nested;
+  sequence<short> sequence_field;
   FinalXcdr2Struct final_nested;
 };
 
 @mutable
 @OpenDDS::data_representation(XCDR2)
 struct NestingMutableStruct {
-  AppendableXcdr2Struct appendable_nested;
   string string_field;
+  AppendableXcdr2Struct appendable_nested;
+  sequence<short> sequence_field;
   FinalXcdr2Struct final_nested;
 };

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -185,3 +185,49 @@ struct LC567Struct {            //LC Size
   @key
   @id(7) string<7> str7;        // 5    7
 };
+
+@mutable
+@OpenDDS::data_representation(XCDR2)
+union NestedUnion switch(octet) {
+case 1:
+  short short_field;
+case 2:
+  sequence<long> sequence_field;
+default:
+  string string_field;
+};
+
+typedef octet OctetArray[5];
+
+@mutable
+@OpenDDS::data_representation(XCDR2)
+struct MixedMutableStruct {
+  COMMON_FIELDS
+  Short3S s3_field;
+  OctetArray array_field;
+  NestedUnion union_field;
+};
+
+@final
+@OpenDDS::data_representation(XCDR2)
+struct NestingFinalStruct {
+  AppendableXcdr2Struct appendable_nested;
+  string string_field;
+  MutableXcdr2Struct mutable_nested;
+};
+
+@appendable
+@OpenDDS::data_representation(XCDR2)
+struct NestingAppendableStruct {
+  MutableXcdr2Struct mutable_nested;
+  string string_field;
+  FinalXcdr2Struct final_nested;
+};
+
+@mutable
+@OpenDDS::data_representation(XCDR2)
+struct NestingMutableStruct {
+  AppendableXcdr2Struct appendable_nested;
+  string string_field;
+  FinalXcdr2Struct final_nested;
+};


### PR DESCRIPTION
- Add more fields to the tested structs and unions: nested structs with different extensibilities, delimited types like sequence of non-primitive elements...
- Test structs and unions without data_representation annotations
- Add little-endian tests