### PR TITLE
Updating Bench To Use Discovery Wait Flag, Fix Failing Tests

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -422,4 +422,4 @@ performance-tests/bench_2/run_test.pl fan: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNE
 performance-tests/bench_2/run_test.pl fan_frag: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl echo: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl echo_frag: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench_2/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench_2/run_test.pl mixed: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON

--- a/performance-tests/bench_2/example/config/scenario/ci_mixed.json
+++ b/performance-tests/bench_2/example/config/scenario/ci_mixed.json
@@ -1,0 +1,27 @@
+{
+  "name": "CI Showtime Mixed 5",
+  "desc": "This is a small mixed-qos & configuration scenario. Reliable and durable topics are actively used during discovery.",
+  "nodes": [
+    {
+      "workers": [
+        {
+          "config": "ci_mixed_daemon.json",
+          "count": 1
+        },
+        {
+          "config": "ci_mixed_worker.json",
+          "count": 1
+        }
+      ],
+      "count": 10,
+      "exclusive": false
+    }
+  ],
+  "any_node": [
+    {
+      "config": "ci_mixed_master.json",
+      "count": 1
+    }
+  ],
+  "timeout": 60
+}

--- a/performance-tests/bench_2/example/config/scenario/ci_mixed.json
+++ b/performance-tests/bench_2/example/config/scenario/ci_mixed.json
@@ -13,7 +13,7 @@
           "count": 1
         }
       ],
-      "count": 10,
+      "count": 5,
       "exclusive": false
     }
   ],

--- a/performance-tests/bench_2/example/config/worker/ci_disco.json
+++ b/performance-tests/bench_2/example/config/worker/ci_disco.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
-  "stop_time": { "sec": -10, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
+  "stop_time": { "sec": -1, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_disco_flag.json
+++ b/performance-tests/bench_2/example/config/worker/ci_disco_flag.json
@@ -3,8 +3,9 @@
   "start_time": { "sec": -3, "nsec": 0 },
   "stop_time": { "sec": -10, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
-  "wait_for_discovery":true,
-  "wait_for_discovery_seconds":30,
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 30,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_echo_client.json
+++ b/performance-tests/bench_2/example/config/worker/ci_echo_client.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
   "stop_time": { "sec": -15, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_echo_client_frag.json
+++ b/performance-tests/bench_2/example/config/worker/ci_echo_client_frag.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
   "stop_time": { "sec": -15, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_echo_server.json
+++ b/performance-tests/bench_2/example/config/worker/ci_echo_server.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
   "stop_time": { "sec": -15, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_fan_client.json
+++ b/performance-tests/bench_2/example/config/worker/ci_fan_client.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
   "stop_time": { "sec": -15, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_fan_client_frag.json
+++ b/performance-tests/bench_2/example/config/worker/ci_fan_client_frag.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
   "stop_time": { "sec": -15, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_fan_server.json
+++ b/performance-tests/bench_2/example/config/worker/ci_fan_server.json
@@ -1,8 +1,11 @@
 {
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -3, "nsec": 0 },
+  "start_time": { "sec": -1, "nsec": 0 },
   "stop_time": { "sec": -15, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
+
+  "wait_for_discovery": true,
+  "wait_for_discovery_seconds": 10,
 
   "process": {
     "config_sections": [

--- a/performance-tests/bench_2/example/config/worker/ci_mixed_daemon.json
+++ b/performance-tests/bench_2/example/config/worker/ci_mixed_daemon.json
@@ -120,7 +120,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -149,7 +149,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -194,7 +194,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -207,7 +207,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 10 }
                   }
                 ],
 
@@ -236,7 +236,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -249,7 +249,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 10 }
                   }
                 ],
 

--- a/performance-tests/bench_2/example/config/worker/ci_mixed_daemon.json
+++ b/performance-tests/bench_2/example/config/worker/ci_mixed_daemon.json
@@ -1,0 +1,318 @@
+{
+  "enable_time": { "sec": -2, "nsec": 0 },
+  "start_time": { "sec": -2, "nsec": 0 },
+  "stop_time": { "sec": -30, "nsec": 0 },
+  "destruction_time": { "sec": -2, "nsec": 0 },
+
+  "properties": [
+    { "name": "default_stat_median_buffer_size",
+      "value": { "_d": "PVK_ULL", "ull_prop": 2000 }
+    }
+  ],
+
+  "process": {
+    "config_sections": [
+      { "name": "common",
+        "properties": [
+          { "name": "DCPSGlobalTransportConfig",
+            "value": "mfs_config"
+          },
+          { "name": "DCPSDefaultDiscovery",
+            "value": "mfs_rtps_discovery"
+          },
+          { "name": "DCPSTransportDebugLevel",
+            "value": "0"
+          },
+          { "name": "DCPSDebugLevel",
+            "value": "0"
+          },
+          { "name": "DCPSPendingTimeout",
+            "value": "3"
+          }
+        ]
+      },
+      { "name": "rtps_discovery/mfs_rtps_discovery",
+        "properties": [
+          { "name": "SedpMulticast",
+            "value": "1"
+          },
+          { "name": "ResendPeriod",
+            "value": "5"
+          },
+          { "name": "TTL",
+            "value": "3"
+          }
+        ]
+      },
+      { "name": "config/mfs_config",
+        "properties": [
+          { "name": "transports",
+            "value": "mfs_rtps_transport"
+          },
+          { "name": "passive_connect_duration",
+            "value": "20000"
+          }
+        ]
+      },
+      { "name": "transport/mfs_rtps_transport",
+        "properties": [
+          { "name": "transport_type",
+            "value": "rtps_udp"
+          },
+          { "name": "thread_per_connection",
+            "value": "1"
+          },
+          { "name": "ttl",
+            "value": "3"
+          },
+          { "name": "use_multicast",
+            "value": "0"
+          },
+          { "name": "handshake_timeout",
+            "value": "5000"
+          }
+        ]
+      }
+    ],
+    "discoveries": [
+      { "name": "bench_test_rtps_01",
+        "type": "rtps",
+        "domain": 7
+      },
+      { "name": "bench_test_rtps_02",
+        "type": "rtps",
+        "domain": 17
+      }
+    ],
+    "instances": [
+      { "name": "rtps_instance_01",
+        "type": "rtps_udp",
+        "domain": 7
+      },
+      { "name": "rtps_instance_02",
+        "type": "rtps_udp",
+        "domain": 17
+      }
+    ],
+    "participants": [
+      { "name": "participant_B1",
+        "domain": 7,
+        "transport_config_name": "rtps_instance_01",
+
+        "qos": { "entity_factory": { "autoenable_created_entities": false } },
+        "qos_mask": { "entity_factory": { "has_autoenable_created_entities": false } },
+
+        "topics": [
+          { "name": "topic_T1",
+            "type_name": "Bench::Data"
+          }
+        ],
+        "subscribers": [
+          { "name": "subscriber_B1",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datareaders": [
+              { "name": "datareader_B1_T1",
+                "topic_name": "topic_T1",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              }
+            ]
+          }
+        ],
+        "publishers": [
+          { "name": "publisher_B1",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datawriters": [
+              { "name": "datawriter_B1_T1",
+                "topic_name": "topic_T1",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              }
+            ]
+          }
+        ]
+      },
+      { "name": "participant_B2",
+        "domain": 17,
+        "transport_config_name": "rtps_instance_02",
+
+        "qos": { "entity_factory": { "autoenable_created_entities": false } },
+        "qos_mask": { "entity_factory": { "has_autoenable_created_entities": false } },
+
+        "topics": [
+          { "name": "topic_T2",
+            "type_name": "Bench::Data"
+          },
+          { "name": "topic_T3",
+            "type_name": "Bench::Data"
+          }
+        ],
+        "subscribers": [
+          { "name": "subscriber_B2",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datareaders": [
+              { "name": "datareader_B2_T2",
+                "topic_name": "topic_T2",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              },
+              { "name": "datareader_B2_T3",
+                "topic_name": "topic_T3",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              }
+            ]
+          }
+        ],
+        "publishers": [
+          { "name": "publisher_B2",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datawriters": [
+              { "name": "datawriter_B2_T2",
+                "topic_name": "topic_T2",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              },
+              { "name": "datawriter_B2_T3",
+                "topic_name": "topic_T3",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "actions": [
+    {
+      "name": "write_action_B1_T1",
+      "type": "write",
+      "writers": [ "datawriter_B1_T1" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 123 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 3.21 }
+        },
+        { "name": "max_count",
+          "value": { "_d": "PVK_ULL", "double_prop": 10 }
+        }
+      ]
+    },
+    {
+      "name": "write_action_B2_T2",
+      "type": "write",
+      "writers": [ "datawriter_B2_T2" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 321 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 1.23 }
+        },
+        { "name": "max_count",
+          "value": { "_d": "PVK_ULL", "double_prop": 10 }
+        }
+      ]
+    },
+    {
+      "name": "write_action_B2_T3",
+      "type": "write",
+      "writers": [ "datawriter_B2_T3" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 222 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 2.22 }
+        }
+      ]
+    }
+  ]
+}

--- a/performance-tests/bench_2/example/config/worker/ci_mixed_master.json
+++ b/performance-tests/bench_2/example/config/worker/ci_mixed_master.json
@@ -120,7 +120,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -149,7 +149,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -194,7 +194,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -207,7 +207,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -230,7 +230,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -243,7 +243,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 

--- a/performance-tests/bench_2/example/config/worker/ci_mixed_master.json
+++ b/performance-tests/bench_2/example/config/worker/ci_mixed_master.json
@@ -1,0 +1,306 @@
+{
+  "enable_time": { "sec": -2, "nsec": 0 },
+  "start_time": { "sec": -2, "nsec": 0 },
+  "stop_time": { "sec": -30, "nsec": 0 },
+  "destruction_time": { "sec": -2, "nsec": 0 },
+
+  "properties": [
+    { "name": "default_stat_median_buffer_size",
+      "value": { "_d": "PVK_ULL", "ull_prop": 2000 }
+    }
+  ],
+
+  "process": {
+    "config_sections": [
+      { "name": "common",
+        "properties": [
+          { "name": "DCPSGlobalTransportConfig",
+            "value": "mfs_config"
+          },
+          { "name": "DCPSDefaultDiscovery",
+            "value": "mfs_rtps_discovery"
+          },
+          { "name": "DCPSTransportDebugLevel",
+            "value": "0"
+          },
+          { "name": "DCPSDebugLevel",
+            "value": "0"
+          },
+          { "name": "DCPSPendingTimeout",
+            "value": "3"
+          }
+        ]
+      },
+      { "name": "rtps_discovery/mfs_rtps_discovery",
+        "properties": [
+          { "name": "SedpMulticast",
+            "value": "1"
+          },
+          { "name": "ResendPeriod",
+            "value": "5"
+          },
+          { "name": "TTL",
+            "value": "3"
+          }
+        ]
+      },
+      { "name": "config/mfs_config",
+        "properties": [
+          { "name": "transports",
+            "value": "mfs_rtps_transport"
+          },
+          { "name": "passive_connect_duration",
+            "value": "20000"
+          }
+        ]
+      },
+      { "name": "transport/mfs_rtps_transport",
+        "properties": [
+          { "name": "transport_type",
+            "value": "rtps_udp"
+          },
+          { "name": "thread_per_connection",
+            "value": "1"
+          },
+          { "name": "ttl",
+            "value": "3"
+          },
+          { "name": "use_multicast",
+            "value": "0"
+          },
+          { "name": "handshake_timeout",
+            "value": "5000"
+          }
+        ]
+      }
+    ],
+    "discoveries": [
+      { "name": "bench_test_rtps_01",
+        "type": "rtps",
+        "domain": 7
+      },
+      { "name": "bench_test_rtps_02",
+        "type": "rtps",
+        "domain": 17
+      }
+    ],
+    "instances": [
+      { "name": "rtps_instance_01",
+        "type": "rtps_udp",
+        "domain": 7
+      },
+      { "name": "rtps_instance_02",
+        "type": "rtps_udp",
+        "domain": 17
+      }
+    ],
+    "participants": [
+      { "name": "participant_A1",
+        "domain": 7,
+        "transport_config_name": "rtps_instance_01",
+
+        "qos": { "entity_factory": { "autoenable_created_entities": false } },
+        "qos_mask": { "entity_factory": { "has_autoenable_created_entities": false } },
+
+        "topics": [
+          { "name": "topic_T1",
+            "type_name": "Bench::Data"
+          }
+        ],
+        "subscribers": [
+          { "name": "subscriber_A1",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datareaders": [
+              { "name": "datareader_A1_T1",
+                "topic_name": "topic_T1",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              }
+            ]
+          }
+        ],
+        "publishers": [
+          { "name": "publisher_A1",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datawriters": [
+              { "name": "datawriter_A1_T1",
+                "topic_name": "topic_T1",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              }
+            ]
+          }
+        ]
+      },
+      { "name": "participant_A2",
+        "domain": 17,
+        "transport_config_name": "rtps_instance_02",
+
+        "qos": { "entity_factory": { "autoenable_created_entities": false } },
+        "qos_mask": { "entity_factory": { "has_autoenable_created_entities": false } },
+
+        "topics": [
+          { "name": "topic_T2",
+            "type_name": "Bench::Data"
+          },
+          { "name": "topic_T4",
+            "type_name": "Bench::Data"
+          }
+        ],
+        "subscribers": [
+          { "name": "subscriber_A2",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datareaders": [
+              { "name": "datareader_A2_T2",
+                "topic_name": "topic_T2",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              },
+              { "name": "datareader_A2_T4",
+                "topic_name": "topic_T4",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              }
+            ]
+          }
+        ],
+        "publishers": [
+          { "name": "publisher_A2",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datawriters": [
+              { "name": "datawriter_A2_T2",
+                "topic_name": "topic_T2",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              },
+              { "name": "datawriter_A2_T4",
+                "topic_name": "topic_T4",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "actions": [
+    {
+      "name": "write_action_A1_T1",
+      "type": "write",
+      "writers": [ "datawriter_A1_T1" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 123 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 3.21 }
+        },
+        { "name": "max_count",
+          "value": { "_d": "PVK_ULL", "double_prop": 10 }
+        }
+      ]
+    },
+    {
+      "name": "write_action_A2_T2",
+      "type": "write",
+      "writers": [ "datawriter_A2_T2" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 321 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 1.23 }
+        },
+        { "name": "max_count",
+          "value": { "_d": "PVK_ULL", "double_prop": 10 }
+        }
+      ]
+    },
+    {
+      "name": "write_action_A2_T4",
+      "type": "write",
+      "writers": [ "datawriter_A2_T4" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 222 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 2.22 }
+        }
+      ]
+    }
+  ]
+}

--- a/performance-tests/bench_2/example/config/worker/ci_mixed_worker.json
+++ b/performance-tests/bench_2/example/config/worker/ci_mixed_worker.json
@@ -1,0 +1,220 @@
+{
+  "enable_time": { "sec": -2, "nsec": 0 },
+  "start_time": { "sec": -2, "nsec": 0 },
+  "stop_time": { "sec": -30, "nsec": 0 },
+  "destruction_time": { "sec": -2, "nsec": 0 },
+
+  "properties": [
+    { "name": "default_stat_median_buffer_size",
+      "value": { "_d": "PVK_ULL", "ull_prop": 2000 }
+    }
+  ],
+
+  "process": {
+    "config_sections": [
+      { "name": "common",
+        "properties": [
+          { "name": "DCPSGlobalTransportConfig",
+            "value": "mfs_config"
+          },
+          { "name": "DCPSDefaultDiscovery",
+            "value": "mfs_rtps_discovery"
+          },
+          { "name": "DCPSTransportDebugLevel",
+            "value": "0"
+          },
+          { "name": "DCPSDebugLevel",
+            "value": "0"
+          },
+          { "name": "DCPSPendingTimeout",
+            "value": "3"
+          }
+        ]
+      },
+      { "name": "rtps_discovery/mfs_rtps_discovery",
+        "properties": [
+          { "name": "SedpMulticast",
+            "value": "1"
+          },
+          { "name": "ResendPeriod",
+            "value": "5"
+          },
+          { "name": "TTL",
+            "value": "3"
+          }
+        ]
+      },
+      { "name": "config/mfs_config",
+        "properties": [
+          { "name": "transports",
+            "value": "mfs_rtps_transport"
+          },
+          { "name": "passive_connect_duration",
+            "value": "20000"
+          }
+        ]
+      },
+      { "name": "transport/mfs_rtps_transport",
+        "properties": [
+          { "name": "transport_type",
+            "value": "rtps_udp"
+          },
+          { "name": "thread_per_connection",
+            "value": "1"
+          },
+          { "name": "ttl",
+            "value": "3"
+          },
+          { "name": "use_multicast",
+            "value": "0"
+          },
+          { "name": "handshake_timeout",
+            "value": "5000"
+          }
+        ]
+      }
+    ],
+    "discoveries": [
+      { "name": "bench_test_rtps_02",
+        "type": "rtps",
+        "domain": 17
+      }
+    ],
+    "instances": [
+      { "name": "rtps_instance_02",
+        "type": "rtps_udp",
+        "domain": 17
+      }
+    ],
+    "participants": [
+      { "name": "participant_C1",
+        "domain": 17,
+        "transport_config_name": "rtps_instance_02",
+
+        "qos": { "entity_factory": { "autoenable_created_entities": false } },
+        "qos_mask": { "entity_factory": { "has_autoenable_created_entities": false } },
+
+        "topics": [
+          { "name": "topic_T3",
+            "type_name": "Bench::Data"
+          },
+          { "name": "topic_T4",
+            "type_name": "Bench::Data"
+          }
+        ],
+        "subscribers": [
+          { "name": "subscriber_C1",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datareaders": [
+              { "name": "datareader_C1_T3",
+                "topic_name": "topic_T3",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              },
+              { "name": "datareader_C1_T4",
+                "topic_name": "topic_T4",
+                "listener_type_name": "bench_drl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              }
+            ]
+          }
+        ],
+        "publishers": [
+          { "name": "publisher_C1",
+
+            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
+            "datawriters": [
+              { "name": "datawriter_C1_T3",
+                "topic_name": "topic_T3",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" },
+                         "durability": { "kind": "TRANSIENT_LOCAL_DURABILITY_QOS" },
+                         "history": { "kind": "KEEP_ALL_HISTORY_QOS" }
+                       },
+                "qos_mask": { "reliability": { "has_kind": true },
+                              "durability": { "has_kind": true },
+                              "history": { "has_kind": true }
+                            }
+              },
+              { "name": "datawriter_C1_T4",
+                "topic_name": "topic_T4",
+                "listener_type_name": "bench_dwl",
+                "listener_status_mask": 4294967295,
+                "listener_properties": [
+                  { "name": "expected_match_count",
+                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                  }
+                ],
+
+                "qos": { "reliability": { "kind": "RELIABLE_RELIABILITY_QOS" } },
+                "qos_mask": { "reliability": { "has_kind": true } }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "actions": [
+    {
+      "name": "write_action_C1_T3",
+      "type": "write",
+      "writers": [ "datawriter_C1_T3" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 321 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 1.23 }
+        }
+      ]
+    },
+    {
+      "name": "write_action_C1_T4",
+      "type": "write",
+      "writers": [ "datawriter_C1_T4" ],
+      "params": [
+        { "name": "data_buffer_bytes",
+          "value": { "_d": "PVK_ULL", "ull_prop": 222 }
+        },
+        { "name": "write_period",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 2.22 }
+        }
+      ]
+    }
+  ]
+}

--- a/performance-tests/bench_2/example/config/worker/ci_mixed_worker.json
+++ b/performance-tests/bench_2/example/config/worker/ci_mixed_worker.json
@@ -115,7 +115,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 10 }
                   }
                 ],
 
@@ -134,7 +134,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 
@@ -157,7 +157,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 20 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 10 }
                   }
                 ],
 
@@ -176,7 +176,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "_d": "PVK_ULL", "ull_prop": 11 }
+                    "value": { "_d": "PVK_ULL", "ull_prop": 6 }
                   }
                 ],
 

--- a/performance-tests/bench_2/run_test.pl
+++ b/performance-tests/bench_2/run_test.pl
@@ -49,6 +49,10 @@ elsif ($test->flag('echo_frag')) {
   $tc_opts .= " ci_echo_frag --override-start-time 15";
   $is_rtps_disc = 1;
 }
+elsif ($test->flag('mixed')) {
+  $tc_opts .= " ci_mixed --override-start-time 15";
+  $is_rtps_disc = 1;
+}
 elsif ($test->flag('sm10')) {
   $tc_opts .= " showtime_mixed_10 --override-start-time 25";
   $is_rtps_disc = 1;

--- a/performance-tests/bench_2/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench_2/test_controller/ScenarioManager.cpp
@@ -124,7 +124,7 @@ void ScenarioManager::customize_configs(std::map<std::string, std::string>& work
 
     // Convert to C++ IDL-generated structures
     std::stringstream iss(it->second);
-    Bench::WorkerConfig wc;
+    Bench::WorkerConfig wc{};
     if (!Bench::json_2_idl(iss, wc)) {
       throw std::runtime_error("Can't parse json configs for customization");
     }
@@ -417,7 +417,7 @@ std::vector<WorkerReport> ScenarioManager::execute(const AllocatedScenario& allo
             << std::string(reports[r].log.in()) + "\n===\n";
           std::cerr << ss.str() << std::flush;
         } else {
-          WorkerReport report;
+          WorkerReport report{};
           std::stringstream ss;
           ss << reports[r].details << std::flush;
           if (json_2_idl(ss, report)) {

--- a/performance-tests/bench_2/test_controller/main.cpp
+++ b/performance-tests/bench_2/test_controller/main.cpp
@@ -199,7 +199,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   // Try To Load Scenario
   std::string scenario_path = join_path(test_context_path, "config", "scenario", scenario_id + ".json");
-  ScenarioPrototype scenario_prototype;
+  ScenarioPrototype scenario_prototype{};
   std::ifstream scenario_file(scenario_path);
   if (scenario_file.is_open()) {
     if (!json_2_idl(scenario_file, scenario_prototype)) {
@@ -273,7 +273,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     ScenarioManager scenario_manager(bench_root, test_context_path, overrides, dds_entities);
 
     // Part 1: Get What Needs to be Broadcast
-    AllocatedScenario allocated_scenario;
+    AllocatedScenario allocated_scenario{};
     if (preallocated_scenario_input_path.size()) {
       std::cout << "Loading Scenario Allocation from File..." << std::endl;
       std::ifstream file(preallocated_scenario_input_path);

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -164,7 +164,24 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
   using Builder::ZERO;
 
-  Bench::WorkerConfig config;
+  typedef TAO::unbounded_value_sequence<Bench::WorkerConfig> WorkerConfigs;
+  WorkerConfigs configs;
+  configs.length(100000);
+  for (size_t i = 0; i < configs.length(); ++i) {
+    assert(configs[i].create_time.sec == 0);
+    assert(configs[i].create_time.nsec == 0);
+    assert(configs[i].enable_time.sec == 0);
+    assert(configs[i].enable_time.nsec == 0);
+    assert(configs[i].start_time.sec == 0);
+    assert(configs[i].start_time.nsec == 0);
+    assert(configs[i].stop_time.sec == 0);
+    assert(configs[i].stop_time.nsec == 0);
+    assert(configs[i].destruction_time.sec == 0);
+    assert(configs[i].destruction_time.nsec == 0);
+  }
+
+
+  Bench::WorkerConfig config{};
 
   config.create_time = ZERO;
   config.enable_time = ZERO;
@@ -267,11 +284,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
     Log::log() << "DDS entities enabled." << std::endl << std::endl;
 
-    Log::log() << "Starting Discovery Check." << std::endl;
-
-    process_start_discovery_time = Builder::get_sys_time();
-
     if (config.wait_for_discovery) {
+
+      Log::log() << "Starting Discovery Check." << std::endl;
+
+      process_start_discovery_time = Builder::get_sys_time();
+
       if (config.wait_for_discovery_seconds > 0) {
 
         const std::chrono::seconds timeoutPeriod(config.wait_for_discovery_seconds);
@@ -313,11 +331,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
           }
         }
       }
+
+      process_stop_discovery_time = Builder::get_sys_time();
+
+      Log::log() << "Discovery of expected entities took " << process_stop_discovery_time - process_start_discovery_time << " seconds." << std::endl << std::endl;
     }
-
-    process_stop_discovery_time = Builder::get_sys_time();
-
-    Log::log() << "Discovery Time Check." << process_stop_discovery_time - process_start_discovery_time << std::endl << std::endl;
 
     do_wait(config.start_time, "start");
 

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -164,23 +164,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
   using Builder::ZERO;
 
-  typedef TAO::unbounded_value_sequence<Bench::WorkerConfig> WorkerConfigs;
-  WorkerConfigs configs;
-  configs.length(100000);
-  for (size_t i = 0; i < configs.length(); ++i) {
-    assert(configs[i].create_time.sec == 0);
-    assert(configs[i].create_time.nsec == 0);
-    assert(configs[i].enable_time.sec == 0);
-    assert(configs[i].enable_time.nsec == 0);
-    assert(configs[i].start_time.sec == 0);
-    assert(configs[i].start_time.nsec == 0);
-    assert(configs[i].stop_time.sec == 0);
-    assert(configs[i].stop_time.nsec == 0);
-    assert(configs[i].destruction_time.sec == 0);
-    assert(configs[i].destruction_time.nsec == 0);
-  }
-
-
   Bench::WorkerConfig config{};
 
   config.create_time = ZERO;


### PR DESCRIPTION
Updating Bench to use value-initialize objects before parsing from JSON (to avoid raw memory values), updating bench CI configs to use discovery wait flag where applicable (all but ci_mixed), forking showtime_mixed_10 into separate ci_mixed scenario and adding expected entity counts.