### PR TITLE
Support Padding Marker in Encapsulation Options

### DIFF
--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -450,8 +450,8 @@ private:
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
       char* wr = tmp_mb->wr_ptr();
-      EncapsulationHeader encap;
       if (encapsulated) {
+        EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
           return 0;
         }
@@ -471,7 +471,7 @@ private:
         return 0;
       }
       if (encapsulated) {
-        encap.set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
+        EncapsulationHeader::set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
       }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
@@ -494,8 +494,8 @@ private:
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
       char* wr = tmp_mb->wr_ptr();
-      EncapsulationHeader encap;
       if (encapsulated) {
+        EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
           return 0;
         }
@@ -515,7 +515,7 @@ private:
         return 0;
       }
       if (encapsulated) {
-        encap.set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
+        EncapsulationHeader::set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -449,6 +449,7 @@ private:
       mb.reset(tmp_mb);
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
+      char* wr = tmp_mb->wr_ptr();
       if (encapsulated) {
         EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
@@ -469,7 +470,11 @@ private:
           TraitsType::type_name()));
         return 0;
       }
-
+      if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1
+        || encoding.kind() == Encoding::KIND_XCDR2)) {
+        unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
+        wr[3] |= (padding & 0x03);
+      }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
         static_cast<ACE_Message_Block*>(

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -417,6 +417,8 @@ public:
 
 private:
 
+  static const int PADDING_MARKER_BYTE_INDEX = 3;
+
   /**
    * Serialize the instance data.
    *
@@ -449,7 +451,7 @@ private:
       mb.reset(tmp_mb);
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
-      char* wr = tmp_mb->wr_ptr();
+      char* const wr = mb->wr_ptr();
       if (encapsulated) {
         EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
@@ -471,7 +473,7 @@ private:
         return 0;
       }
       if (encapsulated) {
-        EncapsulationHeader::set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
+        EncapsulationHeader::set_padding_marker(wr[PADDING_MARKER_BYTE_INDEX], mb->wr_ptr() - wr);
       }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
@@ -493,7 +495,7 @@ private:
       mb.reset(tmp_mb);
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
-      char* wr = tmp_mb->wr_ptr();
+      char* const wr = mb->wr_ptr();
       if (encapsulated) {
         EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
@@ -515,7 +517,7 @@ private:
         return 0;
       }
       if (encapsulated) {
-        EncapsulationHeader::set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
+        EncapsulationHeader::set_padding_marker(wr[PADDING_MARKER_BYTE_INDEX], mb->wr_ptr() - wr);
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -450,8 +450,8 @@ private:
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
       char* wr = tmp_mb->wr_ptr();
+      EncapsulationHeader encap;
       if (encapsulated) {
-        EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
           return 0;
         }
@@ -470,10 +470,8 @@ private:
           TraitsType::type_name()));
         return 0;
       }
-      if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1
-        || encoding.kind() == Encoding::KIND_XCDR2)) {
-        unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
-        wr[serializer.swap_bytes() ? 0 : 3] |= (padding & 0x03);
+      if (encapsulated) {
+        encap.set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
       }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
@@ -496,8 +494,8 @@ private:
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
       char* wr = tmp_mb->wr_ptr();
+      EncapsulationHeader encap;
       if (encapsulated) {
-        EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
           return 0;
         }
@@ -516,10 +514,8 @@ private:
           TraitsType::type_name()));
         return 0;
       }
-      if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1
-          || encoding.kind() == Encoding::KIND_XCDR2)) {
-        unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
-        wr[serializer.swap_bytes() ? 0 : 3] |= (padding & 0x03);
+      if (encapsulated) {
+        encap.set_padding_marker(wr[3], tmp_mb->wr_ptr() - wr);
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -492,7 +492,6 @@ private:
       mb.reset(tmp_mb);
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
-      char* const wr = mb->wr_ptr();
       if (encapsulated) {
         EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -473,7 +473,7 @@ private:
       if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1
         || encoding.kind() == Encoding::KIND_XCDR2)) {
         unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
-        wr[3] |= (padding & 0x03);
+        wr[serializer.swap_bytes() ? 0 : 3] |= (padding & 0x03);
       }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
@@ -519,7 +519,7 @@ private:
       if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1
           || encoding.kind() == Encoding::KIND_XCDR2)) {
         unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
-        wr[3] |= (padding & 0x03);
+        wr[serializer.swap_bytes() ? 0 : 3] |= (padding & 0x03);
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -417,8 +417,6 @@ public:
 
 private:
 
-  static const int PADDING_MARKER_BYTE_INDEX = 3;
-
   /**
    * Serialize the instance data.
    *
@@ -451,7 +449,6 @@ private:
       mb.reset(tmp_mb);
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
-      char* const wr = mb->wr_ptr();
       if (encapsulated) {
         EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
@@ -473,7 +470,7 @@ private:
         return 0;
       }
       if (encapsulated) {
-        EncapsulationHeader::set_padding_marker(wr[PADDING_MARKER_BYTE_INDEX], mb->wr_ptr() - wr);
+        EncapsulationHeader::set_encapsulation_options(mb);
       }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
@@ -517,7 +514,7 @@ private:
         return 0;
       }
       if (encapsulated) {
-        EncapsulationHeader::set_padding_marker(wr[PADDING_MARKER_BYTE_INDEX], mb->wr_ptr() - wr);
+        EncapsulationHeader::set_encapsulation_options(mb);
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -511,7 +511,7 @@ private:
           TraitsType::type_name()));
         return 0;
       }
-      if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1 
+      if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1
           || encoding.kind() == Encoding::KIND_XCDR2)) {
         unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
         wr[3] |= (padding & 0x03);

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -470,7 +470,13 @@ private:
         return 0;
       }
       if (encapsulated) {
-        EncapsulationHeader::set_encapsulation_options(mb);
+        if (!EncapsulationHeader::set_encapsulation_options(mb)) {
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+            ACE_TEXT("%CDataWriterImpl::dds_marshal(): ")
+            ACE_TEXT("set_encapsulation_options error.\n"),
+            TraitsType::type_name()));
+          return 0;
+        }
       }
     } else { // OpenDDS::DCPS::FULL_MARSHALING
       ACE_NEW_MALLOC_RETURN(tmp_mb,
@@ -513,7 +519,13 @@ private:
         return 0;
       }
       if (encapsulated) {
-        EncapsulationHeader::set_encapsulation_options(mb);
+        if (!EncapsulationHeader::set_encapsulation_options(mb)) {
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
+            ACE_TEXT("%CDataWriterImpl::dds_marshal(): ")
+            ACE_TEXT("set_encapsulation_options error.\n"),
+            TraitsType::type_name()));
+          return 0;
+        }
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -513,7 +513,7 @@ private:
       }
       if (encapsulated) {
         unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
-        wr[3] &= (padding | 0xfc);
+        wr[3] |= (padding & 0x03);
       }
     }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -511,7 +511,8 @@ private:
           TraitsType::type_name()));
         return 0;
       }
-      if (encapsulated) {
+      if (encapsulated && (encoding.kind() == Encoding::KIND_XCDR1 
+          || encoding.kind() == Encoding::KIND_XCDR2)) {
         unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
         wr[3] |= (padding & 0x03);
       }

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -490,6 +490,7 @@ private:
       mb.reset(tmp_mb);
 
       OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
+      char* wr = tmp_mb->wr_ptr();
       if (encapsulated) {
         EncapsulationHeader encap;
         if (!encap.from_encoding(encoding, MarshalTraitsType::extensibility())) {
@@ -509,6 +510,10 @@ private:
           ACE_TEXT("data serialization error.\n"),
           TraitsType::type_name()));
         return 0;
+      }
+      if (encapsulated) {
+        unsigned char padding = (tmp_mb->wr_ptr() - wr) % 4;
+        wr[3] &= (padding | 0xfc);
       }
     }
 

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -196,11 +196,11 @@ bool EncapsulationHeader::to_encoding(
   return true;
 }
 
+static const int FOUR_BYTE_ALIGNMENT = 4;
+
 void EncapsulationHeader::set_padding_marker(char& options, size_t size)
 {
-  size_t aligned = size;
-  align(aligned, 4);
-  options |= ((aligned - size) & 0x03);
+  options |= ((FOUR_BYTE_ALIGNMENT - size % FOUR_BYTE_ALIGNMENT) & 0x03);
 }
 
 OPENDDS_STRING EncapsulationHeader::to_string() const

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -198,7 +198,7 @@ bool EncapsulationHeader::to_encoding(
 
 void EncapsulationHeader::set_encapsulation_options(Message_Block_Ptr& mb)
 {
-  mb->rd_ptr()[padding_marker_byte_index] |= ((Encoding::ALIGN_XCDR2 - mb->length() % Encoding::ALIGN_XCDR2) & 0x03);
+  mb->rd_ptr()[padding_marker_byte_index] |= ((padding_marker_alignmet - mb->length() % padding_marker_alignmet) & 0x03);
 }
 
 OPENDDS_STRING EncapsulationHeader::to_string() const

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -196,9 +196,18 @@ bool EncapsulationHeader::to_encoding(
   return true;
 }
 
-void EncapsulationHeader::set_encapsulation_options(Message_Block_Ptr& mb)
+bool EncapsulationHeader::set_encapsulation_options(Message_Block_Ptr& mb)
 {
-  mb->rd_ptr()[padding_marker_byte_index] |= ((padding_marker_alignmet - mb->length() % padding_marker_alignmet) & 0x03);
+  if (mb->length() < padding_marker_byte_index + 1) {
+    if (DCPS_debug_level > 0) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR EncapsulationHeader::set_encapsulation_options: ")
+        ACE_TEXT("Insufficient buffer size %d\n"), mb->length()));
+    }
+    return false;
+  }
+
+  mb->rd_ptr()[padding_marker_byte_index] |= ((padding_marker_alignment - mb->length() % padding_marker_alignment) & 0x03);
+  return true;
 }
 
 OPENDDS_STRING EncapsulationHeader::to_string() const

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -196,11 +196,9 @@ bool EncapsulationHeader::to_encoding(
   return true;
 }
 
-static const int FOUR_BYTE_ALIGNMENT = 4;
-
-void EncapsulationHeader::set_padding_marker(char& options, size_t size)
+void EncapsulationHeader::set_encapsulation_options(Message_Block_Ptr& mb)
 {
-  options |= ((FOUR_BYTE_ALIGNMENT - size % FOUR_BYTE_ALIGNMENT) & 0x03);
+  mb->rd_ptr()[padding_marker_byte_index] |= ((Encoding::ALIGN_XCDR2 - mb->length() % Encoding::ALIGN_XCDR2) & 0x03);
 }
 
 OPENDDS_STRING EncapsulationHeader::to_string() const

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -196,6 +196,13 @@ bool EncapsulationHeader::to_encoding(
   return true;
 }
 
+void EncapsulationHeader::set_padding_marker(char& options, size_t size)
+{
+  size_t aligned = size;
+  align(aligned, 4);
+  options |= ((aligned - size) & 0x03);
+}
+
 OPENDDS_STRING EncapsulationHeader::to_string() const
 {
   switch (kind_) {

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -245,7 +245,7 @@ public:
 
   const static size_t serialized_size = 4;
   const static size_t padding_marker_byte_index = 3;
-  const static int padding_marker_alignment = 4;
+  const static size_t padding_marker_alignment = 4;
 
   EncapsulationHeader();
 

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -263,7 +263,7 @@ public:
 
   OPENDDS_STRING to_string() const;
 
-  void set_padding_marker(char& options, size_t size);
+  static void set_padding_marker(char& options, size_t size);
 
 private:
   /// The first two bytes as a big endian integer

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -245,6 +245,7 @@ public:
 
   const static size_t serialized_size = 4;
   const static size_t padding_marker_byte_index = 3;
+  const static int padding_marker_alignmet = 4;
 
   EncapsulationHeader();
 

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -263,6 +263,8 @@ public:
 
   OPENDDS_STRING to_string() const;
 
+  void set_padding_marker(char& options, size_t size);
+
 private:
   /// The first two bytes as a big endian integer
   Kind kind_;

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -245,7 +245,7 @@ public:
 
   const static size_t serialized_size = 4;
   const static size_t padding_marker_byte_index = 3;
-  const static int padding_marker_alignmet = 4;
+  const static int padding_marker_alignment = 4;
 
   EncapsulationHeader();
 
@@ -266,7 +266,7 @@ public:
 
   OPENDDS_STRING to_string() const;
 
-  static void set_encapsulation_options(Message_Block_Ptr& mb);
+  static bool set_encapsulation_options(Message_Block_Ptr& mb);
 
 private:
   /// The first two bytes as a big endian integer

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -46,6 +46,7 @@
 
 #include "Definitions.h"
 #include "PoolAllocator.h"
+#include "Message_Block_Ptr.h"
 
 #include <tao/String_Alloc.h>
 
@@ -243,6 +244,7 @@ public:
   };
 
   const static size_t serialized_size = 4;
+  const static size_t padding_marker_byte_index = 3;
 
   EncapsulationHeader();
 
@@ -263,7 +265,7 @@ public:
 
   OPENDDS_STRING to_string() const;
 
-  static void set_padding_marker(char& options, size_t size);
+  static void set_encapsulation_options(Message_Block_Ptr& mb);
 
 private:
   /// The first two bytes as a big endian integer

--- a/tests/DCPS/Serializer/SerializerTest.cpp
+++ b/tests/DCPS/Serializer/SerializerTest.cpp
@@ -710,7 +710,7 @@ bool runEncapsulationOptionsTest()
     std::cerr << "EncapsulationHeader::from_encoding failed" << std::endl;
     return false;
   }
-  
+
   bool status = true;
   for (unsigned int i = 1; i <= OpenDDS::DCPS::EncapsulationHeader::padding_marker_alignment; i++) {
     OpenDDS::DCPS::Message_Block_Ptr mb;

--- a/tests/DCPS/Serializer/SerializerTest.cpp
+++ b/tests/DCPS/Serializer/SerializerTest.cpp
@@ -713,7 +713,6 @@ bool runEncapsulationOptionsTest()
     mb.reset(tmp_mb);
 
     OpenDDS::DCPS::Serializer serializer(mb.get(), encodings[5]);
-  
     serializer << encap;
     serializer.write_octet_array(arr, i);
 
@@ -728,7 +727,7 @@ bool runEncapsulationOptionsTest()
         << i << " bytes, padding marker alignment: " << padding_marker_alignment << std::endl;
     }
   }
-  
+
   return true;
 }
 

--- a/tests/DCPS/Serializer/SerializerTest.cpp
+++ b/tests/DCPS/Serializer/SerializerTest.cpp
@@ -1,6 +1,4 @@
 #include "common.h"
-#include "dds/DCPS/dcps_export.h"
-#include "dds/DCPS/DCPS_Utils.h"
 
 #include <ace/ACE.h>
 #include <ace/Message_Block.h>
@@ -724,11 +722,11 @@ bool runEncapsulationOptionsTest()
     OpenDDS::DCPS::Serializer serializer(mb.get(), encoding);
     if (!(serializer << encap) || !serializer.write_octet_array(arr, i)) {
       std::cerr << "Serialization failed in runEncapsulationOptionsTest" << std::endl;
-        return false;
+      return false;
     }
 
     if (!OpenDDS::DCPS::EncapsulationHeader::set_encapsulation_options(mb)) {
-      std::cerr << "EncapsulationHeader::set_encapsulation_options failed. " << "Size: " << mb->length() << std::endl;
+      std::cerr << "EncapsulationHeader::set_encapsulation_options failed. Size: " << mb->length() << std::endl;
       return false;
     }
 


### PR DESCRIPTION
XTypes 1.3 7.6.3.1.2 says we should set the 2 LSB of the second byte of the options to be the number of bytes required to make the serialized size of the payload align to 4.