### PR TITLE
User cannot dynamically toggle RtpsRelay and ICE

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1596,6 +1596,8 @@ namespace OpenDDS {
         : location_ih_(DDS::HANDLE_NIL)
         , bit_ih_(DDS::HANDLE_NIL)
         , seq_reset_count_(0)
+        , have_spdp_info_(false)
+        , have_sedp_info_(false)
 #ifdef OPENDDS_SECURITY
         , have_auth_req_msg_(false)
         , have_handshake_msg_(false)
@@ -1628,6 +1630,8 @@ namespace OpenDDS {
         , bit_ih_(DDS::HANDLE_NIL)
         , last_seq_(seq)
         , seq_reset_count_(0)
+        , have_spdp_info_(false)
+        , have_sedp_info_(false)
 #ifdef OPENDDS_SECURITY
         , have_auth_req_msg_(false)
         , have_handshake_msg_(false)
@@ -1687,6 +1691,10 @@ namespace OpenDDS {
         DDS::InstanceHandle_t bit_ih_;
         SequenceNumber last_seq_;
         ACE_UINT16 seq_reset_count_;
+        bool have_spdp_info_;
+        ICE::AgentInfo spdp_info_;
+        bool have_sedp_info_;
+        ICE::AgentInfo sedp_info_;
 
 #ifdef OPENDDS_SECURITY
         bool have_auth_req_msg_;

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1596,9 +1596,9 @@ namespace OpenDDS {
         : location_ih_(DDS::HANDLE_NIL)
         , bit_ih_(DDS::HANDLE_NIL)
         , seq_reset_count_(0)
+#ifdef OPENDDS_SECURITY
         , have_spdp_info_(false)
         , have_sedp_info_(false)
-#ifdef OPENDDS_SECURITY
         , have_auth_req_msg_(false)
         , have_handshake_msg_(false)
         , auth_state_(AUTH_STATE_HANDSHAKE)
@@ -1630,9 +1630,9 @@ namespace OpenDDS {
         , bit_ih_(DDS::HANDLE_NIL)
         , last_seq_(seq)
         , seq_reset_count_(0)
+#ifdef OPENDDS_SECURITY
         , have_spdp_info_(false)
         , have_sedp_info_(false)
-#ifdef OPENDDS_SECURITY
         , have_auth_req_msg_(false)
         , have_handshake_msg_(false)
         , auth_state_(AUTH_STATE_HANDSHAKE)
@@ -1691,12 +1691,11 @@ namespace OpenDDS {
         DDS::InstanceHandle_t bit_ih_;
         SequenceNumber last_seq_;
         ACE_UINT16 seq_reset_count_;
+#ifdef OPENDDS_SECURITY
         bool have_spdp_info_;
         ICE::AgentInfo spdp_info_;
         bool have_sedp_info_;
         ICE::AgentInfo sedp_info_;
-
-#ifdef OPENDDS_SECURITY
         bool have_auth_req_msg_;
         DDS::Security::ParticipantStatelessMessage auth_req_msg_;
         bool have_handshake_msg_;

--- a/dds/DCPS/RTPS/ICE/EndpointManager.cpp
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.cpp
@@ -817,6 +817,10 @@ void EndpointManager::purge()
   for (UsernameToChecklistType::const_iterator pos = checklists.begin(), limit = checklists.end(); pos != limit; ++pos) {
     pos->second->remove_guids();
   }
+
+  for (AgentInfoListenersType::const_iterator pos = agent_info_listeners_.begin(), limit = agent_info_listeners_.end(); pos != limit; ++pos) {
+    pos->second->remove_agent_info(pos->first);
+  }
 }
 
 #endif /* OPENDDS_SECURITY */

--- a/dds/DCPS/RTPS/ICE/Ice.h
+++ b/dds/DCPS/RTPS/ICE/Ice.h
@@ -71,6 +71,7 @@ public:
   virtual ~AgentInfoListener() {}
   virtual void update_agent_info(const DCPS::RepoId& a_local_guid,
                                  const AgentInfo& a_agent_info) = 0;
+  virtual void remove_agent_info(const DCPS::RepoId& a_local_guid) = 0;
 };
 
 class OpenDDS_Rtps_Export Configuration {

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -692,6 +692,51 @@ RtpsDiscovery::signal_liveliness(const DDS::DomainId_t domain_id,
   get_part(domain_id, part_id)->signal_liveliness(kind);
 }
 
+void
+RtpsDiscovery::rtps_relay_only_now(bool f)
+{
+  config_->rtps_relay_only(f);
+
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  for (DomainParticipantMap::const_iterator dom_pos = participants_.begin(), dom_limit = participants_.end();
+       dom_pos != dom_limit; ++dom_pos) {
+    for (ParticipantMap::const_iterator part_pos = dom_pos->second.begin(), part_limit = dom_pos->second.end(); part_pos != part_limit; ++part_pos) {
+      part_pos->second->rtps_relay_only_now(f);
+    }
+  }
+}
+
+void
+RtpsDiscovery::use_rtps_relay_now(bool f)
+{
+  config_->use_rtps_relay(f);
+
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  for (DomainParticipantMap::const_iterator dom_pos = participants_.begin(), dom_limit = participants_.end();
+       dom_pos != dom_limit; ++dom_pos) {
+    for (ParticipantMap::const_iterator part_pos = dom_pos->second.begin(), part_limit = dom_pos->second.end(); part_pos != part_limit; ++part_pos) {
+      part_pos->second->use_rtps_relay_now(f);
+    }
+  }
+}
+
+void
+RtpsDiscovery::use_ice_now(bool after)
+{
+  const bool before = config_->use_ice();
+  config_->use_ice(after);
+
+  if (before != after) {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    for (DomainParticipantMap::const_iterator dom_pos = participants_.begin(), dom_limit = participants_.end();
+         dom_pos != dom_limit; ++dom_pos) {
+      for (ParticipantMap::const_iterator part_pos = dom_pos->second.begin(), part_limit = dom_pos->second.end(); part_pos != part_limit; ++part_pos) {
+        part_pos->second->use_ice_now(after);
+      }
+    }
+  }
+}
+
 #ifdef OPENDDS_SECURITY
 DDS::Security::ParticipantCryptoHandle
 RtpsDiscovery::get_crypto_handle(DDS::DomainId_t domain,

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -587,6 +587,15 @@ public:
   u_short max_spdp_sequence_msg_reset_check() const { return config_->max_spdp_sequence_msg_reset_check(); }
   void max_spdp_sequence_msg_reset_check(u_short reset_value) { config_->max_spdp_sequence_msg_reset_check(reset_value); }
 
+  bool rtps_relay_only() const { return config_->rtps_relay_only(); }
+  void rtps_relay_only_now(bool f);
+
+  bool use_rtps_relay() const { return config_->use_rtps_relay(); }
+  void use_rtps_relay_now(bool f);
+
+  bool use_ice() const { return config_->use_ice(); }
+  void use_ice_now(bool f);
+
   RtpsDiscoveryConfig_rch config() const { return config_; }
 
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -166,8 +166,10 @@ public:
 
   ICE::Endpoint* get_ice_endpoint();
 
+  void rtps_relay_only(bool f);
+  void use_rtps_relay(bool f);
+  void use_ice_now(bool f);
   void rtps_relay_address(const ACE_INET_Addr& address);
-
   void stun_server_address(const ACE_INET_Addr& address);
 
   DCPS::ReactorTask_rch reactor_task() const { return reactor_task_; }
@@ -844,7 +846,7 @@ protected:
     PublicationAgentInfoListener(Sedp& a_sedp) : sedp(a_sedp) {}
     void update_agent_info(const DCPS::RepoId& a_local_guid,
                            const ICE::AgentInfo& a_agent_info);
-
+    void remove_agent_info(const DCPS::RepoId& a_local_guid);
   } publication_agent_info_listener_;
 
   struct SubscriptionAgentInfoListener : public ICE::AgentInfoListener
@@ -853,6 +855,7 @@ protected:
     SubscriptionAgentInfoListener(Sedp& a_sedp) : sedp(a_sedp) {}
     void update_agent_info(const DCPS::RepoId& a_local_guid,
                            const ICE::AgentInfo& a_agent_info);
+    void remove_agent_info(const DCPS::RepoId& a_local_guid);
   } subscription_agent_info_listener_;
 #endif
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -165,8 +165,10 @@ public:
   u_short get_ipv6_sedp_port() const { return sedp_.ipv6_local_address().get_port_number(); }
 #endif
 
+  void rtps_relay_only_now(bool f);
+  void use_rtps_relay_now(bool f);
+  void use_ice_now(bool f);
   void sedp_rtps_relay_address(const ACE_INET_Addr& address) { sedp_.rtps_relay_address(address); }
-
   void sedp_stun_server_address(const ACE_INET_Addr& address) { sedp_.stun_server_address(address); }
 
   BuiltinEndpointSet_t available_builtin_endpoints() const { return available_builtin_endpoints_; }
@@ -215,6 +217,7 @@ private:
   bool match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& iter);
   void attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery);
   void update_agent_info(const DCPS::RepoId& local_guid, const ICE::AgentInfo& agent_info);
+  void remove_agent_info(const DCPS::RepoId& local_guid);
 #endif
 
   struct SpdpTransport : public virtual DCPS::RcEventHandler, public virtual DCPS::NetworkConfigListener

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -53,6 +53,9 @@ namespace RTPS {
 class RtpsDiscoveryConfig;
 class RtpsDiscovery;
 
+const char SPDP_AGENT_INFO_KEY[] = "SPDP";
+const char SEDP_AGENT_INFO_KEY[] = "SEDP";
+
 /// Each instance of class Spdp represents the implementation of the RTPS
 /// Simple Participant Discovery Protocol for a single local DomainParticipant.
 class OpenDDS_Rtps_Export Spdp : public DCPS::LocalParticipant<Sedp>

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -158,6 +158,7 @@ public:
   };
 
   virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+  virtual void use_ice_now(bool /*flag*/) {}
 
 protected:
   TransportImpl(TransportInst& config);

--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -168,6 +168,15 @@ OpenDDS::DCPS::TransportInst::get_ice_endpoint()
   return temp ? temp->get_ice_endpoint() : 0;
 }
 
+void
+OpenDDS::DCPS::TransportInst::use_ice_now(bool flag)
+{
+  const OpenDDS::DCPS::TransportImpl_rch temp = impl();
+  if (temp) {
+    temp->use_ice_now(flag);
+  }
+}
+
 OpenDDS::DCPS::ReactorTask_rch
 OpenDDS::DCPS::TransportInst::reactor_task()
 {

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -112,6 +112,7 @@ public:
   virtual size_t populate_locator(OpenDDS::DCPS::TransportLocator& trans_info, ConnectionInfoFlags flags) const = 0;
 
   ICE::Endpoint* get_ice_endpoint();
+  void use_ice_now(bool flag);
 
   virtual void update_locators(const RepoId& /*remote_id*/,
                                const TransportLocatorSeq& /*locators*/) {}

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -394,7 +394,7 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
   }
 
   if (cfg.rtps_relay_address() != ACE_INET_Addr() ||
-      cfg.use_rtps_relay_) {
+      cfg.use_rtps_relay()) {
     relay_beacon_.enable(false, cfg.rtps_relay_beacon_period_);
   }
 
@@ -4040,7 +4040,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   OPENDDS_ASSERT(local != GUID_UNKNOWN);
   OPENDDS_ASSERT(remote != GUID_UNKNOWN);
 
-  if (config().rtps_relay_only_) {
+  if (config().rtps_relay_only()) {
     addresses.insert(config().rtps_relay_address());
     return;
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -328,7 +328,6 @@ private:
         return;
       }
 
-      ACE_DEBUG((LM_DEBUG, "Calling replay_durable_data on datalink\n"));
       link->replay_durable_data(local_pub_id_, remote_sub_id_);
     }
   };

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -43,9 +43,6 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , handshake_timeout_(30) // default syn_timeout in OpenDDS_Multicast
   , durable_data_timeout_(60)
   , rtps_relay_beacon_period_(30)
-  , use_rtps_relay_(false)
-  , rtps_relay_only_(false)
-  , use_ice_(false)
   , opendds_discovery_guid_(GUID_UNKNOWN)
   , multicast_group_address_(7401, "239.255.0.2")
   , local_address_(u_short(0), "0.0.0.0")
@@ -53,6 +50,9 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , ipv6_multicast_group_address_(7401, "FF03::2")
   , ipv6_local_address_(u_short(0), "::")
 #endif
+  , rtps_relay_only_(false)
+  , use_rtps_relay_(false)
+  , use_ice_(false)
 {}
 
 TransportImpl_rch

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -99,16 +99,19 @@ public:
 
   /// Relay address and stun server address may change, these use a mutex
   ///{
+  void rtps_relay_only(bool flag);
+  bool rtps_relay_only() const;
+  void use_rtps_relay(bool flag);
+  bool use_rtps_relay() const;
   void rtps_relay_address(const ACE_INET_Addr& address);
   ACE_INET_Addr rtps_relay_address() const;
+  void use_ice(bool flag);
+  bool use_ice() const;
   void stun_server_address(const ACE_INET_Addr& address);
   ACE_INET_Addr stun_server_address() const;
   ///}
 
   TimeDuration rtps_relay_beacon_period_;
-  bool use_rtps_relay_;
-  bool rtps_relay_only_;
-  bool use_ice_;
 
   void update_locators(const RepoId& remote_id,
                        const TransportLocatorSeq& locators);
@@ -133,33 +136,80 @@ private:
   ACE_INET_Addr ipv6_local_address_;
 #endif
 
+  mutable ACE_SYNCH_MUTEX config_lock_;
+  bool rtps_relay_only_;
+  bool use_rtps_relay_;
   ACE_INET_Addr rtps_relay_address_;
-  mutable ACE_SYNCH_MUTEX rtps_relay_config_lock_;
+  bool use_ice_;
   ACE_INET_Addr stun_server_address_;
-  mutable ACE_SYNCH_MUTEX stun_server_config_lock_;
 };
+
+inline void RtpsUdpInst::rtps_relay_only(bool flag)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, config_lock_);
+  rtps_relay_only_ = flag;
+  if (DCPS::DCPS_debug_level > 3) {
+    ACE_DEBUG((LM_INFO, "(%P|%t) RtpsUdpInst::rtps_relay_only is now %d\n", rtps_relay_only_));
+  }
+}
+
+inline bool RtpsUdpInst::rtps_relay_only() const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, config_lock_, false);
+  return rtps_relay_only_;
+}
+
+inline void RtpsUdpInst::use_rtps_relay(bool flag)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, config_lock_);
+  use_rtps_relay_ = flag;
+  if (DCPS::DCPS_debug_level > 3) {
+    ACE_DEBUG((LM_INFO, "(%P|%t) RtpsUdpInst::use_rtps_relay is now %d\n", rtps_relay_only_));
+  }
+}
+
+inline bool RtpsUdpInst::use_rtps_relay() const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, config_lock_, false);
+  return use_rtps_relay_;
+}
 
 inline void RtpsUdpInst::rtps_relay_address(const ACE_INET_Addr& address)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, rtps_relay_config_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, g, config_lock_);
   rtps_relay_address_ = address;
 }
 
 inline ACE_INET_Addr RtpsUdpInst::rtps_relay_address() const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_relay_config_lock_, ACE_INET_Addr());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, config_lock_, ACE_INET_Addr());
   return rtps_relay_address_;
+}
+
+inline void RtpsUdpInst::use_ice(bool flag)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, config_lock_);
+  use_ice_ = flag;
+  if (DCPS::DCPS_debug_level > 3) {
+    ACE_DEBUG((LM_INFO, "(%P|%t) RtpsUdpInst::use_ice is now %d\n", use_ice_));
+  }
+}
+
+inline bool RtpsUdpInst::use_ice() const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, config_lock_, false);
+  return use_ice_;
 }
 
 inline void RtpsUdpInst::stun_server_address(const ACE_INET_Addr& address)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, stun_server_config_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, g, config_lock_);
   stun_server_address_ = address;
 }
 
 inline ACE_INET_Addr RtpsUdpInst::stun_server_address() const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, stun_server_config_lock_, ACE_INET_Addr());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, config_lock_, ACE_INET_Addr());
   return stun_server_address_;
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -61,7 +61,6 @@ RtpsUdpTransport::get_ice_endpoint()
 void
 RtpsUdpTransport::use_ice_now(bool after)
 {
-  // Update the config.
   const bool before = config().use_ice();
   config().use_ice(after);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -34,6 +34,7 @@ public:
   RtpsUdpTransport(RtpsUdpInst& inst);
   RtpsUdpInst& config() const;
   virtual ICE::Endpoint* get_ice_endpoint();
+  virtual void use_ice_now(bool flag);
 
   virtual void update_locators(const RepoId& /*remote*/,
                                const TransportLocatorSeq& /*locators*/);
@@ -145,6 +146,10 @@ private:
     virtual ACE_INET_Addr stun_server_address() const;
   };
   IceEndpoint ice_endpoint_;
+
+  void start_ice();
+  void stop_ice();
+
 #endif
 };
 


### PR DESCRIPTION
The decision to use the RtpsRelay (or to only use the RtpsRelay) or
ICE can only be made at start time.  Users of OpenDDS want the ability
to dynamically turn off the RtpsRelay and ICE for testing purposes.

Solution: Make the corresponding configuration dynamic.  The
configuration for the RtspRelay is straightforward as it can be picked
up on the next send.  The configuration of ICE is more difficult since
ICE needs to be restarted for participants that have already been
discovered.

The code attempts to reset flags in the ParticpantLocationTopic.  The
ParticipantLocationTopic in a remote participant will be updated after
the corresponding entries time out.  To a certain extent, these
controls influence the ways in which other participants can discover a
given participant.  For example, switching to RtpsRelay only means
that a remote participant will eventually say that the given
participant can only be reached via the RtpsRelay.  The local
participant may still be able to discover the remote locally.