### PR TITLE
XTYPE-124: TypeConsistencyEnforcement QoS Policy (initial implementation)

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -246,12 +246,12 @@ namespace {
   {
     DDS::TypeConsistencyEnforcementQosPolicy def_tceqp =
         TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
-    return ((tceqp.kind != def_tceqp.kind) ||
-      (tceqp.ignore_sequence_bounds != def_tceqp.ignore_sequence_bounds) ||
-      (tceqp.ignore_string_bounds != def_tceqp.ignore_string_bounds) ||
-      (tceqp.ignore_member_names != def_tceqp.ignore_member_names) ||
-      (tceqp.prevent_type_widening != def_tceqp.prevent_type_widening) ||
-      (tceqp.force_type_validation != def_tceqp.force_type_validation));
+    return (tceqp.kind != def_tceqp.kind ||
+      tceqp.ignore_sequence_bounds != def_tceqp.ignore_sequence_bounds ||
+      tceqp.ignore_string_bounds != def_tceqp.ignore_string_bounds ||
+      tceqp.ignore_member_names != def_tceqp.ignore_member_names ||
+      tceqp.prevent_type_widening != def_tceqp.prevent_type_widening ||
+      tceqp.force_type_validation != def_tceqp.force_type_validation);
   }
 
   void normalize(DDS::Duration_t& dur)

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1253,8 +1253,6 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     add_param(param_list, param);
   }
 
-
-
   CORBA::ULong i;
   CORBA::ULong locator_len = reader_data.readerProxy.allLocators.length();
   // Serialize from allLocators, rather than the unicastLocatorList

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -242,6 +242,23 @@ namespace {
     return qos.value.length();
   }
 
+  bool not_default(const DDS::TypeConsistencyEnforcementQosPolicy& tceqp)
+  {
+    DDS::TypeConsistencyEnforcementQosPolicy def_tceqp =
+        TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
+    if ((tceqp.kind != def_tceqp.kind) ||
+      (tceqp.ignore_sequence_bounds != def_tceqp.ignore_sequence_bounds) ||
+      (tceqp.ignore_string_bounds != def_tceqp.ignore_string_bounds) ||
+      (tceqp.ignore_member_names != def_tceqp.ignore_member_names) ||
+      (tceqp.prevent_type_widening != def_tceqp.prevent_type_widening) ||
+      (tceqp.force_type_validation != def_tceqp.force_type_validation)) {
+      return true;
+    } else {
+      return false;
+    }
+
+  }
+
   void normalize(DDS::Duration_t& dur)
   {
     // Interoperability note:
@@ -1238,6 +1255,13 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
   {
     Parameter param;
     param.representation(reader_data.ddsSubscriptionData.representation);
+    add_param(param_list, param);
+  }
+
+  if (not_default(reader_data.ddsSubscriptionData.type_consistency))
+  {
+    Parameter param;
+    param.type_consistency(reader_data.ddsSubscriptionData.type_consistency);
     add_param(param_list, param);
   }
 

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -246,17 +246,12 @@ namespace {
   {
     DDS::TypeConsistencyEnforcementQosPolicy def_tceqp =
         TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
-    if ((tceqp.kind != def_tceqp.kind) ||
+    return ((tceqp.kind != def_tceqp.kind) ||
       (tceqp.ignore_sequence_bounds != def_tceqp.ignore_sequence_bounds) ||
       (tceqp.ignore_string_bounds != def_tceqp.ignore_string_bounds) ||
       (tceqp.ignore_member_names != def_tceqp.ignore_member_names) ||
       (tceqp.prevent_type_widening != def_tceqp.prevent_type_widening) ||
-      (tceqp.force_type_validation != def_tceqp.force_type_validation)) {
-      return true;
-    } else {
-      return false;
-    }
-
+      (tceqp.force_type_validation != def_tceqp.force_type_validation));
   }
 
   void normalize(DDS::Duration_t& dur)

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1253,12 +1253,7 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     add_param(param_list, param);
   }
 
-  if (not_default(reader_data.ddsSubscriptionData.type_consistency))
-  {
-    Parameter param;
-    param.type_consistency(reader_data.ddsSubscriptionData.type_consistency);
-    add_param(param_list, param);
-  }
+
 
   CORBA::ULong i;
   CORBA::ULong locator_len = reader_data.readerProxy.allLocators.length();

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -298,6 +298,9 @@ module OpenDDS {
     const ParameterId_t PIDMASK_VENDOR_SPECIFIC = 0x8000;
     const ParameterId_t PIDMASK_INCOMPATIBLE = 0x4000;
 
+    // Type Consistency Enforcement QoS Policy 7.6.3.4 XTypes Spec
+    const ParameterId_t PID_XYTPES_TYPE_CONSISTENCY = 0x0074;
+
     // TypeInformation for XTypes 7.6.3.2.2 XTypes Spec
     const ParameterId_t PID_XTYPES_TYPE_INFORMATION = 0x0075;
 
@@ -487,6 +490,9 @@ module OpenDDS {
 
       case PID_DATA_REPRESENTATION:
         DDS::DataRepresentationQosPolicy representation;
+
+      case PID_XYTPES_TYPE_CONSISTENCY:
+        DDS::TypeConsistencyEnforcementQosPolicy type_consistency;
 
       default:
         DDS::OctetSeq unknown_data;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4447,7 +4447,6 @@ Sedp::write_subscription_data_unsecure(
       result = DDS::RETCODE_ERROR;
     }
 
-    //add TypeConsistencyEnforcementQosPolicy to param list
     DDS::TypeConsistencyEnforcementQosPolicy tceqp = TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
     tceqp.ignore_member_names = true;
     Parameter param;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4451,7 +4451,7 @@ Sedp::write_subscription_data_unsecure(
     DDS::TypeConsistencyEnforcementQosPolicy tceqp = TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
     tceqp.ignore_member_names = true;
     Parameter param;
-    param.type_consistency(tceqp); //JJA convert type_consistency to param
+    param.type_consistency(tceqp);
     OpenDDS::RTPS::add_param(plist, param);
 
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4452,7 +4452,9 @@ Sedp::write_subscription_data_unsecure(
     tceqp.ignore_member_names = true;
     Parameter param;
     param.type_consistency(tceqp);
-    OpenDDS::RTPS::add_param(plist, param);
+    const CORBA::ULong length = plist.length();
+    plist.length(length + 1);
+    plist[length] = param;
 
 #ifdef OPENDDS_SECURITY
     if (ls.have_ice_agent_info) {

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4079,6 +4079,12 @@ Sedp::populate_discovered_reader_msg(
     drd.readerProxy.associatedWriters.length(len + 1);
     drd.readerProxy.associatedWriters[len] = *writer;
   }
+  drd.ddsSubscriptionData.type_consistency.kind = DDS::ALLOW_TYPE_COERCION;
+  drd.ddsSubscriptionData.type_consistency.ignore_sequence_bounds = true;
+  drd.ddsSubscriptionData.type_consistency.ignore_string_bounds = true;
+  drd.ddsSubscriptionData.type_consistency.ignore_member_names = false;
+  drd.ddsSubscriptionData.type_consistency.prevent_type_widening = false;
+  drd.ddsSubscriptionData.type_consistency.force_type_validation = false;
 }
 
 void

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4448,7 +4448,6 @@ Sedp::write_subscription_data_unsecure(
     }
 
     DDS::TypeConsistencyEnforcementQosPolicy tceqp = TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
-    tceqp.ignore_member_names = true;
     Parameter param;
     param.type_consistency(tceqp);
     const CORBA::ULong length = plist.length();

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4079,12 +4079,6 @@ Sedp::populate_discovered_reader_msg(
     drd.readerProxy.associatedWriters.length(len + 1);
     drd.readerProxy.associatedWriters[len] = *writer;
   }
-  drd.ddsSubscriptionData.type_consistency.kind = DDS::ALLOW_TYPE_COERCION;
-  drd.ddsSubscriptionData.type_consistency.ignore_sequence_bounds = true;
-  drd.ddsSubscriptionData.type_consistency.ignore_string_bounds = true;
-  drd.ddsSubscriptionData.type_consistency.ignore_member_names = false;
-  drd.ddsSubscriptionData.type_consistency.prevent_type_widening = false;
-  drd.ddsSubscriptionData.type_consistency.force_type_validation = false;
 }
 
 void
@@ -4452,6 +4446,14 @@ Sedp::write_subscription_data_unsecure(
                  ACE_TEXT("to ParameterList\n")));
       result = DDS::RETCODE_ERROR;
     }
+
+    //add TypeConsistencyEnforcementQosPolicy to param list
+    DDS::TypeConsistencyEnforcementQosPolicy tceqp = TheServiceParticipant->initial_TypeConsistencyEnforcementQosPolicy();
+    tceqp.ignore_member_names = true;
+    Parameter param;
+    param.type_consistency(tceqp); //JJA convert type_consistency to param
+    OpenDDS::RTPS::add_param(plist, param);
+
 #ifdef OPENDDS_SECURITY
     if (ls.have_ice_agent_info) {
       ICE::AgentInfoMap ai_map;

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -787,6 +787,14 @@ Service_Participant::initialize()
   initial_SubscriberQos_.partition = initial_PartitionQosPolicy_;
   initial_SubscriberQos_.group_data = initial_GroupDataQosPolicy_;
   initial_SubscriberQos_.entity_factory = initial_EntityFactoryQosPolicy_;
+
+  initial_TypeConsistencyEnforcementQosPolicy_.kind = DDS::ALLOW_TYPE_COERCION;
+  initial_TypeConsistencyEnforcementQosPolicy_.prevent_type_widening = false;
+  initial_TypeConsistencyEnforcementQosPolicy_.ignore_sequence_bounds = true;
+  initial_TypeConsistencyEnforcementQosPolicy_.ignore_string_bounds = true;
+  initial_TypeConsistencyEnforcementQosPolicy_.ignore_member_names = false;
+  initial_TypeConsistencyEnforcementQosPolicy_.force_type_validation = false;
+
 }
 
 void

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -155,6 +155,7 @@ public:
   const DDS::PublisherQos& initial_PublisherQos() const;
   const DDS::DataReaderQos& initial_DataReaderQos() const;
   const DDS::SubscriberQos& initial_SubscriberQos() const;
+  const DDS::TypeConsistencyEnforcementQosPolicy initial_TypeConsistencyEnforcementQosPolicy() const;
 
   /**
    * This accessor is to provide the configurable number of chunks
@@ -553,6 +554,7 @@ private:
   DDS::DataReaderQos                  initial_DataReaderQos_;
   DDS::SubscriberQos                  initial_SubscriberQos_;
   DDS::DomainParticipantFactoryQos    initial_DomainParticipantFactoryQos_;
+  DDS::TypeConsistencyEnforcementQosPolicy initial_TypeConsistencyEnforcementQosPolicy_;
 
   /// The configurable value of the number chunks that the
   /// @c DataWriter's cached allocator can allocate.

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -155,7 +155,7 @@ public:
   const DDS::PublisherQos& initial_PublisherQos() const;
   const DDS::DataReaderQos& initial_DataReaderQos() const;
   const DDS::SubscriberQos& initial_SubscriberQos() const;
-  const DDS::TypeConsistencyEnforcementQosPolicy initial_TypeConsistencyEnforcementQosPolicy() const;
+  const DDS::TypeConsistencyEnforcementQosPolicy& initial_TypeConsistencyEnforcementQosPolicy() const;
 
   /**
    * This accessor is to provide the configurable number of chunks

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -244,6 +244,13 @@ Service_Participant::initial_SubscriberQos() const
 }
 
 ACE_INLINE
+const DDS::TypeConsistencyEnforcementQosPolicy&
+Service_Participant::initial_TypeConsistencyEnforcementQosPolicy() const
+{
+  return initial_TypeConsistencyEnforcementQosPolicy_;
+}
+
+ACE_INLINE
 int&
 Service_Participant::federation_recovery_duration()
 {

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -274,8 +274,9 @@ module DDS {
     };
     */
     //constants for TypeConsistencyEnforcementQosPolicy::kind field
-    const short DISALLOW_TYPE_COERCION = 1;
-    const short ALLOW_TYPE_COERCION = 2;
+    typedef short TypeConsistencyEnforcementQosPolicyKind_t;
+    const TypeConsistencyEnforcementQosPolicyKind_t DISALLOW_TYPE_COERCION = 1;
+    const TypeConsistencyEnforcementQosPolicyKind_t ALLOW_TYPE_COERCION = 2;
     /*
     const QosPolicyId_t TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_ID = 24;
     const string TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_NAME =
@@ -285,8 +286,7 @@ module DDS {
     // @appendable
     */
     struct TypeConsistencyEnforcementQosPolicy {
-      // TypeConsistencyKind kind;
-      short kind;
+      TypeConsistencyEnforcementQosPolicyKind_t kind;
       boolean ignore_sequence_bounds;
       boolean ignore_string_bounds;
       boolean ignore_member_names;

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -272,22 +272,27 @@ module DDS {
       DISALLOW_TYPE_COERCION,
       ALLOW_TYPE_COERCION
     };
-
+    */
+    //constants for TypeConsistencyEnforcementQosPolicy::kind field
+    const short DISALLOW_TYPE_COERCION = 1;
+    const short ALLOW_TYPE_COERCION = 2;
+    /*
     const QosPolicyId_t TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_ID = 24;
     const string TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_NAME =
       "TypeConsistencyEnforcement";
 
     // This is for when we support XCDR1.
     // @appendable
+    */
     struct TypeConsistencyEnforcementQosPolicy {
-      TypeConsistencyKind kind;
+      // TypeConsistencyKind kind;
+      short kind;
       boolean ignore_sequence_bounds;
       boolean ignore_string_bounds;
       boolean ignore_member_names;
       boolean prevent_type_widening;
       boolean force_type_validation;
     };
-    */
 
     // This is for when we support XCDR1.
     // @mutable
@@ -365,9 +370,7 @@ module DDS {
       TimeBasedFilterQosPolicy time_based_filter;
       ReaderDataLifecycleQosPolicy reader_data_lifecycle;
       DataRepresentationQosPolicy representation;
-      /* TODO
       TypeConsistencyEnforcementQosPolicy type_consistency;
-      */
     };
 
     struct SubscriberQos {
@@ -471,9 +474,7 @@ module DDS {
       @id(0x002E) TopicDataQosPolicy topic_data;
       @id(0x002D) GroupDataQosPolicy group_data;
       @id(0x0073) DataRepresentationQosPolicy representation;
-      /* TODO
       @id(0x0074) TypeConsistencyEnforcementQosPolicy type_consistency;
-      */
     };
 
     BUILT_IN_TOPIC_TYPE

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -474,7 +474,6 @@ module DDS {
       @id(0x002E) TopicDataQosPolicy topic_data;
       @id(0x002D) GroupDataQosPolicy group_data;
       @id(0x0073) DataRepresentationQosPolicy representation;
-      @id(0x0074) TypeConsistencyEnforcementQosPolicy type_consistency;
     };
 
     BUILT_IN_TOPIC_TYPE

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -474,6 +474,7 @@ module DDS {
       @id(0x002E) TopicDataQosPolicy topic_data;
       @id(0x002D) GroupDataQosPolicy group_data;
       @id(0x0073) DataRepresentationQosPolicy representation;
+      @id(0x0074) TypeConsistencyEnforcementQosPolicy type_consistency;
     };
 
     BUILT_IN_TOPIC_TYPE

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -370,7 +370,6 @@ module DDS {
       TimeBasedFilterQosPolicy time_based_filter;
       ReaderDataLifecycleQosPolicy reader_data_lifecycle;
       DataRepresentationQosPolicy representation;
-      TypeConsistencyEnforcementQosPolicy type_consistency;
     };
 
     struct SubscriberQos {
@@ -474,7 +473,6 @@ module DDS {
       @id(0x002E) TopicDataQosPolicy topic_data;
       @id(0x002D) GroupDataQosPolicy group_data;
       @id(0x0073) DataRepresentationQosPolicy representation;
-      @id(0x0074) TypeConsistencyEnforcementQosPolicy type_consistency;
     };
 
     BUILT_IN_TOPIC_TYPE

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -273,7 +273,6 @@ module DDS {
       ALLOW_TYPE_COERCION
     };
     */
-    //constants for TypeConsistencyEnforcementQosPolicy::kind field
     typedef short TypeConsistencyEnforcementQosPolicyKind_t;
     const TypeConsistencyEnforcementQosPolicyKind_t DISALLOW_TYPE_COERCION = 1;
     const TypeConsistencyEnforcementQosPolicyKind_t ALLOW_TYPE_COERCION = 2;

--- a/java/dds/DDS/.gitignore
+++ b/java/dds/DDS/.gitignore
@@ -546,3 +546,8 @@
 /XCDR2_DATA_REPRESENTATION.java
 /XCDR_DATA_REPRESENTATION.java
 /XML_DATA_REPRESENTATION.java
+/ALLOW_TYPE_COERCION.java
+/DISALLOW_TYPE_COERCION.java
+/TypeConsistencyEnforcementQosPolicy.java
+/TypeConsistencyEnforcementQosPolicyHelper.java
+/TypeConsistencyEnforcementQosPolicyHolder.java

--- a/java/dds/DDS/.gitignore
+++ b/java/dds/DDS/.gitignore
@@ -551,3 +551,4 @@
 /TypeConsistencyEnforcementQosPolicy.java
 /TypeConsistencyEnforcementQosPolicyHelper.java
 /TypeConsistencyEnforcementQosPolicyHolder.java
+/TypeConsistencyEnforcementQosPolicyKind_tHelper.java


### PR DESCRIPTION
- Determine values for the enum “kind” and the 5 booleans in TypeConsistencyEnforcementQosPolicy (Annex D)
- These would be constants for our initial implementation, the user will not be able to change them
- Send these values in the SEDP Built-in Subscription endpoint