### PR TITLE
Observed data cannot be logged

### DIFF
--- a/dds/DCPS/DataDurabilityCache.cpp
+++ b/dds/DCPS/DataDurabilityCache.cpp
@@ -832,8 +832,11 @@ OpenDDS::DCPS::DataDurabilityCache::get_data(
                      sample_length);
       mb->wr_ptr(sample_length);
 
-      const DDS::ReturnCode_t ret = data_writer->write(move(mb), handle,
-        source_timestamp, 0 /* no content filtering */);
+      const DDS::ReturnCode_t ret = data_writer->write(move(mb),
+                                                       handle,
+                                                       source_timestamp,
+                                                       0 /* no content filtering */,
+                                                       0 /* no pointer to data */);
 
       if (ret != DDS::RETCODE_OK) {
         return false;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -180,6 +180,20 @@ private:
   };
 };
 
+class MessageHolder : public RcObject {
+public:
+  virtual const void* get() const = 0;
+};
+
+template <typename T>
+class MessageHolder_T : public MessageHolder {
+public:
+  MessageHolder_T(const T& v) : v_(v) {}
+  const void* get() const { return &v_; }
+private:
+  T v_;
+};
+
 /**
 * @class DataReaderImpl
 *
@@ -384,11 +398,11 @@ public:
                                         const DDS::StringSeq& params) = 0;
 #endif
 
-  virtual void dds_demarshal(const ReceivedDataSample& sample,
-                             SubscriptionInstance_rch& instance,
-                             bool& is_new_instance,
-                             bool& filtered,
-                             MarshalingType marshaling_type)= 0;
+  virtual RcHandle<MessageHolder> dds_demarshal(const ReceivedDataSample& sample,
+                                                SubscriptionInstance_rch& instance,
+                                                bool& is_new_instance,
+                                                bool& filtered,
+                                                MarshalingType marshaling_type)= 0;
 
   virtual void dispose_unregister(const ReceivedDataSample& sample,
                                   SubscriptionInstance_rch& instance);
@@ -578,6 +592,8 @@ protected:
 
   // type specific DataReader's part of enable.
   virtual DDS::ReturnCode_t enable_specific() = 0;
+
+  virtual const ValueWriterDispatcher* get_value_writer_dispatcher() const { return 0; }
 
   void sample_info(DDS::SampleInfo & sample_info,
                    const ReceivedDataElement *ptr);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -30,9 +30,9 @@ namespace OpenDDS {
     OpenDDS_Dcps_Export
 #endif
     DataReaderImpl_T
-    : public virtual OpenDDS::DCPS::LocalObject<typename DDSTraits<MessageType>::DataReaderType>
-    , public virtual OpenDDS::DCPS::DataReaderImpl
-    , public OpenDDS::DCPS::ValueWriterDispatcher
+    : public virtual LocalObject<typename DDSTraits<MessageType>::DataReaderType>
+    , public virtual DataReaderImpl
+    , public ValueWriterDispatcher
   {
   public:
     typedef DDSTraits<MessageType> TraitsType;
@@ -262,7 +262,7 @@ namespace OpenDDS {
 
           const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
           if (observer && item->registered_data_ && vwd) {
-            Observer::Sample s(sample_info.instance_handle, sample_info.instance_state, item->source_timestamp_, item->sequence_, item->registered_data_);
+            Observer::Sample s(sample_info.instance_handle, sample_info.instance_state, *item);
             observer->on_sample_read(this, s, *vwd);
           }
 
@@ -326,7 +326,7 @@ namespace OpenDDS {
 
           const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
           if (observer && item->registered_data_ && vwd) {
-            Observer::Sample s(sample_info.instance_handle, sample_info.instance_state, item->source_timestamp_, item->sequence_, item->registered_data_);
+            Observer::Sample s(sample_info.instance_handle, sample_info.instance_state, *item);
             observer->on_sample_taken(this, s, *vwd);
           }
 
@@ -1204,7 +1204,7 @@ private:
 
             const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
             if (observer && item->registered_data_ && vwd) {
-              Observer::Sample s(handle, inst->instance_state_->instance_state(), item->source_timestamp_, item->sequence_, item->registered_data_);
+              Observer::Sample s(handle, inst->instance_state_->instance_state(), *item);
               observer->on_sample_read(this, s, *vwd);
             }
           }
@@ -1219,7 +1219,7 @@ private:
     if (observer && item.rde_->registered_data_ && vwd) {
       typename InstanceMap::iterator i = instance_map_.begin();
       const DDS::InstanceHandle_t handle = (i != instance_map_.end()) ? i->second : DDS::HANDLE_NIL;
-      Observer::Sample s(handle, item.si_->instance_state_->instance_state(), item.rde_->source_timestamp_, item.rde_->sequence_, item.rde_->registered_data_);
+      Observer::Sample s(handle, item.si_->instance_state_->instance_state(), *item.rde_);
       observer->on_sample_read(this, s, *vwd);
     }
   }
@@ -1297,7 +1297,7 @@ DDS::ReturnCode_t take_i(MessageSequenceType& received_data,
 
             const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
             if (observer && item->registered_data_ && vwd) {
-              Observer::Sample s(handle, inst->instance_state_->instance_state(), item->source_timestamp_, item->sequence_, item->registered_data_);
+              Observer::Sample s(handle, inst->instance_state_->instance_state(), *item);
               observer->on_sample_taken(this, s, *vwd);
             }
           }
@@ -1362,7 +1362,7 @@ DDS::ReturnCode_t read_instance_i(MessageSequenceType& received_data,
         results.insert_sample(item, inst, ++i);
         const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
         if (observer && item->registered_data_ && vwd) {
-          Observer::Sample s(a_handle, inst->instance_state_->instance_state(), item->source_timestamp_, item->sequence_, item->registered_data_);
+          Observer::Sample s(a_handle, inst->instance_state_->instance_state(), *item);
           observer->on_sample_read(this, s, *vwd);
         }
       }
@@ -1434,7 +1434,7 @@ DDS::ReturnCode_t take_instance_i(MessageSequenceType& received_data,
         results.insert_sample(item, inst, ++i);
         const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
         if (observer && item->registered_data_ && vwd) {
-          Observer::Sample s(a_handle, inst->instance_state_->instance_state(), item->source_timestamp_, item->sequence_, item->registered_data_);
+          Observer::Sample s(a_handle, inst->instance_state_->instance_state(), *item);
           observer->on_sample_taken(this, s, *vwd);
         }
       }

--- a/dds/DCPS/DataSampleHeader.h
+++ b/dds/DCPS/DataSampleHeader.h
@@ -247,6 +247,19 @@ struct OpenDDS_Dcps_Export DataSampleHeader : public PoolAllocationBase {
   /// Returns true if the sample has a complete serialized payload.
   bool valid_data() const;
 
+  DDS::InstanceStateKind instance_state() const
+  {
+    switch (message_id_) {
+    case UNREGISTER_INSTANCE:
+      return DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE;
+    case DISPOSE_INSTANCE:
+    case DISPOSE_UNREGISTER_INSTANCE:
+      return DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
+    default:
+      return DDS::ALIVE_INSTANCE_STATE;
+    }
+  }
+
 private:
   /// Keep track of the amount of data read from a buffer.
   size_t marshaled_size_;

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1850,7 +1850,8 @@ DDS::ReturnCode_t
 DataWriterImpl::write(Message_Block_Ptr data,
                       DDS::InstanceHandle_t handle,
                       const DDS::Time_t& source_timestamp,
-                      GUIDSeq* filter_out)
+                      GUIDSeq* filter_out,
+                      const void* real_data)
 {
   DBG_ENTRY_LVL("DataWriterImpl","write",6);
 
@@ -1937,10 +1938,11 @@ DataWriterImpl::write(Message_Block_Ptr data,
     this->send(list, transaction_id);
   }
 
+  const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
   const Observer_rch observer = get_observer(Observer::e_SAMPLE_SENT);
-  if (observer) {
-    Observer::Sample s(handle, *element, source_timestamp);
-    observer->on_sample_sent(this, s);
+  if (observer && real_data && vwd) {
+    Observer::Sample s(handle, element->get_header().instance_state(), source_timestamp, element->get_header().sequence_, real_data);
+    observer->on_sample_sent(this, s, *vwd);
   }
 
   return DDS::RETCODE_OK;

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -252,7 +252,8 @@ public:
   DDS::ReturnCode_t write(Message_Block_Ptr sample,
                           DDS::InstanceHandle_t handle,
                           const DDS::Time_t& source_timestamp,
-                          GUIDSeq* filter_out);
+                          GUIDSeq* filter_out,
+                          const void* real_data);
 
   /**
    * Delegate to the WriteDataContainer to dispose all data
@@ -470,6 +471,8 @@ protected:
 
   // type specific DataWriter's part of enable.
   virtual DDS::ReturnCode_t enable_specific() = 0;
+
+  virtual const ValueWriterDispatcher* get_value_writer_dispatcher() const { return 0; }
 
   /// The number of chunks for the cached allocator.
   size_t                     n_chunks_;

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -26,9 +26,9 @@ class
   OpenDDS_Dcps_Export
 #endif
 DataWriterImpl_T
-: public virtual OpenDDS::DCPS::LocalObject<typename DDSTraits<MessageType>::DataWriterType>
-, public virtual OpenDDS::DCPS::DataWriterImpl
-, public OpenDDS::DCPS::ValueWriterDispatcher
+: public virtual LocalObject<typename DDSTraits<MessageType>::DataWriterType>
+, public virtual DataWriterImpl
+, public ValueWriterDispatcher
 {
 public:
   typedef DDSTraits<MessageType> TraitsType;

--- a/dds/DCPS/Observer.cpp
+++ b/dds/DCPS/Observer.cpp
@@ -17,51 +17,11 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-DDS::InstanceStateKind Observer::Sample::to_instance_state(char message_id)
-{
-  switch (message_id) {
-  case UNREGISTER_INSTANCE:
-    return DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE;
-  case DISPOSE_INSTANCE:
-  case DISPOSE_UNREGISTER_INSTANCE:
-    return DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
-  default:
-    return DDS::ALIVE_INSTANCE_STATE;
-  }
-}
-
-Observer::Sample::Sample(DDS::InstanceHandle_t i, const DataSampleElement& e, const DDS::Time_t& t)
-  : instance_(i)
-  , instance_state_(to_instance_state(e.get_header().message_id_))
-  , timestamp_(t)
-  , seq_n_(e.get_header().sequence_)
-  , data_(e.get_sample())
-{}
-
-Observer::Sample::Sample(const ReceivedDataSample& s, DDS::InstanceHandle_t i)
-  : instance_(i)
-  , instance_state_(to_instance_state(s.header_.message_id_))
-  , seq_n_(s.header_.sequence_)
-  , data_(s.sample_.get())
-{
-  timestamp_.sec = s.header_.source_timestamp_sec_;
-  timestamp_.nanosec = s.header_.source_timestamp_nanosec_;
-}
-
-Observer::Sample::Sample(const ReceivedDataElement& s, DDS::InstanceHandle_t i, DDS::InstanceStateKind instance_state)
-  : instance_(i)
-  , instance_state_(to_instance_state(instance_state))
-  , timestamp_(s.source_timestamp_)
-  , seq_n_(s.sequence_)
-  , data_(s.registered_data_)
-{}
-
-Observer::Sample::Sample(
-  DDS::InstanceHandle_t i,
-  DDS::InstanceStateKind instance_state,
-  const DDS::Time_t& t,
-  const SequenceNumber& sn,
-  const void* data)
+Observer::Sample::Sample(DDS::InstanceHandle_t i,
+                         DDS::InstanceStateKind instance_state,
+                         const DDS::Time_t& t,
+                         const SequenceNumber& sn,
+                         const void* data)
   : instance_(i)
   , instance_state_(instance_state)
   , timestamp_(t)

--- a/dds/DCPS/Observer.cpp
+++ b/dds/DCPS/Observer.cpp
@@ -29,6 +29,16 @@ Observer::Sample::Sample(DDS::InstanceHandle_t i,
   , data_(data)
 {}
 
+Observer::Sample::Sample(DDS::InstanceHandle_t i,
+                         DDS::InstanceStateKind instance_state,
+                         const ReceivedDataElement& rde)
+  : instance_(i)
+  , instance_state_(instance_state)
+  , timestamp_(rde.source_timestamp_)
+  , seq_n_(rde.sequence_)
+  , data_(rde.registered_data_)
+{}
+
 Observer::~Observer() {}
 
 } // namespace DCPS

--- a/dds/DCPS/Observer.h
+++ b/dds/DCPS/Observer.h
@@ -12,6 +12,7 @@
 #include "Definitions.h"
 #include "SequenceNumber.h"
 #include "ValueWriter.h"
+#include "ReceivedDataElementList.h"
 
 #include <dds/DdsDcpsCoreC.h>
 #include <dds/DdsDcpsPublicationC.h>
@@ -62,6 +63,10 @@ public:
            const DDS::Time_t& t,
            const SequenceNumber& sn,
            const void* data);
+
+    Sample(DDS::InstanceHandle_t i,
+           DDS::InstanceStateKind instance_state,
+           const ReceivedDataElement& rde);
   };
 
   // Group 1: Reader/Writer enabled, deleted, QoS changed

--- a/dds/DCPS/Observer.h
+++ b/dds/DCPS/Observer.h
@@ -11,6 +11,7 @@
 #include "RcObject.h"
 #include "Definitions.h"
 #include "SequenceNumber.h"
+#include "ValueWriter.h"
 
 #include <dds/DdsDcpsCoreC.h>
 #include <dds/DdsDcpsPublicationC.h>
@@ -56,12 +57,11 @@ public:
     DDS::Time_t timestamp_;
     SequenceNumber seq_n_;
     const void* data_;
-    static DDS::InstanceStateKind to_instance_state(char message_id);
-    Sample(DDS::InstanceHandle_t i, const DataSampleElement& e, const DDS::Time_t& t);
-    explicit Sample(const ReceivedDataSample& s, DDS::InstanceHandle_t i = 0);
-    explicit Sample(const ReceivedDataElement& s, DDS::InstanceHandle_t i = 0, DDS::InstanceStateKind instance_state = 0);
-    Sample(DDS::InstanceHandle_t i, DDS::InstanceStateKind instance_state,
-      const DDS::Time_t& t, const SequenceNumber& sn, const void* data);
+    Sample(DDS::InstanceHandle_t i,
+           DDS::InstanceStateKind instance_state,
+           const DDS::Time_t& t,
+           const SequenceNumber& sn,
+           const void* data);
   };
 
   // Group 1: Reader/Writer enabled, deleted, QoS changed
@@ -79,10 +79,10 @@ public:
   virtual void on_disassociated(DDS::DataReader_ptr, const GUID_t& /* writerId */) {}
 
   // Group 3: Sample sent, received, read, taken
-  virtual void on_sample_sent(DDS::DataWriter_ptr, const Sample&) {}
-  virtual void on_sample_received(DDS::DataReader_ptr, const Sample&) {}
-  virtual void on_sample_read(DDS::DataReader_ptr, const Sample&) {}
-  virtual void on_sample_taken(DDS::DataReader_ptr, const Sample&) {}
+  virtual void on_sample_sent(DDS::DataWriter_ptr, const Sample&, const ValueWriterDispatcher&) {}
+  virtual void on_sample_received(DDS::DataReader_ptr, const Sample&, const ValueWriterDispatcher&) {}
+  virtual void on_sample_read(DDS::DataReader_ptr, const Sample&, const ValueWriterDispatcher&) {}
+  virtual void on_sample_taken(DDS::DataReader_ptr, const Sample&, const ValueWriterDispatcher&) {}
 
   virtual ~Observer();
 protected:

--- a/dds/DCPS/ValueWriter.h
+++ b/dds/DCPS/ValueWriter.h
@@ -82,6 +82,9 @@ struct ValueWriter {
 
 };
 
+template <typename T>
+void vwrite(ValueWriter& value_writer, const T& value);
+
 // Implementations of this interface will call vwrite(value_writer, v)
 // where v is the resulting of casting data to the appropriate type.
 struct ValueWriterDispatcher {

--- a/dds/DCPS/ValueWriter.h
+++ b/dds/DCPS/ValueWriter.h
@@ -65,6 +65,16 @@ struct ValueWriter {
   virtual void write_float32(ACE_CDR::Float /*value*/) = 0;
   virtual void write_float64(ACE_CDR::Double /*value*/) = 0;
   virtual void write_float128(ACE_CDR::LongDouble /*value*/) = 0;
+
+#ifdef NONNATIVE_LONGDOUBLE
+  void write_float128(long double value)
+  {
+    ACE_CDR::LongDouble ld;
+    ACE_CDR_LONG_DOUBLE_ASSIGNMENT(ld, value);
+    write_float128(ld);
+  }
+#endif
+
   virtual void write_fixed(const OpenDDS::FaceTypes::Fixed& /*value*/) = 0;
   virtual void write_char8(ACE_CDR::Char /*value*/) = 0;
   virtual void write_char16(ACE_CDR::WChar /*value*/) = 0;

--- a/dds/DCPS/ValueWriter.h
+++ b/dds/DCPS/ValueWriter.h
@@ -1,0 +1,98 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_VALUE_WRITER_H
+#define OPENDDS_DCPS_VALUE_WRITER_H
+
+#include "dds/Versioned_Namespace.h"
+
+#include "FACE/Fixed.h"
+
+#include <ace/CDR_Base.h>
+
+#include <cstddef>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+// A ValueWriter receives events and values from the recitation of a
+// value.  Typical examples of value recitation are serializing an
+// object for transmission, formatting an object for printing, or
+// copying an object to another representation, e.g., C++ to v8.  To
+// use it, one manually or automatically, e.g., code generation in the
+// IDL compiler, defines a vwrite function for a given type V.
+//
+//   void vwrite(ValueWriter& vw, const V& value)
+//
+// The vwrite function should invoke the appropriate methods of the
+// ValueWriter and dispatch for other vwrite functions.
+
+struct ValueWriter {
+  virtual ~ValueWriter() {}
+
+  virtual void begin_struct() {}
+  virtual void end_struct() {}
+  virtual void begin_union() {}
+  virtual void end_union() {}
+  virtual void begin_discriminator() {}
+  virtual void end_discriminator() {}
+  virtual void begin_field(const char* /*name*/) {}
+  virtual void end_field() {}
+
+  virtual void begin_array() {}
+  virtual void end_array() {}
+  virtual void begin_sequence() {}
+  virtual void end_sequence() {}
+  virtual void begin_element(size_t /*idx*/) {}
+  virtual void end_element() {}
+
+  virtual void write_boolean(ACE_CDR::Boolean /*value*/) = 0;
+  virtual void write_byte(ACE_CDR::Octet /*value*/) = 0;
+  virtual void write_int8(ACE_CDR::Char /*value*/) = 0;
+  virtual void write_uint8(ACE_CDR::Octet /*value*/) = 0;
+  virtual void write_int16(ACE_CDR::Short /*value*/) = 0;
+  virtual void write_uint16(ACE_CDR::UShort /*value*/) = 0;
+  virtual void write_int32(ACE_CDR::Long /*value*/) = 0;
+  virtual void write_uint32(ACE_CDR::ULong /*value*/) = 0;
+  virtual void write_int64(ACE_CDR::LongLong /*value*/) = 0;
+  virtual void write_uint64(ACE_CDR::ULongLong /*value*/) = 0;
+  virtual void write_float32(ACE_CDR::Float /*value*/) = 0;
+  virtual void write_float64(ACE_CDR::Double /*value*/) = 0;
+  virtual void write_float128(ACE_CDR::LongDouble /*value*/) = 0;
+  virtual void write_fixed(const OpenDDS::FaceTypes::Fixed& /*value*/) = 0;
+  virtual void write_char8(ACE_CDR::Char /*value*/) = 0;
+  virtual void write_char16(ACE_CDR::WChar /*value*/) = 0;
+  virtual void write_string(const ACE_CDR::Char* /*value*/) = 0;
+  void write_string(const std::string& value) { write_string(value.c_str()); }
+  virtual void write_wstring(const ACE_CDR::WChar* /*value*/) = 0;
+  void write_wstring(const std::wstring& value) { write_wstring(value.c_str()); }
+
+  virtual void write_enum(const char* /*name*/, ACE_CDR::Long /*value*/) = 0;
+  template <typename T>
+  void write_enum(const char* name, const T& value)
+  {
+    write_enum(name, static_cast<ACE_CDR::Long>(value));
+  }
+
+};
+
+// Implementations of this interface will call vwrite(value_writer, v)
+// where v is the resulting of casting data to the appropriate type.
+struct ValueWriterDispatcher {
+  virtual ~ValueWriterDispatcher() {}
+
+  virtual void write(ValueWriter& value_writer, const void* data) const = 0;
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif  /* OPENDDS_DCPS_VALUE_WRITER_H */

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -185,7 +185,7 @@ struct Function {
   bool has_arg_;
   std::string preamble_;
 
-  Function(const char* name, const char* returntype)
+  Function(const std::string& name, const std::string returntype)
     : has_arg_(false)
   {
     using std::string;

--- a/dds/idl/dds_visitor.cpp
+++ b/dds/idl/dds_visitor.cpp
@@ -15,6 +15,7 @@
 #include "v8_generator.h"
 #include "rapidjson_generator.h"
 #include "langmap_generator.h"
+#include "value_writer_generator.h"
 #include "topic_keys.h"
 
 #include <ast_argument.h>
@@ -62,6 +63,7 @@ namespace {
   v8_generator v8_gen_;
   rapidjson_generator rj_gen_;
   langmap_generator lm_gen_;
+  value_writer_generator value_writer_generator_;
 
   template <typename T>
   void scope2vector(vector<T*>& v, UTL_Scope* s, AST_Decl::NodeType nt)
@@ -83,6 +85,7 @@ dds_visitor::dds_visitor(AST_Decl* scope, bool java_ts_only)
   if (!be_global->no_default_gen()) {
     gen_target_.add_generator(&mar_gen_);
     gen_target_.add_generator(&key_gen_);
+    gen_target_.add_generator(&value_writer_generator_);
     gen_target_.add_generator(&ts_gen_);
     gen_target_.add_generator(&mc_gen_);
   }

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -150,7 +150,7 @@ bool value_writer_generator::gen_enum(AST_Enum*,
   {
     NamespaceGuard guard;
 
-    Function write("vwrite<" + type_name + ">", "template <>  void");
+    Function write("vwrite", "void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -192,7 +192,7 @@ bool value_writer_generator::gen_struct(AST_Structure*,
   {
     NamespaceGuard guard;
 
-    Function write("vwrite<" + type_name + ">", "template <> void");
+    Function write("vwrite", "void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -225,7 +225,7 @@ bool value_writer_generator::gen_union(AST_Union*,
   {
     NamespaceGuard guard;
 
-    Function write("vwrite<" + type_name + ">", "template <> void");
+    Function write("vwrite", "void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -150,7 +150,7 @@ bool value_writer_generator::gen_enum(AST_Enum*,
   {
     NamespaceGuard guard;
 
-    Function write("vwrite", "template <> void");
+    Function write("vwrite<" + type_name + ">", "template <>  void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -192,7 +192,7 @@ bool value_writer_generator::gen_struct(AST_Structure*,
   {
     NamespaceGuard guard;
 
-    Function write("vwrite", "template <> void");
+    Function write("vwrite<" + type_name + ">", "template <> void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -225,7 +225,7 @@ bool value_writer_generator::gen_union(AST_Union*,
   {
     NamespaceGuard guard;
 
-    Function write("vwrite", "template <> void");
+    Function write("vwrite<" + type_name + ">", "template <> void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -60,8 +60,7 @@ namespace {
     } else if (c & CL_STRING) {
       if (c & CL_WIDE) {
         be_global->impl_ << "value_writer.write_wstring(" << expression << ");\n";
-      }
-      else {
+      } else {
         be_global->impl_ << "value_writer.write_string(" << expression << ");\n";
       }
     } else if (c & CL_PRIMITIVE) {
@@ -111,7 +110,6 @@ namespace {
       case AST_PredefinedType::PT_abstract:
       case AST_PredefinedType::PT_void:
       case AST_PredefinedType::PT_pseudo:
-        // TODO
         break;
       }
     } else {
@@ -155,7 +153,7 @@ bool value_writer_generator::gen_enum(AST_Enum*,
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
 
-    be_global->impl_ << "switch(value) {\n";
+    be_global->impl_ << "switch (value) {\n";
     for (std::vector<AST_EnumVal*>::const_iterator pos = contents.begin(), limit = contents.end(); pos != limit; ++pos) {
       AST_EnumVal* val = *pos;
       const std::string value_name = (use_cxx11 ? (type_name + "::") : module_scope(name)) + val->local_name()->get_string();
@@ -170,9 +168,9 @@ bool value_writer_generator::gen_enum(AST_Enum*,
 }
 
 bool value_writer_generator::gen_typedef(AST_Typedef*,
-                                   UTL_ScopedName*,
-                                   AST_Type*,
-                                   const char*)
+                                         UTL_ScopedName*,
+                                         AST_Type*,
+                                         const char*)
 {
   return true;
 }

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -1,0 +1,259 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "value_writer_generator.h"
+#include "be_extern.h"
+#include "global_extern.h"
+
+#include "utl_identifier.h"
+#include "utl_labellist.h"
+
+#include <ast_fixed.h>
+
+using namespace AstTypeClassification;
+
+namespace {
+
+  void generate_write(const std::string& expression, AST_Type* type, const std::string& idx);
+
+  void array_helper(const std::string& expression, AST_Array* array, size_t dim_idx, const std::string& idx)
+  {
+    if (dim_idx < array->n_dims()) {
+      const size_t dim = array->dims()[dim_idx]->ev()->u.ulval;
+      be_global->impl_ << "value_writer.begin_array();\n";
+      be_global->impl_ << "for (size_t " << idx << " = 0; " << idx << " != " << dim << "; ++" << idx << ") {\n";
+      be_global->impl_ << "  value_writer.begin_element(" << idx << ");\n";
+      array_helper(expression + "[" + idx + "]", array, dim_idx + 1, idx + "i");
+      be_global->impl_ << "  value_writer.end_element();\n";
+      be_global->impl_ << "}\n";
+      be_global->impl_ << "value_writer.end_array();\n";
+    } else {
+      generate_write(expression, array->base_type(), idx + "i");
+    }
+  }
+
+  void generate_write(const std::string& expression, AST_Type* type, const std::string& idx)
+  {
+    const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
+    const char* length_func = use_cxx11 ? "size" : "length";
+    AST_Type* actual = resolveActualType(type);
+
+    Classification c = classify(actual);
+    if (c & CL_SEQUENCE) {
+      AST_Sequence* sequence = dynamic_cast<AST_Sequence*>(actual);
+      be_global->impl_ << "value_writer.begin_sequence();\n";
+      be_global->impl_ << "for (size_t " << idx << " = 0; " << idx << " != " << expression << "." << length_func << "(); ++" << idx << ") {\n";
+      be_global->impl_ << "  value_writer.begin_element(" << idx << ");\n";
+      generate_write(expression + "[" + idx + "]", sequence->base_type(), idx + "i");
+      be_global->impl_ << "  value_writer.end_element();\n";
+      be_global->impl_ << "}\n";
+      be_global->impl_ << "value_writer.end_sequence();\n";
+    } else if (c & CL_ARRAY) {
+      AST_Array* array = dynamic_cast<AST_Array*>(actual);
+      array_helper(expression, array, 0, idx);
+    } else if (c & CL_FIXED) {
+      be_global->impl_ << "value_writer.write_fixed(" << expression << ");\n";
+    } else if (c & CL_STRING) {
+      if (c & CL_WIDE) {
+        be_global->impl_ << "value_writer.write_wstring(" << expression << ");\n";
+      }
+      else {
+        be_global->impl_ << "value_writer.write_string(" << expression << ");\n";
+      }
+    } else if (c & CL_PRIMITIVE) {
+      switch (dynamic_cast<AST_PredefinedType*>(actual)->pt()) {
+      case AST_PredefinedType::PT_long:
+        be_global->impl_ << "value_writer.write_int32(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_ulong:
+        be_global->impl_ << "value_writer.write_uint32(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_longlong:
+        be_global->impl_ << "value_writer.write_int64(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_ulonglong:
+        be_global->impl_ << "value_writer.write_uint64(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_short:
+        be_global->impl_ << "value_writer.write_int16(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_ushort:
+        be_global->impl_ << "value_writer.write_uint16(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_float:
+        be_global->impl_ << "value_writer.write_float32(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_double:
+        be_global->impl_ << "value_writer.write_float64(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_longdouble:
+        be_global->impl_ << "value_writer.write_float128(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_char:
+        be_global->impl_ << "value_writer.write_char8(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_wchar:
+        be_global->impl_ << "value_writer.write_char16(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_boolean:
+        be_global->impl_ << "value_writer.write_boolean(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_octet:
+        be_global->impl_ << "value_writer.write_byte(" << expression << ");\n";
+        break;
+      case AST_PredefinedType::PT_any:
+      case AST_PredefinedType::PT_object:
+      case AST_PredefinedType::PT_value:
+      case AST_PredefinedType::PT_abstract:
+      case AST_PredefinedType::PT_void:
+      case AST_PredefinedType::PT_pseudo:
+        // TODO
+        break;
+      }
+    } else {
+      be_global->impl_ << "vwrite(value_writer, " << expression << ");\n";
+    }
+  }
+
+  std::string branch_helper(const std::string& field_name,
+                            AST_Type* type,
+                            const std::string&,
+                            std::string&,
+                            const std::string&)
+  {
+    be_global->impl_ <<
+      "  {\n"
+      "    value_writer.begin_field(\"" << field_name << "\");\n";
+    generate_write(std::string("value.") + field_name + "()", type, "i");
+    be_global->impl_ <<
+      "    value_writer.end_field();\n"
+      "  }\n";
+
+    return "";
+  }
+}
+
+bool value_writer_generator::gen_enum(AST_Enum*,
+                                      UTL_ScopedName* name,
+                                      const std::vector<AST_EnumVal*>& contents,
+                                      const char*)
+{
+  be_global->add_include("dds/DCPS/ValueWriter.h", BE_GlobalData::STREAM_H);
+
+  const std::string type_name = scoped(name);
+  const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
+
+  be_global->header_ << be_global->versioning_begin() << "\n";
+  be_global->impl_ << be_global->versioning_begin() << "\n";
+  {
+    ScopedNamespaceGuard hguard(name, be_global->header_);
+    ScopedNamespaceGuard iguard(name, be_global->impl_);
+
+    Function write("vwrite", "void");
+    write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
+    write.addArg("value", "const " + type_name + "&");
+    write.endArgs();
+
+    be_global->impl_ << "switch(value) {\n";
+    for (std::vector<AST_EnumVal*>::const_iterator pos = contents.begin(), limit = contents.end(); pos != limit; ++pos) {
+      AST_EnumVal* val = *pos;
+      const std::string value_name = (use_cxx11 ? (type_name + "::") : module_scope(name)) + val->local_name()->get_string();
+      be_global->impl_ << "case " << value_name << ":\n";
+      be_global->impl_ << "  value_writer.write_enum(\"" << val->local_name()->get_string() << "\", " << value_name << ");\n";
+      be_global->impl_ << "  break;\n";
+    }
+    be_global->impl_ << "}\n";
+  }
+  be_global->header_ << be_global->versioning_end() << "\n";
+  be_global->impl_ << be_global->versioning_end() << "\n";
+
+  return true;
+}
+
+bool value_writer_generator::gen_typedef(AST_Typedef*,
+                                   UTL_ScopedName*,
+                                   AST_Type*,
+                                   const char*)
+{
+  return true;
+}
+
+bool value_writer_generator::gen_struct(AST_Structure*,
+                                        UTL_ScopedName* name,
+                                        const std::vector<AST_Field*>& fields,
+                                        AST_Type::SIZE_TYPE,
+                                        const char*)
+{
+  be_global->add_include("dds/DCPS/ValueWriter.h", BE_GlobalData::STREAM_H);
+
+  const std::string type_name = scoped(name);
+  const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
+  const std::string accessor_suffix = use_cxx11 ? "()" : "";
+
+  be_global->header_ << be_global->versioning_begin() << "\n";
+  be_global->impl_ << be_global->versioning_begin() << "\n";
+  {
+    ScopedNamespaceGuard hguard(name, be_global->header_);
+    ScopedNamespaceGuard iguard(name, be_global->impl_);
+
+    Function write("vwrite", "void");
+    write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
+    write.addArg("value", "const " + type_name + "&");
+    write.endArgs();
+
+    be_global->impl_ << "  value_writer.begin_struct();\n";
+    for (std::vector<AST_Field*>::const_iterator pos = fields.begin(), limit = fields.end(); pos != limit; ++pos) {
+      AST_Field* field = *pos;
+      const std::string field_name = field->local_name()->get_string();
+      be_global->impl_ << "  value_writer.begin_field(\"" << field_name << "\");\n";
+      generate_write(std::string("value.") + field_name + accessor_suffix, field->field_type(), "i");
+      be_global->impl_ << "  value_writer.end_field();\n";
+    }
+    be_global->impl_ << "  value_writer.end_struct();\n";
+  }
+  be_global->header_ << be_global->versioning_end() << "\n";
+  be_global->impl_ << be_global->versioning_end() << "\n";
+
+  return true;
+}
+
+
+bool value_writer_generator::gen_union(AST_Union*,
+                                       UTL_ScopedName* name,
+                                       const std::vector<AST_UnionBranch*>& branches,
+                                       AST_Type* discriminator,
+                                       const char*)
+{
+  be_global->add_include("dds/DCPS/ValueWriter.h", BE_GlobalData::STREAM_H);
+
+  const std::string type_name = scoped(name);
+
+  be_global->header_ << be_global->versioning_begin() << "\n";
+  be_global->impl_ << be_global->versioning_begin() << "\n";
+  {
+    ScopedNamespaceGuard hguard(name, be_global->header_);
+    ScopedNamespaceGuard iguard(name, be_global->impl_);
+
+    Function write("vwrite", "void");
+    write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
+    write.addArg("value", "const " + type_name + "&");
+    write.endArgs();
+
+    be_global->impl_ << "  value_writer.begin_union();\n";
+    be_global->impl_ << "  value_writer.begin_discriminator();\n";
+    generate_write("value._d()" , discriminator, "i");
+    be_global->impl_ << "  value_writer.end_discriminator();\n";
+
+    generateSwitchForUnion("value._d()", branch_helper, branches, discriminator, "", "", type_name.c_str(), false, false);
+
+    be_global->impl_ << "  value_writer.end_union();\n";
+  }
+  be_global->header_ << be_global->versioning_end() << "\n";
+  be_global->impl_ << be_global->versioning_end() << "\n";
+
+  return true;
+}

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -147,13 +147,10 @@ bool value_writer_generator::gen_enum(AST_Enum*,
   const std::string type_name = scoped(name);
   const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
 
-  be_global->header_ << be_global->versioning_begin() << "\n";
-  be_global->impl_ << be_global->versioning_begin() << "\n";
   {
-    ScopedNamespaceGuard hguard(name, be_global->header_);
-    ScopedNamespaceGuard iguard(name, be_global->impl_);
+    NamespaceGuard guard;
 
-    Function write("vwrite", "void");
+    Function write("vwrite", "template <> void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -168,8 +165,6 @@ bool value_writer_generator::gen_enum(AST_Enum*,
     }
     be_global->impl_ << "}\n";
   }
-  be_global->header_ << be_global->versioning_end() << "\n";
-  be_global->impl_ << be_global->versioning_end() << "\n";
 
   return true;
 }
@@ -194,13 +189,10 @@ bool value_writer_generator::gen_struct(AST_Structure*,
   const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
   const std::string accessor_suffix = use_cxx11 ? "()" : "";
 
-  be_global->header_ << be_global->versioning_begin() << "\n";
-  be_global->impl_ << be_global->versioning_begin() << "\n";
   {
-    ScopedNamespaceGuard hguard(name, be_global->header_);
-    ScopedNamespaceGuard iguard(name, be_global->impl_);
+    NamespaceGuard guard;
 
-    Function write("vwrite", "void");
+    Function write("vwrite", "template <> void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -215,8 +207,6 @@ bool value_writer_generator::gen_struct(AST_Structure*,
     }
     be_global->impl_ << "  value_writer.end_struct();\n";
   }
-  be_global->header_ << be_global->versioning_end() << "\n";
-  be_global->impl_ << be_global->versioning_end() << "\n";
 
   return true;
 }
@@ -232,13 +222,10 @@ bool value_writer_generator::gen_union(AST_Union*,
 
   const std::string type_name = scoped(name);
 
-  be_global->header_ << be_global->versioning_begin() << "\n";
-  be_global->impl_ << be_global->versioning_begin() << "\n";
   {
-    ScopedNamespaceGuard hguard(name, be_global->header_);
-    ScopedNamespaceGuard iguard(name, be_global->impl_);
+    NamespaceGuard guard;
 
-    Function write("vwrite", "void");
+    Function write("vwrite", "template <> void");
     write.addArg("value_writer", "OpenDDS::DCPS::ValueWriter&");
     write.addArg("value", "const " + type_name + "&");
     write.endArgs();
@@ -252,8 +239,6 @@ bool value_writer_generator::gen_union(AST_Union*,
 
     be_global->impl_ << "  value_writer.end_union();\n";
   }
-  be_global->header_ << be_global->versioning_end() << "\n";
-  be_global->impl_ << be_global->versioning_end() << "\n";
 
   return true;
 }

--- a/dds/idl/value_writer_generator.h
+++ b/dds/idl/value_writer_generator.h
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef value_writer_generator_H
+#define value_writer_generator_H
+
+#include "dds_generator.h"
+
+class value_writer_generator : public dds_generator {
+public:
+  bool gen_enum(AST_Enum*, UTL_ScopedName* name,
+                const std::vector<AST_EnumVal*>& contents, const char* repoid);
+
+  bool gen_typedef(AST_Typedef*, UTL_ScopedName*, AST_Type*, const char*);
+
+  bool gen_struct(AST_Structure* node, UTL_ScopedName* name,
+                  const std::vector<AST_Field*>& fields,
+                  AST_Type::SIZE_TYPE size, const char* repoid);
+
+  bool gen_union(AST_Union*, UTL_ScopedName*, const std::vector<AST_UnionBranch*>&,
+                 AST_Type*, const char*);
+};
+
+#endif

--- a/tests/DCPS/Observer/Observer.mpc
+++ b/tests/DCPS/Observer/Observer.mpc
@@ -1,5 +1,8 @@
 project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp, dcps_cm {
   exename = publisher
+  libpaths += ../common
+  libs     +=  common
+  after    += common
 
   Source_Files {
     TestObserver.cpp
@@ -10,6 +13,9 @@ project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp, dcps_cm {
 
 project(*sub) : dcpsexe, dcps_test, dcps_rtps_udp, dcps_cm {
   exename = subscriber
+  libpaths += ../common
+  libs     +=  common
+  after    += common
 
   Source_Files {
     TestObserver.cpp

--- a/tests/DCPS/Observer/TestObserver.cpp
+++ b/tests/DCPS/Observer/TestObserver.cpp
@@ -6,9 +6,11 @@
  */
 
 #include "TestObserver.h"
-#include <dds/DCPS/DataWriterImpl.h>
+
 #include <dds/DCPS/DataReaderImpl.h>
+#include <dds/DCPS/DataWriterImpl.h>
 #include <dds/DCPS/GuidUtils.h>
+#include "../common/JsonValueWriter.h"
 
 #include <ace/OS_NS_time.h>
 
@@ -66,17 +68,23 @@ std::string TestObserver::to_str(DDS::DataReader_ptr r)
   return o.str();
 }
 
-std::string TestObserver::to_str(const Sample& s)
+std::string TestObserver::to_str(const Sample& s, const OpenDDS::DCPS::ValueWriterDispatcher& vwd)
 {
   const std::string t("    ");
   std::time_t seconds = OpenDDS::DCPS::time_to_time_value(s.timestamp_).sec();
   ACE_TCHAR buffer[32];
-  std::ostringstream o; o << '\n'
+  std::ostringstream o;
+  o << '\n'
     << t << "Timestamp: " << ACE_OS::ctime_r(&seconds, buffer, 32)
     << t << "Instance : " << s.instance_ << '\n'
     << t << "State    : " << s.instance_state_ << '\n'
     << t << "SequenceN: " << s.seq_n_.getValue() << '\n'
-    << t << "Data     : " << s.data_ << '\n';
+    << t << "Data     : " << s.data_ << ' ';
+
+  OpenDDS::Test::JsonValueWriter jvw(o);
+  vwd.write(jvw, s.data_);
+  o << '\n';
+
   return o.str();
 }
 
@@ -156,28 +164,28 @@ void TestObserver::on_disassociated(DDS::DataReader_ptr r, const OpenDDS::DCPS::
 // ========== ========== ========== ========== ========== ========== ==========
 // 3. Sample: sent, received, read, taken
 
-void TestObserver::on_sample_sent(DDS::DataWriter_ptr w, const Sample& s)
+void TestObserver::on_sample_sent(DDS::DataWriter_ptr w, const Sample& s, const OpenDDS::DCPS::ValueWriterDispatcher& vwd)
 {
   ++sent_;
-  std::cout << "on_sample_sent " << sent_ << to_str(w) << to_str(s);
+  std::cout << "on_sample_sent " << sent_ << to_str(w) << to_str(s, vwd);
 }
 
-void TestObserver::on_sample_received(DDS::DataReader_ptr r, const Sample& s)
+void TestObserver::on_sample_received(DDS::DataReader_ptr r, const Sample& s, const OpenDDS::DCPS::ValueWriterDispatcher& vwd)
 {
   ++received_;
-  std::cout << "on_sample_received " << received_ << to_str(r) << to_str(s);
+  std::cout << "on_sample_received " << received_ << to_str(r) << to_str(s, vwd);
 }
 
-void TestObserver::on_sample_read(DDS::DataReader_ptr r, const Sample& s)
+void TestObserver::on_sample_read(DDS::DataReader_ptr r, const Sample& s, const OpenDDS::DCPS::ValueWriterDispatcher& vwd)
 {
   ++read_;
-  std::cout << "on_sample_read " << read_ << to_str(r) << to_str(s);
+  std::cout << "on_sample_read " << read_ << to_str(r) << to_str(s, vwd);
 }
 
-void TestObserver::on_sample_taken(DDS::DataReader_ptr r, const Sample& s)
+void TestObserver::on_sample_taken(DDS::DataReader_ptr r, const Sample& s, const OpenDDS::DCPS::ValueWriterDispatcher& vwd)
 {
   ++taken_;
-  std::cout << "on_sample_taken " << taken_ << to_str(r) << to_str(s);
+  std::cout << "on_sample_taken " << taken_ << to_str(r) << to_str(s, vwd);
 }
 
 // ========== ========== ========== ========== ========== ========== ==========

--- a/tests/DCPS/Observer/TestObserver.h
+++ b/tests/DCPS/Observer/TestObserver.h
@@ -32,10 +32,18 @@ public:
   virtual void on_disassociated(DDS::DataWriter_ptr w, const OpenDDS::DCPS::GUID_t& readerId);
   virtual void on_disassociated(DDS::DataReader_ptr r, const OpenDDS::DCPS::GUID_t& writerId);
 
-  virtual void on_sample_sent(DDS::DataWriter_ptr w, const Sample& s);
-  virtual void on_sample_received(DDS::DataReader_ptr r, const Sample& s);
-  virtual void on_sample_read(DDS::DataReader_ptr r, const Sample& s);
-  virtual void on_sample_taken(DDS::DataReader_ptr r, const Sample& s);
+  virtual void on_sample_sent(DDS::DataWriter_ptr w,
+                              const Sample& s,
+                              const OpenDDS::DCPS::ValueWriterDispatcher& vwd);
+  virtual void on_sample_received(DDS::DataReader_ptr r,
+                                  const Sample& s,
+                                  const OpenDDS::DCPS::ValueWriterDispatcher& vwd);
+  virtual void on_sample_read(DDS::DataReader_ptr r,
+                              const Sample& s,
+                              const OpenDDS::DCPS::ValueWriterDispatcher& vwd);
+  virtual void on_sample_taken(DDS::DataReader_ptr r,
+                               const Sample& s,
+                               const OpenDDS::DCPS::ValueWriterDispatcher& vwd);
 
   enum Check { c_SENT = 1, c_W_G1_G2 = 2, c_R_ALL = 3 };
 
@@ -52,7 +60,7 @@ public:
 private:
   static std::string to_str(DDS::DataWriter_ptr w);
   static std::string to_str(DDS::DataReader_ptr w);
-  static std::string to_str(const Sample& s);
+  static std::string to_str(const Sample& s, const OpenDDS::DCPS::ValueWriterDispatcher& vwd);
   static std::string to_str(const OpenDDS::DCPS::GUID_t& guid);
 
   template<typename Qos>

--- a/tests/DCPS/Observer/run_test.pl
+++ b/tests/DCPS/Observer/run_test.pl
@@ -10,6 +10,7 @@ use PerlDDS::Run_Test;
 use strict;
 
 PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
+PerlDDS::add_lib_path('../common');
 
 my $test = new PerlDDS::TestFramework();
 

--- a/tests/DCPS/common/ConnectionRecordLogger.cpp
+++ b/tests/DCPS/common/ConnectionRecordLogger.cpp
@@ -1,5 +1,7 @@
 #include "ConnectionRecordLogger.h"
 
+#include "JsonValueWriter.h"
+
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/DiscoveryBase.h"
 #include "dds/DCPS/GuidConverter.h"
@@ -35,35 +37,12 @@ class Listener : public DDS::DataReaderListener {
       return;
     }
 
-    OpenDDS::DCPS::ConnectionRecord data;
+    OpenDDS::DCPS::ConnectionRecord sample;
     DDS::SampleInfo sample_info;
-    while (r->take_next_sample(data, sample_info) == DDS::RETCODE_OK) {
-      DCPS::RepoId guid;
-      std::memcpy(&guid, data.guid, sizeof(guid));
-
-      switch (sample_info.instance_state) {
-      case DDS::ALIVE_INSTANCE_STATE:
-        ACE_DEBUG((LM_INFO,
-                   ACE_TEXT("connect guid=%C address=%C protocol=%C timestamp=%d.%09d\n"),
-                   DCPS::LogGuid(guid).c_str(),
-                   data.address.in(),
-                   data.protocol.in(),
-                   sample_info.source_timestamp.sec,
-                   sample_info.source_timestamp.nanosec));
-        break;
-      case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:
-      case DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE:
-        ACE_DEBUG((LM_INFO,
-                   ACE_TEXT("disconnect guid=%C address=%C protocol=%C timestamp=%d.%09d\n"),
-                   DCPS::LogGuid(guid).c_str(),
-                   data.address.in(),
-                   data.protocol.in(),
-                   sample_info.source_timestamp.sec,
-                   sample_info.source_timestamp.nanosec));
-        break;
-      }
-
-      // Time_t source_timestamp;
+    while (r->take_next_sample(sample, sample_info) == DDS::RETCODE_OK) {
+      ACE_DEBUG((LM_INFO,
+                 ACE_TEXT("%C\n"),
+                 to_json(r->get_topicdescription(), sample, sample_info).c_str()));
     }
   }
 

--- a/tests/DCPS/common/JsonValueWriter.cpp
+++ b/tests/DCPS/common/JsonValueWriter.cpp
@@ -7,7 +7,7 @@
 
 #include "JsonValueWriter.h"
 
-#include <cmath>
+#include <math.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/tests/DCPS/common/JsonValueWriter.cpp
+++ b/tests/DCPS/common/JsonValueWriter.cpp
@@ -1,0 +1,253 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "JsonValueWriter.h"
+
+#include <cmath>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Test {
+
+void JsonValueWriter::begin_struct()
+{
+  out_ << '{';
+  value_count_.push_back(0);
+}
+
+void JsonValueWriter::end_struct()
+{
+  out_ << '}';
+  value_count_.pop_back();
+}
+
+void JsonValueWriter::begin_union()
+{
+  out_ << '{';
+  value_count_.push_back(0);
+}
+
+void JsonValueWriter::end_union()
+{
+  out_ << '}';
+  value_count_.pop_back();
+}
+
+void JsonValueWriter::begin_discriminator()
+{
+  if (value_count_.back() != 0) {
+    out_ << ',';
+  }
+  out_ << "\"$discriminator\":";
+}
+
+void JsonValueWriter::end_discriminator()
+{
+  ++value_count_.back();
+}
+
+void JsonValueWriter::begin_field(const char* name)
+{
+  if (value_count_.back() != 0) {
+    out_ << ',';
+  }
+  // TODO: Escape.
+  out_ << '"' << name << "\":";
+}
+
+void JsonValueWriter::end_field()
+{
+  ++value_count_.back();
+}
+
+void JsonValueWriter::begin_array()
+{
+  out_ << '[';
+  value_count_.push_back(0);
+}
+
+void JsonValueWriter::end_array()
+{
+  out_ << ']';
+  value_count_.pop_back();
+}
+
+void JsonValueWriter::begin_sequence()
+{
+  out_ << '[';
+  value_count_.push_back(0);
+}
+
+void JsonValueWriter::end_sequence()
+{
+  out_ << ']';
+  value_count_.pop_back();
+}
+
+void JsonValueWriter::begin_element(size_t /*idx*/)
+{
+  if (value_count_.back() != 0) {
+    out_ << ',';
+  }
+}
+
+void JsonValueWriter::end_element()
+{
+  ++value_count_.back();
+}
+
+void JsonValueWriter::write_boolean(ACE_CDR::Boolean value)
+{
+  out_ << (value ? "true" : "false");
+}
+
+void JsonValueWriter::write_byte(ACE_CDR::Octet value)
+{
+  out_ << static_cast<unsigned int>(value);
+}
+
+void JsonValueWriter::write_int8(ACE_CDR::Char value)
+{
+  out_ << static_cast<int>(value);
+}
+
+void JsonValueWriter::write_uint8(ACE_CDR::Octet value)
+{
+  out_ << static_cast<unsigned int>(value);
+}
+
+void JsonValueWriter::write_int16(ACE_CDR::Short value)
+{
+  out_ << static_cast<int>(value);
+}
+
+void JsonValueWriter::write_uint16(ACE_CDR::UShort value)
+{
+  out_ << static_cast<unsigned int>(value);
+}
+
+void JsonValueWriter::write_int32(ACE_CDR::Long value)
+{
+  out_ << value;
+}
+
+void JsonValueWriter::write_uint32(ACE_CDR::ULong value)
+{
+  out_ << value;
+}
+
+void JsonValueWriter::write_int64(ACE_CDR::LongLong value)
+{
+  if (value >= -9007199254740991 && value <= 9007199254740991) {
+    out_ << value;
+  } else {
+    out_ << '"' << value << '"';
+  }
+}
+
+void JsonValueWriter::write_uint64(ACE_CDR::ULongLong value)
+{
+  if (value <= 9007199254740991) {
+    out_ << value;
+  } else {
+    out_ << '"' << value << '"';
+  }
+}
+
+void JsonValueWriter::write_float32(ACE_CDR::Float value)
+{
+  // TODO: Formatting?
+  if (isinf(value)) {
+    if (value < 0) {
+      out_ << "\"-inf\"";
+    } else {
+      out_ << "\"inf\"";
+    }
+  } else if(isnan(value)) {
+    out_ << "\"nan\"";
+  } else {
+    out_ << value;
+  }
+}
+
+void JsonValueWriter::write_float64(ACE_CDR::Double value)
+{
+  // TODO: Formatting?
+  if (isinf(value)) {
+    if (value < 0) {
+      out_ << "\"-inf\"";
+    } else {
+      out_ << "\"inf\"";
+    }
+  } else if(isnan(value)) {
+    out_ << "\"nan\"";
+  } else {
+    out_ << value;
+  }
+}
+
+void JsonValueWriter::write_float128(ACE_CDR::LongDouble value)
+{
+  // TODO: Formatting?
+  // TODO: Base64 encode.
+  if (isinf(value)) {
+    if (value < 0) {
+      out_ << "\"-inf\"";
+    } else {
+      out_ << "\"inf\"";
+    }
+  } else if(isnan(value)) {
+    out_ << "\"nan\"";
+  } else {
+    out_ << value;
+  }
+}
+
+void JsonValueWriter::write_fixed(const OpenDDS::FaceTypes::Fixed& /*value*/)
+{
+  // TODO
+  out_ << "\"fixed\"";
+}
+
+void JsonValueWriter::write_char8(ACE_CDR::Char value)
+{
+  // TODO; Escape.
+  out_ << '"' << value << '"';
+}
+
+void JsonValueWriter::write_char16(ACE_CDR::WChar value)
+{
+  // TODO; Escape.
+  // TODO: Encode.
+  out_ << '"' << value << '"';
+}
+
+void JsonValueWriter::write_string(const ACE_CDR::Char* value)
+{
+  // TODO; Escape.
+  out_ << '"' << value << '"';
+}
+
+void JsonValueWriter::write_wstring(const ACE_CDR::WChar* value)
+{
+  // TODO; Escape.
+  // TODO: Encode.
+  out_ << '"' << value << '"';
+}
+
+void JsonValueWriter::write_enum(const char* name,
+                                 ACE_CDR::Long /*value*/)
+{
+  // TODO; Escape.
+  out_ << '"' << name << '"';
+}
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/tests/DCPS/common/JsonValueWriter.h
+++ b/tests/DCPS/common/JsonValueWriter.h
@@ -1,0 +1,105 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef JSON_VALUE_WRITER_H
+#define JSON_VALUE_WRITER_H
+
+#include "common_export.h"
+
+#include <dds/DCPS/ValueWriter.h>
+#include <dds/DdsDcpsCoreC.h>
+#include <dds/DdsDcpsTopicC.h>
+
+#include <sstream>
+#include <vector>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Test {
+
+// Convert values to JSON.
+// Currently, this class does not produce value JSON nor does it adhere to the DDS JSON spec.
+class Common_Export JsonValueWriter : public DCPS::ValueWriter {
+public:
+  JsonValueWriter(std::ostream& out)
+    : out_(out)
+  {}
+
+  void begin_struct();
+  void end_struct();
+  void begin_union();
+  void end_union();
+  void begin_discriminator();
+  void end_discriminator();
+  void begin_field(const char* /*name*/);
+  void end_field();
+
+  void begin_array();
+  void end_array();
+  void begin_sequence();
+  void end_sequence();
+  void begin_element(size_t /*idx*/);
+  void end_element();
+
+  void write_boolean(ACE_CDR::Boolean /*value*/);
+  void write_byte(ACE_CDR::Octet /*value*/);
+  void write_int8(ACE_CDR::Char /*value*/);
+  void write_uint8(ACE_CDR::Octet /*value*/);
+  void write_int16(ACE_CDR::Short /*value*/);
+  void write_uint16(ACE_CDR::UShort /*value*/);
+  void write_int32(ACE_CDR::Long /*value*/);
+  void write_uint32(ACE_CDR::ULong /*value*/);
+  void write_int64(ACE_CDR::LongLong /*value*/);
+  void write_uint64(ACE_CDR::ULongLong /*value*/);
+  void write_float32(ACE_CDR::Float /*value*/);
+  void write_float64(ACE_CDR::Double /*value*/);
+  void write_float128(ACE_CDR::LongDouble /*value*/);
+  void write_fixed(const OpenDDS::FaceTypes::Fixed& /*value*/);
+  void write_char8(ACE_CDR::Char /*value*/);
+  void write_char16(ACE_CDR::WChar /*value*/);
+  void write_string(const ACE_CDR::Char* /*value*/);
+  void write_wstring(const ACE_CDR::WChar* /*value*/);
+  void write_enum(const char* /*name*/, ACE_CDR::Long /*value*/);
+
+private:
+  std::ostream& out_;
+  std::vector<size_t> value_count_; // The number of values written in each scope.
+};
+
+template<typename T>
+std::string to_json(const ::DDS::TopicDescription_ptr topic, const T& sample, const DDS::SampleInfo& sample_info)
+{
+  std::stringstream str;
+  JsonValueWriter jvw(str);
+  jvw.begin_struct();
+  jvw.begin_field("topic");
+  jvw.begin_struct();
+  jvw.begin_field("name");
+  jvw.write_string(topic->get_name());
+  jvw.end_field();
+  jvw.begin_field("type_name");
+  jvw.write_string(topic->get_type_name());
+  jvw.end_field();
+  jvw.end_struct();
+  jvw.end_field();
+  jvw.begin_field("sample");
+  vwrite(jvw, sample);
+  jvw.end_field();
+  jvw.begin_field("sample_info");
+  vwrite(jvw, sample_info);
+  jvw.end_field();
+  jvw.end_struct();
+  return str.str();
+}
+
+} // namespace Test
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif  /* JSON_VALUE_WRITER_H */

--- a/tests/DCPS/common/JsonValueWriter.h
+++ b/tests/DCPS/common/JsonValueWriter.h
@@ -11,7 +11,7 @@
 #include "common_export.h"
 
 #include <dds/DCPS/ValueWriter.h>
-#include <dds/DdsDcpsCoreC.h>
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
 #include <dds/DdsDcpsTopicC.h>
 
 #include <sstream>

--- a/tests/DCPS/unit/MyTypeSupportImpl.h
+++ b/tests/DCPS/unit/MyTypeSupportImpl.h
@@ -80,11 +80,15 @@ public:
 
   virtual void purge_data(OpenDDS::DCPS::SubscriptionInstance_rch) {}
   virtual void release_instance_i(DDS::InstanceHandle_t) {}
-  virtual void dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample&,
-                             OpenDDS::DCPS::SubscriptionInstance_rch &,
-                             bool&,
-                             bool&,
-                             OpenDDS::DCPS::MarshalingType) {}
+  virtual OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::MessageHolder>
+  dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample&,
+                OpenDDS::DCPS::SubscriptionInstance_rch &,
+                bool&,
+                bool&,
+                OpenDDS::DCPS::MarshalingType)
+  {
+    return OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::MessageHolder>();
+  }
   virtual void dec_ref_data_element(OpenDDS::DCPS::ReceivedDataElement *) {}
   virtual void delete_instance_map (void *) {}
   bool contains_sample_filtered(DDS::SampleStateMask, DDS::ViewStateMask,


### PR DESCRIPTION
Problem
-------

One of the primary motivations for the Observer interface is the
ability to log samples as they are written, received, and accessed.
Currently, users of the Observer interface receive a generic pointer
to sample data which may be a raw sample or something else.
There is no capability that allows a user to take this generic
pointer and log the sample contained therein.

Solution
--------

1. Standardize on the approach that the pointer in the Sample is a
pointer to a raw sample.

2. Introduce the ValueWriter interface and necessary support in the
IDL compiler to allow generic processing of the raw sample.

3. Add plumbing between generic and typed DataReader and DataWriter to
allow a user to dispatch a ValueWriter on the raw sample.

4. Provide an incomplete JsonValueWriter to demonstrate how types
processed by the IDL compiler could be serialized to JSON.

Notes
-----

* It may be necessary/beneficial to augment the ValueWriter interface
  with type information via TypeObjects.

* ValueWriter suggests a symmetric interface called ValueReader that
  takes an opaque representation and populates a raw sample, e.g.,
  deserialization.