### PR TITLE
XTypes: Remove Data Repr. Annotations from XCDR Test

### DIFF
--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -2442,8 +2442,8 @@ bool marshal_generator::gen_struct(AST_Structure* node,
   be_global->add_include("dds/DCPS/Serializer.h");
   const string cxx = scoped(name); // name as a C++ class
   const ExtensibilityKind exten = be_global->extensibility(node);
-  const OpenDDS::DataRepresentation repr =
-    be_global->data_representations(node);
+  OpenDDS::DataRepresentation repr;
+  repr.set_all(true);
 
   const bool xcdr = repr.xcdr1 || repr.xcdr2;
   const bool not_final = exten != extensibilitykind_final;
@@ -2974,7 +2974,7 @@ bool marshal_generator::gen_struct(AST_Structure* node,
       }
     }
 
-    if (!generate_marshal_traits(node, cxx, repr, exten, keys, info, octetSeqOnly)) {
+    if (!generate_marshal_traits(node, cxx, be_global->data_representations(node), exten, keys, info, octetSeqOnly)) {
       return false;
     }
   }

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -1112,31 +1112,29 @@ const unsigned char MutableUnionExpectedXcdr2LongLongBE::expected[] = {
   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +8 value = 24
 };
 const unsigned MutableUnionExpectedXcdr2LongLongBE::layout[] = {4,4,4,4,8};
-/*
+
+template<>
+void expect_values_equal(const MutableUnionWithExplicitIDs& a, const MutableUnionWithExplicitIDs& b)
+{
+  expect_values_equal_base_union(a, b);
+}
+
 TEST(MutableTests, BaselineXcdr2TestUnion)
 {
-  baseline_checks_union<MutableUnion>(
-    xcdr2, MutableUnionExpectedXcdr2ShortBE::expected, E_SHORT_FIELD);
-  baseline_checks_union<MutableUnion>(
-    xcdr2, MutableUnionExpectedXcdr2LongBE::expected, E_LONG_FIELD);
-  baseline_checks_union<MutableUnion>(
-    xcdr2, MutableUnionExpectedXcdr2OctetBE::expected, E_OCTET_FIELD);
-  baseline_checks_union<MutableUnion>(
-    xcdr2, MutableUnionExpectedXcdr2LongLongBE::expected, E_LONG_LONG_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(xcdr2, MutableUnionExpectedXcdr2ShortBE::expected, E_SHORT_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(xcdr2, MutableUnionExpectedXcdr2LongBE::expected, E_LONG_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(xcdr2, MutableUnionExpectedXcdr2OctetBE::expected, E_OCTET_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(xcdr2, MutableUnionExpectedXcdr2LongLongBE::expected, E_LONG_LONG_FIELD);
 }
 
 TEST(MutableTests, BaselineXcdr2TestUnionLE)
 {
-  test_little_endian_union<MutableUnion,
-                           MutableUnionExpectedXcdr2ShortBE>(E_SHORT_FIELD);
-  test_little_endian_union<MutableUnion,
-                           MutableUnionExpectedXcdr2LongBE>(E_LONG_FIELD);
-  test_little_endian_union<MutableUnion,
-                           MutableUnionExpectedXcdr2OctetBE>(E_OCTET_FIELD);
-  test_little_endian_union<MutableUnion,
-                           MutableUnionExpectedXcdr2LongLongBE>(E_LONG_LONG_FIELD);
+  test_little_endian_union<MutableUnionWithExplicitIDs, MutableUnionExpectedXcdr2ShortBE>(E_SHORT_FIELD);
+  test_little_endian_union<MutableUnionWithExplicitIDs, MutableUnionExpectedXcdr2LongBE>(E_LONG_FIELD);
+  test_little_endian_union<MutableUnionWithExplicitIDs, MutableUnionExpectedXcdr2OctetBE>(E_OCTET_FIELD);
+  test_little_endian_union<MutableUnionWithExplicitIDs, MutableUnionExpectedXcdr2LongLongBE>(E_LONG_LONG_FIELD);
 }
-*/
+
 template<typename TypeA, typename TypeB>
 void expect_values_equal_base_union2(const TypeA& a, const TypeB& b)
 {

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -754,7 +754,6 @@ void expect_values_equal(const AppendableWithNestedStruct& a, const AppendableWi
   expect_equal_with_nested(a, b);
 }
 
-/* //compiled but FAILED tests
 TEST(AppendableTests, BothAppendableStruct)
 {
   serializer_test<AppendableStruct>(xcdr2, AppendableExpectedXcdr2BE::expected);
@@ -764,7 +763,6 @@ TEST(AppendableTests, BothAppendableStructLE)
 {
   test_little_endian<AppendableStruct, AppendableExpectedXcdr2BE>();
 }
-*/
 
 template<>
 void expect_values_equal(const AppendableWithNestedStruct& a,
@@ -772,7 +770,7 @@ void expect_values_equal(const AppendableWithNestedStruct& a,
 {
   expect_equal_with_nested(a, b);
 }
-/*
+
 TEST(AppendableTests, FromAppendableStruct)
 {
   amalgam_serializer_test<AppendableStruct, AdditionalFieldAppendableStruct>(
@@ -784,7 +782,6 @@ TEST(AppendableTests, FromAppendableStructLE)
   test_little_endian<AppendableStruct, AdditionalFieldAppendableStruct,
                      AppendableExpectedXcdr2BE>();
 }
-*/
 
 // ---------- AdditionalFieldAppendableStruct
 struct AdditionalAppendableExpectedXcdr2BE {
@@ -839,7 +836,7 @@ void expect_values_equal(const AdditionalFieldAppendableStruct& a,
 {
   expect_equal_with_nested(a, b);
 }
-/*
+
 TEST(AppendableTests, FromAdditionalAppendableStruct)
 {
   amalgam_serializer_test<AdditionalFieldAppendableStruct, AppendableStruct>(
@@ -851,7 +848,6 @@ TEST(AppendableTests, FromAdditionalAppendableStructLE)
   test_little_endian<AdditionalFieldAppendableStruct, AppendableStruct,
                      AdditionalAppendableExpectedXcdr2BE>();
 }
-*/
 
 template<>
 void expect_values_equal(const AdditionalFieldAppendableStruct& a,
@@ -861,7 +857,7 @@ void expect_values_equal(const AdditionalFieldAppendableStruct& a,
   EXPECT_EQ(a.additional_field, b.additional_field);
   EXPECT_EQ(a.nested.additional_field, b.nested.additional_field);
 }
-/*
+
 TEST(AppendableTests, BothAdditionalAppendableStruct)
 {
   serializer_test<AdditionalFieldAppendableStruct>(
@@ -873,7 +869,6 @@ TEST(AppendableTests, BothAdditionalAppendableStructLE)
   test_little_endian<AdditionalFieldAppendableStruct,
                      AdditionalAppendableExpectedXcdr2BE>();
 }
-*/
 
 // ---------- AppendableWithNestedStruct2
 struct AppendableExpected2Xcdr2BE {
@@ -978,7 +973,7 @@ void expect_values_equal(const AppendableUnion& a, const ModifiedAppendableUnion
 {
   expect_values_equal_base_union(a, b);
 }
-/*
+
 TEST(AppendableTests, FromAppendableUnion)
 {
   amalgam_serializer_test_union<AppendableUnion, ModifiedAppendableUnion>(
@@ -1002,7 +997,6 @@ TEST(AppendableTests, FromAppendableUnionLE)
   test_little_endian_union<AppendableUnion, ModifiedAppendableUnion,
                            AppendableUnionXcdr2ExpectedLongLongBE>(E_LONG_LONG_FIELD);
 }
-*/
 
 // Mutable Tests =============================================================
 
@@ -1039,7 +1033,7 @@ const unsigned char MutableStructExpectedXcdr2BE::expected[] = {
 };
 
 const unsigned MutableStructExpectedXcdr2BE::layout[] = {4,4,2,2,4,4,4,1,3,4,8};
-/*
+
 TEST(MutableTests, BaselineXcdr1Test)
 {
   baseline_checks<MutableStruct>(xcdr1, mutable_struct_expected_xcdr1);
@@ -1054,7 +1048,6 @@ TEST(MutableTests, BaselineXcdr2TestLE)
 {
   test_little_endian<MutableStruct, MutableStructExpectedXcdr2BE>();
 }
-*/
 
 // ---------- MutableUnion
 struct MutableUnionExpectedXcdr2ShortBE {
@@ -1120,7 +1113,7 @@ const unsigned char MutableUnionExpectedXcdr2LongLongBE::expected[] = {
   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +8 value = 24
 };
 const unsigned MutableUnionExpectedXcdr2LongLongBE::layout[] = {4,4,4,4,8};
-/*
+
 TEST(MutableTests, BaselineXcdr2TestUnion)
 {
   baseline_checks_union<MutableUnion>(
@@ -1144,7 +1137,6 @@ TEST(MutableTests, BaselineXcdr2TestUnionLE)
   test_little_endian_union<MutableUnion,
                            MutableUnionExpectedXcdr2LongLongBE>(E_LONG_LONG_FIELD);
 }
-*/
 
 template<typename TypeA, typename TypeB>
 void expect_values_equal_base_union2(const TypeA& a, const TypeB& b)
@@ -1167,7 +1159,7 @@ void expect_values_equal(const MutableUnion& a, const ModifiedMutableUnion& b)
 {
   expect_values_equal_base_union2(a, b);
 }
-/*
+
 TEST(MutableTests, FromMutableUnion)
 {
   amalgam_serializer_test_union<MutableUnion, ModifiedMutableUnion>(
@@ -1183,7 +1175,6 @@ TEST(MutableTests, FromMutableUnionLE)
   test_little_endian_union<MutableUnion, ModifiedMutableUnion,
                            MutableUnionExpectedXcdr2LongBE>(E_LONG_FIELD);
 }
-*/
 
 // ---------- ModifiedMutableUnion
 template<>
@@ -1219,7 +1210,7 @@ TEST(MutableTests, FromModifiedMutableUnion)
   // TODO (sonndinh): test try-construct behavior when additional_field of
   // ModifiedMutableUnion is selected
 }
-/*
+
 TEST(MutableTests, FromModifiedMutableUnionLE)
 {
   test_little_endian_union<ModifiedMutableUnion, MutableUnion,
@@ -1290,7 +1281,6 @@ TEST(MutableTests, FromReorderedXcdr2Test)
   change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
   amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr2_le, expected);
 }
-*/
 
 // ---------- AdditionalFieldMutableStruct
 // Test compatibility between two structures with different fields
@@ -1302,7 +1292,7 @@ void set_values<AdditionalFieldMutableStruct>(
   set_base_values(value);
   value.additional_field = 0x12345678;
 }
-/*
+
 TEST(MutableTests, ToAdditionalFieldXcdr1Test)
 {
   MutableStruct value;
@@ -1398,7 +1388,6 @@ TEST(MutableTests, FromAdditionalFieldXcdr2Test)
   change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
   amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr2_le, expected);
 }
-*/
 
 // ---------- LengthCodeStruct
 template<>
@@ -1632,7 +1621,7 @@ const unsigned MixedMutableStructXcdr2BE::layout[] = {4,4,4,4,4,2,2,4,4,4,1,3,4,
                                                       1,1,1,1,1,1,1,1,2,4,4,4,4,4,1,1,
                                                       1,1,1,1,1,1,1,1,1,1,4,1,1,1,1,1,
                                                       1,1,1,1,1,1,1,4,1,1,1,1,1,1,1,1,1,1,1};
-/*
+
 TEST(MutableTests, BothMixedMutableStruct)
 {
   serializer_test<MixedMutableStruct>(xcdr2, MixedMutableStructXcdr2BE::expected);
@@ -1661,7 +1650,6 @@ TEST(MutableTests, FromMixedMutableStructLE)
   test_little_endian<MixedMutableStruct, ModifiedMixedMutableStruct,
                      MixedMutableStructXcdr2BE>();
 }
-*/
 
 // Mixed Extensibility Tests ================================================
 

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -363,15 +363,14 @@ const size_t final_xcdr1_struct_max_size = 24;
 
 TEST(BasicTests, FinalXcdr1Struct)
 {
-  baseline_checks<FinalXcdr1Struct>(xcdr1,
-    final_xcdr1_struct_expected, final_xcdr1_struct_max_size);
+  baseline_checks<FinalStruct>(xcdr1, final_xcdr1_struct_expected, final_xcdr1_struct_max_size);
 }
 
 const DataView appendable_xcdr1_struct_expected(final_xcdr1_struct_expected);
 
 TEST(BasicTests, AppendableXcdr1Struct)
 {
-  baseline_checks<AppendableXcdr1Struct>(xcdr1, appendable_xcdr1_struct_expected);
+  baseline_checks<AppendableStruct>(xcdr1, appendable_xcdr1_struct_expected);
 }
 
 const unsigned char mutable_xcdr1_struct_expected[] = {
@@ -395,7 +394,7 @@ const unsigned char mutable_xcdr1_struct_expected[] = {
 
 TEST(BasicTests, MutableXcdr1Struct)
 {
-  baseline_checks<MutableXcdr1Struct>(xcdr1, mutable_xcdr1_struct_expected);
+  baseline_checks<MutableStruct>(xcdr1, mutable_xcdr1_struct_expected);
 }
 
 // XCDR2 =====================================================================
@@ -421,13 +420,12 @@ const size_t final_xcdr2_struct_max_size = 20;
 
 TEST(BasicTests, FinalXcdr2Struct)
 {
-  baseline_checks<FinalXcdr2Struct>(xcdr2,
-    FinalXcdr2StructExpectedBE::expected, final_xcdr2_struct_max_size);
+  baseline_checks<FinalStruct>(xcdr2, FinalXcdr2StructExpectedBE::expected, final_xcdr2_struct_max_size);
 }
 
 TEST(BasicTests, FinalXcdr2StructLE)
 {
-  test_little_endian<FinalXcdr2Struct, FinalXcdr2StructExpectedBE>();
+  test_little_endian<FinalStruct, FinalXcdr2StructExpectedBE>();
 }
 
 struct AppendableXcdr2StructExpectedBE {
@@ -452,12 +450,12 @@ const unsigned AppendableXcdr2StructExpectedBE::layout[] = {4,2,2,4,1,3,8};
 
 TEST(BasicTests, AppendableXcdr2Struct)
 {
-  baseline_checks<AppendableXcdr2Struct>(xcdr2, AppendableXcdr2StructExpectedBE::expected);
+  baseline_checks<AppendableStruct>(xcdr2, AppendableXcdr2StructExpectedBE::expected);
 }
 
 TEST(BasicTests, AppendableXcdr2StructLE)
 {
-  test_little_endian<AppendableXcdr2Struct, AppendableXcdr2StructExpectedBE>();
+  test_little_endian<AppendableStruct, AppendableXcdr2StructExpectedBE>();
 }
 
 struct MutableXcdr2StructExpectedBE {
@@ -475,49 +473,12 @@ const unsigned MutableXcdr2StructExpectedBE::layout[] = {4,4,2,2,4,4,4,1,3,4,8};
 
 TEST(BasicTests, MutableXcdr2Struct)
 {
-  baseline_checks<MutableXcdr2Struct>(xcdr2, MutableXcdr2StructExpectedBE::expected);
+  baseline_checks<MutableStruct>(xcdr2, MutableXcdr2StructExpectedBE::expected);
 }
 
 TEST(BasicTests, MutableXcdr2StructLE)
 {
-  test_little_endian<MutableXcdr2Struct, MutableXcdr2StructExpectedBE>();
-}
-
-// XCDR1 and XCDR2 ===========================================================
-
-TEST(BasicTests, FinalXcdr12Struct)
-{
-  baseline_checks<FinalXcdr12Struct>(xcdr1,
-    final_xcdr1_struct_expected, final_xcdr2_struct_max_size);
-  baseline_checks<FinalXcdr12Struct>(xcdr2,
-    FinalXcdr2StructExpectedBE::expected, final_xcdr2_struct_max_size);
-}
-
-TEST(BasicTests, FinalXcdr12StructLE)
-{
-  test_little_endian<FinalXcdr12Struct, FinalXcdr2StructExpectedBE>();
-}
-
-TEST(BasicTests, AppendableXcdr12Struct)
-{
-  baseline_checks<AppendableXcdr12Struct>(xcdr1, appendable_xcdr1_struct_expected);
-  baseline_checks<AppendableXcdr12Struct>(xcdr2, AppendableXcdr2StructExpectedBE::expected);
-}
-
-TEST(BasicTests, AppendableXcdr12StructLE)
-{
-  test_little_endian<AppendableXcdr12Struct, AppendableXcdr2StructExpectedBE>();
-}
-
-TEST(BasicTests, MutableXcdr12Struct)
-{
-  baseline_checks<MutableXcdr12Struct>(xcdr1, mutable_xcdr1_struct_expected);
-  baseline_checks<MutableXcdr12Struct>(xcdr2, MutableXcdr2StructExpectedBE::expected);
-}
-
-TEST(BasicTests, MutableXcdr12StructLE)
-{
-  test_little_endian<MutableXcdr12Struct, MutableXcdr2StructExpectedBE>();
+  test_little_endian<MutableStruct, MutableXcdr2StructExpectedBE>();
 }
 
 // Union Tests -----------------------------------------------------
@@ -587,231 +548,88 @@ const unsigned char MutableXcdr2UnionExpectedLongLongBE::expected[] = {
 const unsigned MutableXcdr2UnionExpectedLongLongBE::layout[] = {4,4,4,4,8};
 
 template<>
-void expect_values_equal(const MutableXcdr12Union& a, const MutableXcdr12Union& b)
+void expect_values_equal(const MutableUnion& a, const MutableUnion& b)
 {
   expect_values_equal_base_union(a, b);
 }
 
 TEST(BasicTests, MutableXcdr12Union)
 {
-  baseline_checks_union<MutableXcdr12Union>(
-    xcdr2, MutableXcdr2UnionExpectedShortBE::expected, E_SHORT_FIELD);
-  baseline_checks_union<MutableXcdr12Union>(
-    xcdr2, MutableXcdr2UnionExpectedLongBE::expected, E_LONG_FIELD);
-  baseline_checks_union<MutableXcdr12Union>(
-    xcdr2, MutableXcdr2UnionExpectedOctetBE::expected, E_OCTET_FIELD);
-  baseline_checks_union<MutableXcdr12Union>(
-    xcdr2, MutableXcdr2UnionExpectedLongLongBE::expected, E_LONG_LONG_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr2, MutableXcdr2UnionExpectedShortBE::expected, E_SHORT_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr2, MutableXcdr2UnionExpectedLongBE::expected, E_LONG_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr2, MutableXcdr2UnionExpectedOctetBE::expected, E_OCTET_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr2, MutableXcdr2UnionExpectedLongLongBE::expected, E_LONG_LONG_FIELD);
 }
 
 TEST(BasicTests, MutableXcdr12UnionLE)
 {
-  test_little_endian_union<MutableXcdr12Union,
-                           MutableXcdr2UnionExpectedShortBE>(E_SHORT_FIELD);
-  test_little_endian_union<MutableXcdr12Union,
-                           MutableXcdr2UnionExpectedLongBE>(E_LONG_FIELD);
-  test_little_endian_union<MutableXcdr12Union,
-                           MutableXcdr2UnionExpectedOctetBE>(E_OCTET_FIELD);
-  test_little_endian_union<MutableXcdr12Union,
-                           MutableXcdr2UnionExpectedLongLongBE>(E_LONG_LONG_FIELD);
+  test_little_endian_union<MutableUnion, MutableXcdr2UnionExpectedShortBE>(E_SHORT_FIELD);
+  test_little_endian_union<MutableUnion, MutableXcdr2UnionExpectedLongBE>(E_LONG_FIELD);
+  test_little_endian_union<MutableUnion, MutableXcdr2UnionExpectedOctetBE>(E_OCTET_FIELD);
+  test_little_endian_union<MutableUnion, MutableXcdr2UnionExpectedLongLongBE>(E_LONG_LONG_FIELD);
 }
 
-// No Data-representation Annotation Tests -----------------------------------
-
-TEST(BasicTests, NoDataRepFinalStruct)
-{
-  baseline_checks<NoDataRepFinalStruct>(xcdr2,
-    FinalXcdr2StructExpectedBE::expected, final_xcdr2_struct_max_size);
-}
-
-TEST(BasicTests, NoDataRepAppendableStruct)
-{
-  baseline_checks<NoDataRepAppendableStruct>(xcdr2, AppendableXcdr2StructExpectedBE::expected);
-}
-
-TEST(BasicTests, NoDataRepMutableStruct)
-{
-  baseline_checks<NoDataRepMutableStruct>(xcdr2, MutableXcdr2StructExpectedBE::expected);
-}
-
-// ---------- NoDataRepFinalUnion
-struct NoDataRepFinalUnionExpectedShortBE {
+// ---------- FinalUnion
+struct FinalUnionExpectedShortBE {
   STREAM_DATA
 };
 
-const unsigned char NoDataRepFinalUnionExpectedShortBE::expected[] = {
+const unsigned char FinalUnionExpectedShortBE::expected[] = {
   0x00, 0x00, 0x00, 0x00, // +4 discriminator = 4
   0x7f, 0xff // +2 short_field = 6
 };
-const unsigned NoDataRepFinalUnionExpectedShortBE::layout[] = {4,2};
+const unsigned FinalUnionExpectedShortBE::layout[] = {4,2};
 
-struct NoDataRepFinalUnionExpectedLongBE {
+struct FinalUnionExpectedLongBE {
   STREAM_DATA
 };
 
-const unsigned char NoDataRepFinalUnionExpectedLongBE::expected[] = {
+const unsigned char FinalUnionExpectedLongBE::expected[] = {
   0x00, 0x00, 0x00, 0x01, // +4 discriminator = 4
   0x7f, 0xff, 0xff, 0xff // +4 long_field = 8
 };
-const unsigned NoDataRepFinalUnionExpectedLongBE::layout[] = {4,4};
+const unsigned FinalUnionExpectedLongBE::layout[] = {4,4};
 
-struct NoDataRepFinalUnionExpectedOctetBE {
+struct FinalUnionExpectedOctetBE {
   STREAM_DATA
 };
 
-const unsigned char NoDataRepFinalUnionExpectedOctetBE::expected[] = {
+const unsigned char FinalUnionExpectedOctetBE::expected[] = {
   0x00, 0x00, 0x00, 0x02, // +4 discriminator = 4
   0x01 // +1 octet_field = 5
 };
-const unsigned NoDataRepFinalUnionExpectedOctetBE::layout[] = {4,1};
+const unsigned FinalUnionExpectedOctetBE::layout[] = {4,1};
 
-struct NoDataRepFinalUnionExpectedLongLongBE {
+struct FinalUnionExpectedLongLongBE {
   STREAM_DATA
 };
 
-const unsigned char NoDataRepFinalUnionExpectedLongLongBE::expected[] = {
+const unsigned char FinalUnionExpectedLongLongBE::expected[] = {
   0x00, 0x00, 0x00, 0x03, // +4 discriminator = 4
   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff // +8 long_long_field = 12
 };
-const unsigned NoDataRepFinalUnionExpectedLongLongBE::layout[] = {4,8};
+const unsigned FinalUnionExpectedLongLongBE::layout[] = {4,8};
 
 template<>
-void expect_values_equal(const NoDataRepFinalUnion& a,
-                         const NoDataRepFinalUnion& b)
+void expect_values_equal(const FinalUnion& a, const FinalUnion& b)
 {
   expect_values_equal_base_union(a, b);
 }
 
-TEST(BasicTests, NoDataRepFinalUnion)
+TEST(BasicTests, FinalUnion)
 {
-  baseline_checks_union<NoDataRepFinalUnion>(
-    xcdr2, NoDataRepFinalUnionExpectedShortBE::expected, E_SHORT_FIELD);
-  baseline_checks_union<NoDataRepFinalUnion>(
-    xcdr2, NoDataRepFinalUnionExpectedLongBE::expected, E_LONG_FIELD);
-  baseline_checks_union<NoDataRepFinalUnion>(
-    xcdr2, NoDataRepFinalUnionExpectedOctetBE::expected, E_OCTET_FIELD);
-  baseline_checks_union<NoDataRepFinalUnion>(
-    xcdr2, NoDataRepFinalUnionExpectedLongLongBE::expected, E_LONG_LONG_FIELD);
+  baseline_checks_union<FinalUnion>(xcdr2, FinalUnionExpectedShortBE::expected, E_SHORT_FIELD);
+  baseline_checks_union<FinalUnion>(xcdr2, FinalUnionExpectedLongBE::expected, E_LONG_FIELD);
+  baseline_checks_union<FinalUnion>(xcdr2, FinalUnionExpectedOctetBE::expected, E_OCTET_FIELD);
+  baseline_checks_union<FinalUnion>(xcdr2, FinalUnionExpectedLongLongBE::expected, E_LONG_LONG_FIELD);
 }
 
-TEST(BasicTests, NoDataRepFinalUnionLE)
+TEST(BasicTests, FinalUnionLE)
 {
-  test_little_endian_union<NoDataRepFinalUnion,
-                           NoDataRepFinalUnionExpectedShortBE>(E_SHORT_FIELD);
-  test_little_endian_union<NoDataRepFinalUnion,
-                           NoDataRepFinalUnionExpectedLongBE>(E_LONG_FIELD);
-  test_little_endian_union<NoDataRepFinalUnion,
-                           NoDataRepFinalUnionExpectedOctetBE>(E_OCTET_FIELD);
-  test_little_endian_union<NoDataRepFinalUnion,
-                           NoDataRepFinalUnionExpectedLongLongBE>(E_LONG_LONG_FIELD);
-}
-
-// ---------- NoDataRepAppendableUnion
-struct NoDataRepAppendableUnionExpectedShortBE {
-  STREAM_DATA
-};
-
-const unsigned char NoDataRepAppendableUnionExpectedShortBE::expected[] = {
-  0x00, 0x00, 0x00, 0x06, // +4 Dheader = 4
-  0x00, 0x00, 0x00, 0x00, // +4 discriminator = 8
-  0x7f, 0xff // +2 short_field = 10
-};
-const unsigned NoDataRepAppendableUnionExpectedShortBE::layout[] = {4,4,2};
-
-struct NoDataRepAppendableUnionExpectedLongBE {
-  STREAM_DATA
-};
-
-const unsigned char NoDataRepAppendableUnionExpectedLongBE::expected[] = {
-  0x00, 0x00, 0x00, 0x08, // +4 Dheader = 4
-  0x00, 0x00, 0x00, 0x01, // +4 discriminator = 8
-  0x7f, 0xff, 0xff, 0xff  // +4 long_field = 12
-};
-const unsigned NoDataRepAppendableUnionExpectedLongBE::layout[] = {4,4,4};
-
-struct NoDataRepAppendableUnionExpectedOctetBE {
-  STREAM_DATA
-};
-
-const unsigned char NoDataRepAppendableUnionExpectedOctetBE::expected[] = {
-  0x00, 0x00, 0x00, 0x05, // +4 Dheader = 4
-  0x00, 0x00, 0x00, 0x02, // +4 discriminator = 8
-  0x01  // +1 octet_field = 9
-};
-const unsigned NoDataRepAppendableUnionExpectedOctetBE::layout[] = {4,4,1};
-
-struct NoDataRepAppendableUnionExpectedLongLongBE {
-  STREAM_DATA
-};
-
-const unsigned char NoDataRepAppendableUnionExpectedLongLongBE::expected[] = {
-  0x00, 0x00, 0x00, 0x0c, // +4 Dheader = 4
-  0x00, 0x00, 0x00, 0x03, // +4 discriminator = 8
-  0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +4 long_long_field = 16
-};
-const unsigned NoDataRepAppendableUnionExpectedLongLongBE::layout[] = {4,4,8};
-
-template<>
-void expect_values_equal(const NoDataRepAppendableUnion& a,
-                         const NoDataRepAppendableUnion& b)
-{
-  expect_values_equal_base_union(a, b);
-}
-
-TEST(BasicTests, NoDataRepAppendableUnion)
-{
-  baseline_checks_union<NoDataRepAppendableUnion>(
-    xcdr2, NoDataRepAppendableUnionExpectedShortBE::expected, E_SHORT_FIELD);
-  baseline_checks_union<NoDataRepAppendableUnion>(
-    xcdr2, NoDataRepAppendableUnionExpectedLongBE::expected, E_LONG_FIELD);
-  baseline_checks_union<NoDataRepAppendableUnion>(
-    xcdr2, NoDataRepAppendableUnionExpectedOctetBE::expected, E_OCTET_FIELD);
-  baseline_checks_union<NoDataRepAppendableUnion>(
-    xcdr2, NoDataRepAppendableUnionExpectedLongLongBE::expected, E_LONG_LONG_FIELD);
-}
-
-TEST(BasicTests, NoDataRepAppendableUnionLE)
-{
-  test_little_endian_union<NoDataRepAppendableUnion,
-                           NoDataRepAppendableUnionExpectedShortBE>(E_SHORT_FIELD);
-  test_little_endian_union<NoDataRepAppendableUnion,
-                           NoDataRepAppendableUnionExpectedLongBE>(E_LONG_FIELD);
-  test_little_endian_union<NoDataRepAppendableUnion,
-                           NoDataRepAppendableUnionExpectedOctetBE>(E_OCTET_FIELD);
-  test_little_endian_union<NoDataRepAppendableUnion,
-                           NoDataRepAppendableUnionExpectedLongLongBE>(E_LONG_LONG_FIELD);
-}
-
-// ---------- NoDataRepMutableUnion
-template<>
-void expect_values_equal(const NoDataRepMutableUnion& a,
-                         const NoDataRepMutableUnion& b)
-{
-  expect_values_equal_base_union(a, b);
-}
-
-TEST(BasicTests, NoDataRepMutableUnion)
-{
-  baseline_checks_union<NoDataRepMutableUnion>(
-    xcdr2, MutableXcdr2UnionExpectedShortBE::expected, E_SHORT_FIELD);
-  baseline_checks_union<NoDataRepMutableUnion>(
-    xcdr2, MutableXcdr2UnionExpectedLongBE::expected, E_LONG_FIELD);
-  baseline_checks_union<NoDataRepMutableUnion>(
-    xcdr2, MutableXcdr2UnionExpectedOctetBE::expected, E_OCTET_FIELD);
-  baseline_checks_union<NoDataRepMutableUnion>(
-    xcdr2, MutableXcdr2UnionExpectedLongLongBE::expected, E_LONG_LONG_FIELD);
-}
-
-TEST(BasicTests, NoDataRepMutableUnionLE)
-{
-  test_little_endian_union<NoDataRepMutableUnion,
-                           MutableXcdr2UnionExpectedShortBE>(E_SHORT_FIELD);
-  test_little_endian_union<NoDataRepMutableUnion,
-                           MutableXcdr2UnionExpectedLongBE>(E_LONG_FIELD);
-  test_little_endian_union<NoDataRepMutableUnion,
-                           MutableXcdr2UnionExpectedOctetBE>(E_OCTET_FIELD);
-  test_little_endian_union<NoDataRepMutableUnion,
-                           MutableXcdr2UnionExpectedLongLongBE>(E_LONG_LONG_FIELD);
+  test_little_endian_union<FinalUnion, FinalUnionExpectedShortBE>(E_SHORT_FIELD);
+  test_little_endian_union<FinalUnion, FinalUnionExpectedLongBE>(E_LONG_FIELD);
+  test_little_endian_union<FinalUnion, FinalUnionExpectedOctetBE>(E_OCTET_FIELD);
+  test_little_endian_union<FinalUnion, FinalUnionExpectedLongLongBE>(E_LONG_LONG_FIELD);
 }
 
 // Appendable Tests ==========================================================
@@ -917,7 +735,7 @@ const unsigned char AppendableExpectedXcdr2BE::expected[] = {
 const unsigned AppendableExpectedXcdr2BE::layout[] = {4,4,2,2,4,1,3,8,2,2,4,1,3,8};
 
 template<>
-void set_values(AppendableStruct& value)
+void set_values(AppendableWithNestedStruct& value)
 {
   set_base_values(value.nested);
   set_base_values(value);
@@ -931,11 +749,12 @@ void expect_equal_with_nested(const TypeA& a, const TypeB& b)
 }
 
 template<>
-void expect_values_equal(const AppendableStruct& a, const AppendableStruct& b)
+void expect_values_equal(const AppendableWithNestedStruct& a, const AppendableWithNestedStruct& b)
 {
   expect_equal_with_nested(a, b);
 }
 
+/* //compiled but FAILED tests
 TEST(AppendableTests, BothAppendableStruct)
 {
   serializer_test<AppendableStruct>(xcdr2, AppendableExpectedXcdr2BE::expected);
@@ -945,14 +764,15 @@ TEST(AppendableTests, BothAppendableStructLE)
 {
   test_little_endian<AppendableStruct, AppendableExpectedXcdr2BE>();
 }
+*/
 
 template<>
-void expect_values_equal(const AppendableStruct& a,
+void expect_values_equal(const AppendableWithNestedStruct& a,
                          const AdditionalFieldAppendableStruct& b)
 {
   expect_equal_with_nested(a, b);
 }
-
+/*
 TEST(AppendableTests, FromAppendableStruct)
 {
   amalgam_serializer_test<AppendableStruct, AdditionalFieldAppendableStruct>(
@@ -964,6 +784,7 @@ TEST(AppendableTests, FromAppendableStructLE)
   test_little_endian<AppendableStruct, AdditionalFieldAppendableStruct,
                      AppendableExpectedXcdr2BE>();
 }
+*/
 
 // ---------- AdditionalFieldAppendableStruct
 struct AdditionalAppendableExpectedXcdr2BE {
@@ -1013,11 +834,12 @@ void set_values(AdditionalFieldAppendableStruct& value)
 
 template<>
 void expect_values_equal(const AdditionalFieldAppendableStruct& a,
-                         const AppendableStruct& b)
+                         //const AppendableStruct& b)
+                         const AppendableWithNestedStruct& b)
 {
   expect_equal_with_nested(a, b);
 }
-
+/*
 TEST(AppendableTests, FromAdditionalAppendableStruct)
 {
   amalgam_serializer_test<AdditionalFieldAppendableStruct, AppendableStruct>(
@@ -1029,6 +851,7 @@ TEST(AppendableTests, FromAdditionalAppendableStructLE)
   test_little_endian<AdditionalFieldAppendableStruct, AppendableStruct,
                      AdditionalAppendableExpectedXcdr2BE>();
 }
+*/
 
 template<>
 void expect_values_equal(const AdditionalFieldAppendableStruct& a,
@@ -1038,7 +861,7 @@ void expect_values_equal(const AdditionalFieldAppendableStruct& a,
   EXPECT_EQ(a.additional_field, b.additional_field);
   EXPECT_EQ(a.nested.additional_field, b.nested.additional_field);
 }
-
+/*
 TEST(AppendableTests, BothAdditionalAppendableStruct)
 {
   serializer_test<AdditionalFieldAppendableStruct>(
@@ -1050,8 +873,9 @@ TEST(AppendableTests, BothAdditionalAppendableStructLE)
   test_little_endian<AdditionalFieldAppendableStruct,
                      AdditionalAppendableExpectedXcdr2BE>();
 }
+*/
 
-// ---------- AppendableStruct2
+// ---------- AppendableWithNestedStruct2
 struct AppendableExpected2Xcdr2BE {
   STREAM_DATA
 };
@@ -1080,28 +904,28 @@ const unsigned AppendableExpected2Xcdr2BE::layout[] = {4,4,1,1,1,1,1,1,
                                                        1,1,1,1,2,4,2,2,4,1,3,8};
 
 template<>
-void set_values(AppendableStruct2& value)
+void set_values(AppendableWithNestedStruct2& value)
 {
   set_values(value.nested);
   value.string_field = "abcdefghi";
 }
 
 template<>
-void expect_values_equal(const AppendableStruct2& a,
-                         const AppendableStruct2& b)
+void expect_values_equal(const AppendableWithNestedStruct2& a,
+                         const AppendableWithNestedStruct2& b)
 {
   expect_values_equal(a.nested, b.nested);
   EXPECT_STREQ(a.string_field, b.string_field);
 }
 
-TEST(AppendableTests, BothAppendableStruct2)
+TEST(AppendableTests, BothAppendableWithNestedStruct2)
 {
-  serializer_test<AppendableStruct2>(xcdr2, AppendableExpected2Xcdr2BE::expected);
+  serializer_test<AppendableWithNestedStruct2>(xcdr2, AppendableExpected2Xcdr2BE::expected);
 }
 
-TEST(AppendableTests, BothAppendableStruct2LE)
+TEST(AppendableTests, BothAppendableWithNestedStruct2LE)
 {
-  test_little_endian<AppendableStruct2, AppendableExpected2Xcdr2BE>();
+  test_little_endian<AppendableWithNestedStruct2, AppendableExpected2Xcdr2BE>();
 }
 
 // ---------- AppendableUnion
@@ -1154,7 +978,7 @@ void expect_values_equal(const AppendableUnion& a, const ModifiedAppendableUnion
 {
   expect_values_equal_base_union(a, b);
 }
-
+/*
 TEST(AppendableTests, FromAppendableUnion)
 {
   amalgam_serializer_test_union<AppendableUnion, ModifiedAppendableUnion>(
@@ -1178,6 +1002,7 @@ TEST(AppendableTests, FromAppendableUnionLE)
   test_little_endian_union<AppendableUnion, ModifiedAppendableUnion,
                            AppendableUnionXcdr2ExpectedLongLongBE>(E_LONG_LONG_FIELD);
 }
+*/
 
 // Mutable Tests =============================================================
 
@@ -1214,7 +1039,7 @@ const unsigned char MutableStructExpectedXcdr2BE::expected[] = {
 };
 
 const unsigned MutableStructExpectedXcdr2BE::layout[] = {4,4,2,2,4,4,4,1,3,4,8};
-
+/*
 TEST(MutableTests, BaselineXcdr1Test)
 {
   baseline_checks<MutableStruct>(xcdr1, mutable_struct_expected_xcdr1);
@@ -1229,6 +1054,7 @@ TEST(MutableTests, BaselineXcdr2TestLE)
 {
   test_little_endian<MutableStruct, MutableStructExpectedXcdr2BE>();
 }
+*/
 
 // ---------- MutableUnion
 struct MutableUnionExpectedXcdr2ShortBE {
@@ -1294,13 +1120,7 @@ const unsigned char MutableUnionExpectedXcdr2LongLongBE::expected[] = {
   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +8 value = 24
 };
 const unsigned MutableUnionExpectedXcdr2LongLongBE::layout[] = {4,4,4,4,8};
-
-template<>
-void expect_values_equal(const MutableUnion& a, const MutableUnion& b)
-{
-  expect_values_equal_base_union(a, b);
-}
-
+/*
 TEST(MutableTests, BaselineXcdr2TestUnion)
 {
   baseline_checks_union<MutableUnion>(
@@ -1324,6 +1144,7 @@ TEST(MutableTests, BaselineXcdr2TestUnionLE)
   test_little_endian_union<MutableUnion,
                            MutableUnionExpectedXcdr2LongLongBE>(E_LONG_LONG_FIELD);
 }
+*/
 
 template<typename TypeA, typename TypeB>
 void expect_values_equal_base_union2(const TypeA& a, const TypeB& b)
@@ -1346,7 +1167,7 @@ void expect_values_equal(const MutableUnion& a, const ModifiedMutableUnion& b)
 {
   expect_values_equal_base_union2(a, b);
 }
-
+/*
 TEST(MutableTests, FromMutableUnion)
 {
   amalgam_serializer_test_union<MutableUnion, ModifiedMutableUnion>(
@@ -1362,6 +1183,7 @@ TEST(MutableTests, FromMutableUnionLE)
   test_little_endian_union<MutableUnion, ModifiedMutableUnion,
                            MutableUnionExpectedXcdr2LongBE>(E_LONG_FIELD);
 }
+*/
 
 // ---------- ModifiedMutableUnion
 template<>
@@ -1397,7 +1219,7 @@ TEST(MutableTests, FromModifiedMutableUnion)
   // TODO (sonndinh): test try-construct behavior when additional_field of
   // ModifiedMutableUnion is selected
 }
-
+/*
 TEST(MutableTests, FromModifiedMutableUnionLE)
 {
   test_little_endian_union<ModifiedMutableUnion, MutableUnion,
@@ -1468,6 +1290,7 @@ TEST(MutableTests, FromReorderedXcdr2Test)
   change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
   amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr2_le, expected);
 }
+*/
 
 // ---------- AdditionalFieldMutableStruct
 // Test compatibility between two structures with different fields
@@ -1479,7 +1302,7 @@ void set_values<AdditionalFieldMutableStruct>(
   set_base_values(value);
   value.additional_field = 0x12345678;
 }
-
+/*
 TEST(MutableTests, ToAdditionalFieldXcdr1Test)
 {
   MutableStruct value;
@@ -1575,6 +1398,7 @@ TEST(MutableTests, FromAdditionalFieldXcdr2Test)
   change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
   amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr2_le, expected);
 }
+*/
 
 // ---------- LengthCodeStruct
 template<>
@@ -1808,7 +1632,7 @@ const unsigned MixedMutableStructXcdr2BE::layout[] = {4,4,4,4,4,2,2,4,4,4,1,3,4,
                                                       1,1,1,1,1,1,1,1,2,4,4,4,4,4,1,1,
                                                       1,1,1,1,1,1,1,1,1,1,4,1,1,1,1,1,
                                                       1,1,1,1,1,1,1,4,1,1,1,1,1,1,1,1,1,1,1};
-
+/*
 TEST(MutableTests, BothMixedMutableStruct)
 {
   serializer_test<MixedMutableStruct>(xcdr2, MixedMutableStructXcdr2BE::expected);
@@ -1837,6 +1661,7 @@ TEST(MutableTests, FromMixedMutableStructLE)
   test_little_endian<MixedMutableStruct, ModifiedMixedMutableStruct,
                      MixedMutableStructXcdr2BE>();
 }
+*/
 
 // Mixed Extensibility Tests ================================================
 

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -756,12 +756,12 @@ void expect_values_equal(const AppendableWithNestedStruct& a, const AppendableWi
 
 TEST(AppendableTests, BothAppendableStruct)
 {
-  serializer_test<AppendableStruct>(xcdr2, AppendableExpectedXcdr2BE::expected);
+  serializer_test<AppendableWithNestedStruct>(xcdr2, AppendableExpectedXcdr2BE::expected);
 }
 
 TEST(AppendableTests, BothAppendableStructLE)
 {
-  test_little_endian<AppendableStruct, AppendableExpectedXcdr2BE>();
+  test_little_endian<AppendableWithNestedStruct, AppendableExpectedXcdr2BE>();
 }
 
 template<>
@@ -773,13 +773,13 @@ void expect_values_equal(const AppendableWithNestedStruct& a,
 
 TEST(AppendableTests, FromAppendableStruct)
 {
-  amalgam_serializer_test<AppendableStruct, AdditionalFieldAppendableStruct>(
+  amalgam_serializer_test<AppendableWithNestedStruct, AdditionalFieldAppendableStruct>(
     xcdr2, AppendableExpectedXcdr2BE::expected);
 }
 
 TEST(AppendableTests, FromAppendableStructLE)
 {
-  test_little_endian<AppendableStruct, AdditionalFieldAppendableStruct,
+  test_little_endian<AppendableWithNestedStruct, AdditionalFieldAppendableStruct,
                      AppendableExpectedXcdr2BE>();
 }
 
@@ -831,7 +831,6 @@ void set_values(AdditionalFieldAppendableStruct& value)
 
 template<>
 void expect_values_equal(const AdditionalFieldAppendableStruct& a,
-                         //const AppendableStruct& b)
                          const AppendableWithNestedStruct& b)
 {
   expect_equal_with_nested(a, b);
@@ -839,13 +838,13 @@ void expect_values_equal(const AdditionalFieldAppendableStruct& a,
 
 TEST(AppendableTests, FromAdditionalAppendableStruct)
 {
-  amalgam_serializer_test<AdditionalFieldAppendableStruct, AppendableStruct>(
+  amalgam_serializer_test<AdditionalFieldAppendableStruct, AppendableWithNestedStruct>(
     xcdr2, AdditionalAppendableExpectedXcdr2BE::expected);
 }
 
 TEST(AppendableTests, FromAdditionalAppendableStructLE)
 {
-  test_little_endian<AdditionalFieldAppendableStruct, AppendableStruct,
+  test_little_endian<AdditionalFieldAppendableStruct, AppendableWithNestedStruct,
                      AdditionalAppendableExpectedXcdr2BE>();
 }
 
@@ -1036,17 +1035,17 @@ const unsigned MutableStructExpectedXcdr2BE::layout[] = {4,4,2,2,4,4,4,1,3,4,8};
 
 TEST(MutableTests, BaselineXcdr1Test)
 {
-  baseline_checks<MutableStruct>(xcdr1, mutable_struct_expected_xcdr1);
+  baseline_checks<MutableStructWithExplicitIDs>(xcdr1, mutable_struct_expected_xcdr1);
 }
 
 TEST(MutableTests, BaselineXcdr2Test)
 {
-  baseline_checks<MutableStruct>(xcdr2, MutableStructExpectedXcdr2BE::expected);
+  baseline_checks<MutableStructWithExplicitIDs>(xcdr2, MutableStructExpectedXcdr2BE::expected);
 }
 
 TEST(MutableTests, BaselineXcdr2TestLE)
 {
-  test_little_endian<MutableStruct, MutableStructExpectedXcdr2BE>();
+  test_little_endian<MutableStructWithExplicitIDs, MutableStructExpectedXcdr2BE>();
 }
 
 // ---------- MutableUnion
@@ -1113,7 +1112,7 @@ const unsigned char MutableUnionExpectedXcdr2LongLongBE::expected[] = {
   0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff  // +8 value = 24
 };
 const unsigned MutableUnionExpectedXcdr2LongLongBE::layout[] = {4,4,4,4,8};
-
+/*
 TEST(MutableTests, BaselineXcdr2TestUnion)
 {
   baseline_checks_union<MutableUnion>(
@@ -1137,7 +1136,7 @@ TEST(MutableTests, BaselineXcdr2TestUnionLE)
   test_little_endian_union<MutableUnion,
                            MutableUnionExpectedXcdr2LongLongBE>(E_LONG_LONG_FIELD);
 }
-
+*/
 template<typename TypeA, typename TypeB>
 void expect_values_equal_base_union2(const TypeA& a, const TypeB& b)
 {
@@ -1155,24 +1154,24 @@ void expect_values_equal_base_union2(const TypeA& a, const TypeB& b)
 }
 
 template<>
-void expect_values_equal(const MutableUnion& a, const ModifiedMutableUnion& b)
+void expect_values_equal(const MutableUnionWithExplicitIDs& a, const ModifiedMutableUnion& b)
 {
   expect_values_equal_base_union2(a, b);
 }
 
 TEST(MutableTests, FromMutableUnion)
 {
-  amalgam_serializer_test_union<MutableUnion, ModifiedMutableUnion>(
+  amalgam_serializer_test_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion>(
     xcdr2, MutableUnionExpectedXcdr2ShortBE::expected, E_SHORT_FIELD);
-  amalgam_serializer_test_union<MutableUnion, ModifiedMutableUnion>(
+  amalgam_serializer_test_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion>(
     xcdr2, MutableUnionExpectedXcdr2LongBE::expected, E_LONG_FIELD);
 }
 
 TEST(MutableTests, FromMutableUnionLE)
 {
-  test_little_endian_union<MutableUnion, ModifiedMutableUnion,
+  test_little_endian_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion,
                            MutableUnionExpectedXcdr2ShortBE>(E_SHORT_FIELD);
-  test_little_endian_union<MutableUnion, ModifiedMutableUnion,
+  test_little_endian_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion,
                            MutableUnionExpectedXcdr2LongBE>(E_LONG_FIELD);
 }
 
@@ -1225,7 +1224,7 @@ TEST(MutableTests, FromModifiedMutableUnionLE)
 
 TEST(MutableTests, ToReorderedXcdr1Test)
 {
-  amalgam_serializer_test<MutableStruct, ReorderedMutableStruct>(
+  amalgam_serializer_test<MutableStructWithExplicitIDs, ReorderedMutableStruct>(
     xcdr1, mutable_struct_expected_xcdr1);
 }
 
@@ -1249,18 +1248,18 @@ TEST(MutableTests, FromReorderedXcdr1Test)
     0x00, 0x00, // +2 pad = 36
     0x3f, 0x02, 0x00, 0x00 // +4 = 40
   };
-  amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr1, expected);
+  amalgam_serializer_test<ReorderedMutableStruct, MutableStructWithExplicitIDs>(xcdr1, expected);
 }
 
 TEST(MutableTests, ToReorderedXcdr2Test)
 {
-  amalgam_serializer_test<MutableStruct, ReorderedMutableStruct>(
+  amalgam_serializer_test<MutableStructWithExplicitIDs, ReorderedMutableStruct>(
     xcdr2, MutableStructExpectedXcdr2BE::expected);
 }
 
 TEST(MutableTests, ToReorderedXcdr2TestLE)
 {
-  test_little_endian<MutableStruct, ReorderedMutableStruct,
+  test_little_endian<MutableStructWithExplicitIDs, ReorderedMutableStruct,
                      MutableStructExpectedXcdr2BE>();
 }
 
@@ -1275,11 +1274,11 @@ TEST(MutableTests, FromReorderedXcdr2Test)
   };
   const unsigned layout[] = {4,4,4,4,8,4,1,3,4,2};
 
-  amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr2, expected);
+  amalgam_serializer_test<ReorderedMutableStruct, MutableStructWithExplicitIDs>(xcdr2, expected);
 
   // Little-endian test
   change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
-  amalgam_serializer_test<ReorderedMutableStruct, MutableStruct>(xcdr2_le, expected);
+  amalgam_serializer_test<ReorderedMutableStruct, MutableStructWithExplicitIDs>(xcdr2_le, expected);
 }
 
 // ---------- AdditionalFieldMutableStruct
@@ -1295,7 +1294,7 @@ void set_values<AdditionalFieldMutableStruct>(
 
 TEST(MutableTests, ToAdditionalFieldXcdr1Test)
 {
-  MutableStruct value;
+  MutableStructWithExplicitIDs value;
   set_values(value);
   AdditionalFieldMutableStruct result;
   amalgam_serializer_test(xcdr1, mutable_struct_expected_xcdr1, value, result);
@@ -1326,19 +1325,19 @@ TEST(MutableTests, FromAdditionalFieldXcdr1Test)
     0x00, 0x00, // +2 pad = 44
     0x3f, 0x02, 0x00, 0x00 // +4 = 48
   };
-  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr1, expected);
+  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStructWithExplicitIDs>(xcdr1, expected);
 }
 
 TEST(MutableTests, ToAdditionalFieldXcdr2Test)
 {
-  MutableStruct value;
+  MutableStructWithExplicitIDs value;
   set_values(value);
   AdditionalFieldMutableStruct result;
   amalgam_serializer_test(xcdr2, MutableStructExpectedXcdr2BE::expected, value, result);
   /// TODO(iguessthidlldo): Test for correct try construct behavior (default
   /// value?) if we decide on that.
 
-  test_little_endian<MutableStruct, AdditionalFieldMutableStruct,
+  test_little_endian<MutableStructWithExplicitIDs, AdditionalFieldMutableStruct,
                      MutableStructExpectedXcdr2BE>();
 }
 
@@ -1358,7 +1357,7 @@ TEST(MutableTests, FromAdditionalFieldMustUnderstandTest)
   ACE_Message_Block buffer(1024);
   buffer.copy((const char*)additional_field_must_understand, sizeof(additional_field_must_understand));
   Serializer serializer(&buffer, xcdr2);
-  MutableStruct result;
+  MutableStructWithExplicitIDs result;
   EXPECT_FALSE(serializer >> result);
 
   // Deserialize and Compare C++ Values
@@ -1384,9 +1383,9 @@ TEST(MutableTests, FromAdditionalFieldXcdr2Test)
   };
   unsigned layout[] = {4,4,4,4,4,4,8,4,1,3,4,2};
 
-  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr2, expected);
+  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStructWithExplicitIDs>(xcdr2, expected);
   change_endianness(expected, layout, sizeof(layout)/sizeof(unsigned));
-  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStruct>(xcdr2_le, expected);
+  amalgam_serializer_test<AdditionalFieldMutableStruct, MutableStructWithExplicitIDs>(xcdr2_le, expected);
 }
 
 // ---------- LengthCodeStruct

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -236,7 +236,7 @@ typedef sequence<string> StringSeq;
 
 @mutable
 struct MixedMutableStruct {
-  @id(1) MutableStruct struct_nested;
+  @id(1) MutableStructWithExplicitIDs struct_nested;
   @id(2) sequence<short> sequence_field;
   @id(3) NestedUnion union_nested;
   @id(4) StringSeq sequence_field2;
@@ -246,7 +246,7 @@ struct MixedMutableStruct {
 struct ModifiedMixedMutableStruct {
   @id(3) NestedUnion union_nested;
   @id(4) StringSeq sequence_field2;
-  @id(1) MutableStruct struct_nested;
+  @id(1) MutableStructWithExplicitIDs struct_nested;
 };
 
 // Mixed Extensibility Tests =================================================

--- a/tests/DCPS/Compiler/xcdr/xcdr.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdr.idl
@@ -19,66 +19,18 @@
   case E_LONG_LONG_FIELD: \
     long long long_long_field;
 
-// Generic XCDR1 Tests =======================================================
-
 @final
-@OpenDDS::data_representation(XCDR1)
-struct FinalXcdr1Struct {
+struct FinalStruct {
   COMMON_FIELDS
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR1)
-struct AppendableXcdr1Struct {
+struct AppendableStruct {
   COMMON_FIELDS
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR1)
-struct MutableXcdr1Struct {
-  COMMON_FIELDS
-};
-
-// Generic XCDR2 Tests =======================================================
-
-@final
-@OpenDDS::data_representation(XCDR2)
-struct FinalXcdr2Struct {
-  COMMON_FIELDS
-};
-
-@appendable
-@OpenDDS::data_representation(XCDR2)
-struct AppendableXcdr2Struct {
-  COMMON_FIELDS
-};
-
-@mutable
-@OpenDDS::data_representation(XCDR2)
-struct MutableXcdr2Struct {
-  COMMON_FIELDS
-};
-
-// Generic XCDR1/2 Tests =====================================================
-
-@final
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
-struct FinalXcdr12Struct {
-  COMMON_FIELDS
-};
-
-@appendable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
-struct AppendableXcdr12Struct {
-  COMMON_FIELDS
-};
-
-@mutable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
-struct MutableXcdr12Struct {
+struct MutableStruct {
   COMMON_FIELDS
 };
 
@@ -91,62 +43,32 @@ enum UnionDisc {
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
-union MutableXcdr12Union switch (UnionDisc) {
+union MutableUnion switch (UnionDisc) {
   COMMON_BRANCHES
 };
 
 @final
-struct NoDataRepFinalStruct {
-  COMMON_FIELDS
-};
-
-@appendable
-struct NoDataRepAppendableStruct {
-  COMMON_FIELDS
-};
-
-@mutable
-struct NoDataRepMutableStruct {
-  COMMON_FIELDS
-};
-
-@final
-union NoDataRepFinalUnion switch(UnionDisc) {
-  COMMON_BRANCHES
-};
-
-@appendable
-union NoDataRepAppendableUnion switch(UnionDisc) {
-  COMMON_BRANCHES
-};
-
-@mutable
-union NoDataRepMutableUnion switch(UnionDisc) {
+union FinalUnion switch(UnionDisc) {
   COMMON_BRANCHES
 };
 
 // Appendable Tests ==========================================================
 
-typedef AppendableXcdr2Struct NestedStruct;
+typedef AppendableStruct NestedStruct;
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
-struct AppendableStruct {
+struct AppendableWithNestedStruct {
   NestedStruct nested;
   COMMON_FIELDS
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
 struct AdditionalFieldNestedStruct {
   COMMON_FIELDS
   long additional_field;
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
 struct AdditionalFieldAppendableStruct {
   AdditionalFieldNestedStruct nested;
   COMMON_FIELDS
@@ -154,20 +76,17 @@ struct AdditionalFieldAppendableStruct {
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
-struct AppendableStruct2 {
+struct AppendableWithNestedStruct2 {
   string string_field;
   NestedStruct nested;
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
 union AppendableUnion switch (UnionDisc) {
   COMMON_BRANCHES
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
 union ModifiedAppendableUnion switch (UnionDisc) {
   COMMON_BRANCHES
 case E_ADDITIONAL_FIELD:
@@ -178,9 +97,7 @@ case E_ADDITIONAL_FIELD:
 // Mutable Tests =============================================================
 
 @mutable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
-struct MutableStruct {
+struct MutableStructWithExplicitIDs {
   @id(4) short short_field;
   @id(6) long long_field;
   @id(8) octet octet_field;
@@ -188,8 +105,6 @@ struct MutableStruct {
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
 struct ReorderedMutableStruct {
   @id(6) long long_field;
   @id(10) long long long_long_field;
@@ -198,8 +113,6 @@ struct ReorderedMutableStruct {
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
 struct AdditionalFieldMutableStruct {
   @id(6) long long_field;
   @id(1) long additional_field;
@@ -245,7 +158,6 @@ struct Long3 {
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 struct LengthCodeStruct { //LC Size
   @key
   @id(0) octet o;         // 0    1
@@ -272,7 +184,6 @@ typedef sequence<long long, 3> LongLong3S;
 typedef sequence<short, 3> Short3S;
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 struct LC567Struct {            //LC Size
   @id(0) sequence<octet, 3> o3; // 5    3
   @id(1) sequence<long, 3> l3;  // 6  4x3
@@ -286,9 +197,7 @@ struct LC567Struct {            //LC Size
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR1)
-@OpenDDS::data_representation(XCDR2)
-union MutableUnion switch (UnionDisc) {
+union MutableUnionWithExplicitIDs switch (UnionDisc) {
 case E_SHORT_FIELD:
   @id(4) short short_field;
 case E_LONG_FIELD:
@@ -300,7 +209,6 @@ case E_LONG_LONG_FIELD:
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 union ModifiedMutableUnion switch (UnionDisc) {
 case E_LONG_FIELD:
   @id(6) long long_field;
@@ -313,7 +221,6 @@ case E_ADDITIONAL_FIELD:
 typedef sequence<long> LongSeq;
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 union NestedUnion switch(short) {
 case 1:
   @id(1) short short_field;
@@ -328,7 +235,6 @@ default:
 typedef sequence<string> StringSeq;
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 struct MixedMutableStruct {
   @id(1) MutableStruct struct_nested;
   @id(2) sequence<short> sequence_field;
@@ -337,7 +243,6 @@ struct MixedMutableStruct {
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 struct ModifiedMixedMutableStruct {
   @id(3) NestedUnion union_nested;
   @id(4) StringSeq sequence_field2;
@@ -347,28 +252,25 @@ struct ModifiedMixedMutableStruct {
 // Mixed Extensibility Tests =================================================
 
 @final
-@OpenDDS::data_representation(XCDR2)
 struct NestingFinalStruct {
   string string_field;
-  AppendableXcdr2Struct appendable_nested;
+  AppendableStruct appendable_nested;
   sequence<short> sequence_field;
-  MutableXcdr2Struct mutable_nested;
+  MutableStruct mutable_nested;
 };
 
 @appendable
-@OpenDDS::data_representation(XCDR2)
 struct NestingAppendableStruct {
   string string_field;
-  MutableXcdr2Struct mutable_nested;
+  MutableStruct mutable_nested;
   sequence<long> sequence_field;
-  FinalXcdr2Struct final_nested;
+  FinalStruct final_nested;
 };
 
 @mutable
-@OpenDDS::data_representation(XCDR2)
 struct NestingMutableStruct {
   string string_field;
-  AppendableXcdr2Struct appendable_nested;
+  AppendableStruct appendable_nested;
   sequence<octet> sequence_field;
-  FinalXcdr2Struct final_nested;
+  FinalStruct final_nested;
 };


### PR DESCRIPTION
Remove data representation from the names and annotations of the non-topic types, modify the xcdr test and remove duplicates.