### PR TITLE
Permissions handles are not returned to Access Control Plugin

### DIFF
--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -121,6 +121,20 @@ DomainParticipantImpl::DomainParticipantImpl(
 
 DomainParticipantImpl::~DomainParticipantImpl()
 {
+#ifdef OPENDDS_SECURITY
+  if (security_config_ && perm_handle_ != DDS::HANDLE_NIL) {
+    Security::AccessControl_var access = security_config_->get_access_control();
+    DDS::Security::SecurityException se;
+    const bool okay = access->return_permissions_handle(perm_handle_, se);
+    if (!okay) {
+      ACE_ERROR((LM_ERROR,
+        ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::~DomainParticipantImpl: ")
+        ACE_TEXT("Unable to return permissions handle. SecurityException[%d.%d]: %C\n"),
+          se.code, se.minor_code, se.message.in()));
+    }
+  }
+#endif
+
 }
 
 DDS::Publisher_ptr

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -125,12 +125,13 @@ DomainParticipantImpl::~DomainParticipantImpl()
   if (security_config_ && perm_handle_ != DDS::HANDLE_NIL) {
     Security::AccessControl_var access = security_config_->get_access_control();
     DDS::Security::SecurityException se;
-    const bool okay = access->return_permissions_handle(perm_handle_, se);
-    if (!okay) {
-      ACE_ERROR((LM_ERROR,
-        ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::~DomainParticipantImpl: ")
-        ACE_TEXT("Unable to return permissions handle. SecurityException[%d.%d]: %C\n"),
-          se.code, se.minor_code, se.message.in()));
+    if (!access->return_permissions_handle(perm_handle_, se)) {
+      if (DCPS::security_debug.auth_warn) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::~DomainParticipantImpl: ")
+                   ACE_TEXT("Unable to return permissions handle. SecurityException[%d.%d]: %C\n"),
+                   se.code, se.minor_code, se.message.in()));
+      }
     }
   }
 #endif

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1822,12 +1822,13 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
   if (security_config_) {
     DDS::Security::SecurityException se = {"", 0, 0};
     DDS::Security::Authentication_var auth = security_config_->get_authentication();
+    DDS::Security::AccessControl_var access = security_config_->get_access_control();
 
     if (iter->second.identity_handle_ != DDS::HANDLE_NIL) {
       if (!auth->return_identity_handle(iter->second.identity_handle_, se)) {
         if (DCPS::security_debug.auth_warn) {
           ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("DiscoveryBase::remove_discovered_participant() - ")
+                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
                      ACE_TEXT("Unable to return identity handle. ")
                      ACE_TEXT("Security Exception[%d.%d]: %C\n"),
                      se.code, se.minor_code, se.message.in()));
@@ -1839,7 +1840,7 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
       if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
         if (DCPS::security_debug.auth_warn) {
           ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("DiscoveryBase::remove_discovered_participant() - ")
+                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
                      ACE_TEXT("Unable to return handshake handle. ")
                      ACE_TEXT("Security Exception[%d.%d]: %C\n"),
                      se.code, se.minor_code, se.message.in()));
@@ -1851,18 +1852,26 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
       if (!auth->return_sharedsecret_handle(iter->second.shared_secret_handle_, se)) {
         if (DCPS::security_debug.auth_warn) {
           ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("Spdp::match_authenticated() - ")
+                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
                      ACE_TEXT("Unable to return sharedsecret handle. ")
                      ACE_TEXT("Security Exception[%d.%d]: %C\n"),
                      se.code, se.minor_code, se.message.in()));
         }
       }
     }
-  }
 
-  // TODO:  What other security related clean up needs to be performed? (is every register unregistered)
-  // TODO:  Is a local participant that is destroyed being cleaned up?
-  // TODO:  How should this be split between here and DiscoveryBase?
+    if (iter->second.permissions_handle_ != DDS::HANDLE_NIL) {
+      if (!access->return_permissions_handle(iter->second.permissions_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
+                     ACE_TEXT("Unable to return permissions handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+      }
+    }
+  }
 #endif
 }
 

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -1091,6 +1091,27 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   return true;
 }
 
+::CORBA::Boolean AccessControlBuiltInImpl::return_permissions_handle(
+    ::DDS::Security::PermissionsHandle handle,
+    ::DDS::Security::SecurityException& ex)
+{
+  if (DDS::HANDLE_NIL == handle) {
+    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::return_permissiosn_handle: Invalid permissions handle");
+    return false;
+  }
+
+  ACPermsMap::iterator ac_iter = local_ac_perms_.find(handle);
+
+  if (ac_iter == local_ac_perms_.end()) {
+    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::return_permissions_handle: No matching permissions handle present");
+    return false;
+  }
+
+  local_ac_perms_.erase(ac_iter);
+
+  return true;
+}
+
 ::CORBA::Boolean AccessControlBuiltInImpl::return_permissions_token(
   const ::DDS::Security::PermissionsToken & token,
   ::DDS::Security::SecurityException & ex)

--- a/dds/DCPS/security/AccessControlBuiltInImpl.h
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.h
@@ -183,6 +183,10 @@ public:
     DDS::Security::AccessControlListener_ptr listener,
     DDS::Security::SecurityException& ex);
 
+  virtual bool return_permissions_handle(
+    DDS::Security::PermissionsHandle handle,
+    DDS::Security::SecurityException& ex);
+
   virtual bool return_permissions_token(
     const DDS::Security::PermissionsToken& token,
     DDS::Security::SecurityException& ex);

--- a/dds/DdsSecurityCore.idl
+++ b/dds/DdsSecurityCore.idl
@@ -514,6 +514,12 @@ module DDS {
         in    AccessControlListener  listener,
         inout SecurityException      ex);
 
+      // This method is not in the spec but is necessary for cleanup.
+      boolean
+      return_permissions_handle(
+        in    PermissionsHandle  handle,
+        inout SecurityException  ex);
+
       boolean
       return_permissions_token(
         in    PermissionsToken   token,

--- a/dds/DdsSecurityCore.idl
+++ b/dds/DdsSecurityCore.idl
@@ -515,6 +515,7 @@ module DDS {
         inout SecurityException      ex);
 
       // This method is not in the spec but is necessary for cleanup.
+      // See DDSSEC12-89.
       boolean
       return_permissions_handle(
         in    PermissionsHandle  handle,


### PR DESCRIPTION
Problem
-------

The DDS Security Specification provides no way to return the handles
returned by validate_local_permissions and
validate_remote_permissions.  This creates a resource leak as local
and remote partipants are created and destroyed.

Solution
--------

Add a method return_permissions_handle to free the resources backing
the handle.