### PR TITLE
Publications and Subscriptions BITs don't work in RTPS rediscovery

### DIFF
--- a/dds/DCPS/BitPubListenerImpl.cpp
+++ b/dds/DCPS/BitPubListenerImpl.cpp
@@ -56,8 +56,7 @@ void BitPubListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
           Discovery_rch disc =
             TheServiceParticipant->get_discovery(partipant_->get_domain_id());
-          PublicationId pub_id =
-            disc->bit_key_to_repo_id(partipant_, BUILT_IN_PUBLICATION_TOPIC, data.key);
+          PublicationId pub_id = bit_key_to_repo_id(data.key);
           CORBA::Long const ownership_strength = data.ownership_strength.value;
           this->partipant_->update_ownership_strength(pub_id, ownership_strength);
           if (DCPS_debug_level > 4) {

--- a/dds/DCPS/BitPubListenerImpl.cpp
+++ b/dds/DCPS/BitPubListenerImpl.cpp
@@ -54,9 +54,7 @@ void BitPubListenerImpl::on_data_available(DDS::DataReader_ptr reader)
       if (status == DDS::RETCODE_OK) {
         if (si.valid_data) {
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
-          Discovery_rch disc =
-            TheServiceParticipant->get_discovery(partipant_->get_domain_id());
-          PublicationId pub_id = bit_key_to_repo_id(data.key);
+          const PublicationId pub_id = bit_key_to_repo_id(data.key);
           CORBA::Long const ownership_strength = data.ownership_strength.value;
           this->partipant_->update_ownership_strength(pub_id, ownership_strength);
           if (DCPS_debug_level > 4) {

--- a/dds/DCPS/BuiltInTopicUtils.h
+++ b/dds/DCPS/BuiltInTopicUtils.h
@@ -160,14 +160,7 @@ bool
 BuiltinTopicKeyLess::operator()(const DDS::BuiltinTopicKey_t& lhs,
                                 const DDS::BuiltinTopicKey_t& rhs) const
 {
-  // N.B.  This assumes that the MS index is 2 and the LS index is 0.
-  return (lhs.value[2] < rhs.value[2])? true:
-         (lhs.value[2] > rhs.value[2])? false:
-         (lhs.value[1] < rhs.value[1])? true:
-         (lhs.value[1] > rhs.value[1])? false:
-         (lhs.value[0] < rhs.value[0])? true:
-         false;
-
+  return std::memcmp(lhs.value, rhs.value, sizeof(lhs.value)) < 0;
 }
 
 #if !defined (DDS_HAS_MINIMUM_BIT)
@@ -211,12 +204,11 @@ keyFromSample<DDS::PublicationBuiltinTopicData>(
 #endif
 
 template<typename TopicType>
-inline
 DDS::BuiltinTopicKey_t keyFromSample(TopicType*)
 {
-  DDS::BuiltinTopicKey_t value;
-  value.value[0] = value.value[1] = value.value[2] = 0;
-  return value;
+  DDS::BuiltinTopicKey_t key;
+  std::memset(key.value, 0, sizeof(key.value));
+  return key;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1707,11 +1707,6 @@ DataReaderImpl::get_subscriber_servant()
   return subscriber_servant_.lock();
 }
 
-RepoId DataReaderImpl::get_subscription_id() const
-{
-  return subscription_id_;
-}
-
 bool DataReaderImpl::have_sample_states(
     DDS::SampleStateMask sample_states) const
 {
@@ -1897,7 +1892,7 @@ DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
 
   if (local_timer_id != -1 && cancel) {
     if (DCPS_debug_level >= 5) {
-      GuidConverter converter(data_reader->get_subscription_id());
+      GuidConverter converter(data_reader->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataReaderImpl::handle_timeout: ")
                  ACE_TEXT(" canceling timer for reader %C.\n"),
@@ -1961,7 +1956,7 @@ DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
   }
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter converter(data_reader->get_subscription_id());
+    GuidConverter converter(data_reader->get_repo_id());
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::handle_timeout: ")
         ACE_TEXT("reader %C has %d live writers; from_reactor=%d\n"),
@@ -2458,10 +2453,7 @@ DataReaderImpl::get_next_handle(const DDS::BuiltinTopicKey_t& key)
     return DDS::HANDLE_NIL;
 
   if (is_bit()) {
-    Discovery_rch disc = TheServiceParticipant->get_discovery(domain_id_);
-    CORBA::String_var topic = topic_servant_->get_name();
-
-    RepoId id = bit_key_to_repo_id(key);
+    const RepoId id = bit_key_to_repo_id(key);
     return participant->id_to_handle(id);
 
   } else {

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2461,7 +2461,7 @@ DataReaderImpl::get_next_handle(const DDS::BuiltinTopicKey_t& key)
     Discovery_rch disc = TheServiceParticipant->get_discovery(domain_id_);
     CORBA::String_var topic = topic_servant_->get_name();
 
-    RepoId id = disc->bit_key_to_repo_id(participant.in(), topic, key);
+    RepoId id = bit_key_to_repo_id(key);
     return participant->id_to_handle(id);
 
   } else {

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -367,8 +367,6 @@ public:
 
   virtual bool check_transport_qos(const TransportInst& inst);
 
-  RepoId get_subscription_id() const;
-
   bool have_sample_states(DDS::SampleStateMask sample_states) const;
   bool have_view_states(DDS::ViewStateMask view_states) const;
   bool have_instance_states(DDS::InstanceStateMask instance_states) const;
@@ -566,6 +564,8 @@ public:
 
   virtual ICE::Endpoint* get_ice_endpoint();
 
+  const RepoId& get_repo_id() const { return this->subscription_id_; }
+
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);
@@ -687,8 +687,6 @@ private:
   bool verify_coherent_changes_completion(WriterInfo* writer);
   bool coherent_change_received(WriterInfo* writer);
 #endif
-
-  const RepoId& get_repo_id() const { return this->subscription_id_; }
 
   DDS::Subscriber_var get_builtin_subscriber() const
   {

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1356,7 +1356,7 @@ DDS::ReturnCode_t read_instance_i(MessageSequenceType& received_data,
       msg += state_obj->instance_state_string();
       msg += " while the validity mask is " + InstanceState::instance_state_mask_string(instance_states);
     }
-    const GuidConverter conv(get_subscription_id());
+    const GuidConverter conv(get_repo_id());
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl_T::read_instance_i: ")
                ACE_TEXT("will return no data reading sub %C because:\n  %C\n"),
                OPENDDS_STRING(conv).c_str(), msg.c_str()));
@@ -1646,7 +1646,7 @@ void store_instance_data(
                     ACE_TEXT("(%P|%t) ")
                     ACE_TEXT("%CDataReaderImpl::")
                     ACE_TEXT("store_instance_data, ")
-                    ACE_TEXT("insert handle failed. \n"), TraitsType::type_name()));
+                    ACE_TEXT("insert handle failed, ret = %d.\n"), TraitsType::type_name(), ret));
         return;
       }
     }

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -228,7 +228,7 @@ DataWriterImpl::add_association(const RepoId& yourId,
   }
 
   if (DCPS_debug_level > 4) {
-    GuidConverter converter(get_publication_id());
+    GuidConverter converter(get_repo_id());
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::add_association(): ")
                ACE_TEXT("adding subscription to publication %C with priority %d.\n"),
@@ -2069,12 +2069,6 @@ void
 DataWriterImpl::unregister_all()
 {
   data_container_->unregister_all();
-}
-
-RepoId
-DataWriterImpl::get_publication_id()
-{
-  return publication_id_;
 }
 
 RepoId

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -280,11 +280,6 @@ public:
   }
 
   /**
-   * Accessor of the repository id of this datawriter/publication.
-   */
-  RepoId get_publication_id();
-
-  /**
    * Accessor of the repository id of the domain participant.
    */
   RepoId get_dp_id();
@@ -462,6 +457,10 @@ public:
 
  virtual ICE::Endpoint* get_ice_endpoint();
 
+ const RepoId& get_repo_id() const {
+    return this->publication_id_;
+  }
+
 protected:
 
   DDS::ReturnCode_t wait_for_specific_ack(const AckToken& token);
@@ -545,10 +544,6 @@ private:
   /// Lookup the instance handles by the subscription repo ids
   void lookup_instance_handles(const ReaderIdSeq& ids,
                                DDS::InstanceHandleSeq& hdls);
-
-  const RepoId& get_repo_id() const {
-    return this->publication_id_;
-  }
 
   DDS::Subscriber_var get_builtin_subscriber() const;
 

--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -71,10 +71,6 @@ public:
 
   virtual void fini_bit(DCPS::DomainParticipantImpl* participant) = 0;
 
-  virtual RepoId bit_key_to_repo_id(DomainParticipantImpl* participant,
-                                    const char* bit_topic_name,
-                                    const DDS::BuiltinTopicKey_t& key) const = 0;
-
   RepoKey key() const { return this->key_; }
 
   class OpenDDS_Dcps_Export Config

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -220,19 +220,6 @@ namespace OpenDDS {
 
       virtual ~EndpointManager() { }
 
-      RepoId bit_key_to_repo_id(const char* bit_topic_name,
-                                const DDS::BuiltinTopicKey_t& key)
-      {
-        ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, RepoId());
-        if (0 == std::strcmp(bit_topic_name, BUILT_IN_PUBLICATION_TOPIC)) {
-          return pub_key_to_id_[key];
-        }
-        if (0 == std::strcmp(bit_topic_name, BUILT_IN_SUBSCRIPTION_TOPIC)) {
-          return sub_key_to_id_[key];
-        }
-        return RepoId();
-      }
-
       void purge_dead_topic(const OPENDDS_STRING& topic_name) {
         typename OPENDDS_MAP(OPENDDS_STRING, TopicDetails)::iterator top_it = topics_.find(topic_name);
         topic_names_.erase(top_it->second.topic_id());
@@ -702,9 +689,6 @@ namespace OpenDDS {
         DDS::SubscriberQos subscriber_qos_;
         ContentFilterProperty_t filterProperties;
       };
-
-      typedef OPENDDS_MAP_CMP(DDS::BuiltinTopicKey_t, RepoId,
-                              BuiltinTopicKeyLess) BitKeyMap;
 
       typedef OPENDDS_MAP_CMP(RepoId, LocalPublication,
                               GUID_tKeyLessThan) LocalPublicationMap;
@@ -1265,13 +1249,11 @@ namespace OpenDDS {
 
       void remove_from_bit(const DiscoveredPublication& pub)
       {
-        pub_key_to_id_.erase(get_key(pub));
         remove_from_bit_i(pub);
       }
 
       void remove_from_bit(const DiscoveredSubscription& sub)
       {
-        sub_key_to_id_.erase(get_key(sub));
         remove_from_bit_i(sub);
       }
 
@@ -1295,23 +1277,6 @@ namespace OpenDDS {
         if (td == topics_.end()) return false;
 
         return td->second.has_dcps_key();
-      }
-
-      void
-      increment_key(DDS::BuiltinTopicKey_t& key)
-      {
-        for (int idx = 0; idx < 3; ++idx) {
-          CORBA::ULong ukey = static_cast<CORBA::ULong>(key.value[idx]);
-          if (ukey == 0xFFFFFFFF) {
-            key.value[idx] = 0;
-          } else {
-            ++ukey;
-            key.value[idx] = ukey;
-            return;
-          }
-        }
-        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) EndpointManager::increment_key - ")
-                   ACE_TEXT("ran out of builtin topic keys\n")));
       }
 
 #ifdef OPENDDS_SECURITY
@@ -1363,7 +1328,6 @@ namespace OpenDDS {
 
       ACE_Thread_Mutex& lock_;
       RepoId participant_id_;
-      BitKeyMap pub_key_to_id_, sub_key_to_id_;
       RepoIdSet ignored_guids_;
       unsigned int publication_counter_, subscription_counter_, topic_counter_;
       LocalPublicationMap local_publications_;
@@ -1374,7 +1338,6 @@ namespace OpenDDS {
       TopicNameMap topic_names_;
       OPENDDS_SET(OPENDDS_STRING) ignored_topics_;
       OPENDDS_SET_CMP(RepoId, GUID_tKeyLessThan) relay_only_readers_;
-      DDS::BuiltinTopicKey_t pub_bit_key_, sub_bit_key_;
 
 #ifdef OPENDDS_SECURITY
       DDS::Security::AccessControl_var access_control_;
@@ -1410,20 +1373,6 @@ namespace OpenDDS {
       { }
 
       virtual ~LocalParticipant() { }
-
-      RepoId bit_key_to_repo_id(const char* bit_topic_name,
-                                      const DDS::BuiltinTopicKey_t& key)
-      {
-        if (0 == std::strcmp(bit_topic_name, BUILT_IN_PARTICIPANT_TOPIC)) {
-          RepoId guid;
-          std::memcpy(guid.guidPrefix, key.value, sizeof(DDS::BuiltinTopicKeyValue));
-          guid.entityId = ENTITYID_PARTICIPANT;
-          return guid;
-
-        } else {
-          return endpoint_manager().bit_key_to_repo_id(bit_topic_name, key);
-        }
-      }
 
       void ignore_domain_participant(const RepoId& ignoreId)
       {
@@ -1917,14 +1866,6 @@ namespace OpenDDS {
       virtual void fini_bit(DomainParticipantImpl* participant)
       {
         get_part(participant->get_domain_id(), participant->get_id())->fini_bit();
-      }
-
-      virtual RepoId bit_key_to_repo_id(DomainParticipantImpl* participant,
-                                                       const char* bit_topic_name,
-                                                       const DDS::BuiltinTopicKey_t& key) const
-      {
-        return get_part(participant->get_domain_id(), participant->get_id())
-          ->bit_key_to_repo_id(bit_topic_name, key);
       }
 
       virtual bool attach_participant(DDS::DomainId_t /*domainId*/,

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1598,9 +1598,7 @@ namespace OpenDDS {
         , crypto_handle_(DDS::HANDLE_NIL)
 #endif
         {
-          RepoId guid;
-          std::memcpy(guid.guidPrefix, p.participantProxy.guidPrefix, sizeof(p.participantProxy.guidPrefix));
-          guid.entityId = DCPS::ENTITYID_PARTICIPANT;
+          const RepoId guid = make_guid(p.participantProxy.guidPrefix, DCPS::ENTITYID_PARTICIPANT);
           std::memcpy(location_data_.guid, &guid, sizeof(guid));
           location_data_.location = 0;
           location_data_.change_mask = 0;

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1806,7 +1806,7 @@ DomainParticipantImpl::enable()
 }
 
 RepoId
-DomainParticipantImpl::get_id()
+DomainParticipantImpl::get_id() const
 {
   return dp_id_;
 }

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -286,7 +286,7 @@ public:
   /**
    *  Return the id given by discovery.
    */
-  RepoId get_id();
+  RepoId get_id() const;
 
   /**
    * Return a unique string based on repo ID.

--- a/dds/DCPS/GuidUtils.h
+++ b/dds/DCPS/GuidUtils.h
@@ -183,6 +183,22 @@ OpenDDS_Dcps_Export inline GUID_t make_guid(
 OpenDDS_Dcps_Export
 void intersect(const RepoIdSet& a, const RepoIdSet& b, RepoIdSet& result);
 
+OpenDDS_Dcps_Export inline DDS::BuiltinTopicKey_t
+repo_id_to_bit_key(const RepoId& guid)
+{
+  DDS::BuiltinTopicKey_t key;
+  std::memcpy(key.value, &guid, sizeof(key.value));
+  return key;
+}
+
+OpenDDS_Dcps_Export inline RepoId
+bit_key_to_repo_id(const DDS::BuiltinTopicKey_t& key)
+{
+  RepoId id;
+  std::memcpy(&id, key.value, sizeof(id));
+  return id;
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -404,19 +404,6 @@ InfoRepoDiscovery::fini_bit(DCPS::DomainParticipantImpl* /* participant */)
   // nothing to do for DCPSInfoRepo
 }
 
-RepoId
-InfoRepoDiscovery::bit_key_to_repo_id(DomainParticipantImpl* /*participant*/,
-                                      const char* /*bit_topic_name*/,
-                                      const DDS::BuiltinTopicKey_t& key) const
-{
-  RepoId id = RepoIdBuilder::create();
-  RepoIdBuilder builder(id);
-  builder.federationId(key.value[0]);
-  builder.participantId(key.value[1]);
-  builder.entityId(key.value[2]);
-  return id;
-}
-
 bool
 InfoRepoDiscovery::active()
 {

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
@@ -74,10 +74,6 @@ public:
 
   virtual void fini_bit(DCPS::DomainParticipantImpl* participant);
 
-  virtual RepoId bit_key_to_repo_id(DomainParticipantImpl* participant,
-                                    const char* bit_topic_name,
-                                    const DDS::BuiltinTopicKey_t& key) const;
-
   virtual bool attach_participant(
     DDS::DomainId_t domainId,
     const OpenDDS::DCPS::RepoId& participantId);

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -180,7 +180,7 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
     DDS::Publisher_var dw_publisher(dw_servant->get_publisher());
 
     if (dw_publisher.in() != this) {
-      RepoId id = dw_servant->get_publication_id();
+      RepoId id = dw_servant->get_repo_id();
       GuidConverter converter(id);
       ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) PublisherImpl::delete_datawriter: ")
@@ -207,7 +207,7 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
         this->pi_lock_,
         DDS::RETCODE_ERROR);
 
-    publication_id = dw_servant->get_publication_id();
+    publication_id = dw_servant->get_repo_id();
 
     PublicationMap::iterator it = publication_map_.find(publication_id);
 
@@ -379,7 +379,7 @@ DDS::ReturnCode_t PublisherImpl::delete_contained_entities()
         break;
       } else {
         a_datawriter = datawriter_map_.begin()->second;
-        pub_id = a_datawriter->get_publication_id();
+        pub_id = a_datawriter->get_repo_id();
       }
     }
 
@@ -432,7 +432,7 @@ PublisherImpl::set_qos(const DDS::PublisherQos & qos)
             ++iter) {
           DDS::DataWriterQos qos;
           iter->second->get_qos(qos);
-          RepoId id = iter->second->get_publication_id();
+          RepoId id = iter->second->get_repo_id();
           std::pair<DwIdToQosMap::iterator, bool> pair =
               idToQosMap.insert(DwIdToQosMap::value_type(id, qos));
 
@@ -661,7 +661,7 @@ PublisherImpl::end_coherent_changes()
 
       std::pair<GroupCoherentSamples::iterator, bool> pair =
           group_samples.insert(GroupCoherentSamples::value_type(
-              it->second->get_publication_id(),
+              it->second->get_repo_id(),
               WriterCoherentSample(it->second->coherent_samples_,
                   it->second->sequence_number_)));
 
@@ -845,7 +845,7 @@ PublisherImpl::writer_enabled(const char*     topic_name,
 
   datawriter_map_.insert(DataWriterMap::value_type(topic_name, writer));
 
-  const RepoId publication_id = writer->get_publication_id();
+  const RepoId publication_id = writer->get_repo_id();
 
   std::pair<PublicationMap::iterator, bool> pair =
       publication_map_.insert(PublicationMap::value_type(publication_id, writer));

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -329,10 +329,7 @@ Sedp::Sedp(const RepoId& participant_id, Spdp& owner, ACE_Thread_Mutex& lock) :
   , publication_agent_info_listener_(*this)
   , subscription_agent_info_listener_(*this)
 #endif // OPENDDS_SECURITY
-{
-  pub_bit_key_.value[0] = pub_bit_key_.value[1] = pub_bit_key_.value[2] = 0;
-  sub_bit_key_.value[0] = sub_bit_key_.value[1] = sub_bit_key_.value[2] = 0;
-}
+{}
 
 DDS::ReturnCode_t
 Sedp::init(const RepoId& guid,
@@ -766,17 +763,15 @@ Sedp::multicast_group() const
 void
 Sedp::assign_bit_key(DiscoveredPublication& pub)
 {
-  increment_key(pub_bit_key_);
-  pub_key_to_id_[pub_bit_key_] = pub.writer_data_.writerProxy.remoteWriterGuid;
-  pub.writer_data_.ddsPublicationData.key = pub_bit_key_;
+  const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(pub.writer_data_.writerProxy.remoteWriterGuid);
+  pub.writer_data_.ddsPublicationData.key = key;
 }
 
 void
 Sedp::assign_bit_key(DiscoveredSubscription& sub)
 {
-  increment_key(sub_bit_key_);
-  sub_key_to_id_[sub_bit_key_] = sub.reader_data_.readerProxy.remoteReaderGuid;
-  sub.reader_data_.ddsSubscriptionData.key = sub_bit_key_;
+  const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(sub.reader_data_.readerProxy.remoteReaderGuid);
+  sub.reader_data_.ddsSubscriptionData.key = key;
 }
 
 void
@@ -2103,8 +2098,7 @@ void Sedp::process_discovered_writer_data(DCPS::MessageId message_id,
         // Upsert the remote topic.
         td.add_pub_sub(guid, wdata.ddsPublicationData.type_name.in());
 
-        std::memcpy(pub.writer_data_.ddsPublicationData.participant_key.value,
-                    guid.guidPrefix, sizeof(DDS::BuiltinTopicKey_t));
+        pub.writer_data_.ddsPublicationData.participant_key = repo_id_to_bit_key(guid);
         assign_bit_key(pub);
         wdata_copy = pub.writer_data_;
       }
@@ -2434,8 +2428,7 @@ void Sedp::process_discovered_reader_data(DCPS::MessageId message_id,
         // Upsert the remote topic.
         td.add_pub_sub(guid, rdata.ddsSubscriptionData.type_name.in());
 
-        std::memcpy(sub.reader_data_.ddsSubscriptionData.participant_key.value,
-                    guid.guidPrefix, sizeof(DDS::BuiltinTopicKey_t));
+        sub.reader_data_.ddsSubscriptionData.participant_key = repo_id_to_bit_key(guid);
         assign_bit_key(sub);
         rdata_copy = sub.reader_data_;
       }

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -765,6 +765,7 @@ Sedp::assign_bit_key(DiscoveredPublication& pub)
 {
   const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(pub.writer_data_.writerProxy.remoteWriterGuid);
   pub.writer_data_.ddsPublicationData.key = key;
+  pub.writer_data_.ddsPublicationData.participant_key = repo_id_to_bit_key(make_id(pub.writer_data_.writerProxy.remoteWriterGuid, ENTITYID_PARTICIPANT));
 }
 
 void
@@ -772,6 +773,7 @@ Sedp::assign_bit_key(DiscoveredSubscription& sub)
 {
   const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(sub.reader_data_.readerProxy.remoteReaderGuid);
   sub.reader_data_.ddsSubscriptionData.key = key;
+  sub.reader_data_.ddsSubscriptionData.participant_key = repo_id_to_bit_key(make_id(sub.reader_data_.readerProxy.remoteReaderGuid, ENTITYID_PARTICIPANT));
 }
 
 void
@@ -2098,7 +2100,6 @@ void Sedp::process_discovered_writer_data(DCPS::MessageId message_id,
         // Upsert the remote topic.
         td.add_pub_sub(guid, wdata.ddsPublicationData.type_name.in());
 
-        pub.writer_data_.ddsPublicationData.participant_key = repo_id_to_bit_key(guid);
         assign_bit_key(pub);
         wdata_copy = pub.writer_data_;
       }
@@ -2428,7 +2429,6 @@ void Sedp::process_discovered_reader_data(DCPS::MessageId message_id,
         // Upsert the remote topic.
         td.add_pub_sub(guid, rdata.ddsSubscriptionData.type_name.in());
 
-        sub.reader_data_.ddsSubscriptionData.participant_key = repo_id_to_bit_key(guid);
         assign_bit_key(sub);
         rdata_copy = sub.reader_data_;
       }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -569,10 +569,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       return;
     }
 
-    // copy guid prefix (octet[12]) into BIT key (long[3])
-    std::memcpy(partBitData(pdata).key.value,
-      pdata.participantProxy.guidPrefix,
-      sizeof(DDS::BuiltinTopicKey_t));
+    partBitData(pdata).key = repo_id_to_bit_key(guid);
 
     if (DCPS::DCPS_debug_level) {
       DCPS::GuidConverter local(guid_), remote(guid);

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -78,10 +78,7 @@ StaticEndpointManager::StaticEndpointManager(const RepoId& participant_id,
   : EndpointManager<StaticDiscoveredParticipantData>(participant_id, lock)
   , registry_(registry)
   , participant_(participant)
-{
-  pub_bit_key_.value[0] = pub_bit_key_.value[1] = pub_bit_key_.value[2] = 0;
-  sub_bit_key_.value[0] = sub_bit_key_.value[1] = sub_bit_key_.value[2] = 0;
-}
+{}
 
 void StaticEndpointManager::init_bit()
 {
@@ -95,14 +92,13 @@ void StaticEndpointManager::init_bit()
     const EndpointRegistry::Writer& writer = pos->second;
 
     if (!GuidPrefixEqual()(participant_id_.guidPrefix, remoteid.guidPrefix)) {
-      increment_key(pub_bit_key_);
-      pub_key_to_id_[pub_bit_key_] = remoteid;
+      const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(remoteid);
 
       // pos represents a remote.
       // Populate data.
       DDS::PublicationBuiltinTopicData data;
 
-      data.key = pub_bit_key_;
+      data.key = key;
       OPENDDS_STRING topic_name = writer.topic_name;
       data.topic_name = topic_name.c_str();
       const EndpointRegistry::Topic& topic = registry_.topic_map.find(topic_name)->second;
@@ -140,14 +136,13 @@ void StaticEndpointManager::init_bit()
     const EndpointRegistry::Reader& reader = pos->second;
 
     if (!GuidPrefixEqual()(participant_id_.guidPrefix, remoteid.guidPrefix)) {
-      increment_key(sub_bit_key_);
-      sub_key_to_id_[sub_bit_key_] = remoteid;
+      const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(remoteid);
 
       // pos represents a remote.
       // Populate data.
       DDS::SubscriptionBuiltinTopicData data;
 
-      data.key = sub_bit_key_;
+      data.key = key;
       OPENDDS_STRING topic_name = reader.topic_name;
       data.topic_name = topic_name.c_str();
       const EndpointRegistry::Topic& topic = registry_.topic_map.find(topic_name)->second;

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -268,7 +268,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
     }
     if (rc != DDS::RETCODE_OK) {
       if (DCPS_debug_level) {
-        GuidConverter converter(dr_servant->get_subscription_id());
+        GuidConverter converter(dr_servant->get_repo_id());
         ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) SubscriberImpl::delete_datareader(%C): ")
           ACE_TEXT("will return \"%C\" because datareader %s\n"),
           OPENDDS_STRING(converter).c_str(), retcode_to_string(rc),
@@ -328,7 +328,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
                           ACE_TEXT("for unknown repo id not found.\n"),
                           topic_name.in()), ::DDS::RETCODE_ERROR);
       }
-      RepoId id = dr_servant->get_subscription_id();
+      RepoId id = dr_servant->get_repo_id();
       GuidConverter converter(id);
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: ")
@@ -355,7 +355,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
                       ::DDS::RETCODE_ERROR);
   }
 
-  RepoId subscription_id = dr_servant->get_subscription_id();
+  RepoId subscription_id = dr_servant->get_repo_id();
   Discovery_rch disco = TheServiceParticipant->get_discovery(this->domain_id_);
   if (!disco->remove_subscription(this->domain_id_,
                                   this->dp_id_,
@@ -615,7 +615,7 @@ SubscriberImpl::set_qos(
           reader->set_subscriber_qos (qos);
           DDS::DataReaderQos qos;
           reader->get_qos(qos);
-          RepoId id = reader->get_subscription_id();
+          RepoId id = reader->get_repo_id();
           std::pair<DrIdToQosMap::iterator, bool> pair
             = idToQosMap.insert(DrIdToQosMap::value_type(id, qos));
 
@@ -944,7 +944,7 @@ SubscriberImpl::get_subscription_ids(SubscriptionIdVec& subs)
   for (DataReaderMap::iterator iter = datareader_map_.begin();
        iter != datareader_map_.end();
        ++iter) {
-    subs.push_back(iter->second->get_subscription_id());
+    subs.push_back(iter->second->get_repo_id());
   }
 }
 

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -14,7 +14,6 @@
 #include "tao/LongSeq.pidl"
 
 #define HANDLE_TYPE_NATIVE long
-#define BUILTIN_TOPIC_KEY_TYPE_NATIVE long
 
 #if defined __OPENDDS_IDL && !defined DDS_HAS_MINIMUM_BIT
 #  define BUILT_IN_TOPIC_TYPE @topic
@@ -31,7 +30,6 @@ module DDS {
 
     typedef sequence<string> StringSeq;
     typedef HANDLE_TYPE_NATIVE InstanceHandle_t;
-    typedef BUILTIN_TOPIC_KEY_TYPE_NATIVE BuiltinTopicKeyValue[3];
 
     typedef sequence<InstanceHandle_t> InstanceHandleSeq;
 
@@ -294,8 +292,9 @@ module DDS {
                 PropertyQosPolicy property; // DDS-Security 1.1 ptc/2017-09-26
                 };
 
+    typedef octet OctetArray16[16];
     struct BuiltinTopicKey_t {
-                BUILT_IN_TOPIC_KEY BuiltinTopicKeyValue value;
+                OctetArray16 value;
                 };
 
     // ----------------------------------------------------------------------
@@ -438,8 +437,6 @@ module OpenDDS {
     // network location/connection details.
     typedef unsigned long ParticipantLocation;
 
-    typedef octet OctetGuidArray16[16];
-
     const ParticipantLocation LOCATION_LOCAL = 0x0001 << 0;
     const ParticipantLocation LOCATION_ICE = 0x0001 << 1;
     const ParticipantLocation LOCATION_RELAY = 0x0001 << 2;
@@ -449,7 +446,7 @@ module OpenDDS {
 
     BUILT_IN_TOPIC_TYPE
     struct ParticipantLocationBuiltinTopicData {
-            BUILT_IN_TOPIC_KEY OctetGuidArray16 guid;
+            BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
             ParticipantLocation location;
             ParticipantLocation change_mask;
             string local_addr;
@@ -470,7 +467,7 @@ module OpenDDS {
 
     BUILT_IN_TOPIC_TYPE
     struct ConnectionRecord {
-            BUILT_IN_TOPIC_KEY OctetGuidArray16 guid;
+            BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
             BUILT_IN_TOPIC_KEY string address;
             BUILT_IN_TOPIC_KEY string protocol;
     };

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -993,19 +993,6 @@ DCPS_IR_Domain::last_participant_key(long key)
   this->participantIdGenerator_.last(key);
 }
 
-#if !defined (DDS_HAS_MINIMUM_BIT)
-namespace {
-  void get_BuiltinTopicKey(DDS::BuiltinTopicKey_t& key,
-                           const OpenDDS::DCPS::RepoId& id)
-  {
-    OpenDDS::DCPS::RepoIdConverter c(id);
-    key.value[0] = c.federationId();
-    key.value[1] = c.participantId();
-    key.value[2] = c.entityId();
-  }
-}
-#endif // !defined (DDS_HAS_MINIMUM_BIT)
-
 void DCPS_IR_Domain::publish_participant_bit(DCPS_IR_Participant* participant)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
@@ -1015,7 +1002,7 @@ void DCPS_IR_Domain::publish_participant_bit(DCPS_IR_Participant* participant)
       const DDS::DomainParticipantQos* participantQos = participant->get_qos();
 
       DDS::ParticipantBuiltinTopicData data;
-      get_BuiltinTopicKey(data.key, participant->get_id());
+      data.key = repo_id_to_bit_key(participant->get_id());
       data.user_data = participantQos->user_data;
 
       DDS::InstanceHandle_t handle
@@ -1025,8 +1012,8 @@ void DCPS_IR_Domain::publish_participant_bit(DCPS_IR_Participant* participant)
 
       if (OpenDDS::DCPS::DCPS_debug_level > 0) {
         ACE_DEBUG((LM_DEBUG,
-                   "(%P|%t) DCPS_IR_Domain::publish_participant_bit: [ %d, 0x%x, 0x%x], handle %d.\n",
-                   data.key.value[0], data.key.value[1], data.key.value[2], handle));
+                   "(%P|%t) DCPS_IR_Domain::publish_participant_bit: %C, handle %d.\n",
+                   OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
       }
 
       bitParticipantDataWriter_->write(data, handle);
@@ -1057,7 +1044,7 @@ void DCPS_IR_Domain::publish_topic_bit(DCPS_IR_Topic* topic)
         const DDS::TopicQos* topicQos = topic->get_topic_qos();
 
         DDS::TopicBuiltinTopicData data;
-        get_BuiltinTopicKey(data.key, topic->get_id());
+        data.key = repo_id_to_bit_key(topic->get_id());
         data.name = name;
         data.type_name = type;
         data.durability = topicQos->durability;
@@ -1081,8 +1068,8 @@ void DCPS_IR_Domain::publish_topic_bit(DCPS_IR_Topic* topic)
 
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
-                     "(%P|%t) DCPS_IR_Domain::publish_topic_bit: [ %d, 0x%x, 0x%x], handle %d.\n",
-                     data.key.value[0], data.key.value[1], data.key.value[2], handle));
+                     "(%P|%t) DCPS_IR_Domain::publish_topic_bit: %C, handle %d.\n",
+                     OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
         }
 
         bitTopicDataWriter_->write(data, handle);
@@ -1122,9 +1109,8 @@ void DCPS_IR_Domain::publish_subscription_bit(DCPS_IR_Subscription* subscription
         const DDS::TopicQos* topicQos = topic->get_topic_qos();
 
         DDS::SubscriptionBuiltinTopicData data;
-        get_BuiltinTopicKey(data.key, subscription->get_id());
-        get_BuiltinTopicKey(data.participant_key,
-                            subscription->get_participant_id());
+        data.key = repo_id_to_bit_key(subscription->get_id());
+        data.participant_key = repo_id_to_bit_key(subscription->get_participant_id());
         data.topic_name = name;
         data.type_name = type;
         data.durability = readerQos->durability;
@@ -1148,8 +1134,8 @@ void DCPS_IR_Domain::publish_subscription_bit(DCPS_IR_Subscription* subscription
 
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
-                     "(%P|%t) DCPS_IR_Domain::publish_subscription_bit: [ %d, 0x%x, 0x%x], handle %d.\n",
-                     data.key.value[0], data.key.value[1], data.key.value[2], handle));
+                     "(%P|%t) DCPS_IR_Domain::publish_subscription_bit: %C, handle %d.\n",
+                     OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
         }
 
         bitSubscriptionDataWriter_->write(data,
@@ -1197,9 +1183,8 @@ void DCPS_IR_Domain::publish_publication_bit(DCPS_IR_Publication* publication)
         const DDS::TopicQos* topicQos = topic->get_topic_qos();
 
         DDS::PublicationBuiltinTopicData data;
-        get_BuiltinTopicKey(data.key, publication->get_id());
-        get_BuiltinTopicKey(data.participant_key,
-                            publication->get_participant_id());
+        data.key = repo_id_to_bit_key(publication->get_id());
+        data.participant_key = repo_id_to_bit_key(publication->get_participant_id());
         data.topic_name = desc->get_name();
         data.type_name = desc->get_dataTypeName();
         data.durability = writerQos->durability;
@@ -1225,8 +1210,8 @@ void DCPS_IR_Domain::publish_publication_bit(DCPS_IR_Publication* publication)
 
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
-                     "(%P|%t) DCPS_IR_Domain::publish_publication_bit: [ %d, 0x%x, 0x%x], handle %d.\n",
-                     data.key.value[0], data.key.value[1], data.key.value[2], handle));
+                     "(%P|%t) DCPS_IR_Domain::publish_publication_bit: %C, handle %d.\n",
+                     OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
         }
 
         DDS::ReturnCode_t status = bitPublicationDataWriter_->write(data, handle);

--- a/dds/InfoRepo/FederatorManagerImpl.cpp
+++ b/dds/InfoRepo/FederatorManagerImpl.cpp
@@ -338,7 +338,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed OwnerUpdate writer.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_publication_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation OwnerUpdate writer %C for repository %d\n"),
@@ -371,7 +371,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed OwnerUpdate reader.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_subscription_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation OwnerUpdate reader %C for repository %d\n"),
@@ -419,7 +419,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed TopicUpdate writer.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_publication_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation TopicUpdate writer %C for repository %d\n"),
@@ -452,7 +452,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed TopicUpdate reader.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_subscription_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation TopicUpdate reader %C for repository %d\n"),
@@ -500,7 +500,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed ParticipantUpdate writer.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_publication_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation ParticipantUpdate writer %C for repository %d\n"),
@@ -533,7 +533,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed ParticipantUpdate reader.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_subscription_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation ParticipantUpdate reader %C for repository %d\n"),
@@ -581,7 +581,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed PublicationUpdate writer.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_publication_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation PublicationUpdate writer %C for repository %d\n"),
@@ -614,7 +614,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed PublicationUpdate reader.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_subscription_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation PublicationUpdate reader %C for repository %d\n"),
@@ -662,7 +662,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed SubscriptionUpdate writer.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_publication_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation SubscriptionUpdate writer %C for repository %d\n"),
@@ -695,7 +695,7 @@ ManagerImpl::initialize()
                  ACE_TEXT("unable to extract typed SubscriptionUpdate reader.\n")));
 
     } else {
-      OpenDDS::DCPS::RepoIdConverter converter(servant->get_subscription_id());
+      OpenDDS::DCPS::RepoIdConverter converter(servant->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Federator::ManagerImpl::initialize() - ")
                  ACE_TEXT("created federation SubscriptionUpdate reader %C for repository %d\n"),

--- a/dds/monitor/DRMonitorImpl.cpp
+++ b/dds/monitor/DRMonitorImpl.cpp
@@ -35,7 +35,7 @@ DRMonitorImpl::report() {
     report.dp_id = this->dr_->get_dp_id();
     DDS::Subscriber_var sub = this->dr_->get_subscriber();
     report.sub_handle = sub->get_instance_handle();
-    report.dr_id   = this->dr_->get_subscription_id();
+    report.dr_id   = this->dr_->get_repo_id();
     report.topic_id = this->dr_->get_topic_id();
     DataReaderImpl::InstanceHandleVec instances;
     this->dr_->get_instance_handles(instances);

--- a/dds/monitor/DRPeriodicMonitorImpl.cpp
+++ b/dds/monitor/DRPeriodicMonitorImpl.cpp
@@ -32,7 +32,7 @@ void
 DRPeriodicMonitorImpl::report() {
   if (!CORBA::is_nil(this->dr_per_writer_.in())) {
     DataReaderPeriodicReport report;
-    report.dr_id   = dr_->get_subscription_id();
+    report.dr_id   = dr_->get_repo_id();
     //report.associations = dr_->
     this->dr_per_writer_->write(report, DDS::HANDLE_NIL);
   }

--- a/dds/monitor/DWMonitorImpl.cpp
+++ b/dds/monitor/DWMonitorImpl.cpp
@@ -34,7 +34,7 @@ DWMonitorImpl::report() {
     report.dp_id = this->dw_->get_dp_id();
     DDS::Publisher_var pub = this->dw_->get_publisher();
     report.pub_handle = pub->get_instance_handle();
-    report.dw_id   = this->dw_->get_publication_id();
+    report.dw_id   = this->dw_->get_repo_id();
     DDS::Topic_var topic = this->dw_->get_topic();
     OpenDDS::DCPS::TopicImpl* ti = dynamic_cast<TopicImpl*>(topic.in());
     if (!ti) {

--- a/dds/monitor/DWPeriodicMonitorImpl.cpp
+++ b/dds/monitor/DWPeriodicMonitorImpl.cpp
@@ -31,7 +31,7 @@ void
 DWPeriodicMonitorImpl::report() {
   if (!CORBA::is_nil(this->dw_per_writer_.in())) {
     DataWriterPeriodicReport report;
-    report.dw_id   = dw_->get_publication_id();
+    report.dw_id   = dw_->get_repo_id();
     //report.data_dropped_count = dw_->
     //report.data_delivered_count  = dw_->
     //report.control_dropped_count  = dw_->

--- a/examples/DCPS/DistributedContent/AbstractionLayer.cpp
+++ b/examples/DCPS/DistributedContent/AbstractionLayer.cpp
@@ -117,7 +117,7 @@ AbstractionLayer::init_DDS(int& argc, ACE_TCHAR *argv[])
   }
 
   // Get the repo id for the subscription
-  ::OpenDDS::DCPS::RepoId ignore_id = dr_servant->get_subscription_id ();
+  ::OpenDDS::DCPS::RepoId ignore_id = dr_servant->get_repo_id ();
   // Get the instance handle for the subscription
   ::DDS::InstanceHandle_t handle = dp_servant->id_to_handle(ignore_id);
 

--- a/java/dds/DDS/.gitignore
+++ b/java/dds/DDS/.gitignore
@@ -255,6 +255,8 @@
 /NOT_READ_SAMPLE_STATE.java
 /OctetSeqHelper.java
 /OctetSeqHolder.java
+/OctetArray16Helper.java
+/OctetArray16Holder.java
 /OFFERED_DEADLINE_MISSED_STATUS.java
 /OFFERED_INCOMPATIBLE_QOS_STATUS.java
 /OfferedDeadlineMissedStatus.java

--- a/performance-tests/Bench/src/Publication.cpp
+++ b/performance-tests/Bench/src/Publication.cpp
@@ -408,7 +408,7 @@ Publication::svc ()
   OpenDDS::DCPS::DataWriterImpl* servant
     = dynamic_cast< OpenDDS::DCPS::DataWriterImpl*>( this->writer_.in());
 
-  OpenDDS::DCPS::GuidConverter converter(servant->get_publication_id());
+  OpenDDS::DCPS::GuidConverter converter(servant->get_repo_id());
   int pid = converter.checksum();
 
   ACE_Time_Value startTime = ACE_High_Res_Timer::gettimeofday_hr();

--- a/tests/DCPS/BuiltInTopic/common.cpp
+++ b/tests/DCPS/BuiltInTopic/common.cpp
@@ -122,7 +122,7 @@ int ignore ()
   case IGNORE_PUBLICATION:
     {
       ::OpenDDS::DCPS::RepoId part_id = participant_servant->get_id ();
-      ::OpenDDS::DCPS::RepoId ignore_id = datawriter_servant->get_publication_id ();
+      ::OpenDDS::DCPS::RepoId ignore_id = datawriter_servant->get_repo_id();
 
       std::stringstream participantBuffer;
       participantBuffer << ::OpenDDS::DCPS::to_string(part_id);
@@ -156,7 +156,7 @@ int ignore ()
   case IGNORE_SUBSCRIPTION:
     {
       ::OpenDDS::DCPS::RepoId part_id = participant_servant->get_id ();
-      ::OpenDDS::DCPS::RepoId ignore_id = datareader_servant->get_subscription_id ();
+      ::OpenDDS::DCPS::RepoId ignore_id = datareader_servant->get_repo_id ();
 
       std::stringstream participantBuffer;
       participantBuffer << ::OpenDDS::DCPS::to_string(part_id);

--- a/tests/DCPS/BuiltInTopic/main.cpp
+++ b/tests/DCPS/BuiltInTopic/main.cpp
@@ -211,13 +211,7 @@ void test_bit_participant ()
 
       // BuiltinTopicKey_t is initialized from its corresponding RepoId.
       // This test verifies that the conversion was done correctly.
-
-      //NOTE: this is only valid for InfoRepo-based Discovery
-
-      OpenDDS::DCPS::RepoIdConverter converter(participant_servant->get_id());
-      TEST_CHECK(part_data[0].key.value[0] == converter.federationId());
-      TEST_CHECK(part_data[0].key.value[1] == converter.participantId());
-      TEST_CHECK(part_data[0].key.value[2] == converter.entityId());
+      TEST_CHECK(OpenDDS::DCPS::bit_key_to_repo_id(part_data[0].key) == participant_servant->get_id());
     }
   catch (...)
     {
@@ -260,13 +254,7 @@ void test_bit_topic ()
 
       // BuiltinTopicKey_t is initialized from its corresponding RepoId.
       // This test verifies that the conversion was done correctly.
-
-      //NOTE: this is only valid for InfoRepo-based Discovery
-      OpenDDS::DCPS::RepoIdConverter converter(topic_servant->get_id());
-
-      TEST_CHECK(topic_data[0].key.value[0] == converter.federationId());
-      TEST_CHECK(topic_data[0].key.value[1] == converter.participantId());
-      TEST_CHECK(topic_data[0].key.value[2] == converter.entityId());
+      TEST_CHECK(OpenDDS::DCPS::bit_key_to_repo_id(topic_data[0].key) == topic_servant->get_id());
 
       topic_servant->get_qos (topic_qos);
 
@@ -330,21 +318,11 @@ void test_bit_publication ()
 
       // BuiltinTopicKey_t is initialized from its corresponding RepoId.
       // This test verifies that the conversion was done correctly.
-      OpenDDS::DCPS::RepoIdConverter pub_converter(datawriter_servant->get_publication_id());
-      //NOTE: this is only valid for InfoRepo-based Discovery
-
-      TEST_CHECK(the_pub_data.key.value[0] == pub_converter.federationId());
-      TEST_CHECK(the_pub_data.key.value[1] == pub_converter.participantId());
-      TEST_CHECK(the_pub_data.key.value[2] == pub_converter.entityId());
+      TEST_CHECK(OpenDDS::DCPS::bit_key_to_repo_id(the_pub_data.key) == datawriter_servant->get_repo_id());
 
       // BuiltinTopicKey_t is initialized from its corresponding RepoId.
       // This test verifies that the conversion was done correctly.
-      OpenDDS::DCPS::RepoIdConverter part_converter(participant_servant->get_id());
-      //NOTE: this is only valid for InfoRepo-based Discovery
-
-      TEST_CHECK(the_pub_data.participant_key.value[0] == part_converter.federationId());
-      TEST_CHECK(the_pub_data.participant_key.value[1] == part_converter.participantId());
-      TEST_CHECK(the_pub_data.participant_key.value[2] == part_converter.entityId());
+      TEST_CHECK(OpenDDS::DCPS::bit_key_to_repo_id(the_pub_data.participant_key) == participant_servant->get_id());
 
       TEST_CHECK (ACE_OS::strcmp (the_pub_data.topic_name.in (), TEST_TOPIC) == 0);
       TEST_CHECK (ACE_OS::strcmp (the_pub_data.type_name.in (), TEST_TOPIC_TYPE) == 0);
@@ -409,21 +387,11 @@ void test_bit_subscription ()
 
       // BuiltinTopicKey_t is initialized from its corresponding RepoId.
       // This test verifies that the conversion was done correctly.
-      OpenDDS::DCPS::RepoIdConverter sub_converter(datareader_servant->get_subscription_id());
-      //NOTE: this is only valid for InfoRepo-based Discovery
-
-      TEST_CHECK(the_sub_data.key.value[0] == sub_converter.federationId());
-      TEST_CHECK(the_sub_data.key.value[1] == sub_converter.participantId());
-      TEST_CHECK(the_sub_data.key.value[2] == sub_converter.entityId());
+      TEST_CHECK(OpenDDS::DCPS::bit_key_to_repo_id(the_sub_data.key) == datareader_servant->get_repo_id());
 
       // BuiltinTopicKey_t is initialized from its corresponding RepoId.
       // This test verifies that the conversion was done correctly.
-      OpenDDS::DCPS::RepoIdConverter part_converter(participant_servant->get_id());
-      //NOTE: this is only valid for InfoRepo-based Discovery
-
-      TEST_CHECK(the_sub_data.participant_key.value[0] == part_converter.federationId());
-      TEST_CHECK(the_sub_data.participant_key.value[1] == part_converter.participantId());
-      TEST_CHECK(the_sub_data.participant_key.value[2] == part_converter.entityId());
+      TEST_CHECK(OpenDDS::DCPS::bit_key_to_repo_id(the_sub_data.participant_key) == participant_servant->get_id());
 
       TEST_CHECK (ACE_OS::strcmp (the_sub_data.topic_name.in (), TEST_TOPIC) == 0);
       TEST_CHECK (ACE_OS::strcmp (the_sub_data.type_name.in (), TEST_TOPIC_TYPE) == 0);

--- a/tests/DCPS/BuiltInTopicTest/monitor.cpp
+++ b/tests/DCPS/BuiltInTopicTest/monitor.cpp
@@ -248,10 +248,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           ::DDS::ParticipantBuiltinTopicData data;
           participant->get_discovered_participant_data(data, handles[i]);
 
-          OpenDDS::DCPS::RepoId id =
-            disc->bit_key_to_repo_id(part_svt,
-                                     OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC,
-                                     data.key);
+          OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
           if (part_svt->id_to_handle (id) != handles[i])
           {
@@ -360,10 +357,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           OpenDDS::DCPS::Discovery_rch disc =
             TheServiceParticipant->get_discovery(participant->get_domain_id());
-          OpenDDS::DCPS::RepoId id =
-            disc->bit_key_to_repo_id(part_svt,
-                                     OpenDDS::DCPS::BUILT_IN_TOPIC_TOPIC,
-                                     data.key);
+          OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
           if (part_svt->id_to_handle (id) != handles[i])
           {

--- a/tests/DCPS/FooTest3_0/PubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/PubDriver.cpp
@@ -362,7 +362,7 @@ PubDriver::end()
 void
 PubDriver::run()
 {
-  OpenDDS::DCPS::PublicationId pub_id = datawriter_servant_->get_publication_id ();
+  OpenDDS::DCPS::PublicationId pub_id = datawriter_servant_->get_repo_id ();
   std::stringstream buffer;
 
   buffer << to_string(pub_id);

--- a/tests/DCPS/Observer/TestObserver.cpp
+++ b/tests/DCPS/Observer/TestObserver.cpp
@@ -50,7 +50,7 @@ std::string TestObserver::to_str(DDS::DataWriter_ptr w)
   o << " writer ";
   OpenDDS::DCPS::DataWriterImpl* p = dynamic_cast<OpenDDS::DCPS::DataWriterImpl*>(w);
   if (p) {
-    o << to_str(p->get_publication_id());
+    o << to_str(p->get_repo_id());
   }
   return o.str();
 }
@@ -61,7 +61,7 @@ std::string TestObserver::to_str(DDS::DataReader_ptr r)
   o << " reader ";
   OpenDDS::DCPS::DataReaderImpl* p = dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(r);
   if (p) {
-    o << to_str(p->get_subscription_id());
+    o << to_str(p->get_repo_id());
   }
   return o.str();
 }

--- a/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
+++ b/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
@@ -165,10 +165,7 @@ bool read_participant_bit(const Subscriber_var& bit_sub,
   for (CORBA::ULong i = 0; i < data.length(); ++i) {
     if (infos[i].valid_data) {
       ++num_valid;
-      OpenDDS::DCPS::RepoId repo_id =
-        disc->bit_key_to_repo_id(dp_impl,
-                                 OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC,
-                                 data[i].key);
+      OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].key);
 
       OpenDDS::DCPS::GuidConverter converter(repo_id);
       ACE_DEBUG((LM_DEBUG,
@@ -412,10 +409,7 @@ bool read_publication_bit(const Subscriber_var& bit_sub,
     if (infos[i].valid_data) {
       ++num_valid;
 
-      OpenDDS::DCPS::RepoId repo_id =
-        disc->bit_key_to_repo_id(subscriber_impl,
-                                 OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC,
-                                 data[i].participant_key);
+      OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].participant_key);
 
       OpenDDS::DCPS::GuidConverter converter(repo_id);
 
@@ -542,10 +536,7 @@ bool read_subscription_bit(const Subscriber_var& bit_sub,
     if (infos[i].valid_data) {
       ++num_valid;
 
-      OpenDDS::DCPS::RepoId repo_id =
-        disc->bit_key_to_repo_id(publisher_impl,
-                                 OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC,
-                                 data[i].participant_key);
+      OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].participant_key);
 
       OpenDDS::DCPS::GuidConverter converter(repo_id);
 
@@ -652,10 +643,7 @@ bool check_discovered_participants(DomainParticipant_var& dp,
           false);
       }
 
-      OpenDDS::DCPS::RepoId repo_id = disc->bit_key_to_repo_id(
-          dp_impl,
-          OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC,
-          data.key);
+      OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
       if (dp_impl->id_to_handle(repo_id) != part_handles[0]) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("ERROR: %P discovered participant ")
                                     ACE_TEXT("BIT key could not be converted ")

--- a/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
+++ b/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
@@ -409,15 +409,16 @@ bool read_publication_bit(const Subscriber_var& bit_sub,
     if (infos[i].valid_data) {
       ++num_valid;
 
+      OpenDDS::DCPS::RepoId publication_repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].key);
       OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].participant_key);
 
       OpenDDS::DCPS::GuidConverter converter(repo_id);
 
       ACE_DEBUG((LM_DEBUG,
-                 "%P Read Publication BIT with key: %x %x %x and handle %d\n"
+                 "%P Read Publication BIT with key: %C and handle %d\n"
                  "\tParticipant's GUID=%C\n\tTopic: %C\tType: %C\n",
-                 data[i].key.value[0], data[i].key.value[1],
-                 data[i].key.value[2], infos[i].instance_handle,
+                 OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(publication_repo_id)).c_str(),
+                 infos[i].instance_handle,
                  OPENDDS_STRING(converter).c_str (), data[i].topic_name.in(),
                  data[i].type_name.in()));
 
@@ -536,15 +537,16 @@ bool read_subscription_bit(const Subscriber_var& bit_sub,
     if (infos[i].valid_data) {
       ++num_valid;
 
+      OpenDDS::DCPS::RepoId subscription_repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].key);
       OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].participant_key);
 
       OpenDDS::DCPS::GuidConverter converter(repo_id);
 
       ACE_DEBUG((LM_DEBUG,
-                 "%P Read Subscription BIT with key: %x %x %x and handle %d\n"
+                 "%P Read Subscription BIT with key: %C and handle %d\n"
                  "\tParticipant's GUID=%C\n\tTopic: %C\tType: %C\n",
-                 data[i].key.value[0], data[i].key.value[1],
-                 data[i].key.value[2], infos[i].instance_handle,
+                 OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(subscription_repo_id)).c_str(),
+                 infos[i].instance_handle,
                  OPENDDS_STRING(converter).c_str (), data[i].topic_name.in(),
                  data[i].type_name.in()));
       if (repo_id == subscriber_repo_id) {

--- a/tools/monitor/MonitorDataStorage.inl
+++ b/tools/monitor/MonitorDataStorage.inl
@@ -968,14 +968,7 @@ MonitorDataStorage::update<DDS::ParticipantBuiltinTopicData>(
   //  };
 
   // Extract a GUID from the key.
-  OpenDDS::DCPS::Discovery_rch disc =
-    TheServiceParticipant->get_discovery(participant->get_domain_id());
-  OpenDDS::DCPS::DomainParticipantImpl* dpi =
-    dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant);
-  OpenDDS::DCPS::RepoId id =
-    disc->bit_key_to_repo_id(dpi,
-                             OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC,
-                             data.key);
+  const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
   OpenDDS::DCPS::GuidConverter converter(id);
   ACE_DEBUG((LM_DEBUG,
@@ -1052,14 +1045,7 @@ MonitorDataStorage::update<DDS::TopicBuiltinTopicData>(
   //  };
 
   // Extract a GUID from the key.
-  OpenDDS::DCPS::Discovery_rch disc =
-    TheServiceParticipant->get_discovery(participant->get_domain_id());
-  OpenDDS::DCPS::DomainParticipantImpl* dpi =
-    dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant);
-  OpenDDS::DCPS::RepoId id =
-    disc->bit_key_to_repo_id(dpi,
-                             OpenDDS::DCPS::BUILT_IN_TOPIC_TOPIC,
-                             data.key);
+  const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
   OpenDDS::DCPS::GuidConverter converter( id);
   ACE_DEBUG((LM_DEBUG,
@@ -1145,14 +1131,7 @@ MonitorDataStorage::update<DDS::PublicationBuiltinTopicData>(
   //  };
 
   // Extract a GUID from the key.
-  OpenDDS::DCPS::Discovery_rch disc =
-    TheServiceParticipant->get_discovery(participant->get_domain_id());
-  OpenDDS::DCPS::DomainParticipantImpl* dpi =
-    dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant);
-  OpenDDS::DCPS::RepoId id =
-    disc->bit_key_to_repo_id(dpi,
-                             OpenDDS::DCPS::BUILT_IN_PUBLICATION_TOPIC,
-                             data.key);
+  const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
   OpenDDS::DCPS::GuidConverter converter( id);
   ACE_DEBUG((LM_DEBUG,
@@ -1236,14 +1215,7 @@ MonitorDataStorage::update<DDS::SubscriptionBuiltinTopicData>(
   //  };
 
   // Extract a GUID from the key.
-  OpenDDS::DCPS::Discovery_rch disc =
-    TheServiceParticipant->get_discovery(participant->get_domain_id());
-  OpenDDS::DCPS::DomainParticipantImpl* dpi =
-    dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant);
-  OpenDDS::DCPS::RepoId id =
-    disc->bit_key_to_repo_id(dpi,
-                             OpenDDS::DCPS::BUILT_IN_SUBSCRIPTION_TOPIC,
-                             data.key);
+  const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
   OpenDDS::DCPS::GuidConverter converter( id);
   ACE_DEBUG((LM_DEBUG,


### PR DESCRIPTION
Problem
-------

Consider the following scenario:

* Participant A and B have discovered each other.
* A network partition or other issue that causes participants to
  timeout of discovery occurs.
* The issue resolves and A and B discovery each other again.

Insertion into the Publication and Subscription BITs will fail when A
and B discover each other again.  The core of the problem is that SEDP
will assign a new BIT key to the Publication/Subscription while the
DataReader is expecting the same key since the instance may have not
been removed from the BIT.

Solution
--------

Adopt the resolution of issue 153 for the DDS 1.5 Spec that says that
BIT keys are 16 byte arrays.  This allows a BIT key to store an RTPS
GUID.