### PR TITLE
XTypes: Enum bit_bound assignability refinement

### DIFF
--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -1065,12 +1065,9 @@ bool TypeAssignability::assignable_enum(const MinimalTypeObject& ta,
     return false;
   }
 
-  // T1.bit_bound and T2.bit_bound are in the same equivalence set (DDSXTY14-34)
-  const BitBound ta_bit_bound = ta.enumerated_type.header.common.bit_bound;
-  const BitBound tb_bit_bound = tb.enumerated_type.header.common.bit_bound;
-  if (((ta_bit_bound >= 1 && ta_bit_bound <= 8) && !(tb_bit_bound >= 1 && tb_bit_bound <= 8)) ||
-      ((ta_bit_bound >= 9 && ta_bit_bound <= 16) && !(tb_bit_bound >= 9 && tb_bit_bound <= 16)) ||
-      ((ta_bit_bound >= 17 && ta_bit_bound <= 32) && !(tb_bit_bound >= 17 && tb_bit_bound <= 32))) {
+  // T1.bit_bound and T2.bit_bound must be equal (DDSXTY14-34)
+  if (ta.enumerated_type.header.common.bit_bound !=
+      tb.enumerated_type.header.common.bit_bound) {
     return false;
   }
 

--- a/tests/DCPS/UnitTests/.gitignore
+++ b/tests/DCPS/UnitTests/.gitignore
@@ -14,5 +14,5 @@
 /UnitTests_TimeTSubtraction
 /UnitTests_MultiTask
 /UnitTests_DataSampleHeader
-/UnitTests_XtypesAssignability
+/UnitTests_XTypesAssignability
 /UnitTests_Serializer

--- a/tests/DCPS/UnitTests/UnitTests.mpc
+++ b/tests/DCPS/UnitTests/UnitTests.mpc
@@ -126,10 +126,10 @@ project(*DataSampleHeader): dcps_test, googletest {
   }
 }
 
-project(*XtypesAssignability): dcps_test, googletest {
+project(*XTypesAssignability): dcps_test, googletest {
   exename = *
   Source_Files {
-    XtypesAssignability.cpp
+    XTypesAssignability.cpp
   }
 }
 

--- a/tests/DCPS/UnitTests/XTypesAssignability.cpp
+++ b/tests/DCPS/UnitTests/XTypesAssignability.cpp
@@ -511,7 +511,7 @@ protected:
     enum_a_.enum_flags = IS_APPENDABLE;
     enum_b_.enum_flags = enum_a_.enum_flags;
     enum_a_.header.common.bit_bound = 10;
-    enum_b_.header.common.bit_bound = 13;
+    enum_b_.header.common.bit_bound = 10;
 
     MinimalEnumeratedLiteral l1_a, l2_a;
     l1_a.common.value = 3;
@@ -563,16 +563,8 @@ TEST_F(EnumTypeTest, NotAssignable)
   TypeAssignability test(make_rch<TypeLookupService>());
 
   // Different bit_bounds
-  enum_a_.header.common.bit_bound = 3;
+  enum_a_.header.common.bit_bound = 7;
   enum_b_.header.common.bit_bound = 23;
-  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(enum_a_)),
-                               TypeObject(MinimalTypeObject(enum_b_))));
-  enum_a_.header.common.bit_bound = 11;
-  enum_b_.header.common.bit_bound = 7;
-  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(enum_a_)),
-                               TypeObject(MinimalTypeObject(enum_b_))));
-  enum_a_.header.common.bit_bound = 20;
-  enum_a_.header.common.bit_bound = 15;
   EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(enum_a_)),
                                TypeObject(MinimalTypeObject(enum_b_))));
 
@@ -2278,7 +2270,7 @@ void expect_true_alias_to_alias()
   literal_seq.append(MinimalEnumeratedLiteral(CommonEnumeratedLiteral(4, EnumeratedLiteralFlag()),
                                               MinimalMemberDetail("LITERAL4")));
   MinimalEnumeratedType enum_a(EnumTypeFlag(),
-                               MinimalEnumeratedHeader(CommonEnumeratedHeader(static_cast<BitBound>(4))),
+                               MinimalEnumeratedHeader(CommonEnumeratedHeader(static_cast<BitBound>(5))),
                                literal_seq);
   get_equivalence_hash(hash);
   ali_a.body.common.related_type = make(EK_MINIMAL, hash);


### PR DESCRIPTION
Update the assignability of enum types so that 2 enum types with different bit_bounds are not assignable.