### PR TITLE
BIT readers have spec-defined memory leak

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1816,6 +1816,9 @@ namespace OpenDDS {
         sub->get_default_datareader_qos(dr_qos);
         dr_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
 
+        dr_qos.reader_data_lifecycle.autopurge_nowriter_samples_delay = TheServiceParticipant->bit_autopurge_nowriter_samples_delay();
+        dr_qos.reader_data_lifecycle.autopurge_disposed_samples_delay = TheServiceParticipant->bit_autopurge_disposed_samples_delay();
+
         DDS::TopicDescription_var bit_part_topic =
           participant->lookup_topicdescription(BUILT_IN_PARTICIPANT_TOPIC);
         create_bit_dr(bit_part_topic, BUILT_IN_PARTICIPANT_TOPIC_TYPE,

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -204,7 +204,9 @@ Service_Participant::Service_Participant()
     monitor_enabled_(false),
     shut_down_(false),
     shutdown_listener_(0),
-    default_configuration_file_(ACE_TEXT(""))
+    default_configuration_file_(ACE_TEXT("")),
+    bit_autopurge_nowriter_samples_delay_({DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC}),
+    bit_autopurge_disposed_samples_delay_({DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC})
 {
   initialize();
 }
@@ -2754,6 +2756,30 @@ NetworkConfigModifier* Service_Participant::network_config_modifier()
   return dynamic_cast<NetworkConfigModifier*>(network_config_monitor().get());
 }
 #endif
+
+DDS::Duration_t
+Service_Participant::bit_autopurge_nowriter_samples_delay() const
+{
+  return bit_autopurge_nowriter_samples_delay_;
+}
+
+void
+Service_Participant::bit_autopurge_nowriter_samples_delay(const DDS::Duration_t& duration)
+{
+  bit_autopurge_nowriter_samples_delay_ = duration;
+}
+
+DDS::Duration_t
+Service_Participant::bit_autopurge_disposed_samples_delay() const
+{
+  return bit_autopurge_disposed_samples_delay_;
+}
+
+void
+Service_Participant::bit_autopurge_disposed_samples_delay(const DDS::Duration_t& duration)
+{
+  bit_autopurge_disposed_samples_delay_ = duration;
+}
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -204,9 +204,7 @@ Service_Participant::Service_Participant()
     monitor_enabled_(false),
     shut_down_(false),
     shutdown_listener_(0),
-    default_configuration_file_(ACE_TEXT("")),
-    bit_autopurge_nowriter_samples_delay_({DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC}),
-    bit_autopurge_disposed_samples_delay_({DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC})
+    default_configuration_file_(ACE_TEXT(""))
 {
   initialize();
 }
@@ -783,6 +781,11 @@ Service_Participant::initialize()
   initial_SubscriberQos_.partition = initial_PartitionQosPolicy_;
   initial_SubscriberQos_.group_data = initial_GroupDataQosPolicy_;
   initial_SubscriberQos_.entity_factory = initial_EntityFactoryQosPolicy_;
+
+  bit_autopurge_nowriter_samples_delay_.sec = DDS::DURATION_INFINITE_SEC;
+  bit_autopurge_nowriter_samples_delay_.nanosec = DDS::DURATION_INFINITE_NSEC;
+  bit_autopurge_disposed_samples_delay_.sec = DDS::DURATION_INFINITE_SEC;
+  bit_autopurge_disposed_samples_delay_.nanosec = DDS::DURATION_INFINITE_NSEC;
 }
 
 void

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -424,6 +424,13 @@ public:
 #endif
   NetworkConfigMonitor_rch network_config_monitor();
 
+
+  DDS::Duration_t bit_autopurge_nowriter_samples_delay() const;
+  void bit_autopurge_nowriter_samples_delay(const DDS::Duration_t& duration);
+
+  DDS::Duration_t bit_autopurge_disposed_samples_delay() const;
+  void bit_autopurge_disposed_samples_delay(const DDS::Duration_t& duration);
+
 private:
 
   /// Initialize default qos.
@@ -717,6 +724,9 @@ private:
 
   NetworkConfigMonitor_rch network_config_monitor_;
   mutable ACE_Thread_Mutex network_config_monitor_lock_;
+
+  DDS::Duration_t bit_autopurge_nowriter_samples_delay_;
+  DDS::Duration_t bit_autopurge_disposed_samples_delay_;
 };
 
 #define TheServiceParticipant OpenDDS::DCPS::Service_Participant::instance()

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -203,6 +203,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 #endif
 
+  const DDS::Duration_t one_minute = { 0, 0 };
+
+  TheServiceParticipant->bit_autopurge_nowriter_samples_delay(one_minute);
+  TheServiceParticipant->bit_autopurge_disposed_samples_delay(one_minute);
+
   // Set up the relay participant.
   DDS::DomainParticipantQos participant_qos;
   factory->get_default_participant_qos(participant_qos);
@@ -362,11 +367,15 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   writer_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
   writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
 
+  const DDS::Duration_t zero_seconds = { 0, 0 };
+
   DDS::DataReaderQos reader_qos;
   relay_subscriber->get_default_datareader_qos(reader_qos);
 
   reader_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
   reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+  reader_qos.reader_data_lifecycle.autopurge_nowriter_samples_delay = zero_seconds;
+  reader_qos.reader_data_lifecycle.autopurge_disposed_samples_delay = zero_seconds;
 
   auto participant_entry_writer_var = relay_publisher->create_datawriter(participant_entry_topic, writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (!participant_entry_writer_var) {

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -203,7 +203,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 #endif
 
-  const DDS::Duration_t one_minute = { 0, 0 };
+  const DDS::Duration_t one_minute = { 60, 0 };
 
   TheServiceParticipant->bit_autopurge_nowriter_samples_delay(one_minute);
   TheServiceParticipant->bit_autopurge_disposed_samples_delay(one_minute);


### PR DESCRIPTION
Problem
-------

The DDS Specification says that the members of the
ReaderDataLifecycleQosPolicy are set to infinite which means a
participant will never purge the data stored in the builtin topics.  A
long-running participant will eventually run out of memory.

It is possible to manually change the qos for all of the builtin
participant data readers.  However, the addition of a new builtin
topic would render such code useless and the new builtin topic would
create another memory leak.

Solution
--------

Provide a mechanism to configure the ReaderDataLifecycleQosPolicy for
the builtin topic data readers.