### PR TITLE
Deque is memory inefficient

### DIFF
--- a/dds/DCPS/JobQueue.h
+++ b/dds/DCPS/JobQueue.h
@@ -38,7 +38,7 @@ public:
   {
     ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
     const bool empty = job_queue_.empty();
-    job_queue_.push(job);
+    job_queue_.push_back(job);
     if (empty) {
       guard.release();
       reactor()->notify(this);
@@ -47,20 +47,19 @@ public:
 
 private:
   ACE_Thread_Mutex mutex_;
-  OPENDDS_QUEUE(JobPtr) job_queue_;
+  typedef OPENDDS_VECTOR(JobPtr) Queue;
+  Queue job_queue_;
 
   int handle_exception(ACE_HANDLE /*fd*/)
   {
+    Queue q;
+
     ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
     ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, -1);
-    size_t count = job_queue_.size();
-    while (count--) {
-      JobPtr job = job_queue_.front();
-      job_queue_.pop();
-      {
-        ACE_GUARD_RETURN(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock, -1);
-        job->execute();
-      }
+    q.swap(job_queue_);
+    for (Queue::const_iterator pos = q.begin(), limit = q.end(); pos != limit; ++pos) {
+      ACE_GUARD_RETURN(ACE_Reverse_Lock<ACE_Thread_Mutex>, rev_guard, rev_lock, -1);
+      (*pos)->execute();
     }
 
     if (!job_queue_.empty()) {

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -44,7 +44,7 @@ int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)
 
 void ReactorInterceptor::process_command_queue_i()
 {
-  OPENDDS_DEQUE(CommandPtr) cq;
+  Queue cq;
   ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -52,11 +52,9 @@ void ReactorInterceptor::process_command_queue_i()
   if (!command_queue_.empty()) {
     cq.swap(command_queue_);
     ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rev_guard(rev_lock);
-    while (!cq.empty()) {
-      CommandPtr command = cq.front();
-      cq.pop_front();
-      command->execute();
-      command->executed();
+    for (Queue::const_iterator pos = cq.begin(), limit = cq.end(); pos != limit; ++pos) {
+      (*pos)->execute();
+      (*pos)->executed();
     }
   }
   if (!command_queue_.empty()) {

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -134,7 +134,8 @@ protected:
 
   ACE_thread_t owner_;
   ACE_Thread_Mutex mutex_;
-  OPENDDS_DEQUE(CommandPtr) command_queue_;
+  typedef OPENDDS_VECTOR(CommandPtr) Queue;
+  Queue command_queue_;
   ReactorState state_;
 };
 


### PR DESCRIPTION
Problem
-------

Currently, a typical DDS application might involve 50+
ReactorInterceptors.  Each ReactorInterceptor includes a deque.  A
deque is built from internal nodes.  The internal nodes typically have
a minimum size which is the lesser of the size of the value type and
some constant.  This constant can be much bigger than the size of the
value type.  Consequently, a deque that contains a only a few entries,
such as one for a ReactorInterceptor, is highly memory inefficient.
If an empty deque is 1K, then a typical DDS application will have 50K+
of memory that is not actually being used.

Solution
--------

Change ReactorInterceptor and Job queue to use vectors that are
swapped with empty vectors as they are being processed.