### PR TITLE
Xtypes: Extensibility test fixes

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -68,6 +68,7 @@ tests/DCPS/Compiler/rapidjson_generator/run_test.pl: RAPIDJSON
 tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/xcdr/run_test.pl
+tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN
 
 tests/DCPS/C++11/Messenger/run_test.pl: !DCPS_MIN CXX11
 

--- a/tests/DCPS/Compiler/XtypesExensibility/Extensibility.idl
+++ b/tests/DCPS/Compiler/XtypesExensibility/Extensibility.idl
@@ -40,16 +40,6 @@ module extensibility {
   };
 
   @extensibility(FINAL)
-  enum enum_final {
-   A1, A2, A3
-  };
-
-  @extensibility(APPENDABLE)
-  enum enum_appendable {
-   B1, B2, B3
-  };
-
-  @extensibility(FINAL)
   struct struct_final_nested {
    string member;
   };
@@ -91,10 +81,6 @@ module extensibility {
   union union_default switch(long) {
    case 0: long A;
    case 1: short B;
-  };
-
-  enum enum_default {
-   C1, C2, C3
   };
 
   struct struct_default_nested {

--- a/tests/DCPS/Compiler/XtypesExensibility/XtypesExtensibility.cpp
+++ b/tests/DCPS/Compiler/XtypesExensibility/XtypesExtensibility.cpp
@@ -23,9 +23,6 @@ TEST(TestFinal, flags_match)
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_union_final_xtag>()]
             .minimal.union_type.union_flags, IS_FINAL);
 
-  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_enum_final_xtag>()]
-            .minimal.enumerated_type.enum_flags, IS_FINAL);
-
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_struct_final_nested_xtag>()]
             .minimal.struct_type.struct_flags , IS_FINAL | IS_NESTED);
 
@@ -43,9 +40,6 @@ TEST(TestAppendable, flags_match)
 
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_union_appendable_xtag>()]
             .minimal.union_type.union_flags, IS_APPENDABLE);
-
-  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_enum_appendable_xtag>()]
-            .minimal.enumerated_type.enum_flags, IS_APPENDABLE);
 
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_struct_appendable_nested_xtag>()]
             .minimal.struct_type.struct_flags , IS_APPENDABLE | IS_NESTED);
@@ -83,9 +77,6 @@ TEST(TestDefault, flags_match)
 
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_union_default_xtag>()]
             .minimal.union_type.union_flags, IS_APPENDABLE);
-
-  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_enum_default_xtag>()]
-            .minimal.enumerated_type.enum_flags, IS_APPENDABLE);
 
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_struct_default_nested_xtag>()]
             .minimal.struct_type.struct_flags , IS_APPENDABLE | IS_NESTED);

--- a/tests/DCPS/Compiler/XtypesExensibility/run_test.pl
+++ b/tests/DCPS/Compiler/XtypesExensibility/run_test.pl
@@ -1,0 +1,22 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+     & eval 'exec perl -S $0 $argv:q'
+     if 0;
+
+use Env (DDS_ROOT);
+use lib "$DDS_ROOT/bin";
+use Env (ACE_ROOT);
+use lib "$ACE_ROOT/bin";
+use PerlDDS::Run_Test;
+use strict;
+
+my $name = 'Compiler_XtypesExtensibility';
+my $status = 0;
+my $TESTDVR = PerlDDS::create_process ($name);
+
+my $status = $TESTDVR->SpawnWaitKill (300);
+if ($status != 0) {
+    print STDERR "ERROR: $name returned $status\n";
+    $status = 1;
+}
+
+exit $status;


### PR DESCRIPTION
Adding exten test to test list and removing cases that shouldn't have existed in the first place.