### PR TITLE
Secure discovery is slow

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -644,7 +644,7 @@ namespace OpenDDS {
       virtual void association_complete(const RepoId& localId,
                                         const RepoId& remoteId) = 0;
 
-      virtual bool disassociate(const DiscoveredParticipantData& pdata) = 0;
+      virtual bool disassociate(DiscoveredParticipantData& pdata) = 0;
 
     protected:
       struct LocalEndpoint {
@@ -1556,8 +1556,6 @@ namespace OpenDDS {
         , is_requester_(false)
         , auth_req_sequence_number_(0)
         , handshake_sequence_number_(0)
-        , security_builtins_associated_(false)
-        , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1590,8 +1588,6 @@ namespace OpenDDS {
         , is_requester_(false)
         , auth_req_sequence_number_(0)
         , handshake_sequence_number_(0)
-        , security_builtins_associated_(false)
-        , seen_some_crypto_tokens_(false)
         , identity_handle_(DDS::HANDLE_NIL)
         , handshake_handle_(DDS::HANDLE_NIL)
         , permissions_handle_(DDS::HANDLE_NIL)
@@ -1656,8 +1652,6 @@ namespace OpenDDS {
         bool is_requester_;
         CORBA::LongLong auth_req_sequence_number_;
         CORBA::LongLong handshake_sequence_number_;
-        bool security_builtins_associated_;
-        bool seen_some_crypto_tokens_;
 
         DDS::Security::IdentityToken identity_token_;
         DDS::Security::PermissionsToken permissions_token_;

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -568,6 +568,7 @@ module OpenDDS {
       Count_t manualLivelinessCount;
       DDS::PropertyQosPolicy property;
       OpenDDSParticipantFlags_t opendds_participant_flags;
+      BuiltinEndpointSet_t associated_endpoints;
     };
 
     // top-level data type for SPDP

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -568,7 +568,6 @@ module OpenDDS {
       Count_t manualLivelinessCount;
       DDS::PropertyQosPolicy property;
       OpenDDSParticipantFlags_t opendds_participant_flags;
-      BuiltinEndpointSet_t associated_endpoints;
     };
 
     // top-level data type for SPDP
@@ -576,6 +575,7 @@ module OpenDDS {
       DDS::ParticipantBuiltinTopicData ddsParticipantData;
       ParticipantProxy_t participantProxy;
       Duration_t leaseDuration;
+      BuiltinEndpointSet_t associated_endpoints;
     };
 
     /* Type used to hold data exchanged between Participants.

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -483,7 +483,7 @@ public:
     const DDS::DomainParticipantQos& qos);
 
 #if defined(OPENDDS_SECURITY)
-#  if defined __GNUC__ && ((__GNUC__ == 5 && __GNUC_MINOR__ < 3) || __GNUC__ < 5)
+#  if defined __GNUC__ && ((__GNUC__ == 5 && __GNUC_MINOR__ < 3) || __GNUC__ < 5) && ! defined __clang__
 #    define OPENDDS_GCC_PRE53_DISABLE_OPTIMIZATION __attribute__((optimize("-O0")))
 #  else
 #    define OPENDDS_GCC_PRE53_DISABLE_OPTIMIZATION

--- a/dds/DCPS/RTPS/RtpsSecurity.idl
+++ b/dds/DCPS/RTPS/RtpsSecurity.idl
@@ -27,6 +27,7 @@ module OpenDDS {
       DDS::Security::ParticipantBuiltinTopicDataSecure ddsParticipantDataSecure;
       OpenDDS::RTPS::ParticipantProxy_t participantProxy;
       OpenDDS::RTPS::Duration_t leaseDuration;
+      OpenDDS::RTPS::BuiltinEndpointSet_t associated_endpoints;
     };
   };
 };

--- a/dds/DCPS/RTPS/SecurityHelpers.h
+++ b/dds/DCPS/RTPS/SecurityHelpers.h
@@ -37,12 +37,6 @@ const EntityId_t ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER = {{0x
 const EntityId_t ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER = {{0xff, 0x01, 0x01}, 0xc7};
 ///@}
 
-inline bool
-is_secure(const DCPS::RepoId& id)
-{
-  return id.entityId.entityKey[0] == 0xff;
-}
-
 const DDS::Security::ParticipantSecurityInfo PARTICIPANT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
 const DDS::Security::EndpointSecurityInfo ENDPOINT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
 

--- a/dds/DCPS/RTPS/SecurityHelpers.h
+++ b/dds/DCPS/RTPS/SecurityHelpers.h
@@ -37,6 +37,12 @@ const EntityId_t ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER = {{0x
 const EntityId_t ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER = {{0xff, 0x01, 0x01}, 0xc7};
 ///@}
 
+inline bool
+is_secure(const DCPS::RepoId& id)
+{
+  return id.entityId.entityKey[0] == 0xff;
+}
+
 const DDS::Security::ParticipantSecurityInfo PARTICIPANT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
 const DDS::Security::EndpointSecurityInfo ENDPOINT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -816,7 +816,7 @@ create_association_data_proto(DCPS::AssociationData& proto,
 
 #ifdef OPENDDS_SECURITY
 void
-Sedp::associate_preauth(const Security::SPDPdiscoveredParticipantData& pdata)
+Sedp::associate_preauth(Security::SPDPdiscoveredParticipantData& pdata)
 {
   // First create a 'prototypical' instance of AssociationData.  It will
   // be copied and modified for each of the (up to) four SEDP Endpoints.
@@ -836,18 +836,20 @@ Sedp::associate_preauth(const Security::SPDPdiscoveredParticipantData& pdata)
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
     participant_stateless_message_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= DDS::Security::BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER;
   }
 
   if (avail & DDS::Security::BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
     participant_stateless_message_writer_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= DDS::Security::BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER;
   }
 }
 #endif
 
 void
-Sedp::associate(const ParticipantData_t& pdata)
+Sedp::associate(ParticipantData_t& pdata)
 {
   // First create a 'prototypical' instance of AssociationData.  It will
   // be copied and modified for each of the (up to) four SEDP Endpoints.
@@ -862,23 +864,26 @@ Sedp::associate(const ParticipantData_t& pdata)
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
     publications_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR;
   }
   if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
     subscriptions_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR;
   }
   if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
     DCPS::AssociationData peer = proto;
     peer.remote_id_.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
     participant_message_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER;
   }
 
   job_queue_->enqueue(make_rch<MsgParticipantData>(rchandle_from(this), DCPS::SAMPLE_DATA, pdata));
 }
 
 #ifdef OPENDDS_SECURITY
-void Sedp::associate_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
+void Sedp::associate_volatile(Security::SPDPdiscoveredParticipantData& pdata)
 {
   using namespace DDS::Security;
 
@@ -900,6 +905,7 @@ void Sedp::associate_volatile(const Security::SPDPdiscoveredParticipantData& pda
     peer.remote_data_ = add_security_info(
       peer.remote_data_, peer.remote_id_, participant_volatile_message_secure_reader_->get_repo_id());
     participant_volatile_message_secure_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER;
   }
   if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
     DCPS::AssociationData peer = proto;
@@ -909,6 +915,7 @@ void Sedp::associate_volatile(const Security::SPDPdiscoveredParticipantData& pda
     peer.remote_data_ = add_security_info(
       peer.remote_data_, participant_volatile_message_secure_writer_->get_repo_id(), peer.remote_id_);
     participant_volatile_message_secure_writer_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER;
   }
 }
 
@@ -967,7 +974,7 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
         ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::rekey_volatile calling send_participant_crypto_token\n"));
       }
       spdp_.send_participant_crypto_tokens(part_guid);
-      send_builtin_crypto_tokens(pdata);
+      send_builtin_crypto_tokens(part_guid);
       resend_user_crypto_tokens(part_guid);
     }
   }
@@ -977,11 +984,12 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
 
 #endif // OPENDDS_SECURITY
 
-void Sedp::disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
+void Sedp::disassociate_helper(BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
                                const RepoId& id, const EntityId_t& ent, DCPS::TransportClient& client)
 {
   if (avail & flags) {
     client.disassociate(make_id(id, ent));
+    avail ^= flags;
   }
 }
 
@@ -1024,110 +1032,149 @@ void Sedp::remove_remote_crypto_handle(const RepoId& participant, const EntityId
   }
 }
 
-void Sedp::associate_secure_writers_to_readers(const Security::SPDPdiscoveredParticipantData& pdata)
+void Sedp::generate_remote_crypto_handles(const Security::SPDPdiscoveredParticipantData& pdata)
 {
   using namespace DDS::Security;
 
-  DCPS::AssociationData proto;
-  create_association_data_proto(proto, pdata);
-
-  DCPS::RepoId part = proto.remote_id_;
-  part.entityId = ENTITYID_PARTICIPANT;
+  const DCPS::RepoId part = make_id(pdata.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
+  DCPS::RepoId remote_id = part;
 
   const BuiltinEndpointSet_t& avail = pdata.participantProxy.availableBuiltinEndpoints;
 
   if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
-    remote_writer_crypto_handles_[peer.remote_id_] = generate_remote_matched_writer_crypto_handle(
+    remote_id.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
+    remote_writer_crypto_handles_[remote_id] = generate_remote_matched_writer_crypto_handle(
       part, participant_message_secure_reader_->get_endpoint_crypto_handle());
-    peer.remote_data_ = add_security_info(
-      peer.remote_data_, peer.remote_id_, participant_message_secure_reader_->get_repo_id());
-    participant_message_secure_reader_->assoc(peer);
   }
   if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
-    remote_writer_crypto_handles_[peer.remote_id_] = generate_remote_matched_writer_crypto_handle(
+    remote_id.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
+    remote_writer_crypto_handles_[remote_id] = generate_remote_matched_writer_crypto_handle(
       part, dcps_participant_secure_reader_->get_endpoint_crypto_handle());
-    peer.remote_data_ = add_security_info(
-      peer.remote_data_, peer.remote_id_, dcps_participant_secure_reader_->get_repo_id());
-    dcps_participant_secure_reader_->assoc(peer);
   }
   if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
-    remote_writer_crypto_handles_[peer.remote_id_] = generate_remote_matched_writer_crypto_handle(
+    remote_id.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
+    remote_writer_crypto_handles_[remote_id] = generate_remote_matched_writer_crypto_handle(
       part, publications_secure_reader_->get_endpoint_crypto_handle());
-    peer.remote_data_ = add_security_info(
-      peer.remote_data_, peer.remote_id_, publications_secure_reader_->get_repo_id());
-    publications_secure_reader_->assoc(peer);
   }
   if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
-    remote_writer_crypto_handles_[peer.remote_id_] = generate_remote_matched_writer_crypto_handle(
+    remote_id.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
+    remote_writer_crypto_handles_[remote_id] = generate_remote_matched_writer_crypto_handle(
       part, subscriptions_secure_reader_->get_endpoint_crypto_handle());
-    peer.remote_data_ = add_security_info(
-      peer.remote_data_, peer.remote_id_, subscriptions_secure_reader_->get_repo_id());
-    subscriptions_secure_reader_->assoc(peer);
+  }
+
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
+    remote_id.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+    remote_reader_crypto_handles_[remote_id] = generate_remote_matched_reader_crypto_handle(
+      part, participant_message_secure_writer_->get_endpoint_crypto_handle(), false);
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
+    remote_id.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
+    remote_reader_crypto_handles_[remote_id] = generate_remote_matched_reader_crypto_handle(
+      part, dcps_participant_secure_writer_->get_endpoint_crypto_handle(), false);
+  }
+  if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
+    remote_id.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+    remote_reader_crypto_handles_[remote_id] = generate_remote_matched_reader_crypto_handle(
+      part, publications_secure_writer_->get_endpoint_crypto_handle(), false);
+  }
+  if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
+    remote_id.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+    remote_reader_crypto_handles_[remote_id] = generate_remote_matched_reader_crypto_handle(
+      part, subscriptions_secure_writer_->get_endpoint_crypto_handle(), false);
   }
 }
 
-void Sedp::associate_secure_readers_to_writers(const Security::SPDPdiscoveredParticipantData& pdata)
+void Sedp::associate_secure_reader_to_writer(const RepoId& remote_writer)
 {
   using namespace DDS::Security;
 
-  DCPS::AssociationData proto;
-  create_association_data_proto(proto, pdata);
+  ParticipantData_t& pdata = spdp_.get_participant_data(remote_writer);
 
-  DCPS::RepoId part = proto.remote_id_;
-  part.entityId = ENTITYID_PARTICIPANT;
+  using namespace DDS::Security;
+
+  DCPS::AssociationData peer;
+  create_association_data_proto(peer, pdata);
+  peer.remote_id_ = remote_writer;
+
+  const BuiltinEndpointSet_t& avail = pdata.participantProxy.availableBuiltinEndpoints;
+
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER &&
+      remote_writer.entityId == ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
+    peer.remote_data_ = add_security_info(
+      peer.remote_data_, peer.remote_id_, participant_message_secure_reader_->get_repo_id());
+    participant_message_secure_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
+  }
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER &&
+      remote_writer.entityId == ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER) {
+    peer.remote_data_ = add_security_info(
+      peer.remote_data_, peer.remote_id_, dcps_participant_secure_reader_->get_repo_id());
+    dcps_participant_secure_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= SPDP_BUILTIN_PARTICIPANT_SECURE_READER;
+  }
+  if (remote_writer.entityId == ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER &&
+      avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
+    peer.remote_data_ = add_security_info(
+      peer.remote_data_, peer.remote_id_, publications_secure_reader_->get_repo_id());
+    publications_secure_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
+  }
+  if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER &&
+      remote_writer.entityId == ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
+    peer.remote_data_ = add_security_info(
+      peer.remote_data_, peer.remote_id_, subscriptions_secure_reader_->get_repo_id());
+    subscriptions_secure_reader_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
+  }
+}
+
+void Sedp::associate_secure_writer_to_reader(const RepoId& remote_reader)
+{
+  using namespace DDS::Security;
+
+  ParticipantData_t& pdata = spdp_.get_participant_data(remote_reader);
+
+  DCPS::AssociationData peer;
+  create_association_data_proto(peer, pdata);
+  peer.remote_id_ = remote_reader;
 
   const BuiltinEndpointSet_t& avail = pdata.participantProxy.availableBuiltinEndpoints;
   const BuiltinEndpointQos_t& beq = pdata.participantProxy.builtinEndpointQos;
 
-
-  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
-    DCPS::AssociationData peer = proto;
+  if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER &&
+      remote_reader.entityId == ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
     if (beq & BEST_EFFORT_PARTICIPANT_MESSAGE_DATA_READER) {
       peer.remote_reliable_ = false;
     }
-    peer.remote_id_.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
-    remote_reader_crypto_handles_[peer.remote_id_] = generate_remote_matched_reader_crypto_handle(
-      part, participant_message_secure_writer_->get_endpoint_crypto_handle(), false);
     peer.remote_data_ = add_security_info(
       peer.remote_data_, participant_message_secure_writer_->get_repo_id(), peer.remote_id_);
     participant_message_secure_writer_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
   }
-  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
-    remote_reader_crypto_handles_[peer.remote_id_] = generate_remote_matched_reader_crypto_handle(
-      part, dcps_participant_secure_writer_->get_endpoint_crypto_handle(), false);
+  if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER &&
+      remote_reader.entityId == ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER) {
     peer.remote_data_ = add_security_info(
       peer.remote_data_, dcps_participant_secure_writer_->get_repo_id(), peer.remote_id_);
     dcps_participant_secure_writer_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER;
   }
   if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER &&
-      avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
-    remote_reader_crypto_handles_[peer.remote_id_] = generate_remote_matched_reader_crypto_handle(
-      part, publications_secure_writer_->get_endpoint_crypto_handle(), false);
+      avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER &&
+      remote_reader.entityId == ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
     peer.remote_data_ = add_security_info(
       peer.remote_data_, publications_secure_writer_->get_repo_id(), peer.remote_id_);
     publications_secure_writer_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
   }
   if (spdp_.available_builtin_endpoints() & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER &&
-      avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
-    DCPS::AssociationData peer = proto;
-    peer.remote_id_.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
-    remote_reader_crypto_handles_[peer.remote_id_] = generate_remote_matched_reader_crypto_handle(
-      part, subscriptions_secure_writer_->get_endpoint_crypto_handle(), false);
+      avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER &&
+      remote_reader.entityId == ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
     peer.remote_data_ = add_security_info(
       peer.remote_data_, subscriptions_secure_writer_->get_repo_id(), peer.remote_id_);
     subscriptions_secure_writer_->assoc(peer);
+    pdata.participantProxy.associated_endpoints |= SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
   }
 }
 
@@ -1144,20 +1191,10 @@ Sedp::create_and_send_datareader_crypto_tokens(
                DCPS::LogGuid(remote_writer).c_str(), dwch));
   }
 
-  const DCPS::RepoId remote_volatile_reader = make_id(
-    remote_writer.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-
-  RemoteWriter info;
-  info.local_reader = local_reader;
-  info.remote_writer = remote_writer;
-  DDS::Security::DatareaderCryptoTokenSeq& drcts = info.reader_tokens;
+  DDS::Security::DatareaderCryptoTokenSeq drcts;
   create_datareader_crypto_tokens(drch, dwch, drcts);
 
-  if (associated_volatile_readers_.count(remote_volatile_reader) != 0) {
-    send_datareader_crypto_tokens(local_reader, remote_writer, drcts);
-  } else {
-    datareader_crypto_tokens_[remote_volatile_reader].push_back(info);
-  }
+  send_datareader_crypto_tokens(local_reader, remote_writer, drcts);
 }
 
 void
@@ -1173,20 +1210,10 @@ Sedp::create_and_send_datawriter_crypto_tokens(
                DCPS::LogGuid(remote_reader).c_str(), drch));
   }
 
-  const DCPS::RepoId remote_volatile_reader = make_id(
-    remote_reader.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-
-  RemoteReader info;
-  info.local_writer = local_writer;
-  info.remote_reader = remote_reader;
-  DDS::Security::DatawriterCryptoTokenSeq& dwcts = info.writer_tokens;
+  DDS::Security::DatawriterCryptoTokenSeq dwcts;
   create_datawriter_crypto_tokens(dwch, drch, dwcts);
 
-  if (associated_volatile_readers_.count(remote_volatile_reader) != 0) {
-    send_datawriter_crypto_tokens(local_writer, remote_reader, dwcts);
-  } else {
-    datawriter_crypto_tokens_[remote_volatile_reader].push_back(info);
-  }
+  send_datawriter_crypto_tokens(local_writer, remote_reader, dwcts);
 }
 
 void
@@ -1206,11 +1233,13 @@ Sedp::send_builtin_crypto_tokens(
 }
 
 void
-Sedp::send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& pdata)
+Sedp::send_builtin_crypto_tokens(const DCPS::RepoId& remoteId)
 {
   using namespace DDS::Security;
 
-  const DCPS::RepoId part = make_id(pdata.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
+  const DCPS::RepoId part = make_id(remoteId, ENTITYID_PARTICIPANT);
+  const ParticipantData_t& pdata = spdp_.get_participant_data(part);
+
   const BuiltinEndpointSet_t& avail = pdata.participantProxy.availableBuiltinEndpoints;
 
   if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
@@ -1253,28 +1282,6 @@ Sedp::send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& 
       avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
     send_builtin_crypto_tokens(part, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER,
                                subscriptions_secure_writer_->get_repo_id());
-  }
-}
-
-void
-Sedp::send_cached_crypto_tokens(const DCPS::RepoId& remote_participant)
-{
-  RemoteReaderVectors::iterator reader_map_iter = datawriter_crypto_tokens_.find(remote_participant);
-  if (reader_map_iter != datawriter_crypto_tokens_.end()) {
-    typedef RemoteReaderVector::iterator iter_t;
-    for (iter_t i = reader_map_iter->second.begin(); i != reader_map_iter->second.end(); ++i) {
-      send_datawriter_crypto_tokens(i->local_writer, i->remote_reader, i->writer_tokens);
-    }
-    datawriter_crypto_tokens_.erase(reader_map_iter);
-  }
-
-  RemoteWriterVectors::iterator writer_map_iter = datareader_crypto_tokens_.find(remote_participant);
-  if (writer_map_iter != datareader_crypto_tokens_.end()) {
-    typedef RemoteWriterVector::iterator iter_t;
-    for (iter_t i = writer_map_iter->second.begin(); i != writer_map_iter->second.end(); ++i) {
-      send_datareader_crypto_tokens(i->local_reader, i->remote_writer, i->reader_tokens);
-    }
-    datareader_crypto_tokens_.erase(writer_map_iter);
   }
 }
 #endif
@@ -1358,47 +1365,51 @@ Sedp::MsgParticipantDataSecure::execute()
 #endif
 
 bool
-Sedp::disassociate(const ParticipantData_t& pdata)
+Sedp::disassociate(ParticipantData_t& pdata)
 {
   const RepoId part = make_id(pdata.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
 
   associated_participants_.erase(part);
-  const BuiltinEndpointSet_t avail =
-    pdata.participantProxy.availableBuiltinEndpoints;
 
   { // Release lock, so we can call into transport
-    BuiltinEndpointSet_t local_avail = spdp_.available_builtin_endpoints();
-
     ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
     ACE_GUARD_RETURN(ACE_Reverse_Lock< ACE_Thread_Mutex>, rg, rev_lock, false);
 
-    if (local_avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
-      disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR, part,
-                          ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER, *publications_writer_);
-    }
-    disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER, part,
-      ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER, *publications_reader_);
-
-    if (local_avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
-      disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR, part,
-                          ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER, *subscriptions_writer_);
-    }
-    disassociate_helper(avail, DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER, part,
-      ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER, *subscriptions_reader_);
-
-    if (local_avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
-      disassociate_helper(avail, BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER, part,
-                          ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER, *participant_message_writer_);
-    }
-    disassociate_helper(avail, BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER, part,
-      ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER, *participant_message_reader_);
+    disassociate_helper(pdata.participantProxy.associated_endpoints,
+                        DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER,
+                        part,
+                        ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER,
+                        *publications_writer_);
+    disassociate_helper(pdata.participantProxy.associated_endpoints,
+                        DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR,
+                        part,
+                        ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER,
+                        *publications_reader_);
+    disassociate_helper(pdata.participantProxy.associated_endpoints,
+                        DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER,
+                        part,
+                        ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER,
+                        *subscriptions_writer_);
+    disassociate_helper(pdata.participantProxy.associated_endpoints,
+                        DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR,
+                        part,
+                        ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER,
+                        *subscriptions_reader_);
+    disassociate_helper(pdata.participantProxy.associated_endpoints,
+                        BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER,
+                        part,
+                        ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER,
+                        *participant_message_writer_);
+    disassociate_helper(pdata.participantProxy.associated_endpoints,
+                        BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER,
+                        part,
+                        ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER,
+                        *participant_message_reader_);
 
     //FUTURE: if/when topic propagation is supported, add it here
 
 #ifdef OPENDDS_SECURITY
-    if (spdp_.security_builtins_associated(part)) {
-      disassociate_security_builtins(local_avail, avail, part);
-    }
+    disassociate_security_builtins(pdata);
 #endif
   }
 
@@ -1419,10 +1430,6 @@ Sedp::disassociate(const ParticipantData_t& pdata)
     for (size_t i = 0; i < sizeof secure_entities / sizeof secure_entities[0]; ++i) {
       remove_remote_crypto_handle(part, secure_entities[i]);
     }
-
-    const RepoId remote_volatile = make_id(part, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-    associated_volatile_readers_.erase(remote_volatile);
-    pending_volatile_readers_.erase(remote_volatile);
 
     const DDS::Security::CryptoKeyFactory_var key_factory = spdp_.get_security_config()->get_crypto_key_factory();
     DDS::Security::SecurityException se;
@@ -1463,46 +1470,72 @@ Sedp::disassociate(const ParticipantData_t& pdata)
 }
 
 #ifdef OPENDDS_SECURITY
-void Sedp::disassociate_security_builtins(BuiltinEndpointSet_t local_avail, BuiltinEndpointSet_t avail,
-                                          const RepoId& part)
+void Sedp::disassociate_security_builtins(ParticipantData_t& pdata)
 {
   using namespace DDS::Security;
 
-  if (local_avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
-    disassociate_helper(avail, SEDP_BUILTIN_PUBLICATIONS_SECURE_READER, part,
-                        ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER, *publications_secure_writer_);
-  }
-  disassociate_helper(avail, SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER, part,
-    ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER, *publications_secure_reader_);
+  const RepoId part = make_id(pdata.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
 
-  if (local_avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
-    disassociate_helper(avail, SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER, part,
-                        ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER, *subscriptions_secure_writer_);
-  }
-  disassociate_helper(avail, SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER, part,
-    ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER, *subscriptions_secure_reader_);
-
-  if (local_avail & DDS::Security::BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
-    disassociate_helper(avail, BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER, part,
-                        ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER, *participant_message_secure_writer_);
-  }
-  disassociate_helper(avail, BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER, part,
-    ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER, *participant_message_secure_reader_);
-
-  disassociate_helper(avail, BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER, part,
-    ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER, *participant_stateless_message_writer_);
-  disassociate_helper(avail, BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER, part,
-    ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER, *participant_stateless_message_reader_);
-
-  disassociate_helper(avail, BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER, part,
-    ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER, *participant_volatile_message_secure_writer_);
-  disassociate_helper(avail, BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER, part,
-    ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER, *participant_volatile_message_secure_reader_);
-
-  disassociate_helper(avail, SPDP_BUILTIN_PARTICIPANT_SECURE_READER, part,
-    ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER, *dcps_participant_secure_writer_);
-  disassociate_helper(avail, SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER, part,
-    ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER, *dcps_participant_secure_reader_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER,
+                      part,
+                      ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER,
+                      *publications_secure_writer_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      SEDP_BUILTIN_PUBLICATIONS_SECURE_READER,
+                      part,
+                      ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER,
+                      *publications_secure_reader_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER,
+                      part,
+                      ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER,
+                      *subscriptions_secure_writer_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER,
+                      part,
+                      ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER,
+                      *subscriptions_secure_reader_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER,
+                      part,
+                      ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER,
+                      *participant_message_secure_writer_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER,
+                      part,
+                      ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER,
+                      *participant_message_secure_reader_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER,
+                      part,
+                      ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER,
+                      *participant_stateless_message_writer_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER,
+                      part,
+                      ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER,
+                      *participant_stateless_message_reader_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER,
+                      part,
+                      ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER,
+                      *participant_volatile_message_secure_writer_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER,
+                      part,
+                      ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER,
+                      *participant_volatile_message_secure_reader_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER,
+                      part,
+                      ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER,
+                      *dcps_participant_secure_writer_);
+  disassociate_helper(pdata.participantProxy.associated_endpoints,
+                      SPDP_BUILTIN_PARTICIPANT_SECURE_READER,
+                      part,
+                      ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER,
+                      *dcps_participant_secure_reader_);
 }
 #endif
 
@@ -2852,52 +2885,26 @@ Sedp::received_volatile_message_secure(DCPS::MessageId /* message_id */,
     return;
   }
 
-  bool send_tokens = false;
   if (0 == std::strcmp(msg.message_class_id,
                        DDS::Security::GMCLASSID_SECURITY_PARTICIPANT_CRYPTO_TOKENS)) {
-    if (!spdp_.handle_participant_crypto_tokens(msg, send_tokens)) {
+    if (!spdp_.handle_participant_crypto_tokens(msg)) {
       ACE_DEBUG((LM_DEBUG, "Sedp::received_volatile_message_secure handle_participant_crypto_tokens failed\n"));
       return;
     }
   } else if (0 == std::strcmp(msg.message_class_id,
                               DDS::Security::GMCLASSID_SECURITY_DATAWRITER_CRYPTO_TOKENS)) {
-    if (!handle_datawriter_crypto_tokens(msg, send_tokens)) {
+    if (!handle_datawriter_crypto_tokens(msg)) {
       ACE_DEBUG((LM_DEBUG, "Sedp::received_volatile_message_secure handle_datawriter_crypto_tokens failed\n"));
       return;
     }
   } else if (0 == std::strcmp(msg.message_class_id,
                               DDS::Security::GMCLASSID_SECURITY_DATAREADER_CRYPTO_TOKENS)) {
-    if (!handle_datareader_crypto_tokens(msg, send_tokens)) {
+    if (!handle_datareader_crypto_tokens(msg)) {
       ACE_DEBUG((LM_DEBUG, "Sedp::received_volatile_message_secure handle_datareader_crypto_tokens failed\n"));
       return;
     }
   } else {
     return;
-  }
-
-  if (!send_tokens) {
-    return;
-  }
-
-  const DCPS::RepoId remote_volatile_reader = make_id(msg.message_identity.source_guid,
-                                                      ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-  if (associated_volatile_readers_.count(remote_volatile_reader) == 0) {
-    if (DCPS::security_debug.auth_debug) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::send_crypto_tokens: "
-                 "deferring send_participant_crypto_token until asociation complete %C\n",
-                 OPENDDS_STRING(DCPS::GuidConverter(remote_volatile_reader)).c_str()));
-    }
-    pending_volatile_readers_.insert(remote_volatile_reader);
-  } else {
-    if (DCPS::security_debug.auth_debug) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::send_crypto_tokens: "
-                 "calling send_participant_crypto_tokens\n"));
-    }
-    spdp_.send_participant_crypto_tokens(remote_volatile_reader);
-    send_cached_crypto_tokens(remote_volatile_reader);
-    send_builtin_crypto_tokens(spdp_.get_participant_data(remote_volatile_reader));
-    resend_user_crypto_tokens(remote_volatile_reader);
   }
 }
 #endif
@@ -2940,19 +2947,9 @@ Sedp::association_complete(const RepoId& localId,
   } else if (remoteId.entityId == ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER) {
     write_durable_dcps_participant_secure(remoteId);
   } else if (remoteId.entityId == ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER) {
-    if (DCPS::security_debug.auth_debug) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::association_complete %C\n",
-        OPENDDS_STRING(DCPS::GuidConverter(remoteId)).c_str()));
-    }
-    if (associated_volatile_readers_.insert(remoteId).second) {
-      if (DCPS::security_debug.auth_debug) {
-        ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::association_complete calling send_participant_crypto_token\n"));
-      }
-      spdp_.send_participant_crypto_tokens(remoteId);
-      send_builtin_crypto_tokens(spdp_.get_participant_data(remoteId));
-      send_cached_crypto_tokens(remoteId);
-      pending_volatile_readers_.erase(remoteId);
-    }
+    spdp_.volatile_association_complete(remoteId);
+    spdp_.send_participant_crypto_tokens(remoteId);
+    send_builtin_crypto_tokens(remoteId);
   }
 #endif
   if (remoteId.entityId == ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER) {
@@ -3272,8 +3269,6 @@ Sedp::Writer::write_volatile_message_secure(const DDS::Security::ParticipantVola
                                             const RepoId& reader,
                                             DCPS::SequenceNumber& sequence)
 {
-  OPENDDS_ASSERT(sedp_.associated_volatile_readers_.count(reader) != 0);
-
   using DCPS::Serializer;
 
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
@@ -4675,11 +4670,13 @@ Sedp::send_datawriter_crypto_tokens(const RepoId& local_writer,
 }
 
 bool
-Sedp::handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                      bool& send_our_tokens) {
+Sedp::handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg) {
   if (DCPS::security_debug.auth_debug) {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::handle_datawriter_crypto_tokens\n"));
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("(%P|%t) Sedp::handle_datawriter_crypto_tokens() %C\n"),
+               DCPS::LogGuid(msg.source_endpoint_guid).c_str()));
   }
+
   DDS::Security::SecurityException se = {"", 0, 0};
   Security::CryptoKeyExchange_var key_exchange = spdp_.get_security_config()->get_crypto_key_exchange();
 
@@ -4700,7 +4697,6 @@ Sedp::handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMe
     }
 
     pending_remote_writer_crypto_tokens_[msg.source_endpoint_guid] = dwcts;
-    send_our_tokens = spdp_.seen_crypto_tokens_from(msg.message_identity.source_guid);
     return true;
   }
 
@@ -4721,13 +4717,21 @@ Sedp::handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMe
     return false;
   }
 
-  send_our_tokens = spdp_.seen_crypto_tokens_from(msg.message_identity.source_guid);
+  if (is_secure(w_iter->first)) {
+    associate_secure_reader_to_writer(w_iter->first);
+  }
+
   return true;
 }
 
 bool
-Sedp::handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                      bool& send_our_tokens) {
+Sedp::handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg) {
+  if (DCPS::security_debug.auth_debug) {
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("(%P|%t) Sedp::handle_datareader_crypto_tokens() %C\n"),
+               DCPS::LogGuid(msg.source_endpoint_guid).c_str()));
+  }
+
   DDS::Security::SecurityException se = {"", 0, 0};
   Security::CryptoKeyExchange_var key_exchange = spdp_.get_security_config()->get_crypto_key_exchange();
 
@@ -4748,7 +4752,6 @@ Sedp::handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMe
     }
 
     pending_remote_reader_crypto_tokens_[msg.source_endpoint_guid] = drcts;
-    send_our_tokens = spdp_.seen_crypto_tokens_from(msg.message_identity.source_guid);
     return true;
   }
 
@@ -4775,7 +4778,10 @@ Sedp::handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMe
     return false;
   }
 
-  send_our_tokens = spdp_.seen_crypto_tokens_from(msg.message_identity.source_guid);
+  if (is_secure(r_iter->first)) {
+    associate_secure_writer_to_reader(r_iter->first);
+  }
+
   return true;
 }
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -984,12 +984,12 @@ void Sedp::rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata)
 
 #endif // OPENDDS_SECURITY
 
-void Sedp::disassociate_helper(BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
+void Sedp::disassociate_helper(BuiltinEndpointSet_t& associated_endpoints, const CORBA::ULong flags,
                                const RepoId& id, const EntityId_t& ent, DCPS::TransportClient& client)
 {
-  if (avail & flags) {
+  if (associated_endpoints & flags) {
     client.disassociate(make_id(id, ent));
-    avail &= ~flags;
+    associated_endpoints &= ~flags;
   }
 }
 
@@ -1091,8 +1091,6 @@ void Sedp::associate_secure_reader_to_writer(const RepoId& remote_writer)
   using namespace DDS::Security;
 
   ParticipantData_t& pdata = spdp_.get_participant_data(remote_writer);
-
-  using namespace DDS::Security;
 
   DCPS::AssociationData peer;
   create_association_data_proto(peer, pdata);
@@ -4717,7 +4715,7 @@ Sedp::handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMe
     return false;
   }
 
-  if (is_secure(w_iter->first)) {
+  if (DCPS::GuidConverter(msg.source_endpoint_guid).isBuiltinDomainEntity()) {
     associate_secure_reader_to_writer(w_iter->first);
   }
 
@@ -4778,7 +4776,7 @@ Sedp::handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMe
     return false;
   }
 
-  if (is_secure(r_iter->first)) {
+  if (DCPS::GuidConverter(msg.source_endpoint_guid).isBuiltinDomainEntity()) {
     associate_secure_writer_to_reader(r_iter->first);
   }
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -989,7 +989,7 @@ void Sedp::disassociate_helper(BuiltinEndpointSet_t& avail, const CORBA::ULong f
 {
   if (avail & flags) {
     client.disassociate(make_id(id, ent));
-    avail ^= flags;
+    avail &= ~flags;
   }
 }
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -101,6 +101,8 @@ public:
   void associate_preauth(Security::SPDPdiscoveredParticipantData& pdata);
   void associate_volatile(Security::SPDPdiscoveredParticipantData& pdata);
   void rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
+  void associate_secure_endpoints(Security::SPDPdiscoveredParticipantData& pdata,
+                                  const DDS::Security::ParticipantSecurityAttributes& participant_sec_attr);
   void generate_remote_crypto_handles(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_reader_to_writer(const DCPS::RepoId& remote_writer);
   void associate_secure_writer_to_reader(const DCPS::RepoId& remote_reader);
@@ -204,21 +206,6 @@ private:
   protected:
     DCPS::WeakRcHandle<Sedp> sedp_;
     const DCPS::MessageId id_;
-  };
-
-  class MsgParticipantData : public MsgBase {
-  public:
-    MsgParticipantData(const DCPS::WeakRcHandle<Sedp>& sedp,
-                       DCPS::MessageId id,
-                       const ParticipantData_t& data)
-      : MsgBase(sedp, id)
-      , data_(data)
-    {}
-
-    void execute();
-
-  private:
-    const ParticipantData_t data_;
   };
 
   class MsgDiscoveredPublication : public MsgBase {

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -100,7 +100,7 @@ public:
 #ifdef OPENDDS_SECURITY
   void associate_preauth(Security::SPDPdiscoveredParticipantData& pdata);
   void associate_volatile(Security::SPDPdiscoveredParticipantData& pdata);
-  void rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
+  void disassociate_volatile(Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_endpoints(Security::SPDPdiscoveredParticipantData& pdata,
                                   const DDS::Security::ParticipantSecurityAttributes& participant_sec_attr);
   void generate_remote_crypto_handles(const Security::SPDPdiscoveredParticipantData& pdata);

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -95,20 +95,19 @@ public:
 #endif
   const ACE_INET_Addr& multicast_group() const;
 
-  void associate(const ParticipantData_t& pdata);
+  void associate(ParticipantData_t& pdata);
 
 #ifdef OPENDDS_SECURITY
-  void associate_preauth(const Security::SPDPdiscoveredParticipantData& pdata);
-  void associate_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
+  void associate_preauth(Security::SPDPdiscoveredParticipantData& pdata);
+  void associate_volatile(Security::SPDPdiscoveredParticipantData& pdata);
   void rekey_volatile(const Security::SPDPdiscoveredParticipantData& pdata);
-  void associate_secure_writers_to_readers(const Security::SPDPdiscoveredParticipantData& pdata);
-  void associate_secure_readers_to_writers(const Security::SPDPdiscoveredParticipantData& pdata);
-  void disassociate_security_builtins(BuiltinEndpointSet_t local_avail, BuiltinEndpointSet_t avail,
-                                      const DCPS::RepoId& part);
+  void generate_remote_crypto_handles(const Security::SPDPdiscoveredParticipantData& pdata);
+  void associate_secure_reader_to_writer(const DCPS::RepoId& remote_writer);
+  void associate_secure_writer_to_reader(const DCPS::RepoId& remote_reader);
+  void disassociate_security_builtins(ParticipantData_t& pdata);
   void remove_remote_crypto_handle(const DCPS::RepoId& participant, const EntityId_t& entity);
 
-  /// Create and send keys the first time
-  void send_builtin_crypto_tokens(const Security::SPDPdiscoveredParticipantData& pdata);
+  void send_builtin_crypto_tokens(const DCPS::RepoId& remoteId);
 
   /// Create and send keys for individual endpoints.
   void send_builtin_crypto_tokens(const DCPS::RepoId& dstParticipant,
@@ -117,7 +116,7 @@ public:
   void resend_user_crypto_tokens(const DCPS::RepoId& remote_participant);
 #endif
 
-  bool disassociate(const ParticipantData_t& pdata);
+  bool disassociate(ParticipantData_t& pdata);
 
   void update_locators(const ParticipantData_t& pdata);
 
@@ -812,35 +811,10 @@ protected:
     const DDS::Security::DatawriterCryptoHandle& dwch, const DCPS::RepoId& local_writer,
     const DDS::Security::DatareaderCryptoHandle& drch, const DCPS::RepoId& remote_reader);
 
-  bool handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                       bool& send_our_tokens);
-  bool handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                       bool& send_our_tokens);
-
-  void send_cached_crypto_tokens(const DCPS::RepoId& remote_participant);
+  bool handle_datareader_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
+  bool handle_datawriter_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
 
   DDS::DomainId_t get_domain_id() const;
-
-  DCPS::RepoIdSet associated_volatile_readers_;
-
-  struct RemoteWriter {
-    DCPS::RepoId local_reader, remote_writer;
-    DDS::Security::DatareaderCryptoTokenSeq reader_tokens;
-  };
-  typedef OPENDDS_VECTOR(RemoteWriter) RemoteWriterVector;
-  typedef OPENDDS_MAP_CMP(
-    DCPS::RepoId, RemoteWriterVector, DCPS::GUID_tKeyLessThan) RemoteWriterVectors;
-  RemoteWriterVectors datareader_crypto_tokens_;
-
-  struct RemoteReader {
-    DCPS::RepoId local_writer, remote_reader;
-    DDS::Security::DatawriterCryptoTokenSeq writer_tokens;
-  };
-  typedef OPENDDS_VECTOR(RemoteReader) RemoteReaderVector;
-  typedef OPENDDS_MAP_CMP(
-    DCPS::RepoId, RemoteReaderVector, DCPS::GUID_tKeyLessThan) RemoteReaderVectors;
-  RemoteReaderVectors datawriter_crypto_tokens_;
-  DCPS::RepoIdSet pending_volatile_readers_;
 
   struct PublicationAgentInfoListener : public ICE::AgentInfoListener
   {
@@ -876,7 +850,7 @@ protected:
   void stop_ice(const DCPS::RepoId& guid, const DiscoveredPublication& dpub);
   void stop_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub);
 
-  void disassociate_helper(const BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
+  void disassociate_helper(BuiltinEndpointSet_t& avail, const CORBA::ULong flags,
                            const DCPS::RepoId& id, const EntityId_t& ent, DCPS::TransportClient& client);
   void replay_durable_data_for(const DCPS::RepoId& remote_sub_id);
 };

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -632,7 +632,15 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         iter->second.property_qos_ = pdata.ddsParticipantDataSecure.base.property;
         iter->second.security_info_ = pdata.ddsParticipantDataSecure.base.security_info;
 
+        // The remote needs to see our SPDP before attempting authentication.
+        if (from_relay) {
+          tport_->write_i(guid, SpdpTransport::SEND_TO_RELAY);
+        } else {
+          tport_->write_i(guid, SpdpTransport::SEND_TO_LOCAL);
+        }
+
         attempt_authentication(iter, true);
+
         if (iter->second.auth_state_ == DCPS::AUTH_STATE_UNAUTHENTICATED) {
           if (participant_sec_attr_.allow_unauthenticated_participants == false) {
             if (DCPS::security_debug.auth_debug) {
@@ -1327,16 +1335,8 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
       // Install the shared secret before sending the final so that
       // we are prepared to receive the crypto tokens from the
       // replier.
-      dp.seen_some_crypto_tokens_ = false;
-      // match_authenticated releases the lock which means (1) iter
-      // may become invalid and (2) The resend timer may fire and send
-      // the request again.  So, disable the resend.
-      dp.have_handshake_msg_ = false;
-      match_authenticated(src_participant, iter);
-      if (iter == participants_.end()) {
-        return;
-      }
 
+      // Send the final first because match_authenticated takes forever.
       if (send_handshake_message(src_participant, iter->second, reply) != DDS::RETCODE_OK) {
         if (DCPS::security_debug.auth_warn) {
           ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} WARNING: Spdp::handle_handshake_message() - ")
@@ -1350,6 +1350,14 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
                      OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
         }
       }
+
+      // match_authenticated releases the lock which means iter may
+      // become invalid.
+      match_authenticated(src_participant, iter);
+      if (iter == participants_.end()) {
+        return;
+      }
+
       return;
     }
     case DDS::Security::VALIDATION_OK: {
@@ -1466,8 +1474,7 @@ Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
 }
 
 bool
-Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                       bool& send_our_tokens)
+Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg)
 {
   DDS::Security::SecurityException se = {"", 0, 0};
   Security::CryptoKeyExchange_var key_exchange = security_config_->get_crypto_key_exchange();
@@ -1510,32 +1517,31 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
     return false;
   }
 
-  send_our_tokens = !dp.is_requester_ && !dp.seen_some_crypto_tokens_;
-  dp.seen_some_crypto_tokens_ = true;
   if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN) {
     dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
     purge_handshake_deadlines(iter);
   }
+
+  // TODO: Does a secure remote always send a participant token?
+  // If not, then the following call needs to be copied somewhere else.
+
+  sedp_.associate(iter->second.pdata_);
 
   return true;
 }
 
-bool Spdp::seen_crypto_tokens_from(const RepoId& sender)
+void Spdp::volatile_association_complete(const RepoId& sender)
 {
   const RepoId src_participant = make_id(sender.guidPrefix, ENTITYID_PARTICIPANT);
   const DiscoveredParticipantIter iter = participants_.find(src_participant);
   if (iter == participants_.end()) {
-    return false;
+    return;
   }
   DiscoveredParticipant& dp = iter->second;
-  const bool send_our_tokens = !dp.is_requester_ && !dp.seen_some_crypto_tokens_;
-  dp.seen_some_crypto_tokens_ = true;
   if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN) {
     dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
     purge_handshake_deadlines(iter);
   }
-
-  return send_our_tokens;
 }
 
 DDS::ReturnCode_t
@@ -1726,28 +1732,14 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
   // notify Sedp of association
   // Sedp may call has_discovered_participant, which is the participant must be added before these calls to associate.
 
-  sedp_.associate(iter->second.pdata_);
+  sedp_.generate_remote_crypto_handles(iter->second.pdata_);
   sedp_.associate_volatile(iter->second.pdata_);
-  sedp_.associate_secure_writers_to_readers(iter->second.pdata_);
-  sedp_.associate_secure_readers_to_writers(iter->second.pdata_);
-  iter->second.security_builtins_associated_ = true;
 
   iter->second.bit_ih_ = bit_instance_handle;
 #ifndef DDS_HAS_MINIMUM_BIT
   process_location_updates_i(iter);
 #endif
   return true;
-}
-
-bool Spdp::security_builtins_associated(const DCPS::RepoId& remoteParticipant) const
-{
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
-  if (!security_enabled_) {
-    return false;
-  }
-
-  const DiscoveredParticipantConstIter iter = participants_.find(remoteParticipant);
-  return iter == participants_.end() ? false : iter->second.security_builtins_associated_;
 }
 
 void Spdp::update_agent_info(const DCPS::RepoId&, const ICE::AgentInfo&)
@@ -1985,7 +1977,8 @@ Spdp::build_local_pdata(
       nonEmptyList /*defaultUnicastLocatorList*/,
       {0 /*manualLivelinessCount*/},   //FUTURE: implement manual liveliness
       qos_.property,
-      {PFLAGS_NO_ASSOCIATED_WRITERS} // opendds_participant_flags
+      {PFLAGS_NO_ASSOCIATED_WRITERS}, // opendds_participant_flags
+      0 // associated_endpoints_
     },
     { // Duration_t (leaseDuration)
       static_cast<CORBA::Long>(config_->lease_duration().value().sec()),
@@ -3594,6 +3587,12 @@ bool Spdp::remote_is_requester(const DCPS::RepoId& guid) const
 const ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid) const
 {
   DiscoveredParticipantConstIter iter = participants_.find(make_id(guid, DCPS::ENTITYID_PARTICIPANT));
+  return iter->second.pdata_;
+}
+
+ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid)
+{
+  DiscoveredParticipantIter iter = participants_.find(make_id(guid, DCPS::ENTITYID_PARTICIPANT));
   return iter->second.pdata_;
 }
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1602,7 +1602,9 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
       return false;
     }
 
-    sedp_.rekey_volatile(iter->second.pdata_);
+    sedp_.disassociate_volatile(iter->second.pdata_);
+    //sedp_.rekey_volatile(iter->second.pdata_);
+    sedp_.associate_volatile(iter->second.pdata_);
 
     if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
       if (DCPS::security_debug.auth_warn) {
@@ -1726,9 +1728,9 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
   }
 #endif /* DDS_HAS_MINIMUM_BIT */
 
-  // notify Sedp of association
-  // Sedp may call has_discovered_participant, which is the participant must be added before these calls to associate.
-
+  // notify Sedp of association Sedp may call
+  // has_discovered_participant, which is the participant must be
+  // added before these calls to associate.
 
   if (iter->second.crypto_tokens_.length() == 0) {
     sedp_.associate(iter->second.pdata_);
@@ -3576,15 +3578,6 @@ void Spdp::process_participant_ice(const ParameterList& plist,
 #endif
     }
   }
-}
-
-bool Spdp::remote_is_requester(const DCPS::RepoId& guid) const
-{
-  DiscoveredParticipantConstIter iter = participants_.find(make_id(guid, DCPS::ENTITYID_PARTICIPANT));
-  if (iter != participants_.end()) {
-    return iter->second.is_requester_;
-  }
-  return false;
 }
 
 const ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid) const

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1603,7 +1603,6 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
     }
 
     sedp_.disassociate_volatile(iter->second.pdata_);
-    //sedp_.rekey_volatile(iter->second.pdata_);
     sedp_.associate_volatile(iter->second.pdata_);
 
     if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -151,7 +151,6 @@ public:
                                const ParticipantData_t& pdata,
                                const DCPS::RepoId& guid);
 
-  bool remote_is_requester(const DCPS::RepoId& guid) const;
   const ParticipantData_t& get_participant_data(const DCPS::RepoId& guid) const;
   ParticipantData_t& get_participant_data(const DCPS::RepoId& guid);
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -108,9 +108,8 @@ public:
   void handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg);
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
-  bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg,
-                                        bool& send_our_tokens);
-  bool seen_crypto_tokens_from(const DCPS::RepoId& sender);
+  bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
+  void volatile_association_complete(const DCPS::RepoId& sender);
   DDS::OctetSeq local_participant_data_as_octets() const;
 #endif
 
@@ -134,7 +133,6 @@ public:
   void write_secure_updates();
   void write_secure_disposes();
   bool is_security_enabled() const { return security_enabled_; }
-  bool security_builtins_associated(const DCPS::RepoId& remoteParticipant) const;
 #endif
 
   bool is_expectant_opendds(const GUID_t& participant) const;
@@ -155,6 +153,7 @@ public:
 
   bool remote_is_requester(const DCPS::RepoId& guid) const;
   const ParticipantData_t& get_participant_data(const DCPS::RepoId& guid) const;
+  ParticipantData_t& get_participant_data(const DCPS::RepoId& guid);
 
 #endif
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -283,7 +283,7 @@ StaticEndpointManager::association_complete(const RepoId& /*localId*/,
 }
 
 bool
-StaticEndpointManager::disassociate(const StaticDiscoveredParticipantData& /*pdata*/)
+StaticEndpointManager::disassociate(StaticDiscoveredParticipantData& /*pdata*/)
 {
   ACE_DEBUG((LM_NOTICE, ACE_TEXT("(%P|%t) StaticEndpointManager::disassociate TODO\n")));
   // TODO

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -166,7 +166,7 @@ public:
   virtual void association_complete(const RepoId& /*localId*/,
                                     const RepoId& /*remoteId*/);
 
-  virtual bool disassociate(const StaticDiscoveredParticipantData& /*pdata*/);
+  virtual bool disassociate(StaticDiscoveredParticipantData& /*pdata*/);
 
   virtual DDS::ReturnCode_t add_publication_i(const RepoId& /*rid*/,
                                               LocalPublication& /*pub*/);

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -1645,7 +1645,9 @@ AccessControlBuiltInImpl::RevokePermissionsTimer::~RevokePermissionsTimer()
 
   if (!entry_map_.empty() && reactor) {
     reactor->cancel_timer(this);
-    // TODO: Empty the map.
+    for (EntryMap::const_iterator pos = entry_map_.begin(), limit = entry_map_.end(); pos != limit; ++pos) {
+      delete pos->second;
+    }
   }
 }
 

--- a/dds/DCPS/security/AccessControlBuiltInImpl.h
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.h
@@ -260,20 +260,27 @@ private:
   public:
     RevokePermissionsTimer(AccessControlBuiltInImpl& impl);
     virtual ~RevokePermissionsTimer();
-    bool start_timer(const DCPS::TimeDuration& length, DDS::Security::PermissionsHandle pm_handle);
+    bool start_timer(const time_t& expiration, DDS::Security::PermissionsHandle pm_handle);
     virtual int handle_timeout(const ACE_Time_Value& tv, const void* arg);
-    bool is_scheduled() { return scheduled_; }
 
   protected:
     AccessControlBuiltInImpl& impl_;
 
-    const DCPS::TimeDuration& interval() const { return interval_; }
-
   private:
-    DCPS::TimeDuration interval_;
-    bool scheduled_;
-    long timer_id_;
-    ACE_Thread_Mutex lock_;
+    struct Entry {
+      DDS::Security::PermissionsHandle handle;
+      time_t expiration;
+
+      Entry() : handle(0), expiration(0) {}
+      Entry(DDS::Security::PermissionsHandle a_handle,
+            time_t a_expiration)
+        : handle(a_handle)
+        , expiration(a_expiration)
+      {}
+    };
+    typedef OPENDDS_MAP(DDS::Security::PermissionsHandle, Entry*) EntryMap;
+    EntryMap entry_map_;
+    mutable ACE_Thread_Mutex lock_;
   };
 
   RevokePermissionsTimer local_rp_timer_;
@@ -291,7 +298,7 @@ private:
   time_t convert_permissions_time(const std::string& timeString);
 
   bool validate_date_time(const Permissions::Validity_t& validity,
-                          DCPS::TimeDuration& delta_time,
+                          time_t& expiration,
                           DDS::Security::SecurityException& ex);
 
   bool get_sec_attributes(DDS::Security::PermissionsHandle permissions_handle,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -126,11 +126,11 @@ RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
 namespace {
   ssize_t recv_err(const char* msg, const ACE_INET_Addr& remote, const DCPS::RepoId& peer, bool& stop)
   {
-    if (security_debug.encdec_error) {
+    if (security_debug.encdec_warn) {
       ACE_TCHAR addr_buff[256] = {};
       remote.addr_to_string(addr_buff, 256);
       GuidConverter gc(peer);
-      ACE_ERROR((LM_ERROR, "(%P|%t) {encdec_error} RtpsUdpReceiveStrategy::receive_bytes - "
+      ACE_ERROR((LM_WARNING, "(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy::receive_bytes - "
                  "from %s %C secure RTPS processing failed: %C\n", addr_buff, OPENDDS_STRING(gc).c_str(), msg));
     }
     stop = true;

--- a/tests/security/attributes/subscriber.cpp
+++ b/tests/security/attributes/subscriber.cpp
@@ -156,7 +156,7 @@ int run_test(int argc, ACE_TCHAR *argv[], Args& my_args) {
     DDS::DataReaderQos dr_qos;
     sub->get_default_datareader_qos(dr_qos);
     if (DataReaderListenerImpl::is_reliable()) {
-      std::cout << "Reliable DataReader" << std::endl;
+      std::cerr << "Reliable DataReader" << std::endl;
       dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
     }
 

--- a/tests/transport/spdp/spdp_transport.cpp
+++ b/tests/transport/spdp/spdp_transport.cpp
@@ -340,7 +340,8 @@ bool run_test()
     { // Duration_t (leaseDuration)
       static_cast<CORBA::Long>((rd.resend_period() * 10).value().sec()),
       0 // we are not supporting fractional seconds in the lease duration
-    }
+    },
+    0
   };
 
   if (!OpenDDS::RTPS::ParameterListConverter::to_param_list(pdata, plist)) {


### PR DESCRIPTION
Problem 1
---------

The default configuration delays an SPDP resend for 3 seconds.
However, a participant A receiving an initial SPDP announcement from B
will attempt authentication with B.  However, B will ignore the
authentication messages because it has not discovered A.

Solution 1
----------

Send an SPDP announcement when attempting authentication with a newly
discovered participant.

Problem 2
---------

`match_authenticated` is called before the FINAL in the auth handshake
is sent.  This is problematic because `match_authenticated` is slow,
e.g., takes 1 second to complete.  The other participant is idle while
waiting for the FINAL and will call `match_authenticated` when it gets
the FINAL.

Solution 2
----------

Send the FINAL before calling `match_authenticated`.  While it doesn't
address the reason that `match_authenticated` is so slow, it helps
because both participants can be in `match_authenticated` at the same
time.

Problem 3
---------

`match_authenticated` associates all of the builtin readers and
writers.  At more-or-less the same time, it is sending crypto tokens
for the builtin endpoints.  This creates a race where the heartbeats
and acknacks for reliability can get dropped because the crypto tokens
are not in place to decrypt them.  This means discovery has to wait
one or two rounds of reliability which is 1 or 2 seconds by default.

Solution 3
----------

Defer associating the builtin endpoints until the crypto tokens have
been received for the remote.  This suggests that a similar race
condition may exist for user endpoints.