### PR TITLE
Perform Multicast Join on Loopback Interface

### DIFF
--- a/dds/DCPS/LinuxNetworkConfigMonitor.cpp
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.cpp
@@ -225,7 +225,7 @@ void LinuxNetworkConfigMonitor::process_message(const nlmsghdr* header)
       }
 
       remove_interface(msg->ifi_index);
-      add_interface(NetworkInterface(msg->ifi_index, name, msg->ifi_flags & IFF_MULTICAST));
+      add_interface(NetworkInterface(msg->ifi_index, name, msg->ifi_flags & (IFF_MULTICAST | IFF_LOOPBACK)));
     }
     break;
   case RTM_DELLINK:


### PR DESCRIPTION
Moving to the LinuxNetworkConfigMonitor changed how we do joins on the loopback interface, breaking local discovery when no network connection is available. This allows multicast joins to be performed on the loopback interface despite lack of the explicit multicast flag and resolves the issue.