### PR TITLE
Add Mutex Protection To NetworkInterface And Fix Interaction With MulticastInterface Addresses

### DIFF
--- a/dds/DCPS/NetworkConfigModifier.cpp
+++ b/dds/DCPS/NetworkConfigModifier.cpp
@@ -64,7 +64,7 @@ bool NetworkConfigModifier::open()
 
         std::pair<Nics::iterator, bool> p = nics.insert(std::make_pair(p_if->ifa_name, NetworkInterface(ACE_OS::if_nametoindex(p_if->ifa_name), p_if->ifa_name, p_if->ifa_flags & IFF_MULTICAST)));
 
-        p.first->second.addresses.insert(address);
+        p.first->second.add_address(address);
       }
     }
 # if defined (ACE_HAS_IPV6)
@@ -77,7 +77,7 @@ bool NetworkConfigModifier::open()
 
         std::pair<Nics::iterator, bool> p = nics.insert(std::make_pair(p_if->ifa_name, NetworkInterface(ACE_OS::if_nametoindex(p_if->ifa_name), p_if->ifa_name, p_if->ifa_flags & IFF_MULTICAST)));
 
-        p.first->second.addresses.insert(address);
+        p.first->second.add_address(address);
       }
     }
 # endif /* ACE_HAS_IPV6 */
@@ -148,44 +148,6 @@ void NetworkConfigModifier::add_interface(const OPENDDS_STRING &name)
   validate_interfaces_index();
 }
 
-void NetworkConfigModifier::remove_interface(const OPENDDS_STRING &name)
-{
-  int index = get_index(name);
-  if (index != -1) {
-    NetworkConfigMonitor::remove_interface(index);
-  }
-  else {
-    if (DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: NetworkConfigModifier::remove_interface. Interface '%C' not found.\n"), name.c_str()));
-    }
-  }
-}
-
-void NetworkConfigModifier::add_address(const OPENDDS_STRING &name, const ACE_INET_Addr& address)
-{
-  int index = get_index(name);
-  if (index != -1) {
-    NetworkConfigMonitor::add_address(index, address);
-  }
-  else {
-    if (DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: NetworkConfigModifier::add_address. Interface '%C' not found.\n"), name.c_str()));
-    }
-  }
-}
-
-void NetworkConfigModifier::remove_address(const OPENDDS_STRING &name, const ACE_INET_Addr& address)
-{
-  int index = get_index(name);
-  if (index != -1) {
-    NetworkConfigMonitor::remove_address(index, address);
-  } else {
-    if (DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: NetworkConfigModifier::remove_address. Interface '%C' not found.\n"), name.c_str()));
-    }
-  }
-}
-
 void NetworkConfigModifier::validate_interfaces_index()
 {
   // if the OS has added an interface, which happens when
@@ -217,7 +179,7 @@ void NetworkConfigModifier::validate_interfaces_index()
 
     if (p_if->ifa_addr->sa_family == AF_INET || p_if->ifa_addr->sa_family == AF_INET6) {
       const OPENDDS_STRING name(p_if->ifa_name);
-      NetworkInterfaces nics = get();
+      NetworkInterfaces nics = get_interfaces();
       NetworkInterfaces::iterator nic_pos = std::find_if(nics.begin(), nics.end(), NetworkInterfaceName(name));
       if (nic_pos != nics.end()) {
         nic_pos->index(count);
@@ -227,19 +189,6 @@ void NetworkConfigModifier::validate_interfaces_index()
   }
 
   ::freeifaddrs (p_ifa);
-}
-
-int NetworkConfigModifier::get_index(const OPENDDS_STRING& name)
-{
-  int index = -1;
-
-  NetworkInterfaces nics = get();
-  NetworkInterfaces::iterator nic_pos = std::find_if(nics.begin(), nics.end(), NetworkInterfaceName(name));
-  if (nic_pos != nics.end()) {
-    index = nic_pos->index();
-  }
-
-  return index;
 }
 
 } // DCPS

--- a/dds/DCPS/NetworkConfigModifier.h
+++ b/dds/DCPS/NetworkConfigModifier.h
@@ -22,17 +22,6 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-struct NetworkInterfaceName {
-  explicit NetworkInterfaceName(const OPENDDS_STRING& name) : name_(name) {}
-
-  bool operator()(const NetworkInterface& nic)
-  {
-    return name_ == nic.name();
-  }
-
-  const OPENDDS_STRING name_;
-};
-
 class OpenDDS_Dcps_Export NetworkConfigModifier : public NetworkConfigMonitor {
 public:
   explicit NetworkConfigModifier();
@@ -40,12 +29,6 @@ public:
   bool close();
 
   void add_interface(const OPENDDS_STRING &name);
-  void remove_interface(const OPENDDS_STRING &name);
-  void add_address(const OPENDDS_STRING &name, const ACE_INET_Addr& address);
-  void remove_address(const OPENDDS_STRING &name, const ACE_INET_Addr& address);
-
-protected:
-  int get_index(const OPENDDS_STRING& name);
 
 private:
   void validate_interfaces_index();

--- a/dds/DCPS/NetworkConfigMonitor.cpp
+++ b/dds/DCPS/NetworkConfigMonitor.cpp
@@ -18,42 +18,81 @@ namespace DCPS {
 void NetworkInterface::add_default_addrs()
 {
   const ACE_INET_Addr sp_default = TheServiceParticipant->default_address();
+  ACE_Guard<ACE_Thread_Mutex> g(mutex_);
   if (sp_default != ACE_INET_Addr()) {
-    addresses.insert(sp_default);
+    addresses_.insert(sp_default);
     return;
   }
   static const u_short port_zero = 0;
   ACE_INET_Addr addr(port_zero, "0.0.0.0");
-  addresses.insert(addr);
+  addresses_.insert(addr);
 #ifdef ACE_HAS_IPV6
   ACE_INET_Addr addr2(port_zero, "::");
-  addresses.insert(addr2);
+  addresses_.insert(addr2);
 #endif
 }
 
 bool NetworkInterface::has(const ACE_INET_Addr& addr) const
 {
-  for (AddressSet::const_iterator pos = addresses.begin(), limit = addresses.end(); pos != limit; ++pos) {
-    if (*pos == addr) {
-      return true;
-    }
-  }
-  return false;
+  ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+  return addresses_.count(addr);
 }
 
 bool NetworkInterface::exclude_from_multicast(const char* configured_interface) const
 {
-  if ((*configured_interface && name_ != configured_interface)
-      || addresses.empty() || !can_multicast_) {
+  ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+
+  if (addresses_.empty() || !can_multicast_) {
     return true;
   }
 
+  if (configured_interface && *configured_interface && name_ != configured_interface) {
+    OPENDDS_STRING ci_semi(configured_interface);
+    if (ci_semi.find_first_of(':') == OPENDDS_STRING::npos) {
+      ci_semi += ':';
+    }
+    ACE_INET_Addr as_addr(ci_semi.c_str());
+    if (as_addr == ACE_INET_Addr() || addresses_.count(as_addr) == 0) {
+      return true;
+    }
+  }
+
   const ACE_INET_Addr sp_default = TheServiceParticipant->default_address();
-  if (sp_default != ACE_INET_Addr() && !has(sp_default)) {
+  if (sp_default != ACE_INET_Addr() && addresses_.count(sp_default) == 0) {
     return true;
   }
 
   return false;
+}
+
+bool NetworkInterface::add_address(const ACE_INET_Addr& addr)
+{
+  ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+  return addresses_.insert(addr).second;
+}
+
+bool NetworkInterface::remove_address(const ACE_INET_Addr& addr)
+{
+  ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+  return addresses_.erase(addr) != 0;
+}
+
+NetworkInterface& NetworkInterface::operator=(const NetworkInterface& rhs)
+{
+  if (this != &rhs) {
+    const bool me_first = this < &rhs;
+    ACE_Thread_Mutex* const first = me_first ? &mutex_ : &(rhs.mutex_);
+    ACE_Thread_Mutex* const second = me_first ? &(rhs.mutex_) : &mutex_;
+
+    ACE_Guard<ACE_Thread_Mutex> g1(*first);
+    ACE_Guard<ACE_Thread_Mutex> g2(*second);
+
+    addresses_ = rhs.addresses_;
+    index_ = rhs.index_;
+    name_ = rhs.name_;
+    can_multicast_ = rhs.can_multicast_;
+  }
+  return *this;
 }
 
 void NetworkConfigMonitor::add_listener(NetworkConfigListener_wrch listener)
@@ -77,7 +116,7 @@ void NetworkConfigMonitor::remove_listener(NetworkConfigListener_wrch listener)
   listeners_.erase(listener);
 }
 
-NetworkInterfaces NetworkConfigMonitor::get() const
+NetworkInterfaces NetworkConfigMonitor::get_interfaces() const
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, network_interfaces_mutex_, NetworkInterfaces());
   return network_interfaces_;
@@ -144,9 +183,7 @@ void NetworkConfigMonitor::add_address(int index, const ACE_INET_Addr& address)
     ACE_GUARD(ACE_Thread_Mutex, g, network_interfaces_mutex_);
     NetworkInterfaces::iterator nic_pos = std::find_if(network_interfaces_.begin(), network_interfaces_.end(), NetworkInterfaceIndex(index));
     if (nic_pos != network_interfaces_.end()) {
-      NetworkInterface::AddressSet::const_iterator addr_pos = nic_pos->addresses.find(address);
-      if (addr_pos == nic_pos->addresses.end()) {
-        nic_pos->addresses.insert(address);
+      if (nic_pos->add_address(address)) {
         nic = *nic_pos;
         publish = true;
       }
@@ -179,9 +216,7 @@ void NetworkConfigMonitor::remove_address(int index, const ACE_INET_Addr& addres
     ACE_GUARD(ACE_Thread_Mutex, g, network_interfaces_mutex_);
     NetworkInterfaces::iterator nic_pos = std::find_if(network_interfaces_.begin(), network_interfaces_.end(), NetworkInterfaceIndex(index));
     if (nic_pos != network_interfaces_.end()) {
-      NetworkInterface::AddressSet::iterator addr_pos = nic_pos->addresses.find(address);
-      if (addr_pos != nic_pos->addresses.end()) {
-        nic_pos->addresses.erase(addr_pos);
+      if (nic_pos->remove_address(address)) {
         nic = *nic_pos;
         publish = true;
       }

--- a/dds/DCPS/NetworkConfigMonitor.h
+++ b/dds/DCPS/NetworkConfigMonitor.h
@@ -92,6 +92,17 @@ struct NetworkInterfaceIndex {
   const int index_;
 };
 
+struct NetworkInterfaceName {
+  explicit NetworkInterfaceName(const OPENDDS_STRING& name) : name_(name) {}
+
+  bool operator()(const NetworkInterface& nic)
+  {
+    return name_ == nic.name();
+  }
+
+  const OPENDDS_STRING name_;
+};
+
 class NetworkConfigListener : public virtual RcObject {
 public:
   virtual void add_interface(const NetworkInterface& interface)
@@ -134,8 +145,14 @@ public:
 protected:
   void add_interface(const NetworkInterface& nic);
   void remove_interface(int index);
+  void remove_interface(const OPENDDS_STRING& name);
+  void publish_remove_interface(const NetworkInterface& nic);
   void add_address(int index, const ACE_INET_Addr& address);
+  void add_address(const OPENDDS_STRING& name, const ACE_INET_Addr& address);
+  void publish_add_address(const NetworkInterface& nic, const ACE_INET_Addr& address);
   void remove_address(int index, const ACE_INET_Addr& address);
+  void remove_address(const OPENDDS_STRING& name, const ACE_INET_Addr& address);
+  void publish_remove_address(const NetworkInterface& nic, const ACE_INET_Addr& address);
 
 private:
   typedef OPENDDS_SET(NetworkConfigListener_wrch) Listeners;


### PR DESCRIPTION
Adding mutex protection to NetworkInterface to allow for future thread-safe interactions and expanding exclude_from_multicast to handle configure_interface strings that are IP addresses, since this string comes directly from the MulticastInterface configuration option (which can optionally be an address) or the DCPSDefaultAddress (which is always an address).