### PR TITLE
TransportSendBuffer leaks memory

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -132,6 +132,7 @@ SingleSendBuffer::release_i(BufferMap::iterator buffer_iter)
     }
   }
 
+  destinations_.erase(buffer_iter->first);
   buffers_.erase(buffer_iter);
 }
 
@@ -162,6 +163,7 @@ SingleSendBuffer::remove_i(BufferMap::iterator buffer_iter, BufferVec& removed)
     }
   }
 
+  destinations_.erase(buffer_iter->first);
   buffers_.erase(buffer_iter);
 }
 


### PR DESCRIPTION
Problem
-------

Entries are inserred into the `destinations_` map but never removed.

Solution
--------

Remove entries from `destinations_` when the corresponding entry is
removed from `buffers_`.