### PR TITLE
SEDP ignores dispose messages with security

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2308,7 +2308,7 @@ Sedp::data_received(DCPS::MessageId message_id,
   }
 
 #ifdef OPENDDS_SECURITY
-  if (should_drop_message(wdata.ddsPublicationData.topic_name)) {
+  if (message_id == DCPS::SAMPLE_DATA && should_drop_message(wdata.ddsPublicationData.topic_name)) {
     return;
   }
 #endif
@@ -2684,7 +2684,7 @@ Sedp::data_received(DCPS::MessageId message_id,
   }
 
 #ifdef OPENDDS_SECURITY
-  if (should_drop_message(rdata.ddsSubscriptionData.topic_name)) {
+  if (message_id == DCPS::SAMPLE_DATA && should_drop_message(rdata.ddsSubscriptionData.topic_name)) {
     return;
   }
 #endif


### PR DESCRIPTION
Problem
-------

The code path for discovered readers and writers in secure SEDP checks
that the topic is valid.  However, the topic name is not populated for
unregister/dispose.  Consequently, unregister/dispose messages are not
processed.

Solution
--------

Move the check later to ensure that the topic name is populated.