### PR TITLE
RTPS Transport does send durable data for first ACKNACK

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2776,25 +2776,20 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
     return;
   }
 
-  bool first_ack = false;
-
   if (!ri->second.handshake_done_) {
     ri->second.handshake_done_ = true;
-    first_ack = true;
-  }
-
-  if (first_ack) {
-    // Queue up durable data.
-    ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
-    ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rg, rev_lock);
-    link->invoke_on_start_callbacks(id_, remote, true);
-  }
-
-  ri = remote_readers_.find(remote);
-  if (ri == remote_readers_.end()) {
-    VDBG((LM_WARNING, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
-          "WARNING ReaderInfo not found\n"));
-    return;
+    {
+      // Queue up durable data.
+      ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
+      ACE_GUARD(ACE_Reverse_Lock<ACE_Thread_Mutex>, rg, rev_lock);
+      link->invoke_on_start_callbacks(id_, remote, true);
+    }
+    ri = remote_readers_.find(remote);
+    if (ri == remote_readers_.end()) {
+      VDBG((LM_WARNING, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
+            "WARNING ReaderInfo not found\n"));
+      return;
+    }
   }
 
   OPENDDS_MAP(SequenceNumber, TransportQueueElement*) pendingCallbacks;


### PR DESCRIPTION
Problem
-------

The "association complete" callback for a reliable RTPS writer is
called when the writer receives the first acknack for a reader.  If
the writer is durable, it causes the writer to send the durable data
for the new reader.  This is currently done and the end of the ACKNACK
processing.  Durable data is sent in response to an ACKNACK.
Consequently, a reader must send one ACKNACK to enqueue the durable
data and another to retrieve it.

Solution
--------

Invoke the callback earlier so the durable data will be available for
sending in response to the first ACKNACK.