### PR TITLE
SPDP lease processing is not scalable

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1644,11 +1644,9 @@ namespace OpenDDS {
 
         DiscoveredParticipant(
           const DiscoveredParticipantData& p,
-          const MonotonicTimePoint& t,
           const SequenceNumber& seq)
         : pdata_(p)
         , location_ih_(DDS::HANDLE_NIL)
-        , last_seen_(t)
         , bit_ih_(DDS::HANDLE_NIL)
         , last_seq_(seq)
         , seq_reset_count_(0)
@@ -1705,7 +1703,7 @@ namespace OpenDDS {
         ParticipantLocationBuiltinTopicData location_data_;
         DDS::InstanceHandle_t location_ih_;
 
-        MonotonicTimePoint last_seen_;
+        MonotonicTimePoint lease_expiration_;
         DDS::InstanceHandle_t bit_ih_;
         SequenceNumber last_seq_;
         ACE_UINT16 seq_reset_count_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -592,8 +592,9 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     }
 
     // add a new participant
-    std::pair<DiscoveredParticipantIter, bool> p = participants_.insert(std::make_pair(guid, DiscoveredParticipant(pdata, now, seq)));
+    std::pair<DiscoveredParticipantIter, bool> p = participants_.insert(std::make_pair(guid, DiscoveredParticipant(pdata, seq)));
     iter = p.first;
+    update_lease_expiration_i(iter, now);
 
 #ifndef DDS_HAS_MINIMUM_BIT
     if (!from_sedp) {
@@ -683,7 +684,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     // Non-secure updates for authenticated participants are used for liveliness but
     // are otherwise ignored. Non-secure dispose messages are ignored completely.
     if (is_security_enabled() && iter->second.auth_state_ == DCPS::AUTH_STATE_AUTHENTICATED && !from_sedp) {
-      iter->second.last_seen_ = now;
+      update_lease_expiration_i(iter, now);
 #ifndef DDS_HAS_MINIMUM_BIT
       process_location_updates_i(iter);
 #endif
@@ -739,7 +740,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         }
         pdata.associated_endpoints = iter->second.pdata_.associated_endpoints;
         iter->second.pdata_ = pdata;
-        iter->second.last_seen_ = now;
+        update_lease_expiration_i(iter, now);
 
 #ifndef DDS_HAS_MINIMUM_BIT
         process_location_updates_i(iter);
@@ -1775,57 +1776,18 @@ void Spdp::remove_agent_info(const DCPS::RepoId&)
 #endif
 
 void
-Spdp::remove_expired_participants()
-{
-  // Find and remove any expired discovered participant
-  ACE_GUARD (ACE_Thread_Mutex, g, lock_);
-  // Iterate through a copy of the repo Ids, rather than the map
-  //   as it gets unlocked in remove_discovered_participant()
-  DCPS::RepoIdSet participant_ids;
-  get_discovered_participant_ids(participant_ids);
-  for (DCPS::RepoIdSet::iterator participant_id = participant_ids.begin();
-       participant_id != participant_ids.end();
-       ++participant_id)
-  {
-    DiscoveredParticipantIter part = participants_.find(*participant_id);
-    if (part != participants_.end()) {
-      const MonotonicTimePoint expr(
-        MonotonicTimePoint::now() -
-        rtps_duration_to_time_duration(
-          part->second.pdata_.leaseDuration,
-          part->second.pdata_.participantProxy.protocolVersion,
-          part->second.pdata_.participantProxy.vendorId
-        )
-      );
-      if (part->second.last_seen_ < expr) {
-        if (DCPS::DCPS_debug_level > 1) {
-          DCPS::GuidConverter conv(part->first);
-          ACE_DEBUG((LM_WARNING,
-            ACE_TEXT("(%P|%t) Spdp::remove_expired_participants() - ")
-            ACE_TEXT("participant %C exceeded lease duration, removing\n"),
-            OPENDDS_STRING(conv).c_str()));
-        }
-#ifdef OPENDDS_SECURITY
-        ICE::Endpoint* sedp_endpoint = sedp_.get_ice_endpoint();
-        if (sedp_endpoint) {
-          stop_ice(sedp_endpoint, part->first, part->second.pdata_.participantProxy.availableBuiltinEndpoints);
-        }
-        ICE::Endpoint* spdp_endpoint = tport_->get_ice_endpoint();
-        if (spdp_endpoint) {
-          ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, part->first);
-        }
-        purge_handshake_deadlines(part);
-#endif
-        remove_discovered_participant(part);
-      }
-    }
-  }
-}
-
-void
 Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
 {
   ACE_UNUSED_ARG(iter);
+
+  // Remove the expiration.
+  for (std::pair<TimeQueue::iterator, TimeQueue::iterator> x = lease_expirations_.equal_range(iter->second.lease_expiration_);
+       x.first != x.second; ++x.first) {
+    if (x.first->second == iter->first) {
+      lease_expirations_.erase(x.first);
+      break;
+    }
+  }
 
 #ifdef OPENDDS_SECURITY
   if (security_config_) {
@@ -2183,6 +2145,8 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task)
     directed_sender_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::send_directed);
   }
 
+  lease_expiration_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::process_lease_expirations);
+
 #ifdef OPENDDS_SECURITY
   handshake_deadline_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::process_handshake_deadlines);
   handshake_resend_processor_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::process_handshake_resends);
@@ -2328,7 +2292,9 @@ Spdp::SpdpTransport::close(const DCPS::ReactorTask_rch& reactor_task)
   if (directed_sender_) {
     directed_sender_->cancel_and_wait();
   }
-
+  if (lease_expiration_processor_) {
+    lease_expiration_processor_->cancel_and_wait();
+  }
   if (thread_status_sender_) {
     thread_status_sender_->disable_and_wait();
   }
@@ -3165,6 +3131,82 @@ Spdp::get_discovered_participant_ids(DCPS::RepoIdSet& results) const
   }
 }
 
+void
+Spdp::update_lease_expiration_i(DiscoveredParticipantIter iter,
+                                const DCPS::MonotonicTimePoint& now)
+{
+  // Remove previous expiration.
+  for (std::pair<TimeQueue::iterator, TimeQueue::iterator> x = lease_expirations_.equal_range(iter->second.lease_expiration_);
+       x.first != x.second; ++x.first) {
+    if (x.first->second == iter->first) {
+      lease_expirations_.erase(x.first);
+      break;
+    }
+  }
+
+  // Compute new expiration.
+  const DCPS::TimeDuration d =
+    rtps_duration_to_time_duration(iter->second.pdata_.leaseDuration,
+                                   iter->second.pdata_.participantProxy.protocolVersion,
+                                   iter->second.pdata_.participantProxy.vendorId);
+
+  iter->second.lease_expiration_ = now + d;
+
+  // Insert.
+  const bool cancel = !lease_expirations_.empty() && iter->second.lease_expiration_ < lease_expirations_.begin()->first;
+  const bool schedule = lease_expirations_.empty() || iter->second.lease_expiration_ < lease_expirations_.begin()->first;
+
+  lease_expirations_.insert(std::make_pair(iter->second.lease_expiration_, iter->first));
+
+  if (cancel) {
+    tport_->lease_expiration_processor_->cancel();
+  }
+  if (schedule) {
+    tport_->lease_expiration_processor_->schedule(d);
+  }
+}
+
+void
+Spdp::process_lease_expirations(const DCPS::MonotonicTimePoint& now)
+{
+  ACE_GUARD (ACE_Thread_Mutex, g, lock_);
+
+  for (TimeQueue::iterator pos = lease_expirations_.begin(), limit = lease_expirations_.end();
+       pos != limit && pos->first <= now;) {
+    DiscoveredParticipantIter part = participants_.find(pos->second);
+    // Pre-emptively erase so remove_discovered_participant will not modify lease_expirations_.
+    lease_expirations_.erase(pos++);
+
+    if (part == participants_.end()) {
+      continue;
+    }
+
+    if (DCPS::DCPS_debug_level) {
+      ACE_DEBUG((LM_WARNING,
+                 ACE_TEXT("(%P|%t) Spdp::process_lease_expirations() - ")
+                 ACE_TEXT("participant %C exceeded lease duration, removing\n"),
+                 DCPS::LogGuid(part->first).c_str()));
+    }
+
+#ifdef OPENDDS_SECURITY
+    ICE::Endpoint* sedp_endpoint = sedp_.get_ice_endpoint();
+    if (sedp_endpoint) {
+      stop_ice(sedp_endpoint, part->first, part->second.pdata_.participantProxy.availableBuiltinEndpoints);
+    }
+    ICE::Endpoint* spdp_endpoint = tport_->get_ice_endpoint();
+    if (spdp_endpoint) {
+      ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, part->first);
+    }
+    purge_handshake_deadlines(part);
+#endif
+    remove_discovered_participant(part);
+  }
+
+  if (!lease_expirations_.empty()) {
+    tport_->lease_expiration_processor_->schedule(lease_expirations_.begin()->first - now);
+  }
+}
+
 #ifdef OPENDDS_SECURITY
 Spdp::ParticipantCryptoInfoPair
 Spdp::lookup_participant_crypto_info(const DCPS::RepoId& id) const
@@ -3519,7 +3561,6 @@ void Spdp::SpdpTransport::send_relay(const DCPS::MonotonicTimePoint& /*now*/)
 void Spdp::SpdpTransport::send_local(const DCPS::MonotonicTimePoint& /*now*/)
 {
   write(SEND_TO_LOCAL);
-  outer_->remove_expired_participants();
 }
 
 void Spdp::SpdpTransport::send_directed(const DCPS::MonotonicTimePoint& /*now*/)
@@ -3540,6 +3581,12 @@ void Spdp::SpdpTransport::send_directed(const DCPS::MonotonicTimePoint& /*now*/)
     directed_sender_->schedule(outer_->config_->resend_period() * (1.0 / directed_guids_.size()));
     break;
   }
+}
+
+void
+Spdp::SpdpTransport::process_lease_expirations(const DCPS::MonotonicTimePoint& now)
+{
+  outer_->process_lease_expirations(now);
 }
 
 void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& /*now*/)

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1778,7 +1778,6 @@ void Spdp::remove_agent_info(const DCPS::RepoId&)
 void
 Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
 {
-  ACE_UNUSED_ARG(iter);
 
   remove_lease_expiration_i(iter);
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1780,14 +1780,7 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter iter)
 {
   ACE_UNUSED_ARG(iter);
 
-  // Remove the expiration.
-  for (std::pair<TimeQueue::iterator, TimeQueue::iterator> x = lease_expirations_.equal_range(iter->second.lease_expiration_);
-       x.first != x.second; ++x.first) {
-    if (x.first->second == iter->first) {
-      lease_expirations_.erase(x.first);
-      break;
-    }
-  }
+  remove_lease_expiration_i(iter);
 
 #ifdef OPENDDS_SECURITY
   if (security_config_) {
@@ -3132,10 +3125,8 @@ Spdp::get_discovered_participant_ids(DCPS::RepoIdSet& results) const
 }
 
 void
-Spdp::update_lease_expiration_i(DiscoveredParticipantIter iter,
-                                const DCPS::MonotonicTimePoint& now)
+Spdp::remove_lease_expiration_i(DiscoveredParticipantIter iter)
 {
-  // Remove previous expiration.
   for (std::pair<TimeQueue::iterator, TimeQueue::iterator> x = lease_expirations_.equal_range(iter->second.lease_expiration_);
        x.first != x.second; ++x.first) {
     if (x.first->second == iter->first) {
@@ -3143,6 +3134,13 @@ Spdp::update_lease_expiration_i(DiscoveredParticipantIter iter,
       break;
     }
   }
+}
+
+void
+Spdp::update_lease_expiration_i(DiscoveredParticipantIter iter,
+                                const DCPS::MonotonicTimePoint& now)
+{
+  remove_lease_expiration_i(iter);
 
   // Compute new expiration.
   const DCPS::TimeDuration d =

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -400,8 +400,9 @@ private:
   BuiltinEndpointSet_t available_builtin_endpoints_;
   Sedp sedp_;
 
-  typedef std::multimap<DCPS::MonotonicTimePoint, DCPS::RepoId> TimeQueue;
+  typedef OPENDDS_MULTIMAP(DCPS::MonotonicTimePoint, DCPS::RepoId) TimeQueue;
 
+  void remove_lease_expiration_i(DiscoveredParticipantIter iter);
   void update_lease_expiration_i(DiscoveredParticipantIter iter,
                                  const DCPS::MonotonicTimePoint& now);
   void process_lease_expirations(const DCPS::MonotonicTimePoint& now);

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -225,7 +225,7 @@ private:
 #ifdef OPENDDS_SECURITY
         , public ICE::Endpoint
 #endif
-{
+  {
     typedef size_t WriteFlags;
     static const WriteFlags SEND_TO_LOCAL = (1 << 0);
     static const WriteFlags SEND_TO_RELAY = (1 << 1);
@@ -303,6 +303,8 @@ private:
     void send_directed(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpSporadic> directed_sender_;
     OPENDDS_LIST(DCPS::RepoId) directed_guids_;
+    void process_lease_expirations(const DCPS::MonotonicTimePoint& now);
+    DCPS::RcHandle<SpdpSporadic> lease_expiration_processor_;
     DCPS::ThreadStatus* thread_status_;
     void thread_status_task(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpPeriodic> thread_status_sender_;
@@ -393,11 +395,17 @@ private:
   ACE_Condition_Thread_Mutex shutdown_cond_;
   ACE_Atomic_Op<ACE_Thread_Mutex, bool> shutdown_flag_; // Spdp shutting down
 
-  void remove_expired_participants();
   void get_discovered_participant_ids(DCPS::RepoIdSet& results) const;
 
   BuiltinEndpointSet_t available_builtin_endpoints_;
   Sedp sedp_;
+
+  typedef std::multimap<DCPS::MonotonicTimePoint, DCPS::RepoId> TimeQueue;
+
+  void update_lease_expiration_i(DiscoveredParticipantIter iter,
+                                 const DCPS::MonotonicTimePoint& now);
+  void process_lease_expirations(const DCPS::MonotonicTimePoint& now);
+  TimeQueue lease_expirations_;
 
 #ifdef OPENDDS_SECURITY
   Security::SecurityConfig_rch security_config_;
@@ -416,16 +424,14 @@ private:
 
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
 
-  typedef std::multimap<DCPS::MonotonicTimePoint, DCPS::RepoId> TimeQueue;
-  TimeQueue handshake_deadlines_;
-  TimeQueue handshake_resends_;
-
   void start_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail, const ICE::AgentInfo& agent_info);
   void stop_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, const BuiltinEndpointSet_t& avail);
 
   void purge_handshake_deadlines(DiscoveredParticipantIter iter);
-  void purge_handshake_resends(DiscoveredParticipantIter iter);
+  TimeQueue handshake_deadlines_;
 
+  void purge_handshake_resends(DiscoveredParticipantIter iter);
+  TimeQueue handshake_resends_;
 #endif
 
   friend class ::DDS_TEST;


### PR DESCRIPTION
Problem
-------

Every time the SPDP transport sends a local announcement, it loops
over all discovered participants to check if they have expired.  This
is not scalable.  Furthermore, participants with long resend periods
may accumulate a number of long expired participants.

Solution
--------

Use a TimeQueue and sporadic task to process the lease expirations as needed.