### PR TITLE
RTPS "acked by all" logic is not scalable

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3349,13 +3349,11 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
   //start with the max sequence number writer knows about and decrease
   //by what the min over all readers is
   SequenceNumber all_readers_ack = SequenceNumber::MAX_VALUE;
-
-  typedef ReaderInfoMap::iterator ri_iter;
-  const ri_iter end = remote_readers_.end();
-  for (ri_iter ri = remote_readers_.begin(); ri != end; ++ri) {
-    if (ri->second->cur_cumulative_ack_ < all_readers_ack) {
-      all_readers_ack = ri->second->cur_cumulative_ack_;
-    }
+  if (!lagging_readers_.empty()) {
+    all_readers_ack = std::min(all_readers_ack, lagging_readers_.begin()->first + 1);
+  }
+  if (!leading_readers_.empty()) {
+    all_readers_ack = std::min(all_readers_ack, leading_readers_.begin()->first + 1);
   }
   if (all_readers_ack == SequenceNumber::MAX_VALUE) {
     return;


### PR DESCRIPTION
Problem
-------

When processing an ack, the RtpsWriter iterates over all readers to
determine the minimum sequence number that must be retained and
therefore which samples can be released.

Solution
--------

Use the leading and lagging maps to find the minimum without iteration.