### PR TITLE
RTPS send nack replies is not scalable

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2884,6 +2884,8 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
     process_requested_changes_i(reqs, reader);
     if (reqs.empty()) {
       readers_expecting_heartbeat_.insert(reader);
+    } else {
+      readers_expecting_data_.insert(reader);
     }
   }
 
@@ -2973,46 +2975,40 @@ RtpsUdpDataLink::RtpsWriter::send_and_gather_nack_replies(MetaSubmessageVec& met
   // consolidate requests from N readers
   AddrSet recipients;
   DisjointSequence requests;
-
-  //track if any messages have been fully acked by all readers
-  SequenceNumber all_readers_ack = SequenceNumber::MAX_VALUE;
-
   bool gaps_ok = true;
-  typedef ReaderInfoMap::iterator ri_iter;
-  const ri_iter end = remote_readers_.end();
-  for (ri_iter ri = remote_readers_.begin(); ri != end; ++ri) {
 
-    if (ri->second->cur_cumulative_ack_ < all_readers_ack) {
-      all_readers_ack = ri->second->cur_cumulative_ack_;
-    }
+  for (ReaderInfoSet::const_iterator pos = readers_expecting_data_.begin(), limit = readers_expecting_data_.end();
+       pos != limit; ++pos) {
+
+    const ReaderInfo_rch& info = *pos;
 
 #ifdef OPENDDS_SECURITY
-    if (is_pvs_writer_ && !ri->second->requested_changes_.empty()) {
-      send_directed_nack_replies_i(ri->first, ri->second, meta_submessages);
+    if (is_pvs_writer_ && !info->requested_changes_.empty()) {
+      send_directed_nack_replies_i(info->id_, info, meta_submessages);
       continue;
     }
 #endif
 
-    process_requested_changes_i(requests, ri->second);
+    process_requested_changes_i(requests, info);
 
-    if (!ri->second->requested_changes_.empty()) {
-      AddrSet addrs = link->get_addresses(id_, ri->first);
+    if (!info->requested_changes_.empty()) {
+      AddrSet addrs = link->get_addresses(id_, info->id_);
       if (!addrs.empty()) {
         recipients.insert(addrs.begin(), addrs.end());
-        if (ri->second->expecting_durable_data()) {
+        if (info->expecting_durable_data()) {
           gaps_ok = false;
         }
         if (Transport_debug_level > 5) {
-          const GuidConverter local_conv(id_), remote_conv(ri->first);
           ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::RtpsWriter::send_and_gather_nack_replies "
                      "local %C remote %C requested resend\n",
-                     OPENDDS_STRING(local_conv).c_str(),
-                     OPENDDS_STRING(remote_conv).c_str()));
+                     LogGuid(id_).c_str(),
+                     LogGuid(info->id_).c_str()));
         }
       }
-      ri->second->requested_changes_.clear();
+      info->requested_changes_.clear();
     }
   }
+  readers_expecting_data_.clear();
 
   DisjointSequence gaps;
   if (!requests.empty()) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -358,6 +358,8 @@ private:
     SNRIS lagging_readers_;
     // These reader have acked everything they are supposed to have acked.
     SNRIS leading_readers_;
+    // These readers have sent a nack and are expecting data.
+    ReaderInfoSet readers_expecting_data_;
     RcHandle<SingleSendBuffer> send_buff_;
     SequenceNumber max_sn_;
     typedef OPENDDS_SET(TransportQueueElement*) TqeSet;


### PR DESCRIPTION
Problem
-------

An RtpsWriter loops through every reader to determine if it sent a
nack and is expecting data.

Solution
--------

Maintain a set of readers that have sent a nack.