### PR TITLE
ReactorTask has a busy loop

### DIFF
--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -181,7 +181,6 @@ OpenDDS::DCPS::ReactorTask::svc()
       }
 
       while (state_ == STATE_RUNNING) {
-        ACE_DEBUG((LM_DEBUG, "### Loop 3\n"));
         ACE_Time_Value t = timeout_.value();
         reactor_->run_reactor_event_loop(t, 0);
         if (thread_status_) {


### PR DESCRIPTION
Problem
-------

The thread monitoring code in ReactorTask runs for one cycle and then
degenerates into a busy loop.

Solution
--------

Reset the time given to run the event loop.