### PR TITLE
RtpsRelay drops message when bursting

### DIFF
--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -150,39 +150,68 @@ int RelayHandler::handle_input(ACE_HANDLE handle)
   return 0;
 }
 
-void RelayHandler::send(const ACE_INET_Addr& addr,
-                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
-                        const OpenDDS::DCPS::MonotonicTimePoint& now)
+int RelayHandler::handle_output(ACE_HANDLE)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, outgoing_mutex_);
+  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
-  const int BUFFERS_SIZE = 2;
-  iovec buffers[BUFFERS_SIZE];
-  size_t total_bytes = 0;
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, outgoing_mutex_, 0);
 
-  int idx = 0;
-  for (ACE_Message_Block* block = msg.get(); block && idx < BUFFERS_SIZE; block = block->cont(), ++idx) {
-    buffers[idx].iov_base = block->rd_ptr();
+  if (!outgoing_.empty()) {
+    const auto& out = outgoing_.front();
+
+    const int BUFFERS_SIZE = 2;
+    iovec buffers[BUFFERS_SIZE];
+    size_t total_bytes = 0;
+
+    int idx = 0;
+    for (ACE_Message_Block* block = out.message_block.get(); block && idx < BUFFERS_SIZE; block = block->cont(), ++idx) {
+      buffers[idx].iov_base = block->rd_ptr();
 #ifdef _MSC_VER
 #pragma warning(push)
-    // iov_len is 32-bit on 64-bit VC++, but we don't want a cast here
-    // since on other platforms iov_len is 64-bit
+      // iov_len is 32-bit on 64-bit VC++, but we don't want a cast here
+      // since on other platforms iov_len is 64-bit
 #pragma warning(disable : 4267)
 #endif
-    buffers[idx].iov_len = block->length();
-    total_bytes += block->length();
+      buffers[idx].iov_len = block->length();
+      total_bytes += buffers[idx].iov_len;
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
+    }
+
+    const auto bytes = socket_.send(buffers, idx, out.address, 0);
+
+    if (bytes < 0) {
+      HANDLER_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayHandler::handle_output %C failed to send to %C: %m\n"), name_.c_str(), addr_to_string(out.address).c_str()));
+      const auto new_now = OpenDDS::DCPS::MonotonicTimePoint::now();
+      stats_reporter_.dropped_message(total_bytes, new_now - now, new_now - out.timestamp, now);
+    } else {
+      const auto new_now = OpenDDS::DCPS::MonotonicTimePoint::now();
+      stats_reporter_.output_message(total_bytes, new_now - now, new_now - out.timestamp, now);
+    }
+
+    outgoing_.pop();
   }
 
-  const auto bytes = socket_.send(buffers, idx, addr, 0);
+  if (outgoing_.empty()) {
+    reactor()->remove_handler(this, WRITE_MASK);
+  }
 
-  if (bytes < 0) {
-    HANDLER_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayHandler::send %C failed to send to %C: %m\n"), name_.c_str(), addr_to_string(addr).c_str()));
-    stats_reporter_.dropped_message(total_bytes, now);
-  } else {
-    stats_reporter_.output_message(total_bytes, now);
+  return 0;
+}
+
+void RelayHandler::enqueue_message(const ACE_INET_Addr& addr,
+                                   const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
+                                   const OpenDDS::DCPS::MonotonicTimePoint& now)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, outgoing_mutex_);
+
+  const auto empty = outgoing_.empty();
+
+  outgoing_.push(Element(addr, msg, now));
+  stats_reporter_.max_queue_size(outgoing_.size(), now);
+  if (empty) {
+    reactor()->register_handler(this, WRITE_MASK);
   }
 }
 
@@ -212,15 +241,13 @@ VerticalHandler::VerticalHandler(const Config& config,
   ACE_UNUSED_ARG(crypto);
 }
 
-void VerticalHandler::vsend(const ACE_INET_Addr& addr,
-                            ParticipantStatisticsReporter& stats_reporter,
-                            const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
-                            const OpenDDS::DCPS::MonotonicTimePoint& now)
+void VerticalHandler::venqueue_message(const ACE_INET_Addr& addr,
+                                       ParticipantStatisticsReporter& stats_reporter,
+                                       const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
+                                       const OpenDDS::DCPS::MonotonicTimePoint& now)
 {
-  RelayHandler::send(addr, msg, now);
-  stats_reporter.output_message(msg->length(), now);
+  enqueue_message(addr, msg, now);
 }
-
 
 void VerticalHandler::process_message(const ACE_INET_Addr& remote_address,
                                       const OpenDDS::DCPS::MonotonicTimePoint& now,
@@ -244,7 +271,7 @@ void VerticalHandler::process_message(const ACE_INET_Addr& remote_address,
       association_table_.lookup_destinations(to, src_guid);
       send(src_guid, psr, to, msg, now);
       if (deferred_addr != ACE_INET_Addr()) {
-        RelayHandler::send(deferred_addr, msg, now);
+        enqueue_message(deferred_addr, msg, now);
       }
     }
   } else {
@@ -533,13 +560,13 @@ void VerticalHandler::send(const OpenDDS::DCPS::RepoId&,
     const auto& guids = p.second;
     fan_out += guids.size();
     if (addr != horizontal_address_) {
-      horizontal_handler_->hsend(addr, guids, msg, now);
+      horizontal_handler_->enqueue_message(addr, guids, msg, now);
     } else {
       for (const auto& guid : guids) {
         auto p = find(guid);
         if (p != end()) {
           for (const auto& addr : p->second.addr_set) {
-            vsend(addr, p->second.stats_reporter, msg, now);
+            venqueue_message(addr, p->second.stats_reporter, msg, now);
           }
         } else {
           HANDLER_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: VerticalHandler::send %C failed to get address for %C\n"), name_.c_str(), guid_to_string(guid).c_str()));
@@ -560,7 +587,7 @@ void VerticalHandler::send(const ACE_INET_Addr& addr,
   Serializer serializer(block.get(), Serializer::SWAP_BE);
   message.block = block.get();
   serializer << message;
-  RelayHandler::send(addr, block, now);
+  RelayHandler::enqueue_message(addr, block, now);
 }
 
 void VerticalHandler::populate_address_map(AddressMap& address_map,
@@ -638,10 +665,10 @@ HorizontalHandler::HorizontalHandler(const Config& config,
   , vertical_handler_(nullptr)
 {}
 
-void HorizontalHandler::hsend(const ACE_INET_Addr& addr,
-                              const GuidSet& guids,
-                              const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
-                              const OpenDDS::DCPS::MonotonicTimePoint& now)
+void HorizontalHandler::enqueue_message(const ACE_INET_Addr& addr,
+                                        const GuidSet& guids,
+                                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
+                                        const OpenDDS::DCPS::MonotonicTimePoint& now)
 {
   // Determine how many guids we can pack into a single UDP message.
   const auto max_guids_per_message = (OpenDDS::DCPS::TransportSendStrategy::UDP_MAX_MESSAGE_SIZE - msg->length() - 4) / sizeof(OpenDDS::DCPS::RepoId);
@@ -665,7 +692,7 @@ void HorizontalHandler::hsend(const ACE_INET_Addr& addr,
     OpenDDS::DCPS::Serializer ser(header_block.get());
     ser << relay_header;
     header_block->cont(msg.get()->duplicate());
-    RelayHandler::send(addr, header_block, now);
+    RelayHandler::enqueue_message(addr, header_block, now);
   }
 }
 
@@ -693,7 +720,7 @@ void HorizontalHandler::process_message(const ACE_INET_Addr& from,
     const auto p = vertical_handler_->find(guid_to_repoid(guid));
     if (p != vertical_handler_->end()) {
       for (const auto& addr : p->second.addr_set) {
-        vertical_handler_->vsend(addr, p->second.stats_reporter, msg, now);
+        vertical_handler_->venqueue_message(addr, p->second.stats_reporter, msg, now);
       }
     } else {
       HANDLER_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: HorizontalHandler::process_message %C failed to get address for %C\n"), name_.c_str(), guid_to_string(guid_to_repoid(guid)).c_str()));
@@ -739,7 +766,7 @@ bool SpdpHandler::do_normal_processing(const ACE_INET_Addr& remote,
         const auto pos = guid_addr_set_map_.find(guid);
         if (pos != guid_addr_set_map_.end()) {
           for (const auto& addr : pos->second.addr_set) {
-            vsend(addr, pos->second.stats_reporter, msg, now);
+            venqueue_message(addr, pos->second.stats_reporter, msg, now);
           }
         }
       }
@@ -857,7 +884,7 @@ bool SedpHandler::do_normal_processing(const ACE_INET_Addr& remote,
         auto pos = guid_addr_set_map_.find(guid);
         if (pos != guid_addr_set_map_.end()) {
           for (const auto& addr : pos->second.addr_set) {
-            vsend(addr, pos->second.stats_reporter, msg, now);
+            venqueue_message(addr, pos->second.stats_reporter, msg, now);
           }
         }
       }

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -30,21 +30,31 @@ public:
   {
     relay_statistics_.bytes_in() += byte_count;
     ++relay_statistics_.messages_in();
-    processing_time_ += time;
+    input_processing_time_ += time;
     report(now);
   }
 
-  void output_message(size_t byte_count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void output_message(size_t byte_count,
+                      const OpenDDS::DCPS::TimeDuration& time,
+                      const OpenDDS::DCPS::TimeDuration& queue_latency,
+                      const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     relay_statistics_.bytes_out() += byte_count;
     ++relay_statistics_.messages_out();
+    output_processing_time_ += time;
+    max_queue_latency_ = std::max(max_queue_latency_, queue_latency);
     report(now);
   }
 
-  void dropped_message(size_t byte_count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void dropped_message(size_t byte_count,
+                       const OpenDDS::DCPS::TimeDuration& time,
+                       const OpenDDS::DCPS::TimeDuration& queue_latency,
+                       const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     relay_statistics_.bytes_dropped() += byte_count;
     ++relay_statistics_.messages_dropped();
+    output_processing_time_ += time;
+    max_queue_latency_ = std::max(max_queue_latency_, queue_latency);
     report(now);
   }
 
@@ -84,6 +94,12 @@ public:
     report(now);
   }
 
+  void max_queue_size(size_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    relay_statistics_.max_queue_size() = std::max(relay_statistics_.max_queue_size(), static_cast<ACE_CDR::ULong>(size));
+    report(now);
+  }
+
 private:
 
   void report(const OpenDDS::DCPS::MonotonicTimePoint& now)
@@ -94,7 +110,9 @@ private:
     }
 
     relay_statistics_.interval(time_diff_to_duration(d));
-    relay_statistics_.processing_time(time_diff_to_duration(processing_time_));
+    relay_statistics_.input_processing_time(time_diff_to_duration(input_processing_time_));
+    relay_statistics_.output_processing_time(time_diff_to_duration(output_processing_time_));
+    relay_statistics_.max_queue_latency(time_diff_to_duration(max_queue_latency_));
 
     if (config_.log_relay_statistics()) {
       ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) STAT: %C %C\n"), topic_name_.in(), OpenDDS::DCPS::to_json(relay_statistics_).c_str()));
@@ -121,13 +139,18 @@ private:
     relay_statistics_.expired_address_count(0);
     relay_statistics_.claim_count(0);
     relay_statistics_.disclaim_count(0);
-    processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;
+    relay_statistics_.max_queue_size(0);
+    input_processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;
+    output_processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;
+    max_queue_latency_ = OpenDDS::DCPS::TimeDuration::zero_value;
   }
 
   const Config& config_;
   OpenDDS::DCPS::MonotonicTimePoint last_report_;
   RelayStatistics relay_statistics_;
-  OpenDDS::DCPS::TimeDuration processing_time_;
+  OpenDDS::DCPS::TimeDuration input_processing_time_;
+  OpenDDS::DCPS::TimeDuration output_processing_time_;
+  OpenDDS::DCPS::TimeDuration max_queue_latency_;
   RelayStatisticsDataWriter_var writer_;
   CORBA::String_var topic_name_;
 };

--- a/tools/rtpsrelay/lib/Relay.idl
+++ b/tools/rtpsrelay/lib/Relay.idl
@@ -102,11 +102,12 @@ module RtpsRelay {
     Duration_t interval;
     unsigned long messages_in;
     unsigned long long bytes_in;
-    Duration_t processing_time;
+    Duration_t input_processing_time;
     unsigned long messages_out;
     unsigned long long bytes_out;
     unsigned long messages_dropped;
     unsigned long long bytes_dropped;
+    Duration_t output_processing_time;
     unsigned long max_fan_out;
     unsigned long local_active_participants;
     unsigned long error_count;
@@ -114,6 +115,8 @@ module RtpsRelay {
     unsigned long expired_address_count;
     unsigned long claim_count;
     unsigned long disclaim_count;
+    unsigned long max_queue_size;
+    Duration_t max_queue_latency;
   };
 
   const string RELAY_STATISTICS_TOPIC_NAME = "Relay Statistics";
@@ -124,17 +127,20 @@ module RtpsRelay {
     Duration_t interval;
     unsigned long messages_in;
     unsigned long long bytes_in;
-    Duration_t processing_time;
+    Duration_t input_processing_time;
     unsigned long messages_out;
     unsigned long long bytes_out;
     unsigned long messages_dropped;
     unsigned long long bytes_dropped;
+    Duration_t output_processing_time;
     unsigned long max_fan_out;
     unsigned long error_count;
     unsigned long new_address_count;
     unsigned long expired_address_count;
     unsigned long claim_count;
     unsigned long disclaim_count;
+    unsigned long max_queue_size;
+    Duration_t max_queue_latency;
   };
 
   const string DOMAIN_STATISTICS_TOPIC_NAME = "Domain Statistics";


### PR DESCRIPTION
Problem
-------

The RtpsRelay uses non-blocking I/O.  In practice, it received
EWOULDBLOCK/EAGAIN errors when sending.  Increasing the OS UDP send
buffer size did not help.  The user-space UDP send buffer size is at a
maximum.

Solution
--------

Resurrect the logic that queues output messages to handle bursts.  The
next step may be to bound the length of the output queue.