### PR TITLE
TransportImpl/TransportClient leak resources for pending connections

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -565,14 +565,10 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
   }
 
   // either link is valid or assoc failed, clean up pending object
-  // for passive side processing
-  if (!pend->active_) {
-
-    for (size_t i = 0; i < pend->impls_.size(); ++i) {
-      RcHandle<TransportImpl> impl = pend->impls_[i].lock();
-      if (impl) {
-        impl->stop_accepting_or_connecting(*this, pend->data_.remote_id_);
-      }
+  for (size_t i = 0; i < pend->impls_.size(); ++i) {
+    RcHandle<TransportImpl> impl = pend->impls_[i].lock();
+    if (impl) {
+      impl->stop_accepting_or_connecting(*this, pend->data_.remote_id_);
     }
   }
 


### PR DESCRIPTION
Problem
-------

Active and passive pending connections are inserted into the
`pending_connections_` map in TransportClient.  These pending
connections should be cleaned up by an eventual call to
`stop_accepting_or_connecting`.  However, the code in `use_datalink_i`
that calls `stop_accepting_or_connecting` for the non-active case.

Solution
--------

Unconditionally call `stop_accepting_or_connecting`.