### PR TITLE
Some routers confused over STUN traffic

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -378,6 +378,16 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
           }
           config->use_rtps_relay(bool(smInt));
 #ifdef OPENDDS_SECURITY
+        } else if (name == "SpdpStunServerAddress") {
+          ACE_INET_Addr addr;
+          if (addr.set(it->second.c_str())) {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) ERROR: RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("failed to parse SpdpStunServerAddress %C\n"),
+                              it->second.c_str()),
+                             -1);
+          }
+          config->spdp_stun_server_address(addr);
         } else if (name == "SedpStunServerAddress") {
           ACE_INET_Addr addr;
           if (addr.set(it->second.c_str())) {
@@ -849,6 +859,12 @@ RtpsDiscovery::sedp_rtps_relay_address(const ACE_INET_Addr& address)
       part_pos->second->sedp_rtps_relay_address(address);
     }
   }
+}
+
+void
+RtpsDiscovery::spdp_stun_server_address(const ACE_INET_Addr& address)
+{
+  config_->spdp_stun_server_address(address);
 }
 
 void

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -382,6 +382,17 @@ public:
     rtps_relay_only_ = f;
   }
 
+  ACE_INET_Addr spdp_stun_server_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+    return spdp_stun_server_address_;
+  }
+  void spdp_stun_server_address(const ACE_INET_Addr& address)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_stun_server_address_ = address;
+  }
+
   ACE_INET_Addr sedp_stun_server_address() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
@@ -474,6 +485,7 @@ private:
   ACE_INET_Addr sedp_rtps_relay_address_;
   bool use_rtps_relay_;
   bool rtps_relay_only_;
+  ACE_INET_Addr spdp_stun_server_address_;
   ACE_INET_Addr sedp_stun_server_address_;
   bool use_ice_;
   bool use_ncm_;
@@ -617,6 +629,7 @@ public:
 #endif
   void spdp_rtps_relay_address(const ACE_INET_Addr& address);
   void sedp_rtps_relay_address(const ACE_INET_Addr& address);
+  void spdp_stun_server_address(const ACE_INET_Addr& address);
   void sedp_stun_server_address(const ACE_INET_Addr& address);
 
 private:

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2788,7 +2788,7 @@ Spdp::SendStun::execute()
 ACE_INET_Addr
 Spdp::SpdpTransport::stun_server_address() const
 {
-  return outer_->config_->sedp_stun_server_address();
+  return outer_->config_->spdp_stun_server_address();
 }
 
 #ifndef DDS_HAS_MINIMUM_BIT


### PR DESCRIPTION
Problem
-------

When using the RtpsRelay and ICE, the SPDP port will send STUN packets
to both the SPDP and SEDP port of the relay.  In practice, this
confuses the router and the observed behavior is that all traffic from
the relay's SPDP port was dropped.  The SEDP and DATA channels when
using the same router are not affected.

Solution
--------

Add configuration so that SPDP will send STUN to the SPDP port of the RtpsRelay.