### PR TITLE
RtpsRelay stats don't distinguish directed and undirected gain

### DIFF
--- a/tools/rtpsrelay/HandlerStatisticsReporter.h
+++ b/tools/rtpsrelay/HandlerStatisticsReporter.h
@@ -66,10 +66,17 @@ public:
     report(now);
   }
 
-  void max_fan_out(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void max_directed_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
-    relay_statistics_reporter_.max_fan_out(value, now);
-    handler_statistics_.max_fan_out() = std::max(handler_statistics_.max_fan_out(), static_cast<uint32_t>(value));
+    relay_statistics_reporter_.max_directed_gain(value, now);
+    handler_statistics_.max_directed_gain() = std::max(handler_statistics_.max_directed_gain(), static_cast<uint32_t>(value));
+    report(now);
+  }
+
+  void max_undirected_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    relay_statistics_reporter_.max_undirected_gain(value, now);
+    handler_statistics_.max_undirected_gain() = std::max(handler_statistics_.max_undirected_gain(), static_cast<uint32_t>(value));
     report(now);
   }
 
@@ -154,7 +161,8 @@ private:
     handler_statistics_.bytes_out(0);
     handler_statistics_.messages_dropped(0);
     handler_statistics_.bytes_dropped(0);
-    handler_statistics_.max_fan_out(0);
+    handler_statistics_.max_directed_gain(0);
+    handler_statistics_.max_undirected_gain(0);
     // Don't reset local_active_participant_count.
     handler_statistics_.error_count(0);
     handler_statistics_.new_address_count(0);

--- a/tools/rtpsrelay/ParticipantStatisticsReporter.h
+++ b/tools/rtpsrelay/ParticipantStatisticsReporter.h
@@ -27,23 +27,29 @@ public:
     participant_statistics_.name(name);
   }
 
-  void input_message(size_t byte_count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void message_from(size_t byte_count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
-    participant_statistics_.bytes_in() += byte_count;
-    ++participant_statistics_.messages_in();
+    participant_statistics_.bytes_from() += byte_count;
+    ++participant_statistics_.messages_from();
     report(now);
   }
 
-  void output_message(size_t byte_count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void message_to(size_t byte_count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
-    participant_statistics_.bytes_out() += byte_count;
-    ++participant_statistics_.messages_out();
+    participant_statistics_.bytes_to() += byte_count;
+    ++participant_statistics_.messages_to();
     report(now);
   }
 
-  void max_fan_out(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void max_directed_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
-    participant_statistics_.max_fan_out() = std::max(participant_statistics_.max_fan_out(), static_cast<uint32_t>(value));
+    participant_statistics_.max_directed_gain() = std::max(participant_statistics_.max_directed_gain(), static_cast<uint32_t>(value));
+    report(now);
+  }
+
+  void max_undirected_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    participant_statistics_.max_undirected_gain() = std::max(participant_statistics_.max_undirected_gain(), static_cast<uint32_t>(value));
     report(now);
   }
 
@@ -70,11 +76,12 @@ public:
 
     last_report_ = now;
 
-    participant_statistics_.messages_in(0);
-    participant_statistics_.bytes_in(0);
-    participant_statistics_.messages_out(0);
-    participant_statistics_.bytes_out(0);
-    participant_statistics_.max_fan_out(0);
+    participant_statistics_.messages_from(0);
+    participant_statistics_.bytes_from(0);
+    participant_statistics_.messages_to(0);
+    participant_statistics_.bytes_to(0);
+    participant_statistics_.max_directed_gain(0);
+    participant_statistics_.max_undirected_gain(0);
   }
 
 private:

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -95,6 +95,7 @@ public:
                   GuidNameAddressDataReader_var responsible_relay_reader,
                   const OpenDDS::RTPS::RtpsDiscovery_rch& rtps_discovery,
                   const CRYPTO_TYPE& crypto,
+                  const ACE_INET_Addr& application_participant_addr,
                   HandlerStatisticsReporter& stats_reporter);
 
   void horizontal_handler(HorizontalHandler* horizontal_handler) { horizontal_handler_ = horizontal_handler; }
@@ -121,9 +122,9 @@ protected:
                                     const OpenDDS::DCPS::RepoId& /*src_guid*/,
                                     ParticipantStatisticsReporter& /*stats_reporter*/,
                                     const GuidSet& /*to*/,
+                                    bool& /*send_to_application_participant*/,
                                     const OpenDDS::DCPS::Message_Block_Shared_Ptr& /*msg*/,
-                                    const OpenDDS::DCPS::MonotonicTimePoint& /*now*/,
-                                    ACE_INET_Addr& /*deferred_addr*/) { return true; }
+                                    const OpenDDS::DCPS::MonotonicTimePoint& /*now*/) { return true; }
   virtual void purge(const OpenDDS::DCPS::RepoId& /*guid*/) {}
 
   void process_message(const ACE_INET_Addr& remote,
@@ -136,11 +137,12 @@ protected:
   void send(const OpenDDS::DCPS::RepoId& src_guid,
             ParticipantStatisticsReporter& stats_reporter,
             const GuidSet& to,
+            bool send_to_application_participant,
             const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
             const OpenDDS::DCPS::MonotonicTimePoint& now);
-  void send(const ACE_INET_Addr& addr,
-            OpenDDS::STUN::Message message,
-            const OpenDDS::DCPS::MonotonicTimePoint& now);
+  size_t send(const ACE_INET_Addr& addr,
+              OpenDDS::STUN::Message message,
+              const OpenDDS::DCPS::MonotonicTimePoint& now);
 
   void populate_address_map(AddressMap& address_map,
                             const GuidSet& to,
@@ -155,6 +157,7 @@ protected:
   GuidAddrExpirationMap guid_addr_expiration_map_;
   typedef std::multimap<OpenDDS::DCPS::MonotonicTimePoint, GuidAddr> ExpirationGuidAddrMap;
   ExpirationGuidAddrMap expiration_guid_addr_map_;
+  const ACE_INET_Addr application_participant_addr_;
 
 private:
   bool parse_message(OpenDDS::RTPS::MessageParser& message_parser,
@@ -217,7 +220,6 @@ public:
               const GuidSet& to);
 
 private:
-  const ACE_INET_Addr application_participant_addr_;
   typedef std::map<OpenDDS::DCPS::RepoId, OpenDDS::DCPS::Message_Block_Shared_Ptr, OpenDDS::DCPS::GUID_tKeyLessThan> SpdpMessages;
   SpdpMessages spdp_messages_;
   ACE_Thread_Mutex spdp_messages_mutex_;
@@ -234,9 +236,9 @@ private:
                             const OpenDDS::DCPS::RepoId& src_guid,
                             ParticipantStatisticsReporter& stats_reporter,
                             const GuidSet& to,
+                            bool& send_to_application_participant,
                             const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
-                            const OpenDDS::DCPS::MonotonicTimePoint& now,
-                            ACE_INET_Addr& deferred_addr) override;
+                            const OpenDDS::DCPS::MonotonicTimePoint& now) override;
 
   void purge(const OpenDDS::DCPS::RepoId& guid) override;
   int handle_exception(ACE_HANDLE fd) override;
@@ -257,15 +259,13 @@ public:
               HandlerStatisticsReporter& stats_reporter);
 
 private:
-  const ACE_INET_Addr application_participant_addr_;
-
   bool do_normal_processing(const ACE_INET_Addr& remote,
                             const OpenDDS::DCPS::RepoId& src_guid,
                             ParticipantStatisticsReporter& stats_reporter,
                             const GuidSet& to,
+                            bool& send_to_application_participant,
                             const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
-                            const OpenDDS::DCPS::MonotonicTimePoint& now,
-                            ACE_INET_Addr& deferred_addr) override;
+                            const OpenDDS::DCPS::MonotonicTimePoint& now) override;
 };
 
 class DataHandler : public VerticalHandler {

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -58,9 +58,15 @@ public:
     report(now);
   }
 
-  void max_fan_out(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void max_directed_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
-    relay_statistics_.max_fan_out() = std::max(relay_statistics_.max_fan_out(), static_cast<uint32_t>(value));
+    relay_statistics_.max_directed_gain() = std::max(relay_statistics_.max_directed_gain(), static_cast<uint32_t>(value));
+    report(now);
+  }
+
+  void max_undirected_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    relay_statistics_.max_undirected_gain() = std::max(relay_statistics_.max_undirected_gain(), static_cast<uint32_t>(value));
     report(now);
   }
 
@@ -133,7 +139,8 @@ private:
     relay_statistics_.bytes_out(0);
     relay_statistics_.messages_dropped(0);
     relay_statistics_.bytes_dropped(0);
-    relay_statistics_.max_fan_out(0);
+    relay_statistics_.max_directed_gain(0);
+    relay_statistics_.max_undirected_gain(0);
     relay_statistics_.error_count(0);
     relay_statistics_.new_address_count(0);
     relay_statistics_.expired_address_count(0);

--- a/tools/rtpsrelay/lib/Relay.idl
+++ b/tools/rtpsrelay/lib/Relay.idl
@@ -86,11 +86,12 @@ module RtpsRelay {
     @key GUID_t guid;
     @key string name;
     Duration_t interval;
-    unsigned long messages_in;
-    unsigned long long bytes_in;
-    unsigned long messages_out;
-    unsigned long long bytes_out;
-    unsigned long max_fan_out;
+    unsigned long messages_from;
+    unsigned long long bytes_from;
+    unsigned long messages_to;
+    unsigned long long bytes_to;
+    unsigned long max_directed_gain;
+    unsigned long max_undirected_gain;
   };
 
   const string HANDLER_STATISTICS_TOPIC_NAME = "Handler Statistics";
@@ -108,7 +109,8 @@ module RtpsRelay {
     unsigned long messages_dropped;
     unsigned long long bytes_dropped;
     Duration_t output_processing_time;
-    unsigned long max_fan_out;
+    unsigned long max_directed_gain;
+    unsigned long max_undirected_gain;
     unsigned long local_active_participants;
     unsigned long error_count;
     unsigned long new_address_count;
@@ -133,7 +135,8 @@ module RtpsRelay {
     unsigned long messages_dropped;
     unsigned long long bytes_dropped;
     Duration_t output_processing_time;
-    unsigned long max_fan_out;
+    unsigned long max_directed_gain;
+    unsigned long max_undirected_gain;
     unsigned long error_count;
     unsigned long new_address_count;
     unsigned long expired_address_count;


### PR DESCRIPTION
Problem
-------

When a client sends a message to the RtpsRelay it may get forwarded to
N other clients.  The number N is the gain and is an important
statistic for the RtpsRelay as it will be more performant for small N
and can be used to diagnose potential scalability problems.

Messages where all submessages are prefixed with INFO_DST must be sent
to all named destinations (if they exist).  Otherwise, the relay must
forward the message using the association table.  When applied to
gain, the former is gain for directed messages and the latter is gain
for undirected messages.

Currently, the RtpsRelay does not distinguish these two cases.

Solution
--------

Add statistics for the maximum directed and undirected gain observed
over a statistics interval.