### PR TITLE
Acknack processing does not handle reset

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -507,6 +507,7 @@ private:
     const bool durable_;
     WriterInfoMap remote_writers_;
     WriterInfoSet writers_expecting_nack_;
+    WriterInfoSet writers_expecting_non_final_ack_;
     WriterInfoSet writers_expecting_ack_;
     bool stopping_;
     CORBA::Long acknack_count_;


### PR DESCRIPTION
Problem
-------

Reliable RtpsReaders do not send an ACKNACK to complete association.
Reliable RtpsWriters do not handle the case where a reader is
rediscovered after a network partition.  Reliable readers do not
perform adequate cleanup when a writer is removed.

Solution
--------

Add logic for readers to send ACKNAcks to complete association.  Add
logic to reset a reader.  Add cleanup logic.