### PR TITLE
Monitor Test Failure due to strong RcHandle

### DIFF
--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -32,8 +32,7 @@ public:
     RcHandle<ReactorInterceptor> interceptor = interceptor_.lock();
     if (interceptor) {
       interceptor->execute_or_enqueue(new ScheduleCommand(this, delay));
-    }
-    else {
+    } else {
       ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::schedule"
         " failed to receive ReactorInterceptor handle %p\n", ACE_TEXT("")));
     }
@@ -44,8 +43,7 @@ public:
     RcHandle<ReactorInterceptor> interceptor = interceptor_.lock();
     if (interceptor) {
       interceptor->execute_or_enqueue(new CancelCommand(this));
-    }
-    else {
+    } else {
       ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::cancel"
         " failed to receive ReactorInterceptor handle %p\n", ACE_TEXT("")));
     }
@@ -57,8 +55,7 @@ public:
     if (interceptor) {
       ReactorInterceptor::CommandPtr command = interceptor->execute_or_enqueue(new CancelCommand(this));
       command->wait();
-    }
-    else {
+    } else {
       ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::cancel_and_wait"
         " failed to receive ReactorInterceptor handle %p\n", ACE_TEXT("")));
     }

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -32,9 +32,9 @@ public:
     RcHandle<ReactorInterceptor> interceptor = interceptor_.lock();
     if (interceptor) {
       interceptor->execute_or_enqueue(new ScheduleCommand(this, delay));
-    } else {
-      ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::schedule"
-        " failed to receive ReactorInterceptor handle %p\n", ACE_TEXT("")));
+    } else if (DCPS_debug_level >= 1) {
+      ACE_DEBUG((LM_WARNING, "(%P|%t) SporadicTask::schedule"
+        " failed to receive ReactorInterceptor handle\n", ACE_TEXT("")));
     }
   }
 
@@ -43,9 +43,9 @@ public:
     RcHandle<ReactorInterceptor> interceptor = interceptor_.lock();
     if (interceptor) {
       interceptor->execute_or_enqueue(new CancelCommand(this));
-    } else {
-      ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::cancel"
-        " failed to receive ReactorInterceptor handle %p\n", ACE_TEXT("")));
+    } else if (DCPS_debug_level >= 1) {
+      ACE_DEBUG((LM_WARNING, "(%P|%t) SporadicTask::cancel"
+        " failed to receive ReactorInterceptor handle\n", ACE_TEXT("")));
     }
   }
 
@@ -55,9 +55,9 @@ public:
     if (interceptor) {
       ReactorInterceptor::CommandPtr command = interceptor->execute_or_enqueue(new CancelCommand(this));
       command->wait();
-    } else {
-      ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::cancel_and_wait"
-        " failed to receive ReactorInterceptor handle %p\n", ACE_TEXT("")));
+    } else if (DCPS_debug_level >= 1) {
+      ACE_DEBUG((LM_WARNING, "(%P|%t) SporadicTask::cancel_and_wait"
+        " failed to receive ReactorInterceptor handle\n", ACE_TEXT("")));
     }
   }
 

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -33,8 +33,9 @@ public:
     if (interceptor) {
       interceptor->execute_or_enqueue(new ScheduleCommand(this, delay));
     } else if (DCPS_debug_level >= 1) {
-      ACE_DEBUG((LM_WARNING, "(%P|%t) SporadicTask::schedule"
-        " failed to receive ReactorInterceptor handle\n", ACE_TEXT("")));
+      ACE_ERROR((LM_WARNING,
+                 ACE_TEXT("(%P|%t) WARNING: SporadicTask::schedule")
+                 ACE_TEXT(" failed to receive ReactorInterceptor handle\n")));
     }
   }
 
@@ -44,8 +45,9 @@ public:
     if (interceptor) {
       interceptor->execute_or_enqueue(new CancelCommand(this));
     } else if (DCPS_debug_level >= 1) {
-      ACE_DEBUG((LM_WARNING, "(%P|%t) SporadicTask::cancel"
-        " failed to receive ReactorInterceptor handle\n", ACE_TEXT("")));
+      ACE_ERROR((LM_WARNING,
+                 ACE_TEXT("(%P|%t) WARNING: SporadicTask::cancel")
+                 ACE_TEXT(" failed to receive ReactorInterceptor handle\n")));
     }
   }
 
@@ -56,8 +58,9 @@ public:
       ReactorInterceptor::CommandPtr command = interceptor->execute_or_enqueue(new CancelCommand(this));
       command->wait();
     } else if (DCPS_debug_level >= 1) {
-      ACE_DEBUG((LM_WARNING, "(%P|%t) SporadicTask::cancel_and_wait"
-        " failed to receive ReactorInterceptor handle\n", ACE_TEXT("")));
+      ACE_ERROR((LM_WARNING,
+                 ACE_TEXT("(%P|%t) WARNING: SporadicTask::cancel_and_wait")
+                 ACE_TEXT(" failed to receive ReactorInterceptor handle\n")));
     }
   }
 
@@ -108,8 +111,10 @@ private:
       const long timer = reactor()->schedule_timer(this, 0, delay.value());
 
       if (timer == -1) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) SporadicTask::enable"
-                   " failed to schedule timer %p\n", ACE_TEXT("")));
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("(%P|%t) ERROR: SporadicTask::enable")
+                   ACE_TEXT(" failed to schedule timer %p\n"),
+                   ACE_TEXT("")));
       } else {
         scheduled_ = true;
       }


### PR DESCRIPTION
The RcHandle in sporadictask.h was causing failures for the monitor task.  It has been changed to a WeakRcHandle instead, and the functions that use it now have a lock to grab a strong RcHandle.  Also added an error if that lock is not found.