### PR TITLE
Remove override from ReactorTask::open

### DIFF
--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -47,7 +47,7 @@ public:
 
 public:
   int open_reactor_task(void*, TimeDuration timeout = TimeDuration(0), ThreadStatus* thread_stat = 0, OPENDDS_STRING name = "");
-  virtual int open(void* ptr) override {
+  virtual int open(void* ptr) {
     return open_reactor_task(ptr);
   }
   virtual int svc();


### PR DESCRIPTION
To support older compilers.