### PR TITLE
Reliabilty fixes for Thrasher test

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2985,6 +2985,8 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
     }
   }
 
+  reader->requested_changes_.clear();
+
   // If this ACKNACK was final, the DR doesn't expect a reply, and therefore
   // we don't need to do anything further.
   if (!is_final || bitmapNonEmpty(acknack.readerSNState)) {

--- a/tests/DCPS/Thrasher/ParticipantTask.cpp
+++ b/tests/DCPS/Thrasher/ParticipantTask.cpp
@@ -68,7 +68,8 @@ ParticipantTask::svc()
         ACE_TCHAR nak_depth[8];
         ACE_OS::snprintf(config_name, 64, "cfg_%d", this_thread_index);
         ACE_OS::snprintf(inst_name, 64, "rtps_%d", this_thread_index);
-        ACE_OS::snprintf(nak_depth, 8, ACE_TEXT("%lu"), samples_per_thread_);
+        // The 2 is a safety factor to allow for control messages.
+        ACE_OS::snprintf(nak_depth, 8, ACE_TEXT("%lu"), 2 * samples_per_thread_);
 
         ACE_DEBUG((LM_INFO,
           "(%P|%t)    -> PARTICIPANT %d creating transport config %C\n",


### PR DESCRIPTION
Problem
-------

* The Thrasher Test does not allocate a large enough send buffer to
account for control messages in RTPS.
* An ACK does not clear the requested changes for a reader.  This may
cause the writer to send useless GAPs.

Solution
--------

* Increase the `nak_depth` parameter.
* Clear the requested changes for each received ACKNACK.