### PR TITLE
RTPS direct heartbeats unnecessarily

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -396,6 +396,10 @@ private:
     void make_leader_lagger(const RepoId& reader, SequenceNumber previous_max_sn);
     void make_lagger_leader(const ReaderInfo_rch& reader, const SequenceNumber previous_acked_sn);
     bool is_lagging(const ReaderInfo_rch& reader) const;
+    void expire_durable_data(const ReaderInfo_rch& reader,
+                             const RtpsUdpInst& cfg,
+                             const MonotonicTimePoint& now,
+                             OPENDDS_VECTOR(TransportQueueElement*)& pendingCallbacks);
 
   public:
     RtpsWriter(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable,


### PR DESCRIPTION
Problem
-------

When a reliable writer writes a sample, all of the reader will now be
lagging.  The writer only needs to send a single non-directed
heartbeat instead of sending a directed heartbeat to each reader.

Solution
--------

Send a non-directed heartbeat for the identified case which is not
applicable to the participant volatile secure writer.