### PR TITLE
Durable writers can skip initial sequence numbers in RTPS

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1000,7 +1000,8 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
   const SequenceNumber seq = element->sequence();
   if (seq != SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
     max_sn_ = std::max(max_sn_, seq);
-    if (element->subscription_id() == GUID_UNKNOWN &&
+    if (previous_max_sn != 0 &&
+        element->subscription_id() == GUID_UNKNOWN &&
         previous_max_sn != max_sn_.previous()) {
       add_gap_submsg_i(subm, previous_max_sn + 1);
     }
@@ -3006,6 +3007,7 @@ void RtpsUdpDataLink::RtpsWriter::process_nackfrag(const RTPS::NackFragSubmessag
   SequenceNumber seq;
   seq.setValue(nackfrag.writerSN.high, nackfrag.writerSN.low);
   ri->second->requested_frags_[seq] = nackfrag.fragmentNumberState;
+  readers_expecting_data_.insert(reader);
 
   link->nack_reply_.schedule(); // timer will invoke send_nack_replies()
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3007,7 +3007,7 @@ void RtpsUdpDataLink::RtpsWriter::process_nackfrag(const RTPS::NackFragSubmessag
   SequenceNumber seq;
   seq.setValue(nackfrag.writerSN.high, nackfrag.writerSN.low);
   ri->second->requested_frags_[seq] = nackfrag.fragmentNumberState;
-  readers_expecting_data_.insert(reader);
+  readers_expecting_data_.insert(ri->second);
 
   link->nack_reply_.schedule(); // timer will invoke send_nack_replies()
 }


### PR DESCRIPTION
Problem
-------

If a writer is writing while the first reader associates, the initial
sequence number will jump from 0 to N creating a gap from 1 to N-1
which fouls durable readers.

Solution
--------

Don't insert a gap from 1 to N-1.