### PR TITLE
Thrasher test lacks durability scenarios

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -294,6 +294,22 @@ tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -294,14 +294,14 @@ tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS

--- a/tests/DCPS/Thrasher/ParticipantTask.h
+++ b/tests/DCPS/Thrasher/ParticipantTask.h
@@ -13,8 +13,8 @@
 class ParticipantTask : public ACE_Task_Base
 {
 public:
-  explicit ParticipantTask(std::size_t samples_per_thread,
-                           bool durable);
+  ParticipantTask(std::size_t samples_per_thread,
+                  bool durable);
 
   ~ParticipantTask();
 

--- a/tests/DCPS/Thrasher/ParticipantTask.h
+++ b/tests/DCPS/Thrasher/ParticipantTask.h
@@ -13,7 +13,8 @@
 class ParticipantTask : public ACE_Task_Base
 {
 public:
-  explicit ParticipantTask(const std::size_t& samples_per_thread);
+  explicit ParticipantTask(std::size_t samples_per_thread,
+                           bool durable);
 
   ~ParticipantTask();
 
@@ -24,7 +25,8 @@ private:
   typedef ACE_Guard<LockType> GuardType;
 
   LockType lock_;
-  const std::size_t& samples_per_thread_;
+  const std::size_t samples_per_thread_;
+  const bool durable_;
   int thread_index_;
 };
 

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -21,6 +21,7 @@ namespace
   size_t num_threads = 1;
   size_t samples_per_thread = 1024;
   bool durable = false;
+  unsigned int seed = time(0);
 
   void
   parse_args(int& argc, ACE_TCHAR** argv)
@@ -46,6 +47,11 @@ namespace
         durable = true;
         shifter.consume_arg();
       }
+      else if ((arg = shifter.get_the_parameter(ACE_TEXT("-e"))))
+      {
+        seed = ACE_OS::atoi(arg);
+        shifter.consume_arg();
+      }
       else
       {
         shifter.ignore_arg();
@@ -64,6 +70,8 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     parse_args(argc, argv);
 
     ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) -> PUBLISHER STARTED\n")));
+
+    srand(seed);
 
     // Spawn Participant threads
     ParticipantTask task(samples_per_thread, durable);

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -20,6 +20,7 @@ namespace
 {
   size_t num_threads = 1;
   size_t samples_per_thread = 1024;
+  bool durable = false;
 
   void
   parse_args(int& argc, ACE_TCHAR** argv)
@@ -38,6 +39,11 @@ namespace
       else if ((arg = shifter.get_the_parameter(ACE_TEXT("-t"))))
       {
         num_threads = ACE_OS::atoi(arg);
+        shifter.consume_arg();
+      }
+      else if (ACE_OS::strcmp(shifter.get_current(), ACE_TEXT("-d")) == 0)
+      {
+        durable = true;
         shifter.consume_arg();
       }
       else
@@ -60,7 +66,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) -> PUBLISHER STARTED\n")));
 
     // Spawn Participant threads
-    ParticipantTask task(samples_per_thread);
+    ParticipantTask task(samples_per_thread, durable);
 
     task.activate(DEFAULT_FLAGS, static_cast<int>(num_threads));
     task.wait();

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -28,6 +28,7 @@ namespace
   std::size_t expected_samples = 1024;
   std::size_t received_samples = 0;
   size_t n_publishers = 1;
+  bool durable = false;
 
   void
   parse_args(int& argc, ACE_TCHAR** argv)
@@ -46,6 +47,11 @@ namespace
       else if ((arg = shifter.get_the_parameter(ACE_TEXT("-t"))))
       {
         n_publishers = static_cast<size_t>(ACE_OS::atoi(arg));
+        shifter.consume_arg();
+      }
+      else if (ACE_OS::strcmp(shifter.get_current(), ACE_TEXT("-d")) == 0)
+      {
+        durable = true;
         shifter.consume_arg();
       }
       else
@@ -123,6 +129,9 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
       subscriber->get_default_datareader_qos(reader_qos);
 
       reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+      if (durable) {
+        reader_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+      }
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
       reader_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
 #endif

--- a/tests/DCPS/Thrasher/run_test.pl
+++ b/tests/DCPS/Thrasher/run_test.pl
@@ -14,51 +14,57 @@ use PerlDDS::Run_Test;
 
 PerlDDS::add_lib_path('../FooType');
 
+my $test = new PerlDDS::TestFramework();
+
 my $debug_level = 0;
 my $pub_opts = "";
 my $sub_opts = "";
 # $pub_opts .= "-DCPSChunks 1 ";
 
-my $arg = shift || "";
-if ($arg eq 'low') {
+if ($test->{'flags'}->{'low'}) {
   $pub_opts .= "-t 8 -s 128";
   $sub_opts .= "-t 8 -n 1024";
 
-} elsif ($arg eq 'medium') {
+} elsif ($test->{'flags'}->{'medium'}) {
   $pub_opts .= "-t 16 -s 64";
   $sub_opts .= "-t 16 -n 1024";
 
-} elsif ($arg eq 'high') {
+} elsif ($test->{'flags'}->{'high'}) {
   $pub_opts .= "-t 32 -s 32";
   $sub_opts .= "-t 32 -n 1024";
 
-} elsif ($arg eq 'aggressive') {
+} elsif ($test->{'flags'}->{'aggressive'}) {
   $pub_opts .= "-t 64 -s 16";
   $sub_opts .= "-t 64 -n 1024";
 
-} elsif ($arg eq 'triangle') {
+} elsif ($test->{'flags'}->{'triangle'}) {
   $pub_opts .= "-t 3 -s 3";
   $sub_opts .= "-t 3 -n 9";
 
-} elsif ($arg eq 'double') {
+} elsif ($test->{'flags'}->{'double'}) {
   $pub_opts .= "-t 2 -s 1";
   $sub_opts .= "-t 2 -n 2";
 
-} elsif ($arg eq 'single') {
+} elsif ($test->{'flags'}->{'single'}) {
   $pub_opts .= "-t 1 -s 1";
   $sub_opts .= "-t 1 -n 1";
 
-} elsif ($arg eq 'superlow') {
+} elsif ($test->{'flags'}->{'superlow'}) {
   $pub_opts .= "-t 4 -s 256";
   $sub_opts .= "-t 4 -n 1024";
 
-} elsif ($arg eq 'megalow') {
+} elsif ($test->{'flags'}->{'megalow'}) {
   $pub_opts .= "-t 2 -s 512";
   $sub_opts .= "-t 2 -n 1024";
 
 } else { # default (i.e. lazy)
   $pub_opts .= "-t 1 -s 1024";
   $sub_opts .= "-t 1 -n 1024";
+}
+
+if ($test->{'flags'}->{'durable'}) {
+  $pub_opts .= " -d";
+  $sub_opts .= " -d";
 }
 
 if ($debug_level) {
@@ -69,14 +75,13 @@ if ($debug_level) {
 
 my $ini_file = "thrasher.ini";
 
-if (("rtps" eq $arg) || ("rtps" eq (shift || ""))) {
+if ($test->{'flags'}->{'rtps'}) {
   $ini_file = "thrasher_rtps.ini";
 }
 
 $pub_opts .= " -DCPSConfigFile $ini_file";
 $sub_opts .= " -DCPSConfigFile $ini_file";
 
-my $test = new PerlDDS::TestFramework();
 if ("thrasher.ini" eq $ini_file) {
   $test->setup_discovery();
 }


### PR DESCRIPTION
Problem
--------

The Thrasher tests create T reliable writers in T participants and 1
reliable subscriber.  The writers write N messages and the reader
checks that all messages are received.  The test stresses
discovery (especially RTPS) and reliability including features like
waiting for acknowledgements and waiting for match status.  Durability
is implicitly tested through discovery.  The test could be used to
diagnose problems with durability if it were extended.

Solution
--------

Add flags to enable durability.  When the writer is durable, it either
1) waits for a match and then writes data or 2) writes data and then
waits for a match.