### PR TITLE
Configure QueueTaskBase ACE_Condition to use monotonic time.

### DIFF
--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -41,7 +41,7 @@ template <typename T>
 class QueueTaskBase : public ACE_Task_Base {
 public:
   QueueTaskBase()
-  : work_available_(lock_),
+  : work_available_(lock_, ConditionAttributesMonotonic()),
       shutdown_initiated_(false),
       opened_(false),
       thr_id_(ACE_OS::NULL_thread),
@@ -146,7 +146,8 @@ public:
             MonotonicTimePoint expire = MonotonicTimePoint::now() + interval;
 
             do {
-              this->work_available_.wait(&expire.value()); // wait uses abstime
+              this->work_available_.wait(&expire.value());
+
               MonotonicTimePoint now = MonotonicTimePoint::now();
               if (now > expire) {
                 expire = now + interval;
@@ -155,10 +156,8 @@ public:
                     ACE_DEBUG((LM_DEBUG,
                               "%T (%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
                   }
-                  {
-                    ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status->lock, -1);
-                    status->map[key] = now;
-                  }
+                  ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status->lock, -1);
+                  status->map[key] = now;
                 }
               }
             } while (this->queue_.is_empty() && !shutdown_initiated_);


### PR DESCRIPTION
This fixes an internal thread status monitoring high cpu usage issue.