### PR TITLE
XTypes Branch: Wrap and Deprecate ACE_Condition

### DIFF
--- a/dds/DCPS/.lint_config
+++ b/dds/DCPS/.lint_config
@@ -1,1 +1,1 @@
-ignore check ace_condition path Condition.h
+ignore check ace_condition path ConditionVariable.h

--- a/dds/DCPS/.lint_config
+++ b/dds/DCPS/.lint_config
@@ -1,0 +1,1 @@
+ignore check ace_condition path Condition.h

--- a/dds/DCPS/Condition.h
+++ b/dds/DCPS/Condition.h
@@ -1,0 +1,96 @@
+#ifndef OPENDDS_DCPS_CONDITION_H
+#define OPENDDS_DCPS_CONDITION_H
+
+#include "TimeTypes.h"
+
+#include <ace/Condition_Thread_Mutex.h>
+#include <ace/Condition_Recursive_Thread_Mutex.h>
+#include <ace/Condition_T.h>
+#include <ace/Condition_Attributes.h>
+#include <ace/OS_NS_Thread.h>
+
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+/**
+ * ACE_Condition wrapper based on std::condition_variable that enforces
+ * monotonic time behavior.
+ *
+ * Besides the fact that it only works with ACE Mutexes, the major difference
+ * between this and std::condition_variable_any, the generalized form of
+ * std::condition_variable, is that it takes the mutex as a constructor
+ * argument, where the std::condition_variables take them as method arguments.
+ */
+template <typename Mutex>
+class Condition {
+public:
+  Condition(Mutex& mutex)
+  : impl_(mutex, ACE_Condition_Attributes_T<MonotonicClock>())
+  {
+  }
+
+  enum WaitStatus {
+    NoTimeout,
+    Timeout,
+    WaitError
+  };
+
+  WaitStatus wait()
+  {
+    if (impl_.wait() == 0) {
+      return NoTimeout;
+    }
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Condition::wait: %p\n"));
+    return WaitError;
+  }
+
+  WaitStatus wait_until(const MonotonicTimePoint& expire_at)
+  {
+    if (impl_.wait(&expire_at.value()) == 0) {
+      return NoTimeout;
+    } else if (errno == ETIME) {
+      return Timeout;
+    }
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Condition::wait_until: %p\n"));
+    return WaitError;
+  }
+
+  WaitStatus wait_for(const TimeDuration& expire_in)
+  {
+    return wait_until(MonotonicTimePoint::now() + expire_in);
+  }
+
+  bool notify_one()
+  {
+    if (impl_.signal() == 0) {
+      return true;
+    }
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Condition::notify_one: %p\n"));
+    return false;
+  }
+
+  bool notify_all()
+  {
+    if (impl_.broadcast() == 0) {
+      return true;
+    }
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Condition::notify_all: %p\n"));
+    return false;
+  }
+
+protected:
+  ACE_Condition<Mutex> impl_;
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif // OPENDDS_DCPS_CONDITION_H

--- a/dds/DCPS/ConditionVariable.h
+++ b/dds/DCPS/ConditionVariable.h
@@ -43,7 +43,7 @@ enum CvStatus {
 template <typename Mutex>
 class ConditionVariable {
 public:
-  ConditionVariable(Mutex& mutex)
+  explicit ConditionVariable(Mutex& mutex)
   : impl_(mutex, ACE_Condition_Attributes_T<MonotonicClock>())
   {
   }

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -19,7 +19,7 @@
 #include "SubscriberImpl.h"
 #include "SporadicTask.h"
 #include "TimeTypes.h"
-#include "Condition.h"
+#include "ConditionVariable.h"
 #ifdef OPENDDS_SECURITY
 #  include "Ice.h"
 #endif
@@ -202,7 +202,7 @@ namespace OpenDDS {
       DataWriterCallbacks* const dwr_;
       bool reader_done_, writer_done_;
       ACE_Thread_Mutex mtx_;
-      Condition<ACE_Thread_Mutex> cnd_;
+      ConditionVariable<ACE_Thread_Mutex> cnd_;
 
       // thread reporting
       TimeDuration interval_;

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -162,7 +162,6 @@ namespace OpenDDS {
               }
 
               case CvStatus_Error:
-              default:
                 if (DCPS_debug_level) {
                   ACE_ERROR((LM_ERROR, "(%P|t) ERROR: DcpsUpcalls::svc: error in wait_utill\n"));
                 }

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -6,29 +6,31 @@
 #ifndef OPENDDS_DDS_DCPS_DISCOVERYBASE_H
 #define OPENDDS_DDS_DCPS_DISCOVERYBASE_H
 
-#include "dds/DCPS/TopicDetails.h"
-#include "dds/DCPS/BuiltInTopicUtils.h"
-#include "dds/DCPS/DataReaderImpl_T.h"
-#include "dds/DCPS/DCPS_Utils.h"
-#include "dds/DCPS/Discovery.h"
-#include "dds/DCPS/DomainParticipantImpl.h"
-#include "dds/DCPS/GuidUtils.h"
-#include "dds/DCPS/Marked_Default_Qos.h"
-#include "dds/DCPS/PoolAllocationBase.h"
-#include "dds/DCPS/Registered_Data_Types.h"
-#include "dds/DCPS/SubscriberImpl.h"
+#include "TopicDetails.h"
+#include "BuiltInTopicUtils.h"
+#include "DataReaderImpl_T.h"
+#include "DCPS_Utils.h"
+#include "Discovery.h"
+#include "DomainParticipantImpl.h"
+#include "GuidUtils.h"
+#include "Marked_Default_Qos.h"
+#include "PoolAllocationBase.h"
+#include "Registered_Data_Types.h"
+#include "SubscriberImpl.h"
 #include "SporadicTask.h"
-
-#include "dds/DdsDcpsCoreTypeSupportImpl.h"
-
+#include "TimeTypes.h"
+#include "Condition.h"
+#ifdef OPENDDS_SECURITY
+#  include "Ice.h"
+#endif
 #include "XTypes/TypeAssignability.h"
 
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
 #ifdef OPENDDS_SECURITY
-#include "dds/DdsSecurityCoreC.h"
-#include "dds/DCPS/Ice.h"
+#  include <dds/DdsSecurityCoreC.h>
 #endif
 
-#include "ace/Condition_Thread_Mutex.h"
+#include <ace/Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -108,11 +110,12 @@ namespace OpenDDS {
         status_ = TheServiceParticipant->get_thread_statuses();
 #ifdef ACE_HAS_MAC_OSX
         uint64_t osx_tid;
-        if (!pthread_threadid_np(NULL, &osx_tid)) {
+        if (!pthread_threadid_np(0, &osx_tid)) {
           tid_ = static_cast<unsigned long>(osx_tid);
         } else {
           tid_ = 0;
-          ACE_ERROR((LM_ERROR, ACE_TEXT("%T (%P|%t) DcpsUpcalls::svc. Error getting OSX thread id\n.")));
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DcpsUpcalls: "
+            "Error getting OSX thread id: %p\n")));
         }
 #else
         tid_ = ACE_OS::thr_self();
@@ -127,28 +130,34 @@ namespace OpenDDS {
 
       int svc()
       {
-        ACE_Time_Value expire = MonotonicTimePoint::now().value() + interval_.value();
-        const ACE_Time_Value* expire_ptr = has_timeout() ? &expire : 0;
+        MonotonicTimePoint expire;
+        const bool use_expire = has_timeout();
+        if (use_expire) {
+          expire = MonotonicTimePoint::now() + interval_;
+        }
 
         drr_->add_association(reader_, wa_, active_);
         {
           ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mtx_, -1);
           reader_done_ = true;
-          cnd_.signal();
+          cnd_.notify_one();
           while (!writer_done_) {
-            cnd_.wait(expire_ptr);
-
-            const MonotonicTimePoint now = MonotonicTimePoint::now();
-            if (expire_ptr && now.value() > expire) {
-              expire = now.value() + interval_.value();
-              if (status_) {
-                if (DCPS_debug_level > 4) {
-                  ACE_DEBUG((LM_DEBUG,
-                            "%T (%P|%t) DcpsUpcalls::svc. Updating thread status.\n"));
+            if (use_expire) {
+              cnd_.wait_until(expire);
+              const MonotonicTimePoint now = MonotonicTimePoint::now();
+              if (now > expire) {
+                expire = now + interval_;
+                if (status_) {
+                  if (DCPS_debug_level > 4) {
+                    ACE_DEBUG((LM_DEBUG, "(%P|%t) DcpsUpcalls::svc: "
+                      "Updating thread status.\n"));
+                  }
+                  ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status_->lock, -1);
+                  status_->map[key_] = now;
                 }
-                ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status_->lock, -1);
-                status_->map[key_] = now;
               }
+            } else {
+              cnd_.wait();
             }
           }
         }
@@ -160,29 +169,30 @@ namespace OpenDDS {
         {
           ACE_GUARD(ACE_Thread_Mutex, g, mtx_);
           writer_done_ = true;
-          cnd_.signal();
+          cnd_.notify_one();
         }
 
-        ACE_Time_Value expire;
+        // TODO: Remove?
+        //ACE_Time_Value expire;
 
-        if (has_timeout()) {
-          expire = MonotonicTimePoint::now().value() + interval_.value();
-        }
+        //if (has_timeout()) {
+        //  expire = MonotonicTimePoint::now().value() + interval_.value();
+        //}
 
         wait(); // ACE_Task_Base::wait does not accept a timeout
 
-        const MonotonicTimePoint now = MonotonicTimePoint::now();
-        if (has_timeout() && now.value() > expire) {
-          expire = now.value() + interval_.value();
-          if (status_) {
-            if (DCPS_debug_level > 4) {
-              ACE_DEBUG((LM_DEBUG,
-                        "%T (%P|%t) DcpsUpcalls::writer_done. Updating thread status.\n"));
-            }
-            ACE_WRITE_GUARD(ACE_Thread_Mutex, g, status_->lock);
-            status_->map[key_] = now;
-          }
-        }
+        /* const MonotonicTimePoint now = MonotonicTimePoint::now(); */
+        /* if (has_timeout() && now.value() > expire) { */
+        /*   expire = now.value() + interval_.value(); */
+        /*   if (status_) { */
+        /*     if (DCPS_debug_level > 4) { */
+        /*       ACE_DEBUG((LM_DEBUG, */
+        /*                 "(%P|%t) DcpsUpcalls::writer_done. Updating thread status.\n")); */
+        /*     } */
+        /*     ACE_WRITE_GUARD(ACE_Thread_Mutex, g, status_->lock); */
+        /*     status_->map[key_] = now; */
+        /*   } */
+        /* } */
       }
 
       DataReaderCallbacks* const drr_;
@@ -192,7 +202,7 @@ namespace OpenDDS {
       DataWriterCallbacks* const dwr_;
       bool reader_done_, writer_done_;
       ACE_Thread_Mutex mtx_;
-      ACE_Condition_Thread_Mutex cnd_;
+      Condition<ACE_Thread_Mutex> cnd_;
 
       // thread reporting
       TimeDuration interval_;

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2516,7 +2516,7 @@ DomainParticipantImpl::handle_exception(ACE_HANDLE /*fd*/)
   shutdown_mutex_.acquire();
   shutdown_result_ = ret;
   shutdown_complete_ = true;
-  shutdown_condition_.signal();
+  shutdown_condition_.notify_one();
   shutdown_mutex_.release();
 
   return 0;

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -17,6 +17,7 @@
 #include "PoolAllocator.h"
 #include "Recorder.h"
 #include "Replayer.h"
+#include "ConditionVariable.h"
 #include "TimeTypes.h"
 #include "XTypes/TypeLookupService.h"
 #include "transport/framework/TransportImpl_rch.h"
@@ -479,7 +480,7 @@ private:
   ACE_Recursive_Thread_Mutex handle_protector_;
   /// Protect the shutdown.
   ACE_Thread_Mutex shutdown_mutex_;
-  Condition<ACE_Thread_Mutex> shutdown_condition_;
+  ConditionVariable<ACE_Thread_Mutex> shutdown_condition_;
   DDS::ReturnCode_t shutdown_result_;
   bool shutdown_complete_;
 

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -8,38 +8,34 @@
 #ifndef OPENDDS_DCPS_DOMAIN_PARTICIPANT_IMPL_H
 #define OPENDDS_DCPS_DOMAIN_PARTICIPANT_IMPL_H
 
-#include "dds/DdsDcpsPublicationC.h"
-#include "dds/DdsDcpsSubscriptionExtC.h"
-#include "dds/DdsDcpsTopicC.h"
-#include "dds/DdsDcpsDomainC.h"
-#include "dds/DdsDcpsInfoUtilsC.h"
-#include "dds/DCPS/GuidUtils.h"
-#include "dds/DdsDcpsInfrastructureC.h"
-#include "XTypes/TypeLookupService.h"
-
-#if !defined (DDS_HAS_MINIMUM_BIT)
-#include "dds/DdsDcpsCoreTypeSupportC.h"
-#endif // !defined (DDS_HAS_MINIMUM_BIT)
-
 #include "EntityImpl.h"
 #include "Definitions.h"
 #include "TopicImpl.h"
 #include "InstanceHandle.h"
 #include "OwnershipManager.h"
 #include "GuidBuilder.h"
-
-#include "dds/DCPS/transport/framework/TransportImpl_rch.h"
-
-#include "dds/DCPS/PoolAllocator.h"
-
+#include "PoolAllocator.h"
 #include "Recorder.h"
 #include "Replayer.h"
+#include "TimeTypes.h"
+#include "XTypes/TypeLookupService.h"
+#include "transport/framework/TransportImpl_rch.h"
+#include "security/framework/SecurityConfig_rch.h"
 
-#include "dds/DCPS/security/framework/SecurityConfig_rch.h"
+#include <dds/DdsDcpsPublicationC.h>
+#include <dds/DdsDcpsSubscriptionExtC.h>
+#include <dds/DdsDcpsTopicC.h>
+#include <dds/DdsDcpsDomainC.h>
+#include <dds/DdsDcpsInfoUtilsC.h>
+#include <dds/DCPS/GuidUtils.h>
+#include <dds/DdsDcpsInfrastructureC.h>
+#ifndef DDS_HAS_MINIMUM_BIT
+#  include <dds/DdsDcpsCoreTypeSupportC.h>
+#endif
 
-#include "ace/Null_Mutex.h"
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Recursive_Thread_Mutex.h"
+#include <ace/Null_Mutex.h>
+#include <ace/Thread_Mutex.h>
+#include <ace/Recursive_Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -483,7 +479,7 @@ private:
   ACE_Recursive_Thread_Mutex handle_protector_;
   /// Protect the shutdown.
   ACE_Thread_Mutex shutdown_mutex_;
-  ACE_Condition<ACE_Thread_Mutex> shutdown_condition_;
+  Condition<ACE_Thread_Mutex> shutdown_condition_;
   DDS::ReturnCode_t shutdown_result_;
   bool shutdown_complete_;
 

--- a/dds/DCPS/MessageTracker.cpp
+++ b/dds/DCPS/MessageTracker.cpp
@@ -104,7 +104,6 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
       break;
 
     case CvStatus_Error:
-    default:
       if (DCPS_debug_level) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MessageTracker::wait_messages_pending: "
           "error in wait_until\n"));

--- a/dds/DCPS/MessageTracker.cpp
+++ b/dds/DCPS/MessageTracker.cpp
@@ -108,7 +108,6 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MessageTracker::wait_messages_pending: "
           "error in wait_until\n"));
       }
-      loop = false;
       return;
     }
   }

--- a/dds/DCPS/MessageTracker.cpp
+++ b/dds/DCPS/MessageTracker.cpp
@@ -23,17 +23,14 @@ MessageTracker::MessageTracker(const OPENDDS_STRING& msg_src)
 , dropped_count_(0)
 , delivered_count_(0)
 , sent_count_(0)
-, done_condition_(lock_, ConditionAttributesMonotonic())
+, done_condition_(lock_)
 {
 }
 
 bool
 MessageTracker::pending_messages()
 {
-  if (sent_count_ > delivered_count_ + dropped_count_) {
-    return true;
-  }
-  return false;
+  return sent_count_ > delivered_count_ + dropped_count_;
 }
 
 void
@@ -49,8 +46,9 @@ MessageTracker::message_delivered()
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
   ++delivered_count_;
 
-  if (!pending_messages())
-    done_condition_.broadcast();
+  if (!pending_messages()) {
+    done_condition_.notify_all();
+  }
 }
 
 void
@@ -59,8 +57,9 @@ MessageTracker::message_dropped()
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
   ++dropped_count_;
 
-  if (!pending_messages())
-    done_condition_.broadcast();
+  if (!pending_messages()) {
+    done_condition_.notify_all();
+  }
 }
 
 void MessageTracker::wait_messages_pending(const char* caller)
@@ -72,30 +71,28 @@ void MessageTracker::wait_messages_pending(const char* caller)
 
 void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTimePoint& deadline)
 {
-  const ACE_Time_Value_T<MonotonicClock>* deadline_ptr = deadline.is_zero() ? 0 : &deadline.value();
+  const bool use_deadline = deadline.is_zero();
   ACE_GUARD(ACE_Thread_Mutex, guard, this->lock_);
   const bool report = DCPS_debug_level > 0 && pending_messages();
   if (report) {
-    if (deadline_ptr) {
+    if (use_deadline) {
       ACE_DEBUG((LM_DEBUG,
-                ACE_TEXT("%T (%P|%t) MessageTracker::wait_messages_pending ")
+                ACE_TEXT("(%P|%t) MessageTracker::wait_messages_pending %T ")
                 ACE_TEXT("from source=%C will wait until %#T.\n"),
-                msg_src_.c_str(), deadline_ptr));
+                msg_src_.c_str(), &deadline.value()));
     } else {
       ACE_DEBUG((LM_DEBUG,
-                ACE_TEXT("%T (%P|%t) MessageTracker::wait_messages_pending ")
+                ACE_TEXT("(%P|%t) MessageTracker::wait_messages_pending %T ")
                 ACE_TEXT("from source=%C will wait with no timeout.\n")));
     }
   }
-  while (true) {
-    if (!pending_messages())
-      break;
-
-    if (done_condition_.wait(deadline_ptr) == -1 && pending_messages()) {
+  while (pending_messages()) {
+    if (done_condition_.wait_until(deadline) != ConditionType::NoTimeout &&
+        pending_messages()) {
       if (DCPS_debug_level) {
         ACE_DEBUG((LM_INFO,
-                   ACE_TEXT("(%P|%t) %T MessageTracker::")
-                   ACE_TEXT("wait_messages_pending (Redmine Issue# 1446) %p (caller: %C)\n"),
+                   ACE_TEXT("(%P|%t) MessageTracker::wait_messages_pending %T ")
+                   ACE_TEXT("(Redmine Issue# 1446) (caller: %C)\n"),
                    ACE_TEXT("Timed out waiting for messages to be transported"),
                    caller));
       }
@@ -103,8 +100,7 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
     }
   }
   if (report) {
-    ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) MessageTracker::wait_messages_pending done\n"));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) MessageTracker::wait_messages_pending %T done\n"));
   }
 }
 

--- a/dds/DCPS/MessageTracker.cpp
+++ b/dds/DCPS/MessageTracker.cpp
@@ -106,7 +106,8 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
     case CvStatus_Error:
     default:
       if (DCPS_debug_level) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) MessageTracker::wait_messages_pending: Wait error\n"));
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MessageTracker::wait_messages_pending: "
+          "error in wait_until\n"));
       }
       loop = false;
       return;

--- a/dds/DCPS/MessageTracker.h
+++ b/dds/DCPS/MessageTracker.h
@@ -11,9 +11,9 @@
 #include "dcps_export.h"
 #include "PoolAllocator.h"
 #include "TimeTypes.h"
+#include "Condition.h"
 
 #include <ace/Thread_Mutex.h>
-#include <ace/Condition_Thread_Mutex.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -74,7 +74,8 @@ namespace DCPS {
     ACE_Thread_Mutex lock_;
 
     /// All messages have been transported condition variable.
-    ACE_Condition_Thread_Mutex done_condition_;
+    typedef Condition<ACE_Thread_Mutex> ConditionType;
+    ConditionType done_condition_;
   };
 
 } // namespace DCPS

--- a/dds/DCPS/MessageTracker.h
+++ b/dds/DCPS/MessageTracker.h
@@ -11,7 +11,7 @@
 #include "dcps_export.h"
 #include "PoolAllocator.h"
 #include "TimeTypes.h"
-#include "Condition.h"
+#include "ConditionVariable.h"
 
 #include <ace/Thread_Mutex.h>
 
@@ -74,8 +74,8 @@ namespace DCPS {
     ACE_Thread_Mutex lock_;
 
     /// All messages have been transported condition variable.
-    typedef Condition<ACE_Thread_Mutex> ConditionType;
-    ConditionType done_condition_;
+    typedef ConditionVariable<ACE_Thread_Mutex> ConditionVariableType;
+    ConditionVariableType done_condition_;
   };
 
 } // namespace DCPS

--- a/dds/DCPS/RTPS/SecurityHelpers.h
+++ b/dds/DCPS/RTPS/SecurityHelpers.h
@@ -8,8 +8,11 @@
 #ifndef OPENDDS_SECURITY_HELPERS_H
 #define OPENDDS_SECURITY_HELPERS_H
 
-#include "dds/DdsSecurityCoreC.h"
-#include "dds/DdsDcpsGuidC.h"
+#include <dds/DCPS/Ice.h>
+#include <dds/DCPS/XTypes/TypeObject.h>
+
+#include <dds/DdsSecurityCoreC.h>
+#include <dds/DdsDcpsGuidC.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -9,45 +9,41 @@
 #define OPENDDS_RTPS_SEDP_H
 
 #include "TypeLookup.h"
-#include "RtpsRpcTypeSupportImpl.h"
-
-#include "dds/DdsDcpsInfrastructureC.h"
-#include "dds/DdsDcpsInfoUtilsC.h"
-#include "dds/DdsDcpsCoreTypeSupportImpl.h"
-
-#include "dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h"
-#include "dds/DCPS/RTPS/BaseMessageTypes.h"
-#include "dds/DCPS/RTPS/BaseMessageUtils.h"
-
-#include "dds/DCPS/RTPS/ICE/Ice.h"
-
-#include "dds/DCPS/RcHandle_T.h"
-#include "dds/DCPS/GuidUtils.h"
-#include "dds/DCPS/DataReaderCallbacks.h"
-#include "dds/DCPS/Definitions.h"
-#include "dds/DCPS/BuiltInTopicUtils.h"
-#include "dds/DCPS/DataSampleElement.h"
-#include "dds/DCPS/DataSampleHeader.h"
-#include "dds/DCPS/PoolAllocationBase.h"
-#include "dds/DCPS/DiscoveryBase.h"
-#include "dds/DCPS/JobQueue.h"
-
-#include "dds/DCPS/transport/framework/TransportRegistry.h"
-#include "dds/DCPS/transport/framework/TransportSendListener.h"
-#include "dds/DCPS/transport/framework/TransportClient.h"
-#include "dds/DCPS/transport/framework/TransportInst_rch.h"
-
-#include "dds/DCPS/PoolAllocator.h"
-
+#include "BaseMessageTypes.h"
+#include "BaseMessageUtils.h"
 #ifdef OPENDDS_SECURITY
-#include "dds/DCPS/RTPS/RtpsSecurityC.h"
-#include "dds/DCPS/RTPS/SecurityHelpers.h"
+#  include "SecurityHelpers.h"
+#endif
+#include "ICE/Ice.h"
+#include "RtpsRpcTypeSupportImpl.h"
+#include "RtpsCoreTypeSupportImpl.h"
+#ifdef OPENDDS_SECURITY
+#  include "RtpsSecurityC.h"
 #endif
 
-#include "ace/Atomic_Op.h"
-#include "ace/Task_Ex_T.h"
-#include "ace/Thread_Mutex.h"
-#include "ace/Condition_Thread_Mutex.h"
+#include <dds/DCPS/RcHandle_T.h>
+#include <dds/DCPS/GuidUtils.h>
+#include <dds/DCPS/DataReaderCallbacks.h>
+#include <dds/DCPS/Definitions.h>
+#include <dds/DCPS/BuiltInTopicUtils.h>
+#include <dds/DCPS/DataSampleElement.h>
+#include <dds/DCPS/DataSampleHeader.h>
+#include <dds/DCPS/PoolAllocationBase.h>
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/DiscoveryBase.h>
+#include <dds/DCPS/JobQueue.h>
+#include <dds/DCPS/transport/framework/TransportRegistry.h>
+#include <dds/DCPS/transport/framework/TransportSendListener.h>
+#include <dds/DCPS/transport/framework/TransportClient.h>
+#include <dds/DCPS/transport/framework/TransportInst_rch.h>
+
+#include <dds/DdsDcpsInfrastructureC.h>
+#include <dds/DdsDcpsInfoUtilsC.h>
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
+
+#include <ace/Atomic_Op.h>
+#include <ace/Task_Ex_T.h>
+#include <ace/Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2236,7 +2236,7 @@ Spdp::SpdpTransport::~SpdpTransport()
     ACE_GUARD(ACE_Thread_Mutex, g, outer_->lock_);
     outer_->eh_shutdown_ = true;
   }
-  outer_->shutdown_cond_.signal();
+  outer_->shutdown_cond_.notify_one();
 
   unicast_socket_.close();
   multicast_socket_.close();

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -29,6 +29,7 @@
 #endif
 #include <dds/DCPS/PoolAllocator.h>
 #include <dds/DCPS/PoolAllocationBase.h>
+#include <dds/DCPS/TimeTypes.h>
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DdsDcpsInfoUtilsC.h>
@@ -37,7 +38,7 @@
 #include <ace/Atomic_Op.h>
 #include <ace/SOCK_Dgram.h>
 #include <ace/SOCK_Dgram_Mcast.h>
-#include <ace/Condition_Thread_Mutex.h>
+#include <ace/Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -405,7 +406,7 @@ private:
 
   ACE_Event_Handler_var eh_; // manages our refcount on tport_
   bool eh_shutdown_;
-  ACE_Condition_Thread_Mutex shutdown_cond_;
+  DCPS::Condition<ACE_Thread_Mutex> shutdown_cond_;
   ACE_Atomic_Op<ACE_Thread_Mutex, bool> shutdown_flag_; // Spdp shutting down
 
   void get_discovered_participant_ids(DCPS::RepoIdSet& results) const;

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -406,7 +406,7 @@ private:
 
   ACE_Event_Handler_var eh_; // manages our refcount on tport_
   bool eh_shutdown_;
-  DCPS::Condition<ACE_Thread_Mutex> shutdown_cond_;
+  DCPS::ConditionVariable<ACE_Thread_Mutex> shutdown_cond_;
   ACE_Atomic_Op<ACE_Thread_Mutex, bool> shutdown_flag_; // Spdp shutting down
 
   void get_discovered_participant_ids(DCPS::RepoIdSet& results) const;

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -10,13 +10,15 @@
 
 #include "PoolAllocator.h"
 #include "PoolAllocationBase.h"
-#include "ace/Reactor.h"
-#include "ace/Thread.h"
-#include "ace/Condition_Thread_Mutex.h"
 #include "RcEventHandler.h"
 #include "dcps_export.h"
 #include "unique_ptr.h"
 #include "RcHandle_T.h"
+#include "Condition.h"
+
+#include <ace/Reactor.h>
+#include <ace/Thread.h>
+#include <ace/Thread_Mutex.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -51,7 +53,7 @@ public:
     {
       ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
       executed_ = true;
-      condition_.broadcast();
+      condition_.notify_all();
     }
 
   protected:
@@ -64,7 +66,7 @@ public:
 
     bool executed_;
     mutable ACE_Thread_Mutex mutex_;
-    mutable ACE_Condition_Thread_Mutex condition_;
+    mutable Condition<ACE_Thread_Mutex> condition_;
     ACE_Reactor* reactor_;
   };
   typedef RcHandle<Command> CommandPtr;

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -14,7 +14,7 @@
 #include "dcps_export.h"
 #include "unique_ptr.h"
 #include "RcHandle_T.h"
-#include "Condition.h"
+#include "ConditionVariable.h"
 
 #include <ace/Reactor.h>
 #include <ace/Thread.h>
@@ -66,7 +66,7 @@ public:
 
     bool executed_;
     mutable ACE_Thread_Mutex mutex_;
-    mutable Condition<ACE_Thread_Mutex> condition_;
+    mutable ConditionVariable<ACE_Thread_Mutex> condition_;
     ACE_Reactor* reactor_;
   };
   typedef RcHandle<Command> CommandPtr;

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -149,7 +149,7 @@ OpenDDS::DCPS::ReactorTask::svc()
       state_ = STATE_RUNNING;
 
       // Signal the condition_ that we are here.
-      condition_.signal();
+      condition_.notify_one();
     }
   }
 
@@ -161,11 +161,11 @@ OpenDDS::DCPS::ReactorTask::svc()
 #ifdef ACE_HAS_MAC_OSX
       unsigned long tid = 0;
       uint64_t osx_tid;
-      if (!pthread_threadid_np(NULL, &osx_tid)) {
+      if (!pthread_threadid_np(0, &osx_tid)) {
         tid = static_cast<unsigned long>(osx_tid);
       } else {
         tid = 0;
-        ACE_ERROR((LM_ERROR, ACE_TEXT("%T (%P|%t) ReactorTask::svc. Error getting OSX thread id\n.")));
+        ACE_ERROR((LM_ERROR, "(%P|%t) ReactorTask::svc. Error getting OSX thread id: %p\n"));
       }
 #elif !defined (OPENDDS_SAFETY_PROFILE)
       ACE_thread_t tid = ACE_OS::thr_self();
@@ -186,7 +186,7 @@ OpenDDS::DCPS::ReactorTask::svc()
         if (thread_status_) {
           if (DCPS_debug_level > 4) {
             ACE_DEBUG((LM_DEBUG,
-                       "%T (%P|%t) ReactorTask::svc. Updating thread status.\n"));
+                       "(%P|%t) ReactorTask::svc. Updating thread status.\n"));
           }
           ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, thread_status_->lock, -1);
           thread_status_->map[key] = MonotonicTimePoint::now();

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -13,6 +13,7 @@
 #include "TimeTypes.h"
 #include "ReactorInterceptor.h"
 #include "SafetyProfileStreams.h"
+#include "ConditionVariable.h"
 
 #include <ace/Task.h>
 #include <ace/Barrier.h>
@@ -74,7 +75,7 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
   typedef ACE_Timer_Heap_T<
     ACE_Event_Handler*, ACE_Event_Handler_Handle_Timeout_Upcall,
     ACE_SYNCH_RECURSIVE_MUTEX, MonotonicClock> TimerQueueType;
@@ -99,7 +100,7 @@ private:
   ACE_Barrier   barrier_;
   LockType      lock_;
   State         state_;
-  ConditionType condition_;
+  ConditionVariableType condition_;
   ACE_Reactor*  reactor_;
   ACE_thread_t  reactor_owner_;
   ACE_Proactor* proactor_;

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -8,18 +8,17 @@
 #ifndef OPENDDS_DCPS_REACTORTASK_H
 #define OPENDDS_DCPS_REACTORTASK_H
 
-#include "dds/DCPS/dcps_export.h"
-#include "dds/DCPS/RcObject.h"
-#include "dds/DCPS/TimeTypes.h"
-#include "dds/DCPS/ReactorInterceptor.h"
-#include "dds/DCPS/SafetyProfileStreams.h"
-#include "ace/Task.h"
-#include "ace/Barrier.h"
-#include "ace/Synch_Traits.h"
-#include "ace/Condition_T.h"
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Timer_Heap_T.h"
-#include "ace/Event_Handler_Handle_Timeout_Upcall.h"
+#include "dcps_export.h"
+#include "RcObject.h"
+#include "TimeTypes.h"
+#include "ReactorInterceptor.h"
+#include "SafetyProfileStreams.h"
+
+#include <ace/Task.h>
+#include <ace/Barrier.h>
+#include <ace/Synch_Traits.h>
+#include <ace/Timer_Heap_T.h>
+#include <ace/Event_Handler_Handle_Timeout_Upcall.h>
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Proactor;
@@ -73,9 +72,9 @@ public:
 
 private:
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
   typedef ACE_Timer_Heap_T<
     ACE_Event_Handler*, ACE_Event_Handler_Handle_Timeout_Upcall,
     ACE_SYNCH_RECURSIVE_MUTEX, MonotonicClock> TimerQueueType;

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
-#include "tao/ORB_Core.h"
+
+#include "RecorderImpl.h"
+
 #include "SubscriptionInstance.h"
 #include "ReceivedDataElementList.h"
 #include "DomainParticipantImpl.h"
@@ -14,7 +16,6 @@
 #include "Qos_Helper.h"
 #include "FeatureDisabledQosCheck.h"
 #include "GuidConverter.h"
-#include "TopicImpl.h"
 #include "Serializer.h"
 #include "SubscriberImpl.h"
 #include "Transient_Kludge.h"
@@ -23,22 +24,24 @@
 #include "QueryConditionImpl.h"
 #include "ReadConditionImpl.h"
 #include "MonitorFactory.h"
-#include "dds/DCPS/transport/framework/EntryExit.h"
-#include "dds/DCPS/transport/framework/TransportExceptions.h"
-#include "dds/DdsDcpsCoreC.h"
-#include "dds/DdsDcpsGuidTypeSupportImpl.h"
-#include "dds/DCPS/SafetyProfileStreams.h"
+#include "SafetyProfileStreams.h"
 #include "TypeSupportImpl.h"
-#if !defined (DDS_HAS_MINIMUM_BIT)
-#include "BuiltInTopicUtils.h"
-#include "dds/DdsDcpsCoreTypeSupportC.h"
-#endif // !defined (DDS_HAS_MINIMUM_BIT)
-#include "RecorderImpl.h"
 #include "PoolAllocator.h"
+#ifndef DDS_HAS_MINIMUM_BIT
+#  include "BuiltInTopicUtils.h"
+#endif
+#include "transport/framework/EntryExit.h"
+#include "transport/framework/TransportExceptions.h"
 
-#include "ace/Reactor.h"
-#include "ace/Auto_Ptr.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
+#include <dds/DdsDcpsCoreC.h>
+#include <dds/DdsDcpsGuidTypeSupportImpl.h>
+#ifndef DDS_HAS_MINIMUM_BIT
+#  include <dds/DdsDcpsCoreTypeSupportC.h>
+#endif
+
+#include <tao/ORB_Core.h>
+
+#include <ace/Reactor.h>
 
 #include <stdexcept>
 

--- a/dds/DCPS/RecorderImpl.h
+++ b/dds/DCPS/RecorderImpl.h
@@ -8,19 +8,23 @@
 #ifndef OPENDDS_DCPS_RECORDERIMPL_H
 #define OPENDDS_DCPS_RECORDERIMPL_H
 
-#include "dds/DCPS/RcObject.h"
-#include "dds/DCPS/WriterInfo.h"
-#include "dds/DdsDcpsTopicC.h"
-#include "dds/DdsDcpsSubscriptionExtC.h"
-#include "dds/DdsDcpsDomainC.h"
-#include "dds/DdsDcpsTopicC.h"
+#include "RcObject.h"
+#include "WriterInfo.h"
 #include "Definitions.h"
-#include "dds/DCPS/DataReaderCallbacks.h"
-#include "dds/DCPS/transport/framework/ReceivedDataSample.h"
-#include "dds/DCPS/transport/framework/TransportReceiveListener.h"
-#include "dds/DCPS/transport/framework/TransportClient.h"
+#include "DataReaderCallbacks.h"
 #include "Recorder.h"
 #include "RemoveAssociationSweeper.h"
+#include "EntityImpl.h"
+#include "TopicImpl.h"
+#include "OwnershipManager.h"
+#include "transport/framework/ReceivedDataSample.h"
+#include "transport/framework/TransportReceiveListener.h"
+#include "transport/framework/TransportClient.h"
+
+#include <dds/DdsDcpsTopicC.h>
+#include <dds/DdsDcpsSubscriptionExtC.h>
+#include <dds/DdsDcpsDomainC.h>
+#include <dds/DdsDcpsTopicC.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -152,8 +156,8 @@ private:
   /// lock protecting sample container as well as statuses.
   ACE_Recursive_Thread_Mutex sample_lock_;
 
-  DomainParticipantImpl*       participant_servant_;
-  TopicDescriptionPtr<TopicImpl>              topic_servant_;
+  DomainParticipantImpl* participant_servant_;
+  TopicDescriptionPtr<TopicImpl> topic_servant_;
 
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   bool is_exclusive_ownership_;

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -796,8 +796,8 @@ ReplayerImpl::data_delivered(const DataSampleElement* sample)
 
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
-    if ((--pending_write_count_) == 0) {
-      empty_condition_.broadcast();
+    if (--pending_write_count_ == 0) {
+      empty_condition_.notify_all();
     }
   }
 }
@@ -821,7 +821,7 @@ ReplayerImpl::data_dropped(const DataSampleElement* sample,
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
     if ((--pending_write_count_) == 0) {
-      empty_condition_.broadcast();
+      empty_condition_.notify_all();
     }
   }
 }

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -8,11 +8,8 @@
 #ifndef OPENDDS_DCPS_REPLAYERIMPL_H
 #define OPENDDS_DCPS_REPLAYERIMPL_H
 
-#include "dds/DdsDcpsDomainC.h"
-#include "dds/DdsDcpsTopicC.h"
-#include "dds/DCPS/DataWriterCallbacks.h"
-#include "dds/DCPS/transport/framework/TransportSendListener.h"
-#include "dds/DCPS/transport/framework/TransportClient.h"
+#include "Replayer.h"
+#include "DataWriterCallbacks.h"
 #include "WriteDataContainer.h"
 #include "Definitions.h"
 #include "DataSampleHeader.h"
@@ -21,18 +18,21 @@
 #include "CoherentChangeControl.h"
 #include "GuidUtils.h"
 #include "unique_ptr.h"
-
 #ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
-#include "FilterEvaluator.h"
+#  include "FilterEvaluator.h"
 #endif
+#include "Condition.h"
+#include "transport/framework/TransportSendListener.h"
+#include "transport/framework/TransportClient.h"
 
-#include "ace/Event_Handler.h"
-#include "ace/OS_NS_sys_time.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
+#include <dds/DdsDcpsDomainC.h>
+#include <dds/DdsDcpsTopicC.h>
+
+#include <ace/Event_Handler.h>
+#include <ace/OS_NS_sys_time.h>
+#include <ace/Recursive_Thread_Mutex.h>
 
 #include <memory>
-
-#include "Replayer.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -311,7 +311,7 @@ private:
 
   RepoIdToSequenceMap idToSequence_;
 
-  ACE_Condition<ACE_Recursive_Thread_Mutex> empty_condition_;
+  Condition<ACE_Recursive_Thread_Mutex> empty_condition_;
   int pending_write_count_;
 };
 

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -21,7 +21,7 @@
 #ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
 #  include "FilterEvaluator.h"
 #endif
-#include "Condition.h"
+#include "ConditionVariable.h"
 #include "transport/framework/TransportSendListener.h"
 #include "transport/framework/TransportClient.h"
 
@@ -311,7 +311,7 @@ private:
 
   RepoIdToSequenceMap idToSequence_;
 
-  Condition<ACE_Recursive_Thread_Mutex> empty_condition_;
+  ConditionVariable<ACE_Recursive_Thread_Mutex> empty_condition_;
   int pending_write_count_;
 };
 

--- a/dds/DCPS/TimeTypes.h
+++ b/dds/DCPS/TimeTypes.h
@@ -4,15 +4,14 @@
  * for these types.
  */
 
-#ifndef OPENDDS_DCPS_TIME_TYPES_HEADER
-#define OPENDDS_DCPS_TIME_TYPES_HEADER
+#ifndef OPENDDS_DCPS_TIMETYPES_H
+#define OPENDDS_DCPS_TIMETYPES_H
 
 #include "TimeDuration.h"
 #include "TimePoint_T.h"
 
 #include <ace/Monotonic_Time_Policy.h>
 #include <ace/Time_Policy.h>
-#include <ace/Condition_Attributes.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #  pragma once
@@ -50,13 +49,6 @@ typedef SystemClock MonotonicClock;
 #endif
 typedef TimePoint_T<MonotonicClock> MonotonicTimePoint;
 ///@}
-
-/**
- * ConditionAttributesMonotonic() will have to be passed as the second argument
- * in an ACE_Condition constructor for it to interpret argument of
- * wait(ACE_Time_Value*) as monotonic time.
- */
-typedef ACE_Condition_Attributes_T<MonotonicClock> ConditionAttributesMonotonic;
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/Time_Helper.h
+++ b/dds/DCPS/Time_Helper.h
@@ -8,8 +8,9 @@
 #ifndef OPENDDS_DCPS_TIME_HELPER_H
 #define OPENDDS_DCPS_TIME_HELPER_H
 
-#include "dds/DdsDcpsCoreC.h"
-#include "ace/OS_NS_sys_time.h"
+#include <dds/DdsDcpsCoreC.h>
+
+#include <ace/OS_NS_sys_time.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -106,6 +107,9 @@ ACE_UINT32 uint32_fractional_seconds_to_microseconds(ACE_UINT32 fraction);
 
 ACE_INLINE OpenDDS_Dcps_Export
 ACE_UINT32 microseconds_to_uint32_fractional_seconds(ACE_UINT32 fraction);
+
+ACE_INLINE OpenDDS_Dcps_Export
+bool is_infinite(const DDS::Duration_t& value);
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/Time_Helper.inl
+++ b/dds/DCPS/Time_Helper.inl
@@ -39,18 +39,14 @@ bool operator<(const DDS::Duration_t& t1, const DDS::Duration_t& t2)
   //       maximum values for their corresponding types.
   //       Unfortunately, the OMG DDS specification defines the
   //       infinite nanosec value to be somewhere in the middle.
-  DDS::Duration_t const DDS_DURATION_INFINITY = {
-    DDS::DURATION_INFINITE_SEC,
-    DDS::DURATION_INFINITE_NSEC
-  };
 
   // We assume that either both the DDS::Duration_t::sec and
   // DDS::Duration_t::nanosec fields are INFINITY or neither of them
   // are.  It doesn't make sense for only one of the fields to be
   // INFINITY.
   return
-    t1 != DDS_DURATION_INFINITY
-    && (t2 == DDS_DURATION_INFINITY
+    !is_infinite(t1)
+    && (is_infinite(t2)
         || t1.sec < t2.sec
         || (t1.sec == t2.sec && t1.nanosec < t2.nanosec));
 }
@@ -158,7 +154,7 @@ DDS::Time_t time_value_to_time(const ACE_Time_Value& tv)
 ACE_INLINE
 ACE_Time_Value duration_to_time_value(const DDS::Duration_t& t)
 {
-  if (t.sec == DDS::DURATION_INFINITE_SEC && t.nanosec == DDS::DURATION_INFINITE_NSEC) {
+  if (is_infinite(t)) {
     return ACE_Time_Value::max_time;
   }
 
@@ -208,21 +204,13 @@ DDS::Duration_t time_to_duration(const DDS::Time_t& t)
 ACE_INLINE
 bool valid_duration(const DDS::Duration_t& t)
 {
-  DDS::Duration_t const DDS_DURATION_INFINITY = {
-    DDS::DURATION_INFINITE_SEC,
-    DDS::DURATION_INFINITE_NSEC
-  };
-
   // Only accept infinite or positive finite durations.  (Zero
   // excluded).
   //
   // Note that it doesn't make much sense for users to set
   // durations less than 10 milliseconds since the underlying
   // timer resolution is generally no better than that.
-  return
-    t == DDS_DURATION_INFINITY
-    || t.sec > 0
-    || (t.sec >= 0 && t.nanosec > 0);
+  return is_infinite(t) || t.sec > 0 || (t.sec >= 0 && t.nanosec > 0);
 }
 
 ACE_INLINE
@@ -256,6 +244,12 @@ ACE_INLINE OpenDDS_Dcps_Export
 ACE_UINT32 microseconds_to_uint32_fractional_seconds(ACE_UINT32 usec)
 {
   return static_cast<ACE_UINT32>((static_cast<ACE_UINT64>(usec) << 32) / 1000000);
+}
+
+bool is_infinite(const DDS::Duration_t& value)
+{
+  return value.sec == DDS::DURATION_INFINITE_SEC &&
+    value.nanosec == DDS::DURATION_INFINITE_NSEC;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/WaitSet.cpp
+++ b/dds/DCPS/WaitSet.cpp
@@ -159,7 +159,7 @@ ReturnCode_t WaitSet::wait(ConditionSeq& active_conditions,
   case CvStatus_Error:
   default:
     if (DCPS_debug_level) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) WaitSet::wait: wait_until failed\n"));
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WaitSet::wait: wait_until failed\n"));
     }
     return RETCODE_ERROR;
   }

--- a/dds/DCPS/WaitSet.cpp
+++ b/dds/DCPS/WaitSet.cpp
@@ -157,7 +157,6 @@ ReturnCode_t WaitSet::wait(ConditionSeq& active_conditions,
     return RETCODE_TIMEOUT;
 
   case CvStatus_Error:
-  default:
     if (DCPS_debug_level) {
       ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WaitSet::wait: wait_until failed\n"));
     }

--- a/dds/DCPS/WaitSet.h
+++ b/dds/DCPS/WaitSet.h
@@ -11,7 +11,7 @@
 #include "LocalObject.h"
 #include "Definitions.h"
 #include "PoolAllocator.h"
-#include "Condition.h"
+#include "ConditionVariable.h"
 
 #include <dds/DdsDcpsInfrastructureC.h>
 
@@ -80,8 +80,8 @@ private:
   friend class OpenDDS::DCPS::ConditionImpl;
 
   ACE_Recursive_Thread_Mutex lock_;
-  typedef OpenDDS::DCPS::Condition<ACE_Recursive_Thread_Mutex> ConditionType;
-  ConditionType cond_;
+  typedef OpenDDS::DCPS::ConditionVariable<ACE_Recursive_Thread_Mutex> ConditionVariableType;
+  ConditionVariableType cond_;
   // Treat as a boolean value.
   ACE_Atomic_Op<ACE_Thread_Mutex, long> waiting_;
 

--- a/dds/DCPS/WaitSet.h
+++ b/dds/DCPS/WaitSet.h
@@ -8,20 +8,20 @@
 #ifndef OPENDDS_DCPS_WAITSET_H
 #define OPENDDS_DCPS_WAITSET_H
 
-#include "dds/DdsDcpsInfrastructureC.h"
+#include "LocalObject.h"
+#include "Definitions.h"
+#include "PoolAllocator.h"
+#include "Condition.h"
+
+#include <dds/DdsDcpsInfrastructureC.h>
+
+#include <ace/Thread_Mutex.h>
+#include <ace/Atomic_Op.h>
+#include <ace/Recursive_Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#include "dds/DCPS/LocalObject.h"
-#include "dds/DCPS/Definitions.h"
-#include "dds/DCPS/PoolAllocator.h"
-#include "dds/DCPS/TimeTypes.h"
-
-#include "ace/Thread_Mutex.h"
-#include "ace/Atomic_Op.h"
-#include "ace/Condition_Recursive_Thread_Mutex.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -51,8 +51,8 @@ public:
   typedef WaitSet_var _var_type;
 
   WaitSet()
-    : lock_(),
-      cond_(lock_, OpenDDS::DCPS::ConditionAttributesMonotonic())
+    : lock_()
+    , cond_(lock_)
   {}
 
   virtual ~WaitSet() {}
@@ -72,8 +72,7 @@ public:
 
   static WaitSet_ptr _duplicate(WaitSet_ptr obj);
 
-  typedef OPENDDS_SET_CMP(Condition_var,
-  OpenDDS::DCPS::VarLess<Condition> ) ConditionSet;
+  typedef OPENDDS_SET_CMP(Condition_var, OpenDDS::DCPS::VarLess<Condition>) ConditionSet;
 
 private:
   ReturnCode_t detach_i(const Condition_ptr cond);
@@ -81,7 +80,8 @@ private:
   friend class OpenDDS::DCPS::ConditionImpl;
 
   ACE_Recursive_Thread_Mutex lock_;
-  ACE_Condition_Recursive_Thread_Mutex cond_;
+  typedef OpenDDS::DCPS::Condition<ACE_Recursive_Thread_Mutex> ConditionType;
+  ConditionType cond_;
   // Treat as a boolean value.
   ACE_Atomic_Op<ACE_Thread_Mutex, long> waiting_;
 

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1382,7 +1382,7 @@ void WriteDataContainer::wait_pending(const MonotonicTimePoint& deadline)
     case CvStatus_Error:
     default:
       if (DCPS_debug_level) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) WriteDataContainer::wait_ack_of_seq: "
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WriteDataContainer::wait_ack_of_seq: "
           "error in wait_until\n"));
       }
       break;
@@ -1443,7 +1443,7 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& deadline, const Se
       case CvStatus_Error:
       default:
         if (DCPS_debug_level) {
-          ACE_ERROR((LM_ERROR, "(%P|%t) WriteDataContainer::wait_ack_of_seq: "
+          ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WriteDataContainer::wait_ack_of_seq: "
             "error in wait_until\n"));
         }
         ret = DDS::RETCODE_ERROR;

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1081,7 +1081,6 @@ WriteDataContainer::obtain_buffer(DataSampleElement*& element,
           break;
 
         case CvStatus_Error:
-        default:
           if (DCPS_debug_level) {
             ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WriteDataContainer::obtain_buffer: "
               "error in wait_until\n"));
@@ -1380,7 +1379,6 @@ void WriteDataContainer::wait_pending(const MonotonicTimePoint& deadline)
       break;
 
     case CvStatus_Error:
-    default:
       if (DCPS_debug_level) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WriteDataContainer::wait_ack_of_seq: "
           "error in wait_until\n"));
@@ -1441,7 +1439,6 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& deadline, const Se
         break;
 
       case CvStatus_Error:
-      default:
         if (DCPS_debug_level) {
           ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: WriteDataContainer::wait_ack_of_seq: "
             "error in wait_until\n"));

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -8,12 +8,13 @@
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
 
 #include "WriteDataContainer.h"
+
 #include "DataSampleHeader.h"
 #include "InstanceDataSampleList.h"
 #include "DataWriterImpl.h"
 #include "MessageTracker.h"
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-#include "DataDurabilityCache.h"
+#  include "DataDurabilityCache.h"
 #endif
 #include "PublicationInstance.h"
 #include "Util.h"
@@ -22,8 +23,6 @@
 #include "transport/framework/TransportSendElement.h"
 #include "transport/framework/TransportCustomizedElement.h"
 #include "transport/framework/TransportRegistry.h"
-
-#include <ace/Condition_Recursive_Thread_Mutex.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -95,9 +94,9 @@ WriteDataContainer::WriteDataContainer(
     max_num_samples_(max_total_samples),
     max_blocking_time_(max_blocking_time),
     waiting_on_release_(false),
-    condition_(lock_, ConditionAttributesMonotonic()),
-    empty_condition_(lock_, ConditionAttributesMonotonic()),
-    wfa_condition_(wfa_lock_, ConditionAttributesMonotonic()),
+    condition_(lock_),
+    empty_condition_(lock_),
+    wfa_condition_(wfa_lock_),
     n_chunks_(n_chunks),
     sample_list_element_allocator_(2 * n_chunks_),
     shutdown_(false),
@@ -606,7 +605,7 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       }
 
       if (!pending_data())
-        empty_condition_.broadcast();
+        empty_condition_.notify_all();
     }
 
     return;
@@ -677,12 +676,13 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
                  ACE_TEXT("broadcasting wait_for_acknowledgments update.\n")));
     }
 
-    wfa_condition_.broadcast();
+    wfa_condition_.notify_all();
   }
 
   // Signal if there is no pending data.
-  if (!pending_data())
-    empty_condition_.broadcast();
+  if (!pending_data()) {
+    empty_condition_.notify_all();
+  }
 }
 
 void
@@ -781,8 +781,9 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
       if (containing_list == &this->orphaned_to_transport_) {
         orphaned_to_transport_.dequeue(sample);
         release_buffer(stale);
-        if (!pending_data())
-          empty_condition_.broadcast();
+        if (!pending_data()) {
+          empty_condition_.notify_all();
+        }
 
       } else if (!containing_list) {
         // samples that were retrieved from get_resend_data()
@@ -796,8 +797,9 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
 
   this->wakeup_blocking_writers (stale);
 
-  if (!pending_data())
-    empty_condition_.broadcast();
+  if (!pending_data()) {
+    empty_condition_.notify_all();
+  }
 }
 
 void
@@ -967,7 +969,7 @@ WriteDataContainer::remove_oldest_sample(
   }
 
   if (!pending_data()) {
-    empty_condition_.broadcast();
+    empty_condition_.notify_all();
   }
 
   if (result == false) {
@@ -1028,8 +1030,8 @@ WriteDataContainer::obtain_buffer(DataSampleElement*& element,
   InstanceDataSampleList& instance_list = instance->samples_;
   DDS::ReturnCode_t ret = DDS::RETCODE_OK;
 
-  bool need_to_set_abs_timeout = true;
-  MonotonicTimePoint abs_timeout;
+  bool set_timeout = true;
+  MonotonicTimePoint timeout;
 
   //max_num_samples_ covers ResourceLimitsQosPolicy max_samples and
   //max_instances and max_instances * depth
@@ -1052,11 +1054,11 @@ WriteDataContainer::obtain_buffer(DataSampleElement*& element,
         }
       }
       // Reliable writers can wait
-      if (need_to_set_abs_timeout) {
-        abs_timeout = MonotonicTimePoint(MonotonicTimePoint::now() + TimeDuration(max_blocking_time_));
-        need_to_set_abs_timeout = false;
+      if (set_timeout) {
+        timeout = MonotonicTimePoint::now() + TimeDuration(max_blocking_time_);
+        set_timeout = false;
       }
-      if (!shutdown_ && MonotonicTimePoint::now() < abs_timeout) {
+      if (!shutdown_ && MonotonicTimePoint::now() < timeout) {
         if (DCPS_debug_level >= 2) {
           ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::obtain_buffer")
                                 ACE_TEXT(" instance %d waiting for samples to be released by transport\n"),
@@ -1064,25 +1066,24 @@ WriteDataContainer::obtain_buffer(DataSampleElement*& element,
         }
 
         waiting_on_release_ = true;
-        const int wait_result = condition_.wait(&abs_timeout.value());
-
-        if (wait_result == 0) {
+        switch (condition_.wait_until(timeout)) {
+        case ConditionType::NoTimeout:
           remove_excess_durable();
+          break;
 
-        } else {
-          if (errno == ETIME) {
-            if (DCPS_debug_level >= 2) {
-              ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::obtain_buffer")
-                                    ACE_TEXT(" instance %d timed out waiting for samples to be released by transport\n"),
-                          handle));
-            }
-            ret = DDS::RETCODE_TIMEOUT;
-
-          } else {
-            ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) ERROR: WriteDataContainer::obtain_buffer condition_.wait()")
-                                  ACE_TEXT("%p\n")));
-            ret = DDS::RETCODE_ERROR;
+        case ConditionType::Timeout:
+          if (DCPS_debug_level >= 2) {
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::obtain_buffer")
+              ACE_TEXT(" instance %d timed out waiting for samples to be released by transport\n"),
+              handle));
           }
+          ret = DDS::RETCODE_TIMEOUT;
+          break;
+
+        case ConditionType::WaitError:
+        default:
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: WriteDataContainer::obtain_buffer condition_.wait()")));
+          ret = DDS::RETCODE_ERROR;
         }
 
       } else {
@@ -1198,7 +1199,7 @@ WriteDataContainer::unregister_all()
 
     // Broadcast to wake up all waiting threads.
     if (waiting_on_release_) {
-      condition_.broadcast();
+      condition_.notify_all();
     }
   }
   DDS::ReturnCode_t ret;
@@ -1346,26 +1347,24 @@ WriteDataContainer::persist_data()
 
 void WriteDataContainer::wait_pending(const MonotonicTimePoint& deadline)
 {
-  const bool indefinite = deadline.is_zero();
-  const ACE_Time_Value_T<MonotonicClock>* deadline_ptr = indefinite ? 0 : &deadline.value();
-
+  const bool no_deadline = deadline.is_zero();
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, lock_);
   const bool report = DCPS_debug_level > 0 && pending_data();
   if (report) {
-    if (indefinite) {
+    if (no_deadline) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::wait_pending no timeout\n")));
     } else {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::wait_pending ")
         ACE_TEXT("timeout at %#T\n"),
-        deadline_ptr));
+        &deadline.value()));
     }
   }
 
   while (pending_data()) {
-    if (empty_condition_.wait(deadline_ptr) == -1 && pending_data()) {
+    if (empty_condition_.wait_until(deadline) == ConditionType::Timeout && pending_data()) {
       if (DCPS_debug_level) {
         ACE_DEBUG((LM_INFO,
-                   ACE_TEXT("(%P|%t) WriteDataContainer::wait_pending %p\n"),
+                   ACE_TEXT("(%P|%t) WriteDataContainer::wait_pending "),
                    ACE_TEXT("Timed out waiting for messages to be transported")));
         this->log_send_state_lists("WriteDataContainer::wait_pending - wait failed: ");
       }
@@ -1392,9 +1391,8 @@ WriteDataContainer::get_instance_handles(InstanceHandleVec& instance_handles)
 }
 
 DDS::ReturnCode_t
-WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& abs_deadline, const SequenceNumber& sequence)
+WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& deadline, const SequenceNumber& sequence)
 {
-  const MonotonicTimePoint deadline(abs_deadline);
   DDS::ReturnCode_t ret = DDS::RETCODE_OK;
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, lock_, DDS::RETCODE_ERROR);
   ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, wfa_guard, wfa_lock_, DDS::RETCODE_ERROR);
@@ -1412,20 +1410,25 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& abs_deadline, cons
     if (!sequence_acknowledged(sequence)) {
       // lock is released while waiting and acquired before returning
       // from wait.
-      int const wait_result = wfa_condition_.wait(&deadline.value());
+      switch (wfa_condition_.wait_until(deadline)) {
+      case WfaConditionType::NoTimeout:
+        break;
 
-      if (wait_result != 0) {
-        if (errno == ETIME) {
-          if (DCPS_debug_level >= 2) {
-            ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::wait_ack_of_seq")
-                                  ACE_TEXT(" timed out waiting for sequence %q to be acked\n"),
-                                  sequence.getValue()));
-          }
-          ret = DDS::RETCODE_TIMEOUT;
-        } else {
-          ret = DDS::RETCODE_ERROR;
+      case WfaConditionType::Timeout:
+        if (DCPS_debug_level >= 2) {
+          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::wait_ack_of_seq: ")
+            ACE_TEXT("timed out waiting for sequence %q to be acked\n"),
+            sequence.getValue()));
         }
+        ret = DDS::RETCODE_TIMEOUT;
+        break;
+
+      case WfaConditionType::WaitError:
+      default:
+        ret = DDS::RETCODE_ERROR;
+        break;
       }
+
     } else {
       ret = DDS::RETCODE_OK;
       break;
@@ -1462,7 +1465,7 @@ WriteDataContainer::wakeup_blocking_writers (DataSampleElement* stale)
   if (!stale && waiting_on_release_) {
     waiting_on_release_ = false;
 
-    condition_.broadcast();
+    condition_.notify_all();
   }
 }
 

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -15,16 +15,16 @@
 #include "PoolAllocator.h"
 #include "PoolAllocationBase.h"
 #include "Message_Block_Ptr.h"
-#include "TimeTypes.h"
 #include "SporadicTask.h"
+#include "Condition.h"
+#include "TimeTypes.h"
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DdsDcpsCoreC.h>
 
 #include <ace/Synch_Traits.h>
-#include <ace/Condition_T.h>
-#include <ace/Condition_Thread_Mutex.h>
-#include <ace/Condition_Recursive_Thread_Mutex.h>
+#include <ace/Thread_Mutex.h>
+#include <ace/Recursive_Thread_Mutex.h>
 #include <ace/Reverse_Lock_T.h>
 
 #include <memory>
@@ -487,15 +487,17 @@ private:
   /// same lock will be used by the transport thread to notify
   /// the datawriter the data is delivered. Other internal
   /// operations will not lock.
-  ACE_Recursive_Thread_Mutex                lock_;
-  ACE_Condition<ACE_Recursive_Thread_Mutex> condition_;
-  ACE_Condition<ACE_Recursive_Thread_Mutex> empty_condition_;
+  ACE_Recursive_Thread_Mutex lock_;
+  typedef Condition<ACE_Recursive_Thread_Mutex> ConditionType;
+  ConditionType condition_;
+  ConditionType empty_condition_;
 
   /// Lock used for wait_for_acks() processing.
   ACE_Thread_Mutex wfa_lock_;
 
+  typedef Condition<ACE_Thread_Mutex> WfaConditionType;
   /// Used to block in wait_for_acks().
-  ACE_Condition<ACE_Thread_Mutex> wfa_condition_;
+  WfaConditionType wfa_condition_;
 
   /// The number of chunks that sample_list_element_allocator_
   /// needs initialize.

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -16,7 +16,7 @@
 #include "PoolAllocationBase.h"
 #include "Message_Block_Ptr.h"
 #include "SporadicTask.h"
-#include "Condition.h"
+#include "ConditionVariable.h"
 #include "TimeTypes.h"
 
 #include <dds/DdsDcpsInfrastructureC.h>
@@ -488,16 +488,16 @@ private:
   /// the datawriter the data is delivered. Other internal
   /// operations will not lock.
   ACE_Recursive_Thread_Mutex lock_;
-  typedef Condition<ACE_Recursive_Thread_Mutex> ConditionType;
-  ConditionType condition_;
-  ConditionType empty_condition_;
+  typedef ConditionVariable<ACE_Recursive_Thread_Mutex> ConditionVariableType;
+  ConditionVariableType condition_;
+  ConditionVariableType empty_condition_;
 
   /// Lock used for wait_for_acks() processing.
   ACE_Thread_Mutex wfa_lock_;
 
-  typedef Condition<ACE_Thread_Mutex> WfaConditionType;
+  typedef ConditionVariable<ACE_Thread_Mutex> WfaConditionVariableType;
   /// Used to block in wait_for_acks().
-  WfaConditionType wfa_condition_;
+  WfaConditionVariableType wfa_condition_;
 
   /// The number of chunks that sample_list_element_allocator_
   /// needs initialize.

--- a/dds/DCPS/transport/framework/PerConnectionSynch.cpp
+++ b/dds/DCPS/transport/framework/PerConnectionSynch.cpp
@@ -5,9 +5,11 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+#include <DCPS/DdsDcps_pch.h> //Only the _pch include should start with DCPS/
+
 #include "PerConnectionSynch.h"
-#include "dds/DCPS/debug.h"
+
+#include <dds/DCPS/debug.h>
 
 #if !defined (__ACE_INLINE__)
 #include "PerConnectionSynch.inl"
@@ -24,7 +26,7 @@ OpenDDS::DCPS::PerConnectionSynch::work_available()
   DBG_ENTRY_LVL("PerConnectionSynch","work_available",6);
   GuardType guard(this->lock_);
   this->work_available_ = 1;
-  this->condition_.signal();
+  condition_.notify_one();
 }
 
 int
@@ -189,7 +191,7 @@ OpenDDS::DCPS::PerConnectionSynch::unregister_worker_i()
 
     // Signal the condition_ object in case the svc() method is currently
     // blocked wait()'ing on the condition.
-    this->condition_.signal();
+    condition_.notify_one();
   }
 
   // Wait for all threads running this task (there should just be one thread)

--- a/dds/DCPS/transport/framework/PerConnectionSynch.h
+++ b/dds/DCPS/transport/framework/PerConnectionSynch.h
@@ -10,7 +10,7 @@
 
 #include "ThreadSynch.h"
 
-#include <dds/DCPS/Condition.h>
+#include <dds/DCPS/ConditionVariable.h>
 
 #include <ace/Synch_Traits.h>
 #include <ace/Task.h>
@@ -44,14 +44,14 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
 
-  LockType      lock_;
-  ConditionType condition_;
-  int           work_available_;
-  int           shutdown_;
-  long          dds_priority_;
-  long          scheduler_;
+  LockType lock_;
+  ConditionVariableType condition_;
+  int work_available_;
+  int shutdown_;
+  long dds_priority_;
+  long scheduler_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/PerConnectionSynch.h
+++ b/dds/DCPS/transport/framework/PerConnectionSynch.h
@@ -10,10 +10,10 @@
 
 #include "ThreadSynch.h"
 
-#include "ace/Condition_T.h"
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Synch_Traits.h"
-#include "ace/Task.h"
+#include <dds/DCPS/Condition.h>
+
+#include <ace/Synch_Traits.h>
+#include <ace/Task.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -42,9 +42,9 @@ protected:
 
 private:
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
 
   LockType      lock_;
   ConditionType condition_;

--- a/dds/DCPS/transport/framework/PoolSynchStrategy.h
+++ b/dds/DCPS/transport/framework/PoolSynchStrategy.h
@@ -11,7 +11,7 @@
 #include "ThreadSynchStrategy.h"
 
 #include <dds/DCPS/dcps_export.h>
-#include <dds/DCPS/Condition.h>
+#include <dds/DCPS/ConditionVariable.h>
 
 #include <ace/Synch_Traits.h>
 #include <ace/Task.h>
@@ -42,10 +42,10 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
 
   LockType      lock_;
-  ConditionType condition_;
+  ConditionVariableType condition_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/PoolSynchStrategy.h
+++ b/dds/DCPS/transport/framework/PoolSynchStrategy.h
@@ -8,13 +8,13 @@
 #ifndef OPENDDS_DCPS_POOLSYNCHSTRATEGY_H
 #define OPENDDS_DCPS_POOLSYNCHSTRATEGY_H
 
-#include "dds/DCPS/dcps_export.h"
 #include "ThreadSynchStrategy.h"
 
-#include "ace/Condition_T.h"
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Synch_Traits.h"
-#include "ace/Task.h"
+#include <dds/DCPS/dcps_export.h>
+#include <dds/DCPS/Condition.h>
+
+#include <ace/Synch_Traits.h>
+#include <ace/Task.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -40,9 +40,9 @@ public:
   void operator delete (void* ptr) { ThreadSynchStrategy::operator delete(ptr); }
 private:
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
 
   LockType      lock_;
   ConditionType condition_;

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -13,7 +13,7 @@
 #include <dds/DCPS/PoolAllocator.h>
 #include <dds/DCPS/SafetyProfileStreams.h>
 #include <dds/DCPS/Service_Participant.h>
-#include <dds/DCPS/Condition.h>
+#include <dds/DCPS/ConditionVariable.h>
 #include <dds/DCPS/TimeTypes.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
@@ -225,7 +225,7 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
 
   typedef ACE_Unbounded_Queue<T> Queue;
 
@@ -239,7 +239,7 @@ private:
   /// find a request in the queue_ that needs to be executed.
   /// This condition will be signal()'ed each time a request is
   /// added to the queue_, and also when this task is shutdown.
-  ConditionType work_available_;
+  ConditionVariableType work_available_;
 
   /// Flag used to initiate a shutdown request to all worker threads.
   bool shutdown_initiated_;

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -8,24 +8,22 @@
 #ifndef OPENDDS_DCPS_QUEUE_TASK_BASE_T_H
 #define OPENDDS_DCPS_QUEUE_TASK_BASE_T_H
 
-#include /**/ "ace/pre.h"
-
 #include "EntryExit.h"
 
-#include "dds/DCPS/PoolAllocator.h"
-#include "dds/DCPS/SafetyProfileStreams.h"
-#include "dds/DCPS/Service_Participant.h"
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Condition.h>
+#include <dds/DCPS/TimeTypes.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "ace/Condition_T.h"
-#include "ace/Condition_Thread_Mutex.h"
-#include "ace/Task.h"
-#include "ace/Unbounded_Queue.h"
-#include "ace/INET_Addr.h"
-#include "ace/Synch_Traits.h"
+#include <ace/Task.h>
+#include <ace/Unbounded_Queue.h>
+#include <ace/INET_Addr.h>
+#include <ace/Synch_Traits.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -41,11 +39,12 @@ template <typename T>
 class QueueTaskBase : public ACE_Task_Base {
 public:
   QueueTaskBase()
-  : work_available_(lock_, ConditionAttributesMonotonic()),
-      shutdown_initiated_(false),
-      opened_(false),
-      thr_id_(ACE_OS::NULL_thread),
-      name_("QueueTaskBase") {
+  : work_available_(lock_)
+  , shutdown_initiated_(false)
+  , opened_(false)
+  , thr_id_(ACE_OS::NULL_thread)
+  , name_("QueueTaskBase")
+  {
     DBG_ENTRY("QueueTaskBase","QueueTaskBase");
   }
 
@@ -66,7 +65,7 @@ public:
     int result = this->queue_.enqueue_tail(req);
 
     if (result == 0) {
-      this->work_available_.signal();
+      work_available_.notify_one();
 
     } else
       ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: QueueTaskBase::add %p\n",
@@ -114,11 +113,11 @@ public:
 #ifdef ACE_HAS_MAC_OSX
     unsigned long tid = 0;
     uint64_t osx_tid;
-    if (!pthread_threadid_np(NULL, &osx_tid)) {
+    if (!pthread_threadid_np(0, &osx_tid)) {
       tid = static_cast<unsigned long>(osx_tid);
     } else {
       tid = 0;
-      ACE_ERROR((LM_ERROR, ACE_TEXT("%T (%P|%t) QueueTaskBase::svc. Error getting OSX thread id\n.")));
+      ACE_ERROR((LM_ERROR, "(%P|%t) QueueTaskBase::svc: Error getting OSX thread id: %p\n"));
     }
 #elif !defined (OPENDDS_SAFETY_PROFILE)
     ACE_thread_t tid = thr_id_;
@@ -146,7 +145,7 @@ public:
             MonotonicTimePoint expire = MonotonicTimePoint::now() + interval;
 
             do {
-              this->work_available_.wait(&expire.value());
+              work_available_.wait_until(expire);
 
               MonotonicTimePoint now = MonotonicTimePoint::now();
               if (now > expire) {
@@ -154,7 +153,7 @@ public:
                 if (status) {
                   if (DCPS_debug_level > 4) {
                     ACE_DEBUG((LM_DEBUG,
-                              "%T (%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
+                              "(%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
                   }
                   ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status->lock, -1);
                   status->map[key] = now;
@@ -204,7 +203,7 @@ public:
 
       // Set the shutdown flag to true.
       this->shutdown_initiated_ = true;
-      this->work_available_.signal();
+      work_available_.notify_one();
     }
 
     if (this->opened_ && !ACE_OS::thr_equal(this->thr_id_, ACE_OS::thr_self()))
@@ -224,11 +223,11 @@ public:
 
 private:
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
 
-  typedef ACE_Unbounded_Queue<T>  Queue;
+  typedef ACE_Unbounded_Queue<T> Queue;
 
   /// Lock to protect the "state" (all of the data members) of this object.
   mutable LockType lock_;

--- a/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.cpp
+++ b/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.cpp
@@ -59,7 +59,7 @@ int ThreadPerConnectionSendTask::add_request(SendStrategyOpType op,
     result = queue_.put(req.get());
 
     if (result == 0 && op == SEND_STOP) {
-      work_available_.signal();
+      work_available_.notify_one();
     }
   }
 
@@ -202,7 +202,7 @@ int ThreadPerConnectionSendTask::close(u_long flag)
 
     // Set the shutdown flag to true.
     shutdown_initiated_ = true;
-    work_available_.broadcast();
+    work_available_.notify_all();
   }
 
   if (opened_ && !ACE_OS::thr_equal(thr_id_, ACE_OS::thr_self())) {

--- a/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.h
+++ b/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.h
@@ -8,16 +8,15 @@
 #ifndef OPENDDS_DCPS_THREADPERCONNECTIONSENDER_H
 #define OPENDDS_DCPS_THREADPERCONNECTIONSENDER_H
 
-#include /**/ "ace/pre.h"
-
-#include "dds/DCPS/dcps_export.h"
-#include "dds/DCPS/PoolAllocationBase.h"
 #include "BasicQueue_T.h"
 #include "TransportDefs.h"
 
-#include "ace/Condition_T.h"
-#include "ace/Synch_Traits.h"
-#include "ace/Task.h"
+#include <dds/DCPS/dcps_export.h>
+#include <dds/DCPS/PoolAllocationBase.h>
+#include <dds/DCPS/Condition.h>
+
+#include <ace/Synch_Traits.h>
+#include <ace/Task.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -83,9 +82,9 @@ private:
   /// Handle the request.
   virtual void execute(SendRequest& req);
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
 
   typedef BasicQueue<SendRequest> QueueType;
 
@@ -118,7 +117,5 @@ private:
 } // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
-
-#include /**/ "ace/post.h"
 
 #endif /* OPENDDS_DCPS_THREADPERCONNECTIONSENDER_H */

--- a/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.h
+++ b/dds/DCPS/transport/framework/ThreadPerConnectionSendTask.h
@@ -13,7 +13,7 @@
 
 #include <dds/DCPS/dcps_export.h>
 #include <dds/DCPS/PoolAllocationBase.h>
-#include <dds/DCPS/Condition.h>
+#include <dds/DCPS/ConditionVariable.h>
 
 #include <ace/Synch_Traits.h>
 #include <ace/Task.h>
@@ -84,7 +84,7 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
 
   typedef BasicQueue<SendRequest> QueueType;
 
@@ -98,7 +98,7 @@ private:
   /// find a request in the queue_ that needs to be executed.
   /// This condition will be signal()'ed each time a request is
   /// added to the queue_, and also when this task is shutdown.
-  ConditionType work_available_;
+  ConditionVariableType work_available_;
 
   /// Flag used to initiate a shutdown request to all worker threads.
   bool shutdown_initiated_;

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -9,21 +9,21 @@
 #define OPENDDS_TCPTRANSPORT_H
 
 #include "Tcp_export.h"
-
-#include "dds/DCPS/transport/framework/TransportImpl.h"
 #include "TcpInst_rch.h"
 #include "TcpDataLink_rch.h"
 #include "TcpConnection.h"
 #include "TcpConnection_rch.h"
 
-#include "dds/DCPS/ReactorTask_rch.h"
-#include "dds/DCPS/transport/framework/PriorityKey.h"
+#include <dds/DCPS/ReactorTask_rch.h>
+#include <dds/DCPS/transport/framework/PriorityKey.h>
+#include <dds/DCPS/transport/framework/TransportImpl.h>
+#include <dds/DCPS/TimeTypes.h>
 
-#include "ace/INET_Addr.h"
-#include "ace/Hash_Map_Manager.h"
-#include "ace/Synch_Traits.h"
-#include "ace/Connector.h"
-#include "ace/SOCK_Connector.h"
+#include <ace/INET_Addr.h>
+#include <ace/Hash_Map_Manager.h>
+#include <ace/Synch_Traits.h>
+#include <ace/Connector.h>
+#include <ace/SOCK_Connector.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -113,14 +113,14 @@ private:
             TcpDataLink_rch,
             ACE_Hash<PriorityKey>,
             ACE_Equal_To<PriorityKey>,
-            ACE_Null_Mutex>              AddrLinkMap;
+            ACE_Null_Mutex> AddrLinkMap;
 
   typedef OPENDDS_MAP(PriorityKey, TcpDataLink_rch)   LinkMap;
   typedef OPENDDS_MAP(PriorityKey, TcpConnection_rch) ConnectionMap;
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
 
 // TBD SOON - Something needs to protect the tcp_config_ reference
 //            because it gets set in our configure() method, and

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -120,7 +120,7 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
 
 // TBD SOON - Something needs to protect the tcp_config_ reference
 //            because it gets set in our configure() method, and

--- a/dds/DCPS/transport/udp/UdpTransport.h
+++ b/dds/DCPS/transport/udp/UdpTransport.h
@@ -14,6 +14,7 @@
 #include "UdpDataLink_rch.h"
 
 #include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/ConditionVariable.h>
 #include <dds/DCPS/TimeTypes.h>
 #include <dds/DCPS/transport/framework/PriorityKey.h>
 #include <dds/DCPS/transport/framework/TransportImpl.h>
@@ -65,7 +66,7 @@ private:
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
-  typedef Condition<LockType> ConditionType;
+  typedef ConditionVariable<LockType> ConditionVariableType;
 
   /// This lock is used to protect the client_links_ data member.
   LockType client_links_lock_;

--- a/dds/DCPS/transport/udp/UdpTransport.h
+++ b/dds/DCPS/transport/udp/UdpTransport.h
@@ -8,15 +8,16 @@
 #ifndef DCPS_UDPTRANSPORT_H
 #define DCPS_UDPTRANSPORT_H
 
-#include "Udp_Export.h"
-
 #include "UdpDataLink.h"
+
+#include "Udp_Export.h"
 #include "UdpDataLink_rch.h"
 
-#include "dds/DCPS/transport/framework/PriorityKey.h"
-#include "dds/DCPS/transport/framework/TransportImpl.h"
-#include "dds/DCPS/transport/framework/TransportClient.h"
-#include "dds/DCPS/PoolAllocator.h"
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/TimeTypes.h>
+#include <dds/DCPS/transport/framework/PriorityKey.h>
+#include <dds/DCPS/transport/framework/TransportImpl.h>
+#include <dds/DCPS/transport/framework/TransportClient.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -62,9 +63,9 @@ private:
   PriorityKey blob_to_key(const TransportBLOB& remote,
                           Priority priority, ACE_INET_Addr local_addr, bool active);
 
-  typedef ACE_SYNCH_MUTEX         LockType;
-  typedef ACE_Guard<LockType>     GuardType;
-  typedef ACE_Condition<LockType> ConditionType;
+  typedef ACE_SYNCH_MUTEX LockType;
+  typedef ACE_Guard<LockType> GuardType;
+  typedef Condition<LockType> ConditionType;
 
   /// This lock is used to protect the client_links_ data member.
   LockType client_links_lock_;

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -385,10 +385,9 @@ dealing with ACE code which requires it and using `ACE_OS::gettimeofday()` or
 `MonotonicTimePoint` should be used when tracking time elapsed internally and
 when dealing with `ACE_Time_Value`s being given by the `ACE_Reactor` in
 OpenDDS. `ACE_Condition`s, like all ACE code, will default to using system
-time. They must modified to use monotonic time using by passing
-`ConditionAttributesMonotonic()` as the second argument in the constructor. An
-example of this can be seen `wait_messages_pending()` in
-`dds/DCPS/MessageTracker.cpp`.
+time. Therefore the `Condition` class wraps it and makes it so it always uses
+monotonic time like it should. Like `ACE_OS::gettimeofday()`, referencing
+`ACE_Condition` in dds/DCPS will be treated as an error by `lint.pl`.
 
 More information on using monotonic time with ACE can be found
 [here](http://www.dre.vanderbilt.edu/~schmidt/DOC_ROOT/ACE/docs/ACE-monotonic-timer.html).

--- a/tests/DCPS/Deadline/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Deadline/DataReaderListenerImpl.cpp
@@ -1,6 +1,8 @@
 #include "DataReaderListenerImpl.h"
+
 #include "MessengerTypeSupportC.h"
 #include "MessengerTypeSupportImpl.h"
+
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/TimeTypes.h>
 
@@ -8,7 +10,7 @@ using namespace Messenger;
 
 DataReaderListenerImpl::DataReaderListenerImpl()
   : mutex_()
-  , matched_condition_(mutex_, OpenDDS::DCPS::ConditionAttributesMonotonic())
+  , matched_condition_(mutex_)
   , matched_(0)
   , num_arrived_(0)
   , requested_deadline_total_count_ (0)
@@ -71,7 +73,7 @@ DataReaderListenerImpl::on_subscription_matched(
 {
   ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
   matched_ = status.current_count;
-  matched_condition_.broadcast();
+  matched_condition_.notify_all();
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_subscription_matched\n")));
 }
 
@@ -122,15 +124,31 @@ void DataReaderListenerImpl::on_budget_exceeded(
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_budget_exceeded\n")));
 }
 
-int DataReaderListenerImpl::wait_matched(long count, const ACE_Time_Value *abstime) const
+bool DataReaderListenerImpl::wait_matched(
+  long count, const OpenDDS::DCPS::TimeDuration& max_wait) const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, -1);
+  using namespace OpenDDS::DCPS;
 
-  int result = 0;
-  while (count != matched_ && result == 0) {
-    result = matched_condition_.wait(abstime);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, false);
+
+  const MonotonicTimePoint deadline = MonotonicTimePoint::now() + max_wait;
+  while (count != matched_) {
+    switch (matched_condition_.wait_until(deadline)) {
+    case CvStatus_NoTimeout:
+      break;
+
+    case CvStatus_Timeout:
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DataReaderListenerImpl::wait_matched: Timeout\n"));
+      return false;
+
+    case CvStatus_Error:
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DataReaderListenerImpl::wait_matched: "
+        "Error in wait_until\n"));
+      return false;
+    }
   }
-  return count == matched_ ? 0 : result;
+
+  return true;
 }
 
 CORBA::Long DataReaderListenerImpl::requested_deadline_total_count (void) const

--- a/tests/DCPS/Deadline/DataReaderListenerImpl.h
+++ b/tests/DCPS/Deadline/DataReaderListenerImpl.h
@@ -1,8 +1,13 @@
 #ifndef DATAREADER_LISTENER_IMPL
 #define DATAREADER_LISTENER_IMPL
 
+#include <dds/DCPS/LocalObject.h>
+#include <dds/DCPS/ConditionVariable.h>
+#include <dds/DCPS/TimeDuration.h>
+
 #include <dds/DdsDcpsSubscriptionExtC.h>
-#include "dds/DCPS/LocalObject.h"
+
+#include <ace/Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -61,7 +66,8 @@ public:
     return num_arrived_;
   }
 
-  int wait_matched(long count, const ACE_Time_Value *abstime) const;
+  bool wait_matched(
+    long count, const OpenDDS::DCPS::TimeDuration& max_wait) const;
 
   CORBA::Long requested_deadline_total_count (void) const;
 
@@ -72,7 +78,7 @@ protected:
 private:
 
   mutable ACE_Thread_Mutex mutex_;
-  mutable ACE_Condition<ACE_Thread_Mutex> matched_condition_;
+  mutable OpenDDS::DCPS::ConditionVariable<ACE_Thread_Mutex> matched_condition_;
   long matched_;
   long num_arrived_;
   CORBA::Long requested_deadline_total_count_;

--- a/tests/DCPS/Deadline/DataWriterListenerImpl.h
+++ b/tests/DCPS/Deadline/DataWriterListenerImpl.h
@@ -4,9 +4,13 @@
 #ifndef DATAWRITER_LISTENER_IMPL
 #define DATAWRITER_LISTENER_IMPL
 
-#include "dds/DdsDcpsPublicationC.h"
-#include "dds/DCPS/Definitions.h"
-#include "dds/DCPS/LocalObject.h"
+#include <dds/DCPS/Definitions.h>
+#include <dds/DCPS/LocalObject.h>
+#include <dds/DCPS/ConditionVariable.h>
+
+#include <dds/DdsDcpsPublicationC.h>
+
+#include <ace/Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -55,7 +59,7 @@ protected:
 
 private:
   mutable ACE_Thread_Mutex mutex_;
-  mutable ACE_Condition<ACE_Thread_Mutex> matched_condition_;
+  mutable  matched_condition_;
   long matched_;
   CORBA::Long offered_deadline_total_count_;
 };

--- a/tests/DCPS/Deadline/DataWriterListenerImpl.h
+++ b/tests/DCPS/Deadline/DataWriterListenerImpl.h
@@ -7,6 +7,7 @@
 #include <dds/DCPS/Definitions.h>
 #include <dds/DCPS/LocalObject.h>
 #include <dds/DCPS/ConditionVariable.h>
+#include <dds/DCPS/TimeTypes.h>
 
 #include <dds/DdsDcpsPublicationC.h>
 
@@ -50,7 +51,8 @@ public:
       ::DDS::DataWriter_ptr writer,
       const ::OpenDDS::DCPS::PublicationLostStatus& status);
 
-  int wait_matched(long count, const ACE_Time_Value *abstime) const;
+  bool wait_matched(
+    long count, const OpenDDS::DCPS::TimeDuration& max_wait) const;
 
   CORBA::Long offered_deadline_total_count (void) const;
 
@@ -59,7 +61,7 @@ protected:
 
 private:
   mutable ACE_Thread_Mutex mutex_;
-  mutable  matched_condition_;
+  mutable OpenDDS::DCPS::ConditionVariable<ACE_Thread_Mutex> matched_condition_;
   long matched_;
   CORBA::Long offered_deadline_total_count_;
 };

--- a/tests/DCPS/Deadline/Writer.cpp
+++ b/tests/DCPS/Deadline/Writer.cpp
@@ -2,25 +2,21 @@
 //
 
 #include "Writer.h"
-#include "dds/DCPS/Service_Participant.h"
 
+#include <tests/Utils/ExceptionStreams.h>
+
+#include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/Qos_Helper.h>
 
 #include <ace/OS_NS_unistd.h>
 #include <ace/streams.h>
-#include "tests/Utils/ExceptionStreams.h"
 
 using namespace Messenger;
 using namespace std;
+using OpenDDS::DCPS::TimeDuration;
 
 static const int num_messages = 10;
 static const TimeDuration write_interval(0, 500000);
-
-// Wait for up to 10 seconds for subscription matched status.
-static const DDS::Duration_t MATCHED_WAIT_MAX_DURATION = {
-  10, // seconds
-  0   // nanoseconds
-};
 
 Writer::Writer(::DDS::DataWriter_ptr writer,
                CORBA::Long key,
@@ -64,8 +60,7 @@ Writer::svc()
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Writer::svc begins.\n")));
 
   try {
-    const MonotonicTimePoint connect_deadline(MonotonicTimePoint::now() + TimeDuration(MATCHED_WAIT_MAX_DURATION));
-    if (dwl_servant_->wait_matched(2, &connect_deadline.value()) != 0) {
+    if (!dwl_servant_->wait_matched(2, OpenDDS::DCPS::TimeDuration(10))) {
       cerr << "ERROR: wait for subscription matching failed." << endl;
       exit(1);
     }

--- a/tests/DCPS/Deadline/Writer.h
+++ b/tests/DCPS/Deadline/Writer.h
@@ -3,17 +3,15 @@
 #ifndef WRITER_H
 #define WRITER_H
 
-#include <dds/DdsDcpsPublicationC.h>
-#include "dds/DCPS/TimeTypes.h"
 #include "MessengerTypeSupportC.h"
 #include "DataWriterListenerImpl.h"
 
-#include <ace/Condition_T.h>
+#include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/TimeTypes.h>
+#include <dds/DCPS/ConditionVariable.h>
+
 #include <ace/Synch_Traits.h>
 #include <ace/Task.h>
-
-using OpenDDS::DCPS::TimeDuration;
-using OpenDDS::DCPS::MonotonicTimePoint;
 
 class Writer : public ACE_Task_Base
 {
@@ -41,7 +39,7 @@ private:
   typedef ACE_Guard<LockType> GuardType;
 
   LockType lock_;
-  ACE_Condition<ACE_SYNCH_MUTEX> condition_;
+  OpenDDS::DCPS::ConditionVariable<ACE_SYNCH_MUTEX> condition_;
 
   bool associated_;
   DataWriterListenerImpl* dwl_servant_;

--- a/tests/DCPS/Deadline/Writer.h
+++ b/tests/DCPS/Deadline/Writer.h
@@ -19,7 +19,7 @@ public:
 
   Writer(::DDS::DataWriter_ptr writer,
          CORBA::Long key,
-         TimeDuration sleep_duration);
+         OpenDDS::DCPS::TimeDuration sleep_duration);
 
   void start ();
 
@@ -45,7 +45,7 @@ private:
   DataWriterListenerImpl* dwl_servant_;
   ::DDS::InstanceHandle_t instance_handle_;
   CORBA::Long key_;
-  TimeDuration sleep_duration_;
+  OpenDDS::DCPS::TimeDuration sleep_duration_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/Deadline/publisher.cpp
+++ b/tests/DCPS/Deadline/publisher.cpp
@@ -11,22 +11,23 @@
 #include "MessengerTypeSupportImpl.h"
 #include "Writer.h"
 #include "DataWriterListenerImpl.h"
+
+#include <tests/Utils/ExceptionStreams.h>
+
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include <dds/DCPS/Qos_Helper.h>
 #include <dds/DCPS/unique_ptr.h>
-
-#include "dds/DCPS/StaticIncludes.h"
+#include <dds/DCPS/StaticIncludes.h>
 #ifdef ACE_AS_STATIC_LIBS
-#include <dds/DCPS/RTPS/RtpsDiscovery.h>
-#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #endif
 
 #include <ace/streams.h>
 #include <ace/OS_NS_unistd.h>
-#include "tests/Utils/ExceptionStreams.h"
-#include "ace/Get_Opt.h"
+#include <ace/Get_Opt.h>
 
 #include <memory>
 #include <assert.h>
@@ -44,7 +45,7 @@ static DDS::Duration_t const DEADLINE_PERIOD =
 static int NUM_EXPIRATIONS = 2;
 
 // Time to sleep waiting for deadline periods to expire
-const static TimeDuration SLEEP_DURATION(DEADLINE_PERIOD.sec * NUM_EXPIRATIONS + 1);
+const static OpenDDS::DCPS::TimeDuration SLEEP_DURATION(DEADLINE_PERIOD.sec * NUM_EXPIRATIONS + 1);
 
 static int NUM_WRITE_THREADS = 2;
 

--- a/tests/DCPS/Deadline/subscriber.cpp
+++ b/tests/DCPS/Deadline/subscriber.cpp
@@ -42,12 +42,6 @@ const static TimeDuration write_interval(0, 500000);
 const long NUM_EXPIRATIONS = 2;
 const int NUM_INSTANCE = 2;
 
-// Wait for up to 10 seconds for subscription matched status.
-const static DDS::Duration_t MATCHED_WAIT_MAX_DURATION = {
-  10, // seconds
-  0   // nanoseconds
-};
-
 // Set up a 5 second recurring deadline.
 const static DDS::Duration_t DEADLINE_PERIOD = {
   5, // seconds
@@ -237,8 +231,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         exit(1);
       }
 
-      const MonotonicTimePoint connect_deadline(MonotonicTimePoint::now() + TimeDuration(MATCHED_WAIT_MAX_DURATION));
-      if (listener_servant->wait_matched(1, &connect_deadline.value()) != 0) {
+      if (!listener_servant->wait_matched(1, OpenDDS::DCPS::TimeDuration(10))) {
         cerr << "ERROR: sub: wait for subscription matching failed." << endl;
         exit(1);
       }

--- a/tools/scripts/lint.pl
+++ b/tools/scripts/lint.pl
@@ -223,9 +223,18 @@ my %all_checks = (
 
   gettimeofday => {
     path_matches_all_of => ['cpp_file', 'in_dds_dcps'],
-    line_matches => qr/gettimeofday/,
+    line_matches => qr/gettimeofday|ACE_Time_Value\(\)\.now\(\)/,
     message => [
       'ACE_OS::gettimeofday() and "ACE_Time_Value().now()" are forbidden in the core libraries.',
+      'See the "Time" section in docs/guidelines.md.',
+    ],
+  },
+
+  ace_condition => {
+    path_matches_all_of => ['cpp_file', 'in_dds_dcps'],
+    line_matches => qr/(?:ACE_|ace\/)Condition(?:(?:_Recursive)?_Thread_Mutex)?/,
+    message => [
+      'Except for in Condition.h, ACE_Condition and related types are forbidden in the core libraries.',
       'See the "Time" section in docs/guidelines.md.',
     ],
   },


### PR DESCRIPTION
Prompted by https://github.com/objectcomputing/OpenDDS/pull/2106. Do a similar thing to `ACE_Condition` as what was done to `ACE_Time_Value` in https://github.com/objectcomputing/OpenDDS/pull/1256, which is to wrap and deprecate it. In wrapping it we can force monotonic time behavior and make it so it only accepts `MonotonicTimePoint` and `TimeDuration`.

Fixed include order along the way, including a pretty bad case in the `RecorderImpl` files where the header depended on the include order in the source file.