### PR TITLE
Pending RTPS writers/readers orphaned

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -61,7 +61,7 @@ TransportClient::~TransportClient()
     for (size_t i = 0; i < impls_.size(); ++i) {
       RcHandle<TransportImpl> impl = impls_[i].lock();
       if (impl) {
-        impl->stop_accepting_or_connecting(it->second->client_, it->second->data_.remote_id_);
+        impl->stop_accepting_or_connecting(it->second->client_, it->second->data_.remote_id_, false);
       }
     }
   }
@@ -569,7 +569,7 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
   for (size_t i = 0; i < pend->impls_.size(); ++i) {
     RcHandle<TransportImpl> impl = pend->impls_[i].lock();
     if (impl) {
-      impl->stop_accepting_or_connecting(*this, pend->data_.remote_id_);
+      impl->stop_accepting_or_connecting(*this, pend->data_.remote_id_, false);
     }
   }
 
@@ -650,6 +650,13 @@ TransportClient::disassociate(const RepoId& peerId)
 
   PendingMap::iterator iter = pending_.find(peerId);
   if (iter != pending_.end()) {
+    // The transport impl may have resource for a pending connection.
+    for (size_t i = 0; i < iter->second->impls_.size(); ++i) {
+      RcHandle<TransportImpl> impl = iter->second->impls_[i].lock();
+      if (impl) {
+        impl->stop_accepting_or_connecting(*this, iter->second->data_.remote_id_, true);
+      }
+    }
     iter->second->reset_client();
     pending_assoc_timer_->cancel_timer(iter->second);
     prev_pending_.insert(std::make_pair(iter->first, iter->second));

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -197,7 +197,8 @@ protected:
   /// The TransportClient* passed in to accept or connect is not
   /// valid after this method is called.
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                            const RepoId& remote_id) = 0;
+                                            const RepoId& remote_id,
+                                            bool disassociate) = 0;
 
 
   /// Called during the shutdown() method in order to give the

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -267,7 +267,8 @@ MulticastTransport::accept_datalink(const RemoteTransport& remote,
 
 void
 MulticastTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                                 const RepoId& remote_id)
+                                                 const RepoId& remote_id,
+                                                 bool /*disassociate*/)
 {
   VDBG((LM_DEBUG, "(%P|%t) MulticastTransport::stop_accepting_or_connecting\n"));
 

--- a/dds/DCPS/transport/multicast/MulticastTransport.h
+++ b/dds/DCPS/transport/multicast/MulticastTransport.h
@@ -45,7 +45,8 @@ protected:
                                               const TransportClient_rch& client);
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                            const RepoId& remote_id);
+                                            const RepoId& remote_id,
+                                            bool disassociate);
 
   bool configure_i(MulticastInst& config);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -677,6 +677,13 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
 }
 
 void
+RtpsUdpDataLink::disassociated(const RepoId& local_id,
+                               const RepoId& remote_id)
+{
+  release_reservations_i(local_id, remote_id);
+}
+
+void
 RtpsUdpDataLink::register_for_reader(const RepoId& writerid,
                                      const RepoId& readerid,
                                      const ACE_INET_Addr& address,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -146,6 +146,8 @@ public:
                   SequenceNumber max_sn,
                   const TransportClient_rch& client);
 
+  void disassociated(const RepoId& local, const RepoId& remote);
+
   void register_for_reader(const RepoId& writerid,
                            const RepoId& readerid,
                            const ACE_INET_Addr& address,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -56,7 +56,8 @@ private:
                                               const TransportClient_rch& client);
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                            const RepoId& remote_id);
+                                            const RepoId& remote_id,
+                                            bool disassociate);
 
   bool configure_i(RtpsUdpInst& config);
 

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -93,7 +93,7 @@ ShmemTransport::accept_datalink(const RemoteTransport& remote,
 }
 
 void
-ShmemTransport::stop_accepting_or_connecting(const TransportClient_wrch&, const RepoId&)
+ShmemTransport::stop_accepting_or_connecting(const TransportClient_wrch&, const RepoId&, bool)
 {
   // no-op: accept and connect either complete or fail immediately
 }

--- a/dds/DCPS/transport/shmem/ShmemTransport.h
+++ b/dds/DCPS/transport/shmem/ShmemTransport.h
@@ -46,7 +46,8 @@ protected:
                                               const TransportClient_rch& client);
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                            const RepoId& remote_id);
+                                            const RepoId& remote_id,
+                                            bool disassociate);
 
   bool configure_i(ShmemInst& config);
 

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -283,7 +283,8 @@ TcpTransport::accept_datalink(const RemoteTransport& remote,
 
 void
 TcpTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                           const RepoId& remote_id)
+                                           const RepoId& remote_id,
+                                           bool /*disassociate*/)
 {
   GuidConverter remote_converted(remote_id);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TcpTransport::stop_accepting_or_connecting "

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -67,7 +67,8 @@ private:
                                               const TransportClient_rch& client);
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                            const RepoId& remote_id);
+                                            const RepoId& remote_id,
+                                            bool disassociate);
 
   virtual bool configure_i(TcpInst& config);
 

--- a/dds/DCPS/transport/udp/UdpTransport.cpp
+++ b/dds/DCPS/transport/udp/UdpTransport.cpp
@@ -127,7 +127,8 @@ UdpTransport::accept_datalink(const RemoteTransport& remote,
 
 void
 UdpTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                           const RepoId& remote_id)
+                                           const RepoId& remote_id,
+                                           bool /*disassociate*/)
 {
   VDBG((LM_DEBUG, "(%P|%t) UdpTransport::stop_accepting_or_connecting\n"));
 

--- a/dds/DCPS/transport/udp/UdpTransport.h
+++ b/dds/DCPS/transport/udp/UdpTransport.h
@@ -42,7 +42,8 @@ protected:
                                               const TransportClient_rch& client);
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
-                                            const RepoId& remote_id);
+                                            const RepoId& remote_id,
+                                            bool disassociate);
 
   bool configure_i(UdpInst& config);
 

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
@@ -388,10 +388,11 @@ bool WorkerDataReaderListener::wait_for_expected_match(const std::chrono::system
 
   while (expected_match_count_ > match_count_) {
     if (expected_match_cv.wait_until(expected_lock, deadline) == std::cv_status::timeout) {
-      return match_count_ <= expected_match_count_;
+      return match_count_ >= expected_match_count_;
     }
   }
-  return true;
+
+  return match_count_ >= expected_match_count_;
 }
 
 }

--- a/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataWriterListener.cpp
@@ -106,10 +106,11 @@ bool WorkerDataWriterListener::wait_for_expected_match(const std::chrono::system
 
   while (expected_match_count_ > match_count_) {
     if (expected_match_cv.wait_until(expected_lock, deadline) == std::cv_status::timeout) {
-      return match_count_ <= expected_match_count_;
+      return match_count_ >= expected_match_count_;
     }
   }
-  return true;
+
+  return match_count_ >= expected_match_count_;
 }
 
 }

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -308,7 +308,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
             Bench::WorkerDataWriterListener* wdwl = dynamic_cast<Bench::WorkerDataWriterListener*>(dtWtrPtr->get_dds_datawriterlistener().in());
 
             if (!wdwl->wait_for_expected_match(timeout_time)) {
-              Log::log() << "Error: " << it->first << " Expected writers not found." << std::endl << std::endl;
+              Log::log() << "Error: " << it->first << " Expected readers not found." << std::endl << std::endl;
             }
           }
         }


### PR DESCRIPTION
Problem
-------

When a reliable TransportClient using RTPS associates with a reliable
peer that peer is put in a pending state.  If the client disassociates
with the peer while it is still pending, then it is not cleaned up in
the datalink.  Consequently, the remote peers linger and consume
resources trying to associate.

Solution
--------

Inform the datalink that the pending peer should be disassociated.