### PR TITLE
Application participant sends non-directed heartbeats

### DIFF
--- a/dds/DCPS/BuiltInTopicUtils.h
+++ b/dds/DCPS/BuiltInTopicUtils.h
@@ -33,6 +33,10 @@ OpenDDS_Dcps_Export extern const char* const BUILT_IN_SUBSCRIPTION_TOPIC_TYPE;
 OpenDDS_Dcps_Export extern const char* const BUILT_IN_PUBLICATION_TOPIC;
 OpenDDS_Dcps_Export extern const char* const BUILT_IN_PUBLICATION_TOPIC_TYPE;
 
+// TODO: When the ParticipantLocationTopic is retired, then it may be
+// possible to disable the secure participant writer in the RtpsRelay.
+// If it is disabled, then the is_ps_writer_ flag in the RTPS
+// transport can be removed.
 OpenDDS_Dcps_Export extern const char* const BUILT_IN_PARTICIPANT_LOCATION_TOPIC;
 OpenDDS_Dcps_Export extern const char* const BUILT_IN_PARTICIPANT_LOCATION_TOPIC_TYPE;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3733,6 +3733,7 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
     if (leading_readers_.empty() && remote_readers_.size() > 1
 #ifdef OPENDDS_SECURITY
         && !is_pvs_writer_
+        && !is_ps_writer_
 #endif
         ) {
       // Every reader is lagging and there is more than one.
@@ -4018,6 +4019,7 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
  , heartbeat_count_(heartbeat_count)
 #ifdef OPENDDS_SECURITY
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
+ , is_ps_writer_(id_.entityId == RTPS::ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER)
 #endif
 {
   send_buff_->bind(link->send_strategy());

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -379,6 +379,7 @@ private:
     CORBA::Long heartbeat_count_;
 #ifdef OPENDDS_SECURITY
     const bool is_pvs_writer_; // Participant Volatile Secure writer
+    const bool is_ps_writer_; // Partcicipant Secure (Reliable SPDP) writer
 #endif
     mutable ACE_Thread_Mutex mutex_;
     mutable ACE_Thread_Mutex elems_not_acked_mutex_;


### PR DESCRIPTION
Problem
-------

The reliable SPDP writer in the application participant of the
RtpsRelay can send undirected heartbeats that will be dropped by the
relay.

Solution
--------

Force directed heartbeats for the reliable SPDP writer.  This is a
work-around that may be removed in the future if the reliable SPDP
writer is disabled in the application participant.  Otherwise,
additional configuration plumbing will be needed to accomplish the
same result.