### PR TITLE
Lost SPDP prevents secure discovery

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1447,6 +1447,9 @@ Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
         pit->second.stateless_msg_deadline_ <= now) {
       const RepoId reader = make_id(pit->first, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER);
       pit->second.stateless_msg_deadline_ = now + config_->auth_resend_period();
+      // Send the SPDP announcement in case it got lost.
+      tport_->write_i(pit->first, SpdpTransport::SEND_TO_RELAY | SpdpTransport::SEND_TO_LOCAL);
+
       // Send the auth req first to reset the remote if necessary.
       if (pit->second.have_auth_req_msg_) {
         if (sedp_.write_stateless_message(pit->second.auth_req_msg_, reader) != DDS::RETCODE_OK) {


### PR DESCRIPTION
Problem
-------

RtpsRelay deployments send directed SPDP announcements with a very
long period.  Furthermore, they send one (and only one) announcement
when a client is first discovered.  If that announcement is lost,
discovery will certainly stall and fail.

Solution
--------

Send an SPDP announcement with an authentication resend.  The client
will send SPDP to the relay frequently so the relay should discover
the client in a timely manner.  The relay will start authentication
resends, which happen with a very small period, so the client will
eventually discover the relay.

The non-secure case is not handled in this commit.