### PR TITLE
Reliable RTPS readers don't know where to begin

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1075,7 +1075,7 @@ DataWriterImpl::wait_for_acknowledgments(const DDS::Duration_t& max_wait)
 DDS::ReturnCode_t
 DataWriterImpl::wait_for_specific_ack(const AckToken& token)
 {
-  return this->data_container_->wait_ack_of_seq(token.deadline(), token.sequence_);
+  return this->data_container_->wait_ack_of_seq(token.deadline(), token.deadline_is_infinite(), token.sequence_);
 }
 
 DDS::Publisher_ptr

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -107,6 +107,10 @@ public:
     MonotonicTimePoint deadline() const {
       return tstamp_ + TimeDuration(max_wait_);
     }
+
+    bool deadline_is_infinite() const {
+      return max_wait_.sec == DDS::DURATION_INFINITE_SEC && max_wait_.nanosec == DDS::DURATION_INFINITE_NSEC;
+    }
   };
 
   DataWriterImpl();

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3069,12 +3069,7 @@ Sedp::Writer::transport_assoc_done(int flags, const RepoId& remote) {
     return;
   }
 
-  if (is_reliable()) {
-    ACE_GUARD(ACE_Thread_Mutex, g, sedp_.lock_);
-    sedp_.association_complete_i(repo_id_, remote);
-  } else {
-    sedp_.association_complete_i(repo_id_, remote);
-  }
+  sedp_.association_complete_i(repo_id_, remote);
 }
 
 void

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1397,44 +1397,33 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& abs_deadline,
                                     const SequenceNumber& sequence)
 {
   const MonotonicTimePoint deadline(abs_deadline);
-  DDS::ReturnCode_t ret = DDS::RETCODE_OK;
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, lock_, DDS::RETCODE_ERROR);
   ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, wfa_guard, wfa_lock_, DDS::RETCODE_ERROR);
 
-  SequenceNumber last_acked = acked_sequences_.last_ack();
-  SequenceNumber acked = acked_sequences_.cumulative_ack();
+  const SequenceNumber last_acked = acked_sequences_.last_ack();
+  const SequenceNumber acked = acked_sequences_.cumulative_ack();
   if (sequence == last_acked && sequence == acked && sending_data_.size() != 0) {
     acked_sequences_.insert(sending_data_.head()->get_header().sequence_.previous());
   }
 
   guard.release();
 
-  while (deadline_is_infinite || MonotonicTimePoint::now() < deadline) {
-
-    if (!sequence_acknowledged(sequence)) {
-      // lock is released while waiting and acquired before returning
-      // from wait.
-      int const wait_result = wfa_condition_.wait(deadline_is_infinite ? 0 : &deadline.value());
-
-      if (wait_result != 0) {
-        if (errno == ETIME) {
-          if (DCPS_debug_level >= 2) {
-            ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::wait_ack_of_seq")
-                                  ACE_TEXT(" timed out waiting for sequence %q to be acked\n"),
-                                  sequence.getValue()));
-          }
-          ret = DDS::RETCODE_TIMEOUT;
-        } else {
-          ret = DDS::RETCODE_ERROR;
+  while ((deadline_is_infinite || MonotonicTimePoint::now() < deadline) && !sequence_acknowledged(sequence)) {
+    if (wfa_condition_.wait(deadline_is_infinite ? 0 : &deadline.value()) != 0) {
+      if (errno == ETIME) {
+        if (DCPS_debug_level >= 2) {
+          ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) WriteDataContainer::wait_ack_of_seq")
+                               ACE_TEXT(" timed out waiting for sequence %q to be acked\n"),
+                               sequence.getValue()));
         }
+        return DDS::RETCODE_TIMEOUT;
+      } else {
+        return DDS::RETCODE_ERROR;
       }
-    } else {
-      ret = DDS::RETCODE_OK;
-      break;
     }
   }
 
-  return ret;
+  return sequence_acknowledged(sequence) ? DDS::RETCODE_OK : DDS::RETCODE_TIMEOUT;
 }
 
 bool

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -339,7 +339,9 @@ public:
   typedef OPENDDS_VECTOR(DDS::InstanceHandle_t) InstanceHandleVec;
   void get_instance_handles(InstanceHandleVec& instance_handles);
 
-  DDS::ReturnCode_t wait_ack_of_seq(const MonotonicTimePoint& abs_deadline, const SequenceNumber& sequence);
+  DDS::ReturnCode_t wait_ack_of_seq(const MonotonicTimePoint& abs_deadline,
+                                    bool deadline_is_infinite,
+                                    const SequenceNumber& sequence);
 
   bool sequence_acknowledged(const SequenceNumber sequence);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3979,8 +3979,8 @@ RtpsUdpDataLink::DeliverHeldData::~DeliverHeldData()
   const SequenceNumber ca = writer_->recvd_.cumulative_ack();
   const WriterInfo::HeldMap::iterator end = writer_->held_.upper_bound(ca);
 
-    if (Transport_debug_level > 5) {
   for (WriterInfo::HeldMap::iterator it = writer_->held_.begin(); it != end; /*increment in loop body*/) {
+    if (Transport_debug_level > 5) {
       GuidConverter reader(reader_id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::DeliverHeldData::~DeliverHeldData -")
                  ACE_TEXT(" deliver sequence: %q to %C\n"),

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -651,7 +651,7 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
       if (rr == readers_.end()) {
         pending_reliable_readers_.erase(local_id);
         RtpsUdpDataLink_rch link(this, OpenDDS::DCPS::inc_count());
-        RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id, local_durable);
+        RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id);
         rr = readers_.insert(RtpsReaderMap::value_type(local_id, reader)).first;
       }
       RtpsReader_rch reader = rr->second;
@@ -1587,94 +1587,83 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
 void
 RtpsUdpDataLink::received(const RTPS::GapSubmessage& gap,
-                          const GuidPrefix_t& src_prefix)
+                          const GuidPrefix_t& src_prefix,
+                          bool directed)
 {
-  datareader_dispatch(gap, src_prefix, &RtpsReader::process_gap_i);
+  datareader_dispatch(gap, src_prefix, directed, &RtpsReader::process_gap_i);
 }
 
 bool
 RtpsUdpDataLink::RtpsReader::process_gap_i(const RTPS::GapSubmessage& gap,
                                            const RepoId& src,
+                                           bool /*directed*/,
                                            MetaSubmessageVec&)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
+
   RtpsUdpDataLink_rch link = link_.lock();
 
   if (!link) {
     return false;
   }
 
-  const WriterInfoMap::iterator wi = remote_writers_.find(src);
-  if (wi != remote_writers_.end()) {
-    const WriterInfo_rch& writer = wi->second;
-
-    if (writer->recvd_.empty()) {
-      return false;
-    }
-
-    SequenceNumber start, base;
-    start.setValue(gap.gapStart.high, gap.gapStart.low);
-    base.setValue(gap.gapList.bitmapBase.high, gap.gapList.bitmapBase.low);
-
-    SequenceRange sr;
-    sr.first = std::max(writer->recvd_.low(), start);
-    sr.second = base.previous();
-
-    // Insert the GAP range (but not before recvd_.low())
-    if (sr.first <= sr.second) {
-      if (Transport_debug_level > 5) {
-        const GuidConverter conv(src);
-        const GuidConverter rdr(id_);
-        ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::process_gap_i "
-                  "Reader %C received GAP with range [%q, %q] (inserting range [%q, %q]) from %C\n",
-                  OPENDDS_STRING(rdr).c_str(),
-                  sr.first.getValue(), base.previous().getValue(),
-                  sr.first.getValue(), sr.second.getValue(),
-                  OPENDDS_STRING(conv).c_str()));
-      }
-      writer->recvd_.insert(sr);
-    } else {
-      const GuidConverter conv(src);
-      VDBG_LVL((LM_WARNING, "(%P|%t) RtpsUdpDataLink::process_gap_i "
-                "received GAP with invalid range [%q, %q] from %C\n",
-                sr.first.getValue(), sr.second.getValue(),
-                OPENDDS_STRING(conv).c_str()), 2);
-    }
-
-    // Insert the GAP bitmap (but not before recvd_.low())
-    if (base < sr.first) {
-      // Check to see if entire bitmap is below recvd_.low()
-      if (sr.first < (base + gap.gapList.numBits)) {
-        // If not, partially apply gapList to recvd_ by building temporary
-        // disjoint sequence and deriving 'adjusted' bitmap to apply
-        DisjointSequence temp;
-        temp.insert(base, gap.gapList.numBits,
-                          gap.gapList.bitmap.get_buffer());
-        temp.insert(SequenceRange(base, sr.first));
-
-        OpenDDS::RTPS::LongSeq8 bitmap;
-        CORBA::ULong num_bits = 0;
-        bitmap.length((gap.gapList.numBits + 31) / 32); // won't be any larger than original
-        memset(&bitmap[0], 0, sizeof (CORBA::ULong) * ((gap.gapList.numBits + 31) / 32));
-
-        (void) temp.to_bitmap(bitmap.get_buffer(), bitmap.length(), num_bits, true);
-        if (num_bits) {
-          writer->recvd_.insert(temp.cumulative_ack(), num_bits, &bitmap[0]);
-        }
-      }
-    } else {
-      writer->recvd_.insert(base, gap.gapList.numBits, gap.gapList.bitmap.get_buffer());
-    }
-
-    DeliverHeldData dhd(link, id_, writer);
+  GuardType guard(link->strategy_lock_);
+  if (link->receive_strategy() == 0) {
+    return false;
   }
+
+  const WriterInfoMap::iterator wi = remote_writers_.find(src);
+  if (wi == remote_writers_.end()) {
+    return false;
+  }
+
+  const WriterInfo_rch& writer = wi->second;
+
+  // TODO: Compare and update counts?
+
+  if (writer->recvd_.empty()) {
+    return false;
+  }
+
+  SequenceNumber start, base;
+  start.setValue(gap.gapStart.high, gap.gapStart.low);
+  base.setValue(gap.gapList.bitmapBase.high, gap.gapList.bitmapBase.low);
+
+  writer->recvd_.insert(SequenceRange(start, base.previous()));
+  writer->recvd_.insert(base, gap.gapList.numBits, gap.gapList.bitmap.get_buffer());
+
+  DisjointSequence gaps;
+  gaps.insert(SequenceRange(start, base.previous()));
+  gaps.insert(base, gap.gapList.numBits, gap.gapList.bitmap.get_buffer());
+
+  if (!gaps.empty()) {
+    for (OPENDDS_MAP(SequenceNumber, ReceivedDataSample)::iterator pos = writer->held_.lower_bound(gaps.low()),
+           limit = writer->held_.upper_bound(gaps.high()); pos != limit;) {
+      if (gaps.contains(pos->first)) {
+        writer->held_.erase(pos++);
+      } else {
+        ++pos;
+      }
+    }
+  }
+
+  const OPENDDS_VECTOR(SequenceRange) psr = gaps.present_sequence_ranges();
+  for (OPENDDS_VECTOR(SequenceRange)::const_iterator pos = psr.begin(), limit = psr.end(); pos != limit; ++pos) {
+    link->receive_strategy()->remove_fragments(*pos, writer->id_);
+  }
+
+  guard.release();
+  g.release();
+
+  DeliverHeldData dhd(link, id_, writer);
 
   return false;
 }
 
 void
 RtpsUdpDataLink::received(const RTPS::HeartBeatSubmessage& heartbeat,
-                          const GuidPrefix_t& src_prefix)
+                          const GuidPrefix_t& src_prefix,
+                          bool directed)
 {
   RepoId src;
   std::memcpy(src.guidPrefix, src_prefix, sizeof(GuidPrefix_t));
@@ -1723,13 +1712,13 @@ RtpsUdpDataLink::received(const RTPS::HeartBeatSubmessage& heartbeat,
     heartbeat_reply_.enable(normal_heartbeat_response_delay_);
   }
 
-  datareader_dispatch(heartbeat, src_prefix,
-                      &RtpsReader::process_heartbeat_i);
+  datareader_dispatch(heartbeat, src_prefix, directed, &RtpsReader::process_heartbeat_i);
 }
 
 bool
 RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage& heartbeat,
                                                  const RepoId& src,
+                                                 bool directed,
                                                  MetaSubmessageVec& meta_submessages)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
@@ -1747,7 +1736,6 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
 
   const WriterInfoMap::iterator wi = remote_writers_.find(src);
   if (wi == remote_writers_.end()) {
-    // we may not be associated yet, even if the writer thinks we are
     return false;
   }
 
@@ -1763,10 +1751,6 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
   SequenceNumber hb_last;
   hb_last.setValue(heartbeat.lastSN.high, heartbeat.lastSN.low);
 
-  // Internal Sequence Range
-  SequenceNumber& wi_first = writer->hb_range_.first;
-  SequenceNumber& wi_last = writer->hb_range_.second;
-
   static const SequenceNumber one, zero = SequenceNumber::ZERO();
 
   bool first_ever_hb = false;
@@ -1776,49 +1760,34 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
     first_ever_hb = true;
   }
 
-  if (writer->recvd_.empty()) {
-    if (!durable_) {
-      if (hb_last > zero) {
-        writer->recvd_.insert(SequenceRange(zero, hb_last));
-      } else {
-        writer->recvd_.insert(zero);
+  // Only valid heartbeats (see spec) will be "fully" applied to writer info
+  if (!(hb_first < 1 || hb_last < 0 || hb_last < hb_first.previous())) {
+    // TODO: This check breaks interoperability.
+    if (writer->first_valid_hb_ && directed && heartbeat.readerId == id_.entityId) {
+      OPENDDS_ASSERT(preassociation_writers_.count(writer));
+      OPENDDS_ASSERT(writer->recvd_.empty());
+
+      writer->first_valid_hb_ = false;
+
+      preassociation_writers_.erase(writer);
+
+      SequenceNumber x = std::min(hb_first, hb_last);
+      if (x > 0) {
+        x = x.previous();
       }
-      wi_first = hb_last; // non-durable reliable connections ignore previous data
-      while (!writer->held_.empty() && writer->held_.begin()->first <= hb_last) {
+      const SequenceRange sr(zero, x);
+      writer->recvd_.insert(sr);
+      while (!writer->held_.empty() && writer->held_.begin()->first <= sr.second) {
         writer->held_.erase(writer->held_.begin());
       }
-    } else {
-      writer->recvd_.insert(zero);
+      link->receive_strategy()->remove_fragments(sr, writer->id_);
     }
-    typedef OPENDDS_MAP(SequenceNumber, ReceivedDataSample)::iterator iter;
-    for (iter it = writer->held_.begin(); it != writer->held_.end(); ++it) {
-      writer->recvd_.insert(it->first);
+
+    if (!writer->recvd_.empty()) {
+      writer->hb_last_ = std::max(writer->hb_last_, hb_last);
+      gather_ack_nacks_i(writer, link, !(heartbeat.smHeader.flags & RTPS::FLAG_F), meta_submessages);
     }
   }
-
-  DeliverHeldData dhd;
-
-  // Only valid heartbeats (see spec) will be "fully" applied to writer info
-  if (hb_first <= hb_last + 1 || (hb_first == one && wi_last == zero)) {
-    if (writer->first_valid_hb_) {
-      writer->first_valid_hb_ = false;
-      preassociation_writers_.erase(writer);
-    }
-    if (!durable_) {
-      if (wi_first < hb_first) {
-        writer->recvd_.insert(SequenceRange(wi_first, hb_first.previous()));
-        link->receive_strategy()->remove_fragments(SequenceRange(wi_first, hb_first.previous()), writer->id_);
-        wi_first = hb_first;
-        DeliverHeldData dhd2(link, id_, writer);
-        std::swap(dhd, dhd2);
-      }
-    }
-    wi_last = wi_last < hb_last ? hb_last : wi_last;
-
-    writer->first_valid_hb_ = false;
-  }
-
-  gather_ack_nacks_i(writer, link, !(heartbeat.smHeader.flags & RTPS::FLAG_F), meta_submessages);
 
   guard.release();
   g.release();
@@ -1827,6 +1796,8 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
     link->invoke_on_start_callbacks(id_, src, true);
   }
 
+  DeliverHeldData dhd(link, id_, writer);
+
   //FUTURE: support assertion of liveliness for MANUAL_BY_TOPIC
   return false;
 }
@@ -1834,11 +1805,11 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
 bool
 RtpsUdpDataLink::WriterInfo::should_nack() const
 {
-  if (recvd_.disjoint() && recvd_.cumulative_ack() < hb_range_.second) {
+  if (recvd_.empty() || (recvd_.disjoint() && recvd_.cumulative_ack() < hb_last_)) {
     return true;
   }
   if (!recvd_.empty()) {
-    return recvd_.high() < hb_range_.second;
+    return recvd_.high() < hb_last_;
   }
   return false;
 }
@@ -1941,12 +1912,6 @@ RtpsUdpDataLink::RtpsReader::writer_count() const
 }
 
 bool
-RtpsUdpDataLink::RtpsReader::should_nack_durable(const WriterInfo_rch& info)
-{
-  return durable_ && (info->recvd_.empty() || info->recvd_.low() > info->hb_range_.first);
-}
-
-bool
 RtpsUdpDataLink::RtpsReader::should_nack_fragments(const RcHandle<RtpsUdpDataLink>& link,
                                                    const WriterInfo_rch& info)
 {
@@ -1955,7 +1920,7 @@ RtpsUdpDataLink::RtpsReader::should_nack_fragments(const RcHandle<RtpsUdpDataLin
   }
 
   if (!info->recvd_.empty()) {
-    const SequenceRange range(info->recvd_.cumulative_ack() + 1, info->hb_range_.second);
+    const SequenceRange range(info->recvd_.cumulative_ack() + 1, info->hb_last_);
     if (link->receive_strategy()->has_fragments(range, info->id_)) {
       return true;
     }
@@ -1998,8 +1963,7 @@ RtpsUdpDataLink::RtpsReader::gather_preassociation_ack_nacks_i(MetaSubmessageVec
     const DisjointSequence& recvd = info->recvd_;
     const CORBA::ULong num_bits = 0;
     const LongSeq8 bitmap;
-    const SequenceNumber& hb_low = info->hb_range_.first;
-    const SequenceNumber ack = std::max(++SequenceNumber(recvd.cumulative_ack()), hb_low);
+    const SequenceNumber ack = recvd.empty() ? 1 : ++SequenceNumber(recvd.cumulative_ack());
     const EntityId_t reader_id = id_.entityId;
     const EntityId_t writer_id = info->id_.entityId;
 
@@ -2030,7 +1994,6 @@ RtpsUdpDataLink::RtpsReader::gather_ack_nacks_i(const WriterInfo_rch& writer,
 {
   const bool should_nack_frags = should_nack_fragments(link, writer);
   if (writer->should_nack() ||
-      should_nack_durable(writer) ||
       should_nack_frags) {
     using namespace OpenDDS::RTPS;
     const EntityId_t reader_id = id_.entityId;
@@ -2038,9 +2001,8 @@ RtpsUdpDataLink::RtpsReader::gather_ack_nacks_i(const WriterInfo_rch& writer,
     MetaSubmessage meta_submessage(id_, writer->id_);
 
     const DisjointSequence& recvd = writer->recvd_;
-    const SequenceNumber& hb_low = writer->hb_range_.first;
-    const SequenceNumber& hb_high = writer->hb_range_.second;
-    const SequenceNumber ack = std::max(++SequenceNumber(recvd.cumulative_ack()), hb_low);
+    const SequenceNumber& hb_high = writer->hb_last_;
+    const SequenceNumber ack = recvd.empty() ? 1 : ++SequenceNumber(recvd.cumulative_ack());
     const SequenceNumber::Value ack_val = ack.getValue();
     CORBA::ULong num_bits = 0;
     LongSeq8 bitmap;
@@ -2122,8 +2084,7 @@ RtpsUdpDataLink::RtpsReader::gather_ack_nacks_i(const WriterInfo_rch& writer,
     const DisjointSequence& recvd = writer->recvd_;
     const CORBA::ULong num_bits = 0;
     const LongSeq8 bitmap;
-    const SequenceNumber& hb_low = writer->hb_range_.first;
-    const SequenceNumber ack = std::max(++SequenceNumber(recvd.cumulative_ack()), hb_low);
+    const SequenceNumber ack = recvd.empty() ? 1 : ++SequenceNumber(recvd.cumulative_ack());
     const EntityId_t reader_id = id_.entityId;
     const EntityId_t writer_id = writer->id_.entityId;
 
@@ -2482,7 +2443,7 @@ RtpsUdpDataLink::RtpsReader::generate_nack_frags_i(MetaSubmessageVec& meta_subme
   }
   // 1b. larger than the last received seq# but less than the heartbeat.lastSN
   if (!wi->recvd_.empty()) {
-    const SequenceRange range(wi->recvd_.high(), wi->hb_range_.second);
+    const SequenceRange range(wi->recvd_.high(), wi->hb_last_);
     link->receive_strategy()->has_fragments(range, wi->id_, &frag_info);
   }
   for (size_t i = 0; i < frag_info.size(); ++i) {
@@ -2568,19 +2529,21 @@ RtpsUdpDataLink::extend_bitmap_range(RTPS::FragmentNumberSet& fnSet,
 
 void
 RtpsUdpDataLink::received(const RTPS::HeartBeatFragSubmessage& hb_frag,
-                          const GuidPrefix_t& src_prefix)
+                          const GuidPrefix_t& src_prefix,
+                          bool directed)
 {
-  datareader_dispatch(hb_frag, src_prefix, &RtpsReader::process_heartbeat_frag_i);
+  datareader_dispatch(hb_frag, src_prefix, directed, &RtpsReader::process_heartbeat_frag_i);
 }
 
 bool
 RtpsUdpDataLink::RtpsReader::process_heartbeat_frag_i(const RTPS::HeartBeatFragSubmessage& hb_frag,
                                                       const RepoId& src,
+                                                      bool /*directed*/,
                                                       MetaSubmessageVec& meta_submessages)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
 
-    RtpsUdpDataLink_rch link = link_.lock();
+  RtpsUdpDataLink_rch link = link_.lock();
 
   if (!link) {
     return false;
@@ -2610,8 +2573,7 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_frag_i(const RTPS::HeartBeatFragS
   // it yet, send a NackFrag along with the AckNack.  The heartbeat range needs
   // to be checked first because recvd_ contains the numbers below the
   // heartbeat range (so that we don't NACK those).
-  if (seq < writer->hb_range_.first || seq > writer->hb_range_.second
-      || !writer->recvd_.contains(seq)) {
+  if (seq > writer->hb_last_ || !writer->recvd_.contains(seq)) {
     writer->frags_[seq] = hb_frag.lastFragmentNum;
     gather_ack_nacks_i(writer, link, !(hb_frag.smHeader.flags & RTPS::FLAG_F), meta_submessages);
   }
@@ -2955,16 +2917,14 @@ void RtpsUdpDataLink::RtpsWriter::process_nackfrag(const RTPS::NackFragSubmessag
     return;
   }
 
-  RepoId remote = src;
-
   if (Transport_debug_level > 5) {
-    GuidConverter local_conv(id_), remote_conv(remote);
+    GuidConverter local_conv(id_), remote_conv(src);
     ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::received(NACK_FRAG) "
       "local %C remote %C\n", OPENDDS_STRING(local_conv).c_str(),
       OPENDDS_STRING(remote_conv).c_str()));
   }
 
-  const ReaderInfoMap::iterator ri = remote_readers_.find(remote);
+  const ReaderInfoMap::iterator ri = remote_readers_.find(src);
   if (ri == remote_readers_.end()) {
     VDBG((LM_WARNING, "(%P|%t) RtpsUdpDataLink::received(NACK_FRAG) "
       "WARNING ReaderInfo not found\n"));
@@ -3351,6 +3311,12 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
     return;
   }
 
+  // Prevent changes to the send buffer so new readers can ge
+  // associated and find the start of their reliable range.
+  if (!preassociation_readers_.empty()) {
+    return;
+  }
+
   //start with the max sequence number writer knows about and decrease
   //by what the min over all readers is
   SequenceNumber all_readers_ack = SequenceNumber::MAX_VALUE;
@@ -3360,6 +3326,7 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
   if (!leading_readers_.empty()) {
     all_readers_ack = std::min(all_readers_ack, leading_readers_.begin()->first + 1);
   }
+
   if (all_readers_ack == SequenceNumber::MAX_VALUE) {
     return;
   }
@@ -3583,7 +3550,9 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
 
   using namespace OpenDDS::RTPS;
 
-  const SequenceNumber firstSN = (durable_ || !send_buff_ || send_buff_->empty()) ? 1 : send_buff_->low();
+  // Assume no samples are available.
+  const SequenceNumber nonDurableFirstSN = (send_buff_ && !send_buff_->empty()) ? send_buff_->low() : (max_sn_ + 1);
+  const SequenceNumber firstSN = durable_ ? 1 : nonDurableFirstSN;
   const SequenceNumber lastSN = max_sn_;
 
   const HeartBeatSubmessage hb = {
@@ -3614,12 +3583,16 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
 
     for (ReaderInfoSet::const_iterator pos = preassociation_readers_.begin(), limit = preassociation_readers_.end();
          pos != limit; ++pos) {
-      // Initialize high and low.
-      const SequenceNumber sn = expected_max_sn(*pos);
-      meta_submessage.dst_guid_ = (*pos)->id_;
-      meta_submessage.sm_.heartbeat_sm().readerId = (*pos)->id_.entityId;
-      meta_submessage.sm_.heartbeat_sm().lastSN.low = sn.getLow();
-      meta_submessage.sm_.heartbeat_sm().lastSN.high = sn.getHigh();
+      const ReaderInfo_rch& reader = *pos;
+      // Initialize first and last for the specific reader.
+      const SequenceNumber first_sn = reader->durable_ ? 1 : nonDurableFirstSN;
+      const SequenceNumber last_sn = expected_max_sn(reader);
+      meta_submessage.dst_guid_ = reader->id_;
+      meta_submessage.sm_.heartbeat_sm().readerId = reader->id_.entityId;
+      meta_submessage.sm_.heartbeat_sm().firstSN.low = first_sn.getLow();
+      meta_submessage.sm_.heartbeat_sm().firstSN.high = first_sn.getHigh();
+      meta_submessage.sm_.heartbeat_sm().lastSN.low = last_sn.getLow();
+      meta_submessage.sm_.heartbeat_sm().lastSN.high = last_sn.getHigh();
       meta_submessages.push_back(meta_submessage);
       meta_submessage.reset_destination();
     }
@@ -3635,6 +3608,11 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
 #endif
         ) {
       // Every reader is lagging and there is more than one.
+      meta_submessage.sm_.heartbeat_sm().readerId = ENTITYID_UNKNOWN;
+      meta_submessage.sm_.heartbeat_sm().firstSN.low = firstSN.getLow();
+      meta_submessage.sm_.heartbeat_sm().firstSN.high = firstSN.getHigh();
+      meta_submessage.sm_.heartbeat_sm().lastSN.low = lastSN.getLow();
+      meta_submessage.sm_.heartbeat_sm().lastSN.high = lastSN.getHigh();
       for (ReaderInfoMap::const_iterator pos = remote_readers_.begin(), limit = remote_readers_.end(); pos != limit; ++pos) {
         // TODO: This should be factored out in a sporadic task.
         expire_durable_data(pos->second, cfg, now, pendingCallbacks);
@@ -3648,15 +3626,17 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
         for (ReaderInfoSet::const_iterator pos = snris_pos->second->readers.begin(),
                limit = snris_pos->second->readers.end();
              pos != limit; ++pos) {
-          const ReaderInfo_rch& ri = (*pos);
+          const ReaderInfo_rch& reader = (*pos);
           // TODO: This should be factored out in a sporadic task.
-          expire_durable_data(ri, cfg, now, pendingCallbacks);
-
-          const SequenceNumber sn = expected_max_sn(ri);
-          meta_submessage.dst_guid_ = ri->id_;
-          meta_submessage.sm_.heartbeat_sm().readerId = ri->id_.entityId;
-          meta_submessage.sm_.heartbeat_sm().lastSN.low = sn.getLow();
-          meta_submessage.sm_.heartbeat_sm().lastSN.high = sn.getHigh();
+          expire_durable_data(reader, cfg, now, pendingCallbacks);
+          const SequenceNumber first_sn = (*pos)->durable_ ? 1 : nonDurableFirstSN;
+          const SequenceNumber last_sn = expected_max_sn(*pos);
+          meta_submessage.dst_guid_ = reader->id_;
+          meta_submessage.sm_.heartbeat_sm().readerId = reader->id_.entityId;
+          meta_submessage.sm_.heartbeat_sm().lastSN.low = first_sn.getLow();
+          meta_submessage.sm_.heartbeat_sm().lastSN.high = first_sn.getHigh();
+          meta_submessage.sm_.heartbeat_sm().lastSN.low = last_sn.getLow();
+          meta_submessage.sm_.heartbeat_sm().lastSN.high = last_sn.getHigh();
           meta_submessages.push_back(meta_submessage);
           meta_submessage.reset_destination();
         }
@@ -3672,12 +3652,16 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
     for (ReaderInfoSet::const_iterator pos = readers_expecting_heartbeat_.begin(),
            limit = readers_expecting_heartbeat_.end();
          pos != limit; ++pos) {
-      if (preassociation_readers_.count(*pos) == 0 || !is_lagging(*pos)) {
-        const SequenceNumber sn = expected_max_sn(*pos);
-        meta_submessage.dst_guid_ = (*pos)->id_;
-        meta_submessage.sm_.heartbeat_sm().readerId = (*pos)->id_.entityId;
-        meta_submessage.sm_.heartbeat_sm().lastSN.low = sn.getLow();
-        meta_submessage.sm_.heartbeat_sm().lastSN.high = sn.getHigh();
+      const ReaderInfo_rch& reader = *pos;
+      if (preassociation_readers_.count(reader) == 0 || !is_lagging(reader)) {
+        const SequenceNumber first_sn = reader->durable_ ? 1 : nonDurableFirstSN;
+        const SequenceNumber last_sn = expected_max_sn(reader);
+        meta_submessage.dst_guid_ = reader->id_;
+        meta_submessage.sm_.heartbeat_sm().readerId = reader->id_.entityId;
+        meta_submessage.sm_.heartbeat_sm().lastSN.low = first_sn.getLow();
+        meta_submessage.sm_.heartbeat_sm().lastSN.high = first_sn.getHigh();
+        meta_submessage.sm_.heartbeat_sm().lastSN.low = last_sn.getLow();
+        meta_submessage.sm_.heartbeat_sm().lastSN.high = last_sn.getHigh();
         meta_submessages.push_back(meta_submessage);
         meta_submessage.reset_destination();
       }
@@ -3725,6 +3709,7 @@ RtpsUdpDataLink::send_heartbeats_manual_i(const TransportSendControlElement* tsc
   SequenceNumber firstSN, lastSN;
   CORBA::Long counter;
 
+  // TODO: firstSN doesn't seem to be initialized properly.
   firstSN = 1;
   lastSN = tsce->sequence();
 
@@ -3772,6 +3757,7 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats_manual_i(MetaSubmessageVec& meta_su
     }
   }
 
+  // TODO: Make sure these are initialized properly.
   const SequenceNumber firstSN = (durable_ || !has_data) ? 1 : send_buff_->low();
   const SequenceNumber lastSN = std::max(durable_max, has_data ? send_buff_->high() : 1);
   const int counter = ++heartbeat_count_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1633,7 +1633,7 @@ RtpsUdpDataLink::RtpsReader::process_gap_i(const RTPS::GapSubmessage& gap,
   gaps.insert(base, gap.gapList.numBits, gap.gapList.bitmap.get_buffer());
 
   if (!gaps.empty()) {
-    for (OPENDDS_MAP(SequenceNumber, ReceivedDataSample)::iterator pos = writer->held_.lower_bound(gaps.low()),
+    for (WriterInfo::HeldMap::iterator pos = writer->held_.lower_bound(gaps.low()),
            limit = writer->held_.upper_bound(gaps.high()); pos != limit;) {
       if (gaps.contains(pos->first)) {
         writer->held_.erase(pos++);
@@ -1772,6 +1772,9 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
       writer->recvd_.insert(sr);
       while (!writer->held_.empty() && writer->held_.begin()->first <= sr.second) {
         writer->held_.erase(writer->held_.begin());
+      }
+      for (WriterInfo::HeldMap::const_iterator it = writer->held_.begin(); it != writer->held_.end(); ++it) {
+        writer->recvd_.insert(it->first);
       }
       link->receive_strategy()->remove_fragments(sr, writer->id_);
     }
@@ -3974,11 +3977,10 @@ RtpsUdpDataLink::DeliverHeldData::~DeliverHeldData()
   }
 
   const SequenceNumber ca = writer_->recvd_.cumulative_ack();
-  typedef OPENDDS_MAP(SequenceNumber, ReceivedDataSample)::iterator iter;
-  const iter end = writer_->held_.upper_bound(ca);
+  const WriterInfo::HeldMap::iterator end = writer_->held_.upper_bound(ca);
 
-  for (iter it = writer_->held_.begin(); it != end; /*increment in loop body*/) {
     if (Transport_debug_level > 5) {
+  for (WriterInfo::HeldMap::iterator it = writer_->held_.begin(); it != end; /*increment in loop body*/) {
       GuidConverter reader(reader_id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::DeliverHeldData::~DeliverHeldData -")
                  ACE_TEXT(" deliver sequence: %q to %C\n"),

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1818,6 +1818,9 @@ RtpsUdpDataLink::RtpsWriter::add_reader(const ReaderInfo_rch& reader)
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
   ReaderInfoMap::const_iterator iter = remote_readers_.find(reader->id_);
   if (iter == remote_readers_.end()) {
+#ifdef OPENDDS_SECURITY
+    reader->max_pvs_sn_ = max_sn_;
+#endif
     remote_readers_.insert(ReaderInfoMap::value_type(reader->id_, reader));
     preassociation_readers_.insert(reader);
     return true;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -106,13 +106,17 @@ public:
   void received(const RTPS::DataSubmessage& data,
                 const GuidPrefix_t& src_prefix);
 
-  void received(const RTPS::GapSubmessage& gap, const GuidPrefix_t& src_prefix);
+  void received(const RTPS::GapSubmessage& gap,
+                const GuidPrefix_t& src_prefix,
+                bool directed);
 
   void received(const RTPS::HeartBeatSubmessage& heartbeat,
-                const GuidPrefix_t& src_prefix);
+                const GuidPrefix_t& src_prefix,
+                bool directed);
 
   void received(const RTPS::HeartBeatFragSubmessage& hb_frag,
-                const GuidPrefix_t& src_prefix);
+                const GuidPrefix_t& src_prefix,
+                bool directed);
 
   void received(const RTPS::AckNackSubmessage& acknack,
                 const GuidPrefix_t& src_prefix);
@@ -458,19 +462,20 @@ private:
     const RepoId id_;
     DisjointSequence recvd_;
     OPENDDS_MAP(SequenceNumber, ReceivedDataSample) held_;
-    SequenceRange hb_range_;
+    SequenceNumber hb_last_;
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumber_t) frags_;
     bool first_activity_, first_valid_hb_;
     CORBA::Long heartbeat_recvd_count_, hb_frag_recvd_count_, nackfrag_count_;
 
     WriterInfo(const RepoId& id)
       : id_(id)
+      , hb_last_(SequenceNumber::ZERO())
       , first_activity_(true)
       , first_valid_hb_(true)
       , heartbeat_recvd_count_(0)
       , hb_frag_recvd_count_(0)
       , nackfrag_count_(0)
-    { hb_range_.second = SequenceNumber::ZERO(); }
+    { }
 
     bool should_nack() const;
   };
@@ -480,23 +485,36 @@ private:
 
   class RtpsReader : public RcObject {
   public:
-    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable) : link_(link), id_(id), durable_(durable), stopping_(false), acknack_count_(0) {}
+    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id)
+      : link_(link)
+      , id_(id)
+      , stopping_(false)
+      , acknack_count_(0)
+    {}
 
     bool add_writer(const WriterInfo_rch& info);
     bool has_writer(const RepoId& id) const;
     bool remove_writer(const RepoId& id);
     size_t writer_count() const;
 
-    bool should_nack_durable(const WriterInfo_rch& info);
     bool should_nack_fragments(const RcHandle<RtpsUdpDataLink>& link,
                                const WriterInfo_rch& info);
 
     void pre_stop_helper();
 
-    bool process_heartbeat_i(const RTPS::HeartBeatSubmessage& heartbeat, const RepoId& src, MetaSubmessageVec& meta_submessages);
+    bool process_heartbeat_i(const RTPS::HeartBeatSubmessage& heartbeat,
+                             const RepoId& src,
+                             bool directed,
+                             MetaSubmessageVec& meta_submessages);
     bool process_data_i(const RTPS::DataSubmessage& data, const RepoId& src, MetaSubmessageVec& meta_submessages);
-    bool process_gap_i(const RTPS::GapSubmessage& gap, const RepoId& src, MetaSubmessageVec& meta_submessages);
-    bool process_heartbeat_frag_i(const RTPS::HeartBeatFragSubmessage& hb_frag, const RepoId& src, MetaSubmessageVec& meta_submessages);
+    bool process_gap_i(const RTPS::GapSubmessage& gap,
+                       const RepoId& src,
+                       bool directed,
+                       MetaSubmessageVec& meta_submessages);
+    bool process_heartbeat_frag_i(const RTPS::HeartBeatFragSubmessage& hb_frag,
+                                  const RepoId& src,
+                                  bool directed,
+                                  MetaSubmessageVec& meta_submessages);
 
     void gather_preassociation_ack_nacks(MetaSubmessageVec& meta_submessages);
     const RepoId& id() const { return id_; }
@@ -516,7 +534,6 @@ private:
     mutable ACE_Thread_Mutex mutex_;
     WeakRcHandle<RtpsUdpDataLink> link_;
     const RepoId id_;
-    const bool durable_;
     WriterInfoMap remote_writers_;
     WriterInfoSet preassociation_writers_;
     bool stopping_;
@@ -603,7 +620,9 @@ private:
   }
 
   template<typename T, typename FN>
-  void datareader_dispatch(const T& submessage, const GuidPrefix_t& src_prefix,
+  void datareader_dispatch(const T& submessage,
+                           const GuidPrefix_t& src_prefix,
+                           bool directed,
                            const FN& func)
   {
     RepoId local;
@@ -634,7 +653,7 @@ private:
     MetaSubmessageVec meta_submessages;
     for (OPENDDS_VECTOR(RtpsReader_rch)::const_iterator it = to_call.begin(); it < to_call.end(); ++it) {
       RtpsReader& reader = **it;
-      schedule_timer |= (reader.*func)(submessage, src, meta_submessages);
+      schedule_timer |= (reader.*func)(submessage, src, directed, meta_submessages);
     }
     send_bundled_submessages(meta_submessages);
     if (schedule_timer) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -464,7 +464,8 @@ private:
   struct WriterInfo : RcObject {
     const RepoId id_;
     DisjointSequence recvd_;
-    OPENDDS_MAP(SequenceNumber, ReceivedDataSample) held_;
+    typedef OPENDDS_MAP(SequenceNumber, ReceivedDataSample) HeldMap;
+    HeldMap held_;
     SequenceNumber hb_last_;
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumber_t) frags_;
     bool first_activity_, first_valid_hb_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -991,7 +991,8 @@ RtpsUdpReceiveStrategy::has_fragments(const SequenceRange& range,
 // MessageReceiver nested class
 
 RtpsUdpReceiveStrategy::MessageReceiver::MessageReceiver(const GuidPrefix_t& local)
-  : have_timestamp_(false)
+  : directed_(false)
+  , have_timestamp_(false)
 {
   RTPS::assign(local_, local);
   source_version_.major = source_version_.minor = 0;
@@ -1000,7 +1001,6 @@ RtpsUdpReceiveStrategy::MessageReceiver::MessageReceiver(const GuidPrefix_t& loc
     source_guid_prefix_[i] = 0;
     dest_guid_prefix_[i] = 0;
   }
-  directed_ = false;
   timestamp_.seconds = 0;
   timestamp_.fraction = 0;
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -483,15 +483,14 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
     if (!check_encoded(submessage.gap_sm().writerId)) {
       break;
     }
-    link_->received(submessage.gap_sm(), receiver_.source_guid_prefix_);
+    link_->received(submessage.gap_sm(), receiver_.source_guid_prefix_, receiver_.directed_);
     break;
 
   case HEARTBEAT:
     if (!check_encoded(submessage.heartbeat_sm().writerId)) {
       break;
     }
-    link_->received(submessage.heartbeat_sm(),
-                    receiver_.source_guid_prefix_);
+    link_->received(submessage.heartbeat_sm(), receiver_.source_guid_prefix_, receiver_.directed_);
     if (submessage.heartbeat_sm().smHeader.flags & FLAG_L) {
       // Liveliness has been asserted.  Create a DATAWRITER_LIVELINESS message.
       sample.header_.message_id_ = DATAWRITER_LIVELINESS;
@@ -513,8 +512,7 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
     if (!check_encoded(submessage.hb_frag_sm().writerId)) {
       break;
     }
-    link_->received(submessage.hb_frag_sm(),
-                    receiver_.source_guid_prefix_);
+    link_->received(submessage.hb_frag_sm(), receiver_.source_guid_prefix_, receiver_.directed_);
     break;
 
   case NACK_FRAG:
@@ -1002,6 +1000,7 @@ RtpsUdpReceiveStrategy::MessageReceiver::MessageReceiver(const GuidPrefix_t& loc
     source_guid_prefix_[i] = 0;
     dest_guid_prefix_[i] = 0;
   }
+  directed_ = false;
   timestamp_.seconds = 0;
   timestamp_.fraction = 0;
 }
@@ -1017,6 +1016,7 @@ RtpsUdpReceiveStrategy::MessageReceiver::reset(const ACE_INET_Addr& addr,
 
   assign(source_guid_prefix_, hdr.guidPrefix);
   assign(dest_guid_prefix_, local_);
+  directed_ = false;
 
   unicast_reply_locator_list_.length(1);
   unicast_reply_locator_list_[0].kind = address_to_kind(addr);
@@ -1071,10 +1071,12 @@ RtpsUdpReceiveStrategy::MessageReceiver::submsg(
   for (size_t i = 0; i < sizeof(GuidPrefix_t); ++i) {
     if (id.guidPrefix[i]) { // if some byte is > 0, it's not UNKNOWN
       RTPS::assign(dest_guid_prefix_, id.guidPrefix);
+      directed_ = true;
       return;
     }
   }
   RTPS::assign(dest_guid_prefix_, local_);
+  directed_ = false;
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -147,6 +147,7 @@ private:
     RTPS::VendorId_t source_vendor_;
     GuidPrefix_t source_guid_prefix_;
     GuidPrefix_t dest_guid_prefix_;
+    bool directed_;
     DCPS::LocatorSeq unicast_reply_locator_list_;
     DCPS::LocatorSeq multicast_reply_locator_list_;
     bool have_timestamp_;

--- a/java/tests/messenger/publisher/run_test.pl
+++ b/java/tests/messenger/publisher/run_test.pl
@@ -30,18 +30,12 @@ if ($config eq '') {
 my $use_repo = ($config !~ /^rtps_disc/);
 
 my $reliable = '-r';
-my $wait_for_acks = '-w';
 
 if ($config eq 'udp') {
   $reliable = '';
 }
 
-if (($config =~ 'rtps') || ($config =~ 'rtps_uni') ||
-    ($config eq 'rtps_disc') || ($config eq 'udp')) {
-  $wait_for_acks = '';
-}
-
-my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini $reliable $wait_for_acks";
+my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini $reliable";
 my $pub_opts = $opts;
 my $sub_opts = $opts;
 if ($debug ne '0') {

--- a/java/tests/messenger/subscriber/run_test.pl
+++ b/java/tests/messenger/subscriber/run_test.pl
@@ -30,18 +30,12 @@ if ($config eq '') {
 my $use_repo = ($config !~ /^rtps_disc/);
 
 my $reliable = '-r';
-my $wait_for_acks = '-w';
 
 if ($config eq 'udp') {
   $reliable = '';
 }
 
-if (($config =~ 'rtps') || ($config =~ 'rtps_uni') ||
-    ($config eq 'rtps_disc') || ($config eq 'udp')) {
-  $wait_for_acks = '';
-}
-
-my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini $reliable $wait_for_acks";
+my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini $reliable";
 my $pub_opts = $opts;
 my $sub_opts = $opts;
 if ($debug ne '0') {

--- a/tests/DCPS/Messenger/Args.h
+++ b/tests/DCPS/Messenger/Args.h
@@ -23,7 +23,6 @@
 
 const int num_messages = 40;
 extern bool reliable;
-extern bool wait_for_acks;
 
 inline int
 parse_args(int argc, ACE_TCHAR *argv[])
@@ -53,9 +52,6 @@ parse_args(int argc, ACE_TCHAR *argv[])
       break;
     case 'r':
       reliable = true;
-      break;
-    case 'w':
-      wait_for_acks = true;
       break;
     case '?':
     default:

--- a/tests/DCPS/Messenger/Writer.cpp
+++ b/tests/DCPS/Messenger/Writer.cpp
@@ -20,7 +20,6 @@
 
 const int num_instances_per_writer = 1;
 bool reliable = false;
-bool wait_for_acks = false;
 
 Writer::Writer(DDS::DataWriter_ptr writer)
   : writer_(DDS::DataWriter::_duplicate(writer)),

--- a/tests/DCPS/Messenger/publisher.cpp
+++ b/tests/DCPS/Messenger/publisher.cpp
@@ -197,7 +197,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       std::cout << "Writer finished " << std::endl;
       writer->end();
 
-      if (wait_for_acks) {
+      if (dw_reliable()) {
         std::cout << "Writer wait for ACKS" << std::endl;
 
         DDS::Duration_t timeout =

--- a/tests/DCPS/Messenger/stack_subscriber.cpp
+++ b/tests/DCPS/Messenger/stack_subscriber.cpp
@@ -25,7 +25,6 @@
 #include "Args.h"
 
 bool reliable = false;
-bool wait_for_acks = false;
 
 int
 ACE_TMAIN(int argc, ACE_TCHAR *argv[])

--- a/tests/DCPS/Messenger/subscriber.cpp
+++ b/tests/DCPS/Messenger/subscriber.cpp
@@ -48,7 +48,6 @@ const char permissions_file[] = "file:./permissions_2_signed.p7s";
 #endif
 
 bool reliable = false;
-bool wait_for_acks = false;
 
 void append(DDS::PropertySeq& props, const char* name, const char* value, bool propagate = false)
 {

--- a/tests/DCPS/TransientLocalTest/DataReaderListener.h
+++ b/tests/DCPS/TransientLocalTest/DataReaderListener.h
@@ -44,14 +44,23 @@ public:
     DDS::DataReader_ptr reader,
     const DDS::SampleLostStatus& status);
 
-  long num_reads() const {
-    return num_reads_;
+  long durable_reads() const {
+    return durable_reads_;
   }
 
-  bool ok_;
+  long volatile_reads() const {
+    return volatile_reads_;
+  }
+
+  bool ok() {
+    return ok_;
+  }
 
 private:
-  long num_reads_, last_non_durable_;
+  long durable_reads_;
+  long volatile_reads_;
+  long last_volatile_;
+  bool ok_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/TransientLocalTest/publisher.cpp
+++ b/tests/DCPS/TransientLocalTest/publisher.cpp
@@ -104,7 +104,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: get_publication_matched_status\n")));
         break;
-      } else if (pubmatched.current_count == 0 && pubmatched.total_count > 0) {
+      } else if (pubmatched.current_count == 0 && pubmatched.total_count == 4) {
         // subscriber has come and gone
         break;
       }

--- a/tests/DCPS/TransientLocalTest/publisher.cpp
+++ b/tests/DCPS/TransientLocalTest/publisher.cpp
@@ -105,7 +105,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
           ACE_TEXT("(%P|%t) ERROR: get_publication_matched_status\n")));
         break;
       } else if (pubmatched.current_count == 0 && pubmatched.total_count == 4) {
-        // subscriber has come and gone
+        // subscribers have come and gone.
         break;
       }
 

--- a/tests/DCPS/TransientLocalTest/subscriber.cpp
+++ b/tests/DCPS/TransientLocalTest/subscriber.cpp
@@ -113,12 +113,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       cerr << "create_datareader durable success." << endl;
     }
 
-    const int expected = 50;
-    while (listener_servant->num_reads() < expected) {
+    while (listener_servant->durable_reads() < 50 ||
+           listener_servant->volatile_reads() < 10) {
       ACE_OS::sleep(1);
     }
 
-    ok = listener_servant->ok_;
+    ok = listener_servant->ok();
 
     if (!CORBA::is_nil(participant)) {
       participant->delete_contained_entities();

--- a/tests/DCPS/UnionTopic/UnionTopic.cpp
+++ b/tests/DCPS/UnionTopic/UnionTopic.cpp
@@ -256,6 +256,16 @@ basic_test(DDS::DomainParticipant_var& participant, DDS::Topic_var& topic)
         i->first.c_str(), retcode_to_string(rc)), false);
     }
   }
+
+  DDS::Duration_t timeout =
+    { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+  rc = writer_i->wait_for_acknowledgments(timeout);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")
+      ACE_TEXT("Unable to wait for acknowledgements: %C\n"),
+      retcode_to_string(rc)), false);
+  }
+
   rc = writer_i->dispose(news, DDS::HANDLE_NIL);
   if (rc != DDS::RETCODE_OK) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%N:%l basic_test() ERROR: ")

--- a/tests/security/attributes/Args.cpp
+++ b/tests/security/attributes/Args.cpp
@@ -25,7 +25,6 @@ Args::Args()
  , domain_(0)
  , topic_name_("OD_OA_OM_OD")
  , reliable_(false)
- , wait_for_acks_(false)
  , num_messages_(DEFAULT_NUM_MESSAGES)
  , expected_result_(0)
  , timeout_(0)
@@ -124,9 +123,6 @@ int Args::parse_args(int argc, ACE_TCHAR* argv[], Args& args)
       break;
     case 'r':
       args.reliable_ = true;
-      break;
-    case 'w':
-      args.wait_for_acks_ = true;
       break;
     case '?':
     default:

--- a/tests/security/attributes/Args.h
+++ b/tests/security/attributes/Args.h
@@ -35,7 +35,6 @@ struct Args {
   std::vector<std::string> partition_;
 
   bool reliable_;
-  bool wait_for_acks_;
 
   int num_messages_;
 

--- a/tests/security/attributes/publisher.cpp
+++ b/tests/security/attributes/publisher.cpp
@@ -210,17 +210,10 @@ int run_test(int argc, ACE_TCHAR *argv[], Args& my_args)
       std::cerr << "Writer finished " << std::endl;
       writer->end();
 
-      if (my_args.wait_for_acks_) {
-        std::cerr << "Writer wait for ACKS" << std::endl;
-        ACE_Time_Value difference = deadline - ACE_OS::gettimeofday();
-        DDS::Duration_t ack_timeout = {static_cast<CORBA::Long>(difference.sec()), static_cast<CORBA::ULong>(difference.usec() * 1000)};
-        dw->wait_for_acknowledgments(ack_timeout);
-      } else {
-        // let any missed multicast/rtps messages get re-delivered
-        std::cerr << "Writer wait small time" << std::endl;
-        ACE_Time_Value small_time(0, 250000);
-        ACE_OS::sleep(small_time);
-      }
+      std::cerr << "Writer wait for ACKS" << std::endl;
+      ACE_Time_Value difference = deadline - ACE_OS::gettimeofday();
+      DDS::Duration_t ack_timeout = {static_cast<CORBA::Long>(difference.sec()), static_cast<CORBA::ULong>(difference.usec() * 1000)};
+      dw->wait_for_acknowledgments(ack_timeout);
 
       std::cerr << "deleting DW" << std::endl;
       delete writer;

--- a/tests/transport/RtpsUtils.h
+++ b/tests/transport/RtpsUtils.h
@@ -21,7 +21,7 @@ inline OpenDDS::RTPS::SequenceNumber_t toSN(unsigned int n)
   return sn;
 }
 
-inline OpenDDS::DCPS::Message_Block_Ptr
+inline ACE_Message_Block*
 buildHeartbeat(const OpenDDS::DCPS::EntityId_t& writer, const OpenDDS::RTPS::Header& header,
                const SequencePair& sequenceRange, int& count,
                const OpenDDS::DCPS::RepoId& reader = OpenDDS::DCPS::GUID_UNKNOWN)
@@ -50,5 +50,5 @@ buildHeartbeat(const OpenDDS::DCPS::EntityId_t& writer, const OpenDDS::RTPS::Hea
   if (!ok) {
     mb.reset();
   }
-  return mb;
+  return mb.release();
 }

--- a/tests/transport/RtpsUtils.h
+++ b/tests/transport/RtpsUtils.h
@@ -52,4 +52,3 @@ buildHeartbeat(const OpenDDS::DCPS::EntityId_t& writer, const OpenDDS::RTPS::Hea
   }
   return mb;
 }
-

--- a/tests/transport/RtpsUtils.h
+++ b/tests/transport/RtpsUtils.h
@@ -1,0 +1,55 @@
+// Utilities for writing RTPS messages directly to a socket in order to
+// test the rtps_udp transport
+
+#include <dds/DCPS/RTPS/MessageTypes.h>
+#include <dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h>
+
+#include <dds/DCPS/GuidUtils.h>
+#include <dds/DCPS/Message_Block_Ptr.h>
+
+#include <ace/Message_Block.h>
+
+#define INITIALIZE_GUID_PREFIX(A)                 \
+  (A)[0], (A)[1], (A)[2], (A)[3], (A)[4], (A)[5], \
+  (A)[6], (A)[7], (A)[8], (A)[9], (A)[10], (A)[11]
+
+typedef std::pair<OpenDDS::RTPS::SequenceNumber_t, OpenDDS::RTPS::SequenceNumber_t> SequencePair;
+
+inline OpenDDS::RTPS::SequenceNumber_t toSN(unsigned int n)
+{
+  const OpenDDS::RTPS::SequenceNumber_t sn = {0, n};
+  return sn;
+}
+
+inline OpenDDS::DCPS::Message_Block_Ptr
+buildHeartbeat(const OpenDDS::DCPS::EntityId_t& writer, const OpenDDS::RTPS::Header& header,
+               const SequencePair& sequenceRange, int& count,
+               const OpenDDS::DCPS::RepoId& reader = OpenDDS::DCPS::GUID_UNKNOWN)
+{
+  using namespace OpenDDS::DCPS;
+  using namespace OpenDDS::RTPS;
+  const InfoDestinationSubmessage infoDst = {
+    {INFO_DST, FLAG_E, INFO_DST_SZ},
+    {INITIALIZE_GUID_PREFIX(reader.guidPrefix)}
+  };
+  const HeartBeatSubmessage hb = {
+    {HEARTBEAT, FLAG_E, 0},
+    reader.entityId, writer, sequenceRange.first, sequenceRange.second,
+    {++count}
+  };
+  size_t size = RTPSHDR_SZ, padding = 0;
+  if (reader != GUID_UNKNOWN) {
+    size += SMHDR_SZ + INFO_DST_SZ;
+  }
+  gen_find_size(hb, size, padding);
+  Message_Block_Ptr mb(new ACE_Message_Block(size + padding));
+  Serializer ser(mb.get(), !ACE_CDR_BYTE_ORDER, Serializer::ALIGN_CDR);
+  const bool ok = (ser << header) &&
+    (reader == GUID_UNKNOWN || ser << infoDst) &&
+    (ser << hb);
+  if (!ok) {
+    mb.reset();
+  }
+  return mb;
+}
+

--- a/tests/transport/best_effort_reader/SocketWriter.h
+++ b/tests/transport/best_effort_reader/SocketWriter.h
@@ -20,7 +20,8 @@ public:
   void addDestination(const ACE_INET_Addr& dest);
   bool write(CORBA::ULong seqN, const TestMsg& msg) const;
   bool write(CORBA::ULong seqN, const TestMsg& msg, const OpenDDS::DCPS::RepoId& directedWrite) const;
-  bool writeHeartbeat(CORBA::ULong seqN, CORBA::Long heartbeatCount) const;
+  bool writeHeartbeat(CORBA::ULong seqN, CORBA::Long heartbeatCount,
+                      const OpenDDS::DCPS::RepoId& reader = OpenDDS::DCPS::GUID_UNKNOWN) const;
 
 private:
   static const bool hostIsBigEndian = !ACE_CDR_BYTE_ORDER;
@@ -32,7 +33,6 @@ private:
 
   OpenDDS::RTPS::InfoTimestampSubmessage timeSubMsg() const;
   OpenDDS::RTPS::DataSubmessage dataSubMsg(CORBA::ULong seqN, const TestMsg& msg) const;
-  OpenDDS::RTPS::HeartBeatSubmessage heartBeatSubMsg(CORBA::ULong seqN, CORBA::Long heartbeatCount) const;
 
   size_t msgSize(const OpenDDS::RTPS::InfoTimestampSubmessage& t,
                  const OpenDDS::RTPS::DataSubmessage& d, const TestMsg& m) const;

--- a/tests/transport/best_effort_reader/publisher.cpp
+++ b/tests/transport/best_effort_reader/publisher.cpp
@@ -16,23 +16,31 @@ public:
     SocketWriter sw2(AppConfig::writerId[1], config.getHostAddress());
     SocketWriter sw3(AppConfig::writerId[2], config.getHostAddress());
 
-    bool r = sw1.writeHeartbeat(1, 1);
-    r = r && sw2.writeHeartbeat(1, 1);
-    r = r && sw3.writeHeartbeat(1, 1);
+    unsigned int seq = 2;
+    bool r = sw1.writeHeartbeat(seq, 1, AppConfig::readerId[0]);
 
-    r = r && sw1.write(2, TestMsg(10, "1-2"));
-    r = r && sw2.write(2, TestMsg(10, "2-2"));
-    r = r && sw3.write(2, TestMsg(10, "3-2"));
+    r = r && sw2.writeHeartbeat(seq, 1, AppConfig::readerId[0]);
+    r = r && sw2.writeHeartbeat(seq, 1, AppConfig::readerId[1]);
 
-    r = r && sw1.write(2, TestMsg(10, "1-2 Duplicate"));
-    r = r && sw2.write(2, TestMsg(10, "2-2 Duplicate"));
-    r = r && sw3.write(2, TestMsg(10, "3-2 Duplicate"));
+    r = r && sw3.writeHeartbeat(seq, 1, AppConfig::readerId[0]);
+    r = r && sw3.writeHeartbeat(seq, 1, AppConfig::readerId[1]);
+    r = r && sw3.writeHeartbeat(seq, 1, AppConfig::readerId[2]);
 
-    r = r && sw3.write(3, TestMsg(10, "3-3"));
+    r = r && sw1.write(seq, TestMsg(10, "1-2"));
+    r = r && sw2.write(seq, TestMsg(10, "2-2"));
+    r = r && sw3.write(seq, TestMsg(10, "3-2"));
 
-    r = r && sw1.write(4, TestMsg(99, "1-4 end"));
-    r = r && sw2.write(4, TestMsg(99, "2-4 end"));
-    r = r && sw3.write(4, TestMsg(99, "3-4 end"));
+    r = r && sw1.write(seq, TestMsg(10, "1-2 Duplicate"));
+    r = r && sw2.write(seq, TestMsg(10, "2-2 Duplicate"));
+    r = r && sw3.write(seq, TestMsg(10, "3-2 Duplicate"));
+
+    ++seq;
+    r = r && sw3.write(seq, TestMsg(10, "3-3"));
+
+    ++seq;
+    r = r && sw1.write(seq, TestMsg(99, "1-4 end"));
+    r = r && sw2.write(seq, TestMsg(99, "2-4 end"));
+    r = r && sw3.write(seq, TestMsg(99, "3-4 end"));
 
     return (r ? 0 : 1);
   }

--- a/tests/transport/rtps_directed_write/AppConfig.h
+++ b/tests/transport/rtps_directed_write/AppConfig.h
@@ -16,6 +16,8 @@ public:
   ~AppConfig();
 
   const OpenDDS::DCPS::RepoId& getPubWtrId() const { return pubWtrId; }
+
+  size_t nReaders() const { return sizeof subRdrId / sizeof subRdrId[0]; }
   const OpenDDS::DCPS::RepoId& getSubRdrId(int i) const { return subRdrId[i]; }
 
   ACE_INET_Addr getHostAddress() const;

--- a/tests/transport/rtps_reliability/rtps_reliability.cpp
+++ b/tests/transport/rtps_reliability/rtps_reliability.cpp
@@ -6,6 +6,8 @@
 #include "dds/DCPS/transport/rtps_udp/RtpsUdp.h"
 #endif
 
+#include "../RtpsUtils.h"
+
 #include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include "dds/DCPS/transport/framework/TransportSendListener.h"
 #include "dds/DCPS/transport/framework/TransportClient.h"
@@ -193,8 +195,7 @@ struct TestParticipant: ACE_Event_Handler {
   {
     const Header hdr = {
       {'R', 'T', 'P', 'S'}, PROTOCOLVERSION, VENDORID_OPENDDS,
-      {prefix[0], prefix[1], prefix[2], prefix[3], prefix[4], prefix[5],
-       prefix[6], prefix[7], prefix[8], prefix[9], prefix[10], prefix[11]}
+      {INITIALIZE_GUID_PREFIX(prefix)}
     };
     std::memcpy(&hdr_, &hdr, sizeof(Header));
     for (CORBA::ULong i = 0; i < FRAG_SIZE; ++i) {
@@ -350,35 +351,16 @@ struct TestParticipant: ACE_Event_Handler {
 
   bool send_hb(const OpenDDS::DCPS::EntityId_t& writer,
                const SequenceNumber_t& firstSN, const SequenceNumber_t& lastSN,
-               const ACE_INET_Addr& send_to)
+               const ACE_INET_Addr& send_to, const RepoId& reader = GUID_UNKNOWN)
   {
-#ifdef __SUNPRO_CC
-    HeartBeatSubmessage hb;
-    hb.smHeader.submessageId = HEARTBEAT;
-    hb.smHeader.flags = FLAG_E;
-    hb.smHeader.submessageLength = 0;
-    hb.readerId = ENTITYID_UNKNOWN;
-    hb.writerId = writer;
-    hb.firstSN = firstSN;
-    hb.lastSN = lastSN;
-    hb.count.value = ++heartbeat_count_;
-#else
-    const HeartBeatSubmessage hb = {
-      {HEARTBEAT, FLAG_E, 0},
-      ENTITYID_UNKNOWN, writer, firstSN, lastSN, {++heartbeat_count_}
-    };
-#endif
-    size_t size = 0, padding = 0;
-    gen_find_size(hdr_, size, padding);
-    gen_find_size(hb, size, padding);
-    ACE_Message_Block mb(size + padding);
-    Serializer ser(&mb, host_is_bigendian, Serializer::ALIGN_CDR);
-    bool ok = (ser << hdr_) && (ser << hb);
-    if (!ok) {
+    const Message_Block_Ptr mb(buildHeartbeat(writer, hdr_,
+                                              std::make_pair(firstSN, lastSN),
+                                              heartbeat_count_, reader));
+    if (!mb) {
       ACE_DEBUG((LM_DEBUG, "ERROR: failed to serialize heartbeat\n"));
       return false;
     }
-    return send(mb, send_to);
+    return send(*mb, send_to);
   }
 
   bool send_hbfrag(const OpenDDS::DCPS::EntityId_t& writer,
@@ -863,6 +845,10 @@ bool run_test()
 
   TestParticipant part1(part1_sock, reader1.guidPrefix, reader1.entityId);
   SequenceNumber_t first_seq = {0, 1}, seq = first_seq;
+  if (!part1.send_hb(writer1.entityId, seq, seq, part2_addr, reader2)) {
+    return false;
+  }
+
   if (!part1.send_data(writer1.entityId, seq, part2_addr)) {
     return false;
   }


### PR DESCRIPTION
Problem
-------

For reliability to work (see below), the reader must have some
commitment from the writer that it will receive all samples past a
certain sequence number.  That sequence number defines the beginnning
of the reliable range.  For durable reliable readers, the reliable
range begins at one.  Non-durable readers have a choice.  The current
implementation picks the lastSN + 1 offered by the writer based on the
first heartbeat it receives.

However, given network delay, reordering, etc., the minimum sequence
number the writer has for reliable resend may be greater than the
sequence number picked by the reader.  In this case, the reader will
receive a gap to catch up.  If the reader has received some data after
the beginning of it's reliable range, then that data will be delivered
(still in order but stopping, otherwise, no gap).  If there is gap,
the application reader uses  monotonically increasing counter, then it
detect a missing sample.

Solution
--------

The writer and the reader have to agree on the beginning of the
reliable range.  The writer has to offer a starting sequence
number (through a heartbeat) and the reader has to accept it (through
an acknack).  In order to offer, the writer must not allow changes to
the send buffer until the reader has accepted the offer.  This is
accomplished by not removing data from the send buffer while offers
are outstanding, i.e., there are pre-associated readers.  The reader
has to accept the sequence number (or a subsequent sequence number)
offered by the writer.  To do this, logic was added to initialize the
reader on a directed heartbeat.  This breaks interoperability.

Note
----

There are a couple of use cases where agreement on the beginning of
the reliable range is important.  First, tests and applications often
use the publication matched status as a signal that every subsequent
sample will fall in the reliable range.  Thus, there is a guarantee
that subsequent samples will be delivered to the reader.  Second, the
participant volatile secure (PVS) writer for DDS Security is reliable
but not durable.  Thus, the PVS writer must defer writting samples
until the reliable range has started.  Thus, the PVS writer uses the
same technique as publication matched status.