### PR TITLE
Removed %T from the log messages, the timestamp is added by the ACE l…

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -109,7 +109,7 @@ namespace OpenDDS {
           tid_ = static_cast<unsigned long>(osx_tid);
         } else {
           tid_ = 0;
-          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DcpsUpcalls::svc. Error getting OSX thread id\n.")));
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DcpsUpcalls::svc. Error getting OSX thread id\n")));
         }
 #else
         tid_ = ACE_OS::thr_self();

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -109,7 +109,7 @@ namespace OpenDDS {
           tid_ = static_cast<unsigned long>(osx_tid);
         } else {
           tid_ = 0;
-          ACE_ERROR((LM_ERROR, ACE_TEXT("%T (%P|%t) DcpsUpcalls::svc. Error getting OSX thread id\n.")));
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DcpsUpcalls::svc. Error getting OSX thread id\n.")));
         }
 #else
         tid_ = ACE_OS::thr_self();
@@ -141,7 +141,7 @@ namespace OpenDDS {
               if (status_) {
                 if (DCPS_debug_level > 4) {
                   ACE_DEBUG((LM_DEBUG,
-                            "%T (%P|%t) DcpsUpcalls::svc. Updating thread status.\n"));
+                            "(%P|%t) DcpsUpcalls::svc. Updating thread status.\n"));
                 }
                 ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status_->lock, -1);
                 status_->map[key_] = now;
@@ -174,7 +174,7 @@ namespace OpenDDS {
           if (status_) {
             if (DCPS_debug_level > 4) {
               ACE_DEBUG((LM_DEBUG,
-                        "%T (%P|%t) DcpsUpcalls::writer_done. Updating thread status.\n"));
+                        "(%P|%t) DcpsUpcalls::writer_done. Updating thread status.\n"));
             }
             ACE_WRITE_GUARD(ACE_Thread_Mutex, g, status_->lock);
             status_->map[key_] = now;

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -34,7 +34,7 @@ DomainParticipantFactoryImpl::~DomainParticipantFactoryImpl()
 {
   if (DCPS_debug_level > 0) {
     ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) DomainParticipantFactoryImpl::"
+               "(%P|%t) DomainParticipantFactoryImpl::"
                "~DomainParticipantFactoryImpl()\n"));
   }
 }

--- a/dds/DCPS/MessageTracker.cpp
+++ b/dds/DCPS/MessageTracker.cpp
@@ -78,12 +78,12 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
   if (report) {
     if (deadline_ptr) {
       ACE_DEBUG((LM_DEBUG,
-                ACE_TEXT("%T (%P|%t) MessageTracker::wait_messages_pending ")
+                ACE_TEXT("(%P|%t) MessageTracker::wait_messages_pending ")
                 ACE_TEXT("from source=%C will wait until %#T.\n"),
                 msg_src_.c_str(), deadline_ptr));
     } else {
       ACE_DEBUG((LM_DEBUG,
-                ACE_TEXT("%T (%P|%t) MessageTracker::wait_messages_pending ")
+                ACE_TEXT("(%P|%t) MessageTracker::wait_messages_pending ")
                 ACE_TEXT("from source=%C will wait with no timeout.\n")));
     }
   }
@@ -104,7 +104,7 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
   }
   if (report) {
     ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) MessageTracker::wait_messages_pending done\n"));
+               "(%P|%t) MessageTracker::wait_messages_pending done\n"));
   }
 }
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3597,7 +3597,7 @@ void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& /*n
 #ifndef DDS_HAS_MINIMUM_BIT
   if (DCPS::DCPS_debug_level > 4) {
     ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) Spdp::SpdpTransport::thread_status_task(): Updating internal thread status BIT.\n"));
+               "(%P|%t) Spdp::SpdpTransport::thread_status_task(): Updating internal thread status BIT.\n"));
   }
 
   const DCPS::RepoId guid = outer_->guid();
@@ -3620,7 +3620,7 @@ void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& /*n
     } else {
       // Not necessarily and error. App could be shutting down.
       ACE_DEBUG((LM_DEBUG,
-                 "%T (%P|%t) Spdp::ThreadStatusHandler: Could not get thread data reader.\n"));
+                 "(%P|%t) Spdp::ThreadStatusHandler: Could not get thread data reader.\n"));
     }
   }
 #endif /* DDS_HAS_MINIMUM_BIT */

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -165,7 +165,7 @@ OpenDDS::DCPS::ReactorTask::svc()
         tid = static_cast<unsigned long>(osx_tid);
       } else {
         tid = 0;
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ReactorTask::svc. Error getting OSX thread id\n.")));
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ReactorTask::svc. Error getting OSX thread id\n")));
       }
 #elif !defined (OPENDDS_SAFETY_PROFILE)
       ACE_thread_t tid = ACE_OS::thr_self();

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -165,7 +165,7 @@ OpenDDS::DCPS::ReactorTask::svc()
         tid = static_cast<unsigned long>(osx_tid);
       } else {
         tid = 0;
-        ACE_ERROR((LM_ERROR, ACE_TEXT("%T (%P|%t) ReactorTask::svc. Error getting OSX thread id\n.")));
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ReactorTask::svc. Error getting OSX thread id\n.")));
       }
 #elif !defined (OPENDDS_SAFETY_PROFILE)
       ACE_thread_t tid = ACE_OS::thr_self();
@@ -186,7 +186,7 @@ OpenDDS::DCPS::ReactorTask::svc()
         if (thread_status_) {
           if (DCPS_debug_level > 4) {
             ACE_DEBUG((LM_DEBUG,
-                       "%T (%P|%t) ReactorTask::svc. Updating thread status.\n"));
+                       "(%P|%t) ReactorTask::svc. Updating thread status.\n"));
           }
           ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, thread_status_->lock, -1);
           thread_status_->map[key] = MonotonicTimePoint::now();

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -216,7 +216,7 @@ Service_Participant::~Service_Participant()
 
   if (DCPS_debug_level > 0) {
     ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) Service_Participant::~Service_Participant()\n"));
+               "(%P|%t) Service_Participant::~Service_Participant()\n"));
   }
 }
 
@@ -2764,13 +2764,13 @@ NetworkConfigMonitor_rch Service_Participant::network_config_monitor()
 #ifdef OPENDDS_LINUX_NETWORK_CONFIG_MONITOR
     if (DCPS_debug_level > 0) {
       ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) Service_Participant::network_config_monitor(). Creating LinuxNetworkConfigMonitor\n"));
+               "(%P|%t) Service_Participant::network_config_monitor(). Creating LinuxNetworkConfigMonitor\n"));
     }
     network_config_monitor_ = make_rch<LinuxNetworkConfigMonitor>(reactor_task_.interceptor());
 #elif defined(OPENDDS_NETWORK_CONFIG_MODIFIER)
     if (DCPS_debug_level > 0) {
       ACE_DEBUG((LM_DEBUG,
-               "%T (%P|%t) Service_Participant::network_config_monitor(). Creating NetworkConfigModifier\n"));
+               "(%P|%t) Service_Participant::network_config_monitor(). Creating NetworkConfigModifier\n"));
     }
     network_config_monitor_ = make_rch<NetworkConfigModifier>();
 #endif

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -118,7 +118,7 @@ public:
       tid = static_cast<unsigned long>(osx_tid);
     } else {
       tid = 0;
-      ACE_ERROR((LM_ERROR, ACE_TEXT("%T (%P|%t) QueueTaskBase::svc. Error getting OSX thread id\n.")));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) QueueTaskBase::svc. Error getting OSX thread id\n.")));
     }
 #elif !defined (OPENDDS_SAFETY_PROFILE)
     ACE_thread_t tid = thr_id_;
@@ -154,7 +154,7 @@ public:
                 if (status) {
                   if (DCPS_debug_level > 4) {
                     ACE_DEBUG((LM_DEBUG,
-                              "%T (%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
+                              "(%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
                   }
                   ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, status->lock, -1);
                   status->map[key] = now;

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -118,7 +118,7 @@ public:
       tid = static_cast<unsigned long>(osx_tid);
     } else {
       tid = 0;
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) QueueTaskBase::svc. Error getting OSX thread id\n.")));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) QueueTaskBase::svc. Error getting OSX thread id\n")));
     }
 #elif !defined (OPENDDS_SAFETY_PROFILE)
     ACE_thread_t tid = thr_id_;

--- a/tests/DCPS/ManyToMany/Writer.cpp
+++ b/tests/DCPS/ManyToMany/Writer.cpp
@@ -33,7 +33,7 @@ Writer::write()
     const unsigned int subscribers = options_.num_sub_processes *
       options_.num_sub_participants * options_.num_readers;
     ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("%T (%P|%t) Writers wait for %d subscribers\n"),
+               ACE_TEXT("(%P|%t) Writers wait for %d subscribers\n"),
                subscribers));
 
     // Block until Subscriber is available
@@ -56,7 +56,7 @@ Writer::write()
       handles.push_back(message_dw->register_instance(writer->message));
     }
 
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Writers matched\n")));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Writers matched\n")));
 
     const ACE_Time_Value delay(options_.delay_msec / 1000,
                                (options_.delay_msec % 1000) * 1000);
@@ -74,7 +74,7 @@ Writer::write()
         ++writer->message.sample_id;
 
         ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("%T (%P|%t) Writing Message: process_id = %d ")
+                   ACE_TEXT("(%P|%t) Writing Message: process_id = %d ")
                    ACE_TEXT("participant_id = %d ")
                    ACE_TEXT("writer_id = %d ")
                    ACE_TEXT("sample_id = %d\n"),
@@ -95,7 +95,7 @@ Writer::write()
       }
     }
 
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Messages written, waiting for readers to disconnect\n")));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Messages written, waiting for readers to disconnect\n")));
 
     // Let readers disconnect first, once they either get the data or
     // give up and time-out.  This allows the writer to be alive while

--- a/tests/DCPS/ManyToMany/publisher.cpp
+++ b/tests/DCPS/ManyToMany/publisher.cpp
@@ -165,18 +165,18 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       status = writer.write();
     }
 
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Writers Done\n")));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Writers Done\n")));
 
     for (Participants::iterator part = participants.begin();
          part != participants.end();
          ++part, ++ws.message.participant_id) {
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Cleanup Participant\n")));
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Cleanup Participant\n")));
       // Clean-up!
       (*part)->delete_contained_entities();
       dpf->delete_participant(part->in());
     }
 
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Publisher shutting down\n")));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Publisher shutting down\n")));
 
     TheServiceParticipant->shutdown();
 
@@ -188,6 +188,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     return -1;
   }
 
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Publisher exiting\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Publisher exiting\n")));
   return (status ? 0 : -1);
 }

--- a/tests/DCPS/ManyToMany/subscriber.cpp
+++ b/tests/DCPS/ManyToMany/subscriber.cpp
@@ -90,13 +90,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     const std::string pid = ss.str();
 
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Created dpf\n")));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Created dpf\n")));
 
     unsigned int part_index = 0;
     for (Participants::iterator part = participants.begin();
          part != participants.end();
          ++part, ++part_index) {
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Creating participant\n")));
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Creating participant\n")));
 
       *part =
         dpf->create_participant(111,
@@ -162,7 +162,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       }
 
       for (unsigned int reader = 0; reader < options.num_readers; ++reader) {
-        ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Creating reader\n")));
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Creating reader\n")));
 
         // Create DataReader
         listener_servants.push_back(new DataReaderListenerImpl(options, pid, part_index, reader));
@@ -200,7 +200,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       delay += sleep_delay_msec;
       ACE_OS::sleep(ACE_Time_Value(0, sleep_delay_msec * 1000));
     }
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Listeners done (ran for %d msec)\n"), delay));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Listeners done (ran for %d msec)\n"), delay));
 
     if (delay >= options.total_duration_msec) {
       for (ListenerServants::const_iterator listener = listener_servants.begin();
@@ -233,6 +233,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     return -1;
   }
 
-  ACE_DEBUG((LM_DEBUG, ACE_TEXT("%T (%P|%t) Subscriber exiting\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Subscriber exiting\n")));
   return ok ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
…ogging framework already when the logging flags are setup

    * dds/DCPS/transport/framework/QueueTaskBase_T.h:
    * tests/DCPS/ManyToMany/Writer.cpp:
    * tests/DCPS/ManyToMany/publisher.cpp:
    * tests/DCPS/ManyToMany/subscriber.cpp: