### PR TITLE
Use size_t to get rid of some c-style casts

### DIFF
--- a/tests/DCPS/Messenger/Args.h
+++ b/tests/DCPS/Messenger/Args.h
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <cstdlib>
 
-const int num_messages = 40;
+const size_t num_messages = 40;
 extern bool reliable;
 extern bool wait_for_acks;
 

--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -205,8 +205,8 @@ bool DataReaderListenerImpl::is_valid() const
     valid_count = false;
   }
   // if didn't receive all the messages (for reliable transport) or didn't receive even get 1/4, then report error
-  else if ((int)counts_.size() < num_messages &&
-           (reliable_ || (int)(counts_.size() * 4) < num_messages)) {
+  else if (counts_.size() < num_messages &&
+           (reliable_ || (counts_.size() * 4) < num_messages)) {
     std::cout << "ERROR: received " << counts_.size() << " messages, but expected " << num_messages << std::endl;
     valid_count = false;
   }

--- a/tests/DCPS/Messenger/Writer.cpp
+++ b/tests/DCPS/Messenger/Writer.cpp
@@ -106,7 +106,7 @@ Writer::svc()
     message.text         = "Worst. Movie. Ever.";
     message.count        = 0;
 
-    for (int i = 0; i < num_messages; i++) {
+    for (size_t i = 0; i < num_messages; i++) {
       DDS::ReturnCode_t error;
       do {
         error = message_dw->write(message, handle);
@@ -125,7 +125,7 @@ Writer::svc()
     e._tao_print_exception("Exception caught in svc():");
   }
 
-  finished_instances_ ++;
+  ++finished_instances_;
 
   return 0;
 }


### PR DESCRIPTION
    * tests/DCPS/Messenger/Args.h:
    * tests/DCPS/Messenger/DataReaderListener.cpp:
    * tests/DCPS/Messenger/Writer.cpp: