### PR TITLE
Bench2: Make worker's WriteAction use infinite wait_for_acks on stop()

### DIFF
--- a/performance-tests/bench_2/worker/WriteAction.h
+++ b/performance-tests/bench_2/worker/WriteAction.h
@@ -37,6 +37,7 @@ protected:
   size_t filter_class_start_value_;
   size_t filter_class_stop_value_;
   size_t filter_class_increment_;
+  DDS::Duration_t final_wait_for_ack_;
 };
 
 }

--- a/performance-tests/bench_2/worker/configs/simple_action_config.json
+++ b/performance-tests/bench_2/worker/configs/simple_action_config.json
@@ -84,6 +84,9 @@
         },
         { "name": "write_frequency",
           "value": { "_d": "PVK_DOUBLE", "double_prop": 2.0 }
+        },
+        { "name": "final_wait_for_ack",
+          "value": { "_d": "PVK_DOUBLE", "double_prop": 2.7 }
         }
       ]
     }


### PR DESCRIPTION
... but make it configurable so we can change as needed when testing needs demand it.