### PR TITLE
clang warning fixes

### DIFF
--- a/performance-tests/bench_2/test_controller/main.cpp
+++ b/performance-tests/bench_2/test_controller/main.cpp
@@ -7,7 +7,13 @@
 
 #ifdef __GNUC__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#  if defined(__has_warning)
+#    if __has_warning("-Wclass-memaccess")
+#      pragma GCC diagnostic ignored "-Wclass-memaccess"
+#    endif
+#  elif __GNUC__ > 7
+#    pragma GCC diagnostic ignored "-Wclass-memaccess"
+#  endif
 #endif
 #include "BenchTypeSupportImpl.h"
 #ifdef __GNUC__

--- a/performance-tests/bench_2/test_controller/main.cpp
+++ b/performance-tests/bench_2/test_controller/main.cpp
@@ -6,7 +6,7 @@
 #include <json_conversion.h>
 
 #ifdef __GNUC__
-#pragma GCC diagnostic push
+#  pragma GCC diagnostic push
 #  if defined(__has_warning)
 #    if __has_warning("-Wclass-memaccess")
 #      pragma GCC diagnostic ignored "-Wclass-memaccess"

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -89,7 +89,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_TString command_line = stubCmd + ACE_TEXT(" ") + stubArgs;
       ACE_DEBUG((LM_INFO, ACE_TEXT("stub command line: %s\n"), command_line.c_str()));
 
-      if (options.command_line(ACE_TEXT("%s"), command_line.c_str()) != 0)
+      if (options.command_line("%s", ACE_TEXT_ALWAYS_CHAR(command_line.c_str())) != 0)
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT ("%p\n"), ACE_TEXT("set options")) ,-1);
 
       if (stub_ready_filename.empty())

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -89,7 +89,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_TString command_line = stubCmd + ACE_TEXT(" ") + stubArgs;
       ACE_DEBUG((LM_INFO, ACE_TEXT("stub command line: %s\n"), command_line.c_str()));
 
-      if (options.command_line(command_line.c_str()) != 0)
+      if (options.command_line(ACE_TEXT_CHAR_TO_TCHAR(command_line.c_str())) != 0)
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT ("%p\n"), ACE_TEXT("set options")) ,-1);
 
       if (stub_ready_filename.empty())

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -89,7 +89,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_TString command_line = stubCmd + ACE_TEXT(" ") + stubArgs;
       ACE_DEBUG((LM_INFO, ACE_TEXT("stub command line: %s\n"), command_line.c_str()));
 
-      if (options.command_line(ACE_TEXT(command_line.c_str())) != 0)
+      if (options.command_line(ACE_TEXT("%s"), command_line.c_str()) != 0)
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT ("%p\n"), ACE_TEXT("set options")) ,-1);
 
       if (stub_ready_filename.empty())

--- a/tests/DCPS/TcpReconnect/publisher.cpp
+++ b/tests/DCPS/TcpReconnect/publisher.cpp
@@ -89,7 +89,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       ACE_TString command_line = stubCmd + ACE_TEXT(" ") + stubArgs;
       ACE_DEBUG((LM_INFO, ACE_TEXT("stub command line: %s\n"), command_line.c_str()));
 
-      if (options.command_line(ACE_TEXT_CHAR_TO_TCHAR(command_line.c_str())) != 0)
+      if (options.command_line(ACE_TEXT(command_line.c_str())) != 0)
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT ("%p\n"), ACE_TEXT("set options")) ,-1);
 
       if (stub_ready_filename.empty())


### PR DESCRIPTION
OpenDDS/tests/DCPS/TcpReconnect/publisher.cpp:92:32: warning: format string is not a string literal (potentially insecure)
OpenDDS/performance-tests/bench_2/test_controller/main.cpp:10:32: warning: unknown warning group '-Wclass-memaccess'
OpenDDS/performance-tests/bench_2/worker/main.cpp:16:32: warning: unknown warning group '-Wclass-memaccess', ignored [-Wunknown-warning-option]
