### PR TITLE
Remove workaround for ACE 6.0

### DIFF
--- a/dds/DCPS/RTPS/GuidGenerator.cpp
+++ b/dds/DCPS/RTPS/GuidGenerator.cpp
@@ -36,10 +36,6 @@
 # include <winsock2.h>
 # include <iphlpapi.h>
 # include "ace/Version.h"
-// older versions of ACE don't link to IPHlpApi.Lib, see acedefaults.mpb
-# if ACE_MAJOR_VERSION == 6 && ACE_MINOR_VERSION == 0 && defined _MSC_VER
-#  pragma comment(lib, "IPHlpApi.Lib")
-# endif
 #endif
 
 #ifdef ACE_VXWORKS


### PR DESCRIPTION
    * dds/DCPS/RTPS/GuidGenerator.cpp: