### PR TITLE
Generate check that the generated header still matches with the current OpenDDS version

### DIFF
--- a/dds/idl/be_produce.cpp
+++ b/dds/idl/be_produce.cpp
@@ -196,6 +196,17 @@ void postprocess(const char* fn, ostringstream& content,
     if (which == BE_GlobalData::STREAM_H) {
       out << "#include \"dds/DCPS/Definitions.h\"\n";
       out << "#include \"dds/DdsDcpsC.h\"\n";
+      out << "#include \"dds/Version.h\"\n";
+      #define DDS_MAJOR_VERSION 3
+#define DDS_MINOR_VERSION 15
+#define DDS_MICRO_VERSION 0
+
+      out << "#if DDS_MAJOR_VERSION != " << DDS_MAJOR_VERSION
+          << " || DDS_MINOR_VERSION != " << DDS_MINOR_VERSION
+          << " || DDS_MICRO_VERSION != " << DDS_MICRO_VERSION
+          << "\n";
+      out << "#error This file should be regenerated with opendds_idl\n";
+      out << "#endif\n";
     }
   }
   break;

--- a/dds/idl/be_produce.cpp
+++ b/dds/idl/be_produce.cpp
@@ -197,10 +197,6 @@ void postprocess(const char* fn, ostringstream& content,
       out << "#include \"dds/DCPS/Definitions.h\"\n";
       out << "#include \"dds/DdsDcpsC.h\"\n";
       out << "#include \"dds/Version.h\"\n";
-      #define DDS_MAJOR_VERSION 3
-#define DDS_MINOR_VERSION 15
-#define DDS_MICRO_VERSION 0
-
       out << "#if DDS_MAJOR_VERSION != " << DDS_MAJOR_VERSION
           << " || DDS_MINOR_VERSION != " << DDS_MINOR_VERSION
           << " || DDS_MICRO_VERSION != " << DDS_MICRO_VERSION


### PR DESCRIPTION
…current OpenDDS version. Through this check we force our users to regenerate all files with opendds_idl when they change their OpenDDS release

    * dds/idl/be_produce.cpp: