### PR TITLE
generate correct initializer for arrays in the C++11 mapping, trigge…

### DIFF
--- a/dds/idl/langmap_generator.cpp
+++ b/dds/idl/langmap_generator.cpp
@@ -1474,9 +1474,7 @@ struct Cxx11Generator : GeneratorBase
       }
     } else {
       if (af.cls_ & CL_ARRAY) {
-        // With array no initialize, gives a warning with gcc 4.8.5, for example
-        // warning: missing initializer for member ‘std::array<std::basic_string<char>, 5ul>::_M_elems’ [-Wmissing-field-initializers]
-        initializer = "";
+        initializer = "{{}}";
       }
       be_global->add_include("<utility>", BE_GlobalData::STREAM_LANG_H);
       be_global->lang_header_ <<

--- a/dds/idl/langmap_generator.cpp
+++ b/dds/idl/langmap_generator.cpp
@@ -1474,7 +1474,9 @@ struct Cxx11Generator : GeneratorBase
       }
     } else {
       if (af.cls_ & CL_ARRAY) {
-        initializer = "{}";
+        // With array no initialize, gives a warning with gcc 4.8.5, for example
+        // warning: missing initializer for member ‘std::array<std::basic_string<char>, 5ul>::_M_elems’ [-Wmissing-field-initializers]
+        initializer = "";
       }
       be_global->add_include("<utility>", BE_GlobalData::STREAM_LANG_H);
       be_global->lang_header_ <<

--- a/tests/DCPS/Compiler/C++11/idl_test1_main/main.cpp
+++ b/tests/DCPS/Compiler/C++11/idl_test1_main/main.cpp
@@ -336,6 +336,16 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
   foo2.ushrtseq()[1] = 11;
   foo2.theString() = "four";
 
+  // Check that all array members are value initialized
+  Xyz::Foo foo;
+  uint8_t oai {};
+  for (const auto& oamember : foo.ooo()) {
+    if (oamember != oai) {
+      ACE_ERROR((LM_ERROR, "OctetArray member not value initialized, %d instead of %d\n", oamember, oai));
+      failed = true;
+    }
+  }
+
   std::map<Xyz::Foo, Xyz::Foo*, Xyz::Foo_OpenDDS_KeyLessThan> foomap;
 
   if (OpenDDS::DCPS::DDSTraits<Xyz::Foo>::gen_has_key()) {


### PR DESCRIPTION
…rs a warning with gcc 4.8.5

    * dds/idl/langmap_generator.cpp:

Fixes warning given by gcc 4.8.5, for example:
[Details] /home/build/jenkins/workspace/rhel75_opendds_versioned/BUILD/DOC_ROOT/DDS/tests/DCPS/Compiler/C++11/idl_test1_lib/FooDefC.h:293:27: warning: missing initializer for member ‘std::array<std::basic_string<char>, 5ul>::_M_elems’ [-Wmissing-field-initializers]