### PR TITLE
Fixed unitialized warning on rhel75

### DIFF
--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -1721,7 +1721,7 @@ bool CryptoBuiltInImpl::decode_rtps_message(
   CryptoHeader ch;
   CryptoFooter cf;
   bool haveCryptoHeader = false, haveCryptoFooter = false;
-  const char* afterSrtpsPrefix;
+  const char* afterSrtpsPrefix = 0;
   unsigned int sizeOfAuthenticated, sizeOfEncrypted;
   const char* encrypted = 0;
 


### PR DESCRIPTION
    * dds/DCPS/security/CryptoBuiltInImpl.cpp: