### PR TITLE
SPDP stops sending auth final

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -76,9 +76,6 @@ namespace OpenDDS {
       // Requester and replier should call process handshake
       HANDSHAKE_STATE_PROCESS_HANDSHAKE,
 
-      // Requester is waiting to see a token from replier.
-      HANDSHAKE_STATE_WAITING_FOR_TOKEN,
-
       // Handshake concluded or timed out
       HANDSHAKE_STATE_DONE
     };

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3283,7 +3283,6 @@ Sedp::association_complete_i(const RepoId& localId,
   } else if (remoteId.entityId == ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER) {
     write_durable_dcps_participant_secure(remoteId);
   } else if (remoteId.entityId == ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER) {
-    spdp_.volatile_association_complete(remoteId);
     spdp_.send_participant_crypto_tokens(remoteId);
     send_builtin_crypto_tokens(remoteId);
     resend_user_crypto_tokens(remoteId);

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -109,7 +109,6 @@ public:
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
   bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
-  void volatile_association_complete(const DCPS::RepoId& sender);
   DDS::OctetSeq local_participant_data_as_octets() const;
 #endif
 


### PR DESCRIPTION
Problem
-------

The auth requester transitions immediately from
HANDSHAKE_STATE_WAITING_FOR_TOKEN to HANDSHAKE_STATE_DONE due to the
fact that association completes immediately.  This causes the
requester to only send the auth final once and not attempt any
resends.

Solution
--------

Eliminate the HANDSHAKE_STATE_WAITING_FOR_TOKEN state.  To handle
resends, a participant will send its most recent auth message when it
receives an auth message when in HANDSHAKE_STATE_DONE.