### PR TITLE
SPDP stops sending auth final

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -71,9 +71,6 @@ namespace OpenDDS {
       // Requester and replier should call process handshake
       HANDSHAKE_STATE_PROCESS_HANDSHAKE,
 
-      // Requester is waiting to see a token from replier.
-      HANDSHAKE_STATE_WAITING_FOR_TOKEN,
-
       // Handshake concluded or timed out
       HANDSHAKE_STATE_DONE
     };

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2916,7 +2916,6 @@ Sedp::association_complete_i(const RepoId& localId,
   } else if (remoteId.entityId == ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER) {
     write_durable_dcps_participant_secure(remoteId);
   } else if (remoteId.entityId == ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER) {
-    spdp_.volatile_association_complete(remoteId);
     spdp_.send_participant_crypto_tokens(remoteId);
     send_builtin_crypto_tokens(remoteId);
     resend_user_crypto_tokens(remoteId);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1025,7 +1025,7 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
       dp.auth_state_, dp.handshake_state_));
   }
 
-  if (!from_discovery && dp.handshake_state_ != DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN && dp.handshake_state_ != DCPS::HANDSHAKE_STATE_DONE) {
+  if (!from_discovery && dp.handshake_state_ != DCPS::HANDSHAKE_STATE_DONE) {
     // Ignore auth reqs when already in progress.
     return;
   }
@@ -1160,19 +1160,39 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
       dp.auth_state_, dp.handshake_state_));
   }
 
+  // We have received a handshake message from the remote which means
+  // we don't need to send the auth req.
+  dp.have_auth_req_msg_ = false;
+
+  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_DONE) {
+    // Remote is still sending (reply), so resend (the final).
+    const RepoId reader = make_id(iter->first, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER);
+    if (sedp_.write_stateless_message(dp.handshake_msg_, reader) != DDS::RETCODE_OK) {
+      if (DCPS::security_debug.auth_debug) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Unable to write handshake message.\n")));
+      }
+    } else {
+      if (DCPS::security_debug.auth_debug) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
+                   ACE_TEXT("Sent handshake message for participant: %C\n"),
+                   DCPS::LogGuid(iter->first).c_str()));
+      }
+    }
+    return;
+  }
+
   if (msg.message_identity.sequence_number <= iter->second.handshake_sequence_number_) {
     return;
   }
   iter->second.handshake_sequence_number_ = msg.message_identity.sequence_number;
 
-  // We have received a handshake message from the remote which means
-  // we don't need to send the auth req.
-  dp.have_auth_req_msg_ = false;
-
   switch (dp.handshake_state_) {
-  case DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST:
-  case DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN:
-  case DCPS::HANDSHAKE_STATE_DONE: {
+  case DCPS::HANDSHAKE_STATE_DONE:
+    // Handled above.
+    return;
+
+  case DCPS::HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST: {
     if (DCPS::security_debug.auth_warn) {
       ACE_DEBUG((LM_WARNING,
                  ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
@@ -1346,7 +1366,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
     }
     case DDS::Security::VALIDATION_OK_FINAL_MESSAGE: {
       dp.auth_state_ = DCPS::AUTH_STATE_AUTHENTICATED;
-      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN;
+      dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
       // Install the shared secret before sending the final so that
       // we are prepared to receive the crypto tokens from the
       // replier.
@@ -1366,13 +1386,8 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
         }
       }
 
-      // match_authenticated releases the lock which means iter may
-      // become invalid.
+      purge_handshake_deadlines(iter);
       match_authenticated(src_participant, iter);
-      if (iter == participants_.end()) {
-        return;
-      }
-
       return;
     }
     case DDS::Security::VALIDATION_OK: {
@@ -1541,29 +1556,10 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
     return false;
   }
 
-  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN) {
-    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
-    purge_handshake_deadlines(iter);
-  }
-
   sedp_.associate(iter->second.pdata_);
   sedp_.associate_secure_endpoints(iter->second.pdata_, participant_sec_attr_);
 
   return true;
-}
-
-void Spdp::volatile_association_complete(const RepoId& sender)
-{
-  const RepoId src_participant = make_id(sender.guidPrefix, ENTITYID_PARTICIPANT);
-  const DiscoveredParticipantIter iter = participants_.find(src_participant);
-  if (iter == participants_.end()) {
-    return;
-  }
-  DiscoveredParticipant& dp = iter->second;
-  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_WAITING_FOR_TOKEN) {
-    dp.handshake_state_ = DCPS::HANDSHAKE_STATE_DONE;
-    purge_handshake_deadlines(iter);
-  }
 }
 
 DDS::ReturnCode_t

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -108,7 +108,6 @@ public:
   void send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp);
   void handle_handshake_message(const DDS::Security::ParticipantStatelessMessage& msg);
   bool handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg);
-  void volatile_association_complete(const DCPS::RepoId& sender);
   DDS::OctetSeq local_participant_data_as_octets() const;
 #endif
 


### PR DESCRIPTION
Problem
-------

The auth requester transitions immediately from
HANDSHAKE_STATE_WAITING_FOR_TOKEN to HANDSHAKE_STATE_DONE due to the
fact that association completes immediately.  This causes the
requester to only send the auth final once and not attempt any
resends.

Solution
--------

Eliminate the HANDSHAKE_STATE_WAITING_FOR_TOKEN state.  To handle
resends, a participant will send its most recent auth message when it
receives an auth message when in HANDSHAKE_STATE_DONE.