### PR TITLE
Changed count to a unsinged long, fixes the last warnings on RHEL75 (…

### DIFF
--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -163,7 +163,7 @@ void DataReaderListenerImpl::on_sample_lost(
 
 bool DataReaderListenerImpl::is_valid() const
 {
-  size_t expected = 0;
+  CORBA::ULong expected = 0;
   Counts::const_iterator count = counts_.begin();
   bool valid_count = true;
   while (count != counts_.end() && expected < num_messages) {

--- a/tests/DCPS/Messenger/DataReaderListener.h
+++ b/tests/DCPS/Messenger/DataReaderListener.h
@@ -57,7 +57,7 @@ public:
   bool is_valid() const;
 
 private:
-  typedef std::set<CORBA::Long> Counts;
+  typedef std::set<CORBA::ULong> Counts;
 
   DDS::DataReader_var reader_;
   long                num_reads_;

--- a/tests/DCPS/Messenger/Messenger.idl
+++ b/tests/DCPS/Messenger/Messenger.idl
@@ -12,6 +12,6 @@ module Messenger {
     string subject;
     @key long subject_id;
     string text;
-    long count;
+    unsigned long count;
   };
 };


### PR DESCRIPTION
…tested manually)

    * tests/DCPS/Messenger/DataReaderListener.cpp:
    * tests/DCPS/Messenger/DataReaderListener.h:
    * tests/DCPS/Messenger/Messenger.idl: