### PR TITLE
Only use {{}} as array initializer for arrays of pod types

### DIFF
--- a/dds/idl/langmap_generator.cpp
+++ b/dds/idl/langmap_generator.cpp
@@ -1474,7 +1474,12 @@ struct Cxx11Generator : GeneratorBase
       }
     } else {
       if (af.cls_ & CL_ARRAY) {
-        initializer = "{{}}";
+        AST_Array* elem = dynamic_cast<AST_Array*>(af.act_);
+        const Classification elem_cls = classify(elem->base_type ());
+        // Only required when we have an array of pod types
+        if (elem_cls & (CL_PRIMITIVE | CL_ENUM)) {
+          initializer = "{{}}";
+        }
       }
       be_global->add_include("<utility>", BE_GlobalData::STREAM_LANG_H);
       be_global->lang_header_ <<

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -40,6 +40,11 @@ module Xyz {
   typedef short ArrayOfShorts[5];
 
   typedef short ArrayOfShorts2[3];
+  typedef short MultiDimArrayOfShorts[2][3][4];
+
+  struct StructOfMultiDimArrayOfShorts {
+    MultiDimArrayOfShorts mds;
+  };
 
   typedef string MultiDimArray[2][3][4][5];
 
@@ -54,6 +59,10 @@ module Xyz {
 
   // +4
   enum ColorX { redx, greenx, bluex, yellowx };
+  typedef ColorX ArrayOfColorX[5];
+  struct StructofArrayOfColorX {
+    ArrayOfColorX x1;
+  };
 
   const ColorX c15 = greenx;
 


### PR DESCRIPTION
    * dds/idl/langmap_generator.cpp:
    * tests/DCPS/Compiler/idl_test1_lib/FooDef.idl:

Matches the functionality as we have in TAOX11, see https://github.com/RemedyIT/taox11/blob/9719377a200a0859755c1dd4a064a2ebc9e21e2f/ridlbe/c%2B%2B11/templates/cli/hdr/struct_post.erb#L48