### PR TITLE
Add requires for googletest, makes it possible to disable the compila…

### DIFF
--- a/MPC/config/googletest.mpb
+++ b/MPC/config/googletest.mpb
@@ -1,4 +1,6 @@
 project {
+  requires += googletest
+
   expand(GTEST_ROOT) {
     $GTEST_ROOT
     $(DDS_ROOT)/tests/googletest/build/install


### PR DESCRIPTION
…tion of all tests dependent on googletest using googletest=0 through default.features

    * MPC/config/googletest.mpb: