### PR TITLE
Fixed unitialized warning on rhel75 with gcc48

### DIFF
--- a/tools/rtpsrelay/utility.h
+++ b/tools/rtpsrelay/utility.h
@@ -15,7 +15,7 @@ namespace RtpsRelay {
 
 inline std::string addr_to_string(const ACE_INET_Addr& a_addr)
 {
-  std::array<ACE_TCHAR, 256> as_string{};
+  std::array<ACE_TCHAR, 256> as_string{{}};
   if (a_addr.addr_to_string(as_string.data(), as_string.size()) != 0) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: addr_to_string failed to convert address to string")));
     return "";


### PR DESCRIPTION
    * tools/rtpsrelay/utility.h: