### PR TITLE
DRAFT: IPv6 Failed to Join Multicast Group

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2985,7 +2985,7 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
 
     // Windows 7 has an issue with different threads concurrently calling join for ipv6
     static ACE_Thread_Mutex ipv6_static_lock;
-    ACE_GUARD(ACE_Thread_Mutex, g3, ipv6_static_lock);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g3, ipv6_static_lock, false);
     if (0 == multicast_ipv6_socket_.join(multicast_ipv6_address_, 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
       joined_ipv6_interfaces_.insert(nic.name());
 
@@ -3002,7 +3002,7 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
       multicast_ipv6_address_.addr_to_string(buff, 256);
       if (DCPS::DCPS_debug_level > 0) {
         ACE_DEBUG((LM_WARNING,
-                   ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::join_multicast_group() - ")
+                   ACE_TEXT("(%P|%t) WARNING: Spdp::SpdpTransport::join_multicast_group() - ")
                    ACE_TEXT("failed to join multicast group %s on %C: %p\n"),
                    buff,
                    all_interfaces ? "all interfaces" : nic.name().c_str(),
@@ -3011,6 +3011,7 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
     }
   }
 #endif
+  return success;
 }
 
 void

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -347,7 +347,7 @@ private:
     {
       if (action_ == CMG_JOIN) {
         bool success = false;
-        for (int count = 0; count <= && !success; ++count) {
+        for (int count = 0; count <= 1 && !success; ++count) {
           success = tport_->join_multicast_group(nic_, all_interfaces_);
         }
         if (!success) {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -260,7 +260,7 @@ private:
     bool open_unicast_ipv6_socket(u_short port);
 #endif
 
-    void join_multicast_group(const DCPS::NetworkInterface& nic,
+    bool join_multicast_group(const DCPS::NetworkInterface& nic,
                               bool all_interfaces = false);
     void leave_multicast_group(const DCPS::NetworkInterface& nic);
     void add_address(const DCPS::NetworkInterface& interface,
@@ -346,7 +346,15 @@ private:
     void execute()
     {
       if (action_ == CMG_JOIN) {
-        tport_->join_multicast_group(nic_, all_interfaces_);
+        bool success = false;
+        for (int count = 0; count <= && !success; ++count) {
+          success = tport_->join_multicast_group(nic_, all_interfaces_);
+        }
+        if (!success) {
+          ACE_ERROR((LM_ERROR,
+            ACE_TEXT("(%P|%t) ERROR: Spdp::ChangeMultiCastGroup::execute() - ")
+            ACE_TEXT("multiple attempts to join multicast group failed\n")));
+        }
       } else {
         tport_->leave_multicast_group(nic_);
       }


### PR DESCRIPTION
The previous change seems to have fixed tests where it was one process with multiple participants, such as the DCPSInfoRepo test.  This change should make tests with multiple processes more reliable. 

The same problem is that multiple things are accessing the join at the same time. 