### PR TITLE
Best Effort Reader Test Fix for IPv6

### DIFF
--- a/tests/transport/best_effort_reader/SocketWriter.cpp
+++ b/tests/transport/best_effort_reader/SocketWriter.cpp
@@ -148,7 +148,14 @@ bool SocketWriter::serialize(ACE_Message_Block& mb, const OpenDDS::RTPS::HeartBe
 bool SocketWriter::send(const ACE_Message_Block& mb) const
 {
   for (std::set<ACE_INET_Addr>::const_iterator i = dest_addr_.begin(); i != dest_addr_.end(); ++i) {
-    ssize_t res = socket_.send(mb.rd_ptr(), mb.length(), *i);
+    Locator_t locator;
+    locator.kind = address_to_kind(*i);
+    locator.port = i->get_port_number();
+    address_to_bytes(locator.address, *i);
+    ACE_INET_Addr dest;
+    locator_to_address(dest, locator, local_addr_.get_type() != AF_INET);
+
+    ssize_t res = socket_.send(mb.rd_ptr(), mb.length(), dest);
     if (res >= 0) {
       ACE_DEBUG((LM_INFO, "SocketWriter %C sent %C (%d bytes)\n",
                  OPENDDS_STRING(GuidConverter(id_)).c_str(), i->get_host_addr(), res));


### PR DESCRIPTION
tests/transport/best_effort_reader/run_test.pl
[Details] 2020-12-09 23:16:23: ERROR: publisher returned 1 (started at 2020-12-09 23:16:23)
[Details] ERROR: subscriber timedout
[Details] 2020-12-09 23:16:48: ERROR: subscriber returned -1 (started at 2020-12-09 23:16:23)
[Details] 2020-12-09 23:16:23.589@LM_ERROR@(5812|880) ERROR: in socket_.send()bad address
[Details] test FAILED.
[Details] ERROR: test returned 1
[Details] 2020-12-09 23:16:48: ERROR: publisher returned 1 (started at 2020-12-09 23:16:48)
[Details] ERROR: subscriber timedout
[Details] 2020-12-09 23:17:13: ERROR: subscriber returned -1 (started at 2020-12-09 23:16:48)
[Details] 2020-12-09 23:16:48.771@LM_ERROR@(3476|6476) ERROR: in socket_.send()bad address
[Details] test FAILED.
[Details] ERROR: test returned 1