### PR TITLE
Volatile Writer leaks resources

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1089,6 +1089,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
         subm, *tsce, requires_inline_qos);
       make_leader_lagger(element->subscription_id(), previous_max_sn);
       check_leader_lagger();
+      record_directed(element->subscription_id(), seq);
     } else if (tsce->header().message_id_ == END_HISTORIC_SAMPLES) {
       end_historic_samples_i(tsce->header(), msg->cont());
       g.release();
@@ -1113,6 +1114,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
       subm, *dsle, requires_inline_qos);
     make_leader_lagger(element->subscription_id(), previous_max_sn);
     check_leader_lagger();
+    record_directed(element->subscription_id(), seq);
     durable = dsle->get_header().historic_sample_;
 
   } else if (tce) {  // Customized data message
@@ -1124,6 +1126,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
       subm, *dsle, requires_inline_qos);
     make_leader_lagger(element->subscription_id(), previous_max_sn);
     check_leader_lagger();
+    record_directed(element->subscription_id(), seq);
     durable = dsle->get_header().historic_sample_;
 
   } else {
@@ -2926,6 +2929,26 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   TqeSet to_deliver;
   acked_by_all_helper_i(to_deliver);
 
+#ifdef OPENDDS_SECURITY
+  if (is_pvs_writer_ &&
+      !reader->pvs_outstanding_.empty() &&
+      reader->pvs_outstanding_.low() < reader->cur_cumulative_ack_) {
+    const OPENDDS_VECTOR(SequenceRange) psr = reader->pvs_outstanding_.present_sequence_ranges();
+    for (OPENDDS_VECTOR(SequenceRange)::const_iterator pos = psr.begin(), limit = psr.end();
+         pos != limit && pos->first < reader->cur_cumulative_ack_; ++pos) {
+      for (SequenceNumber seq = pos->first; seq <= pos->second && seq < reader->cur_cumulative_ack_; ++seq) {
+        reader->pvs_outstanding_.erase(seq);
+        OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*)::iterator iter = elems_not_acked_.find(seq);
+        if (iter != elems_not_acked_.end()) {
+          send_buff_->release_acked(iter->first);
+          to_deliver.insert(iter->second);
+          elems_not_acked_.erase(iter);
+        }
+      }
+    }
+  }
+#endif
+
   if (!is_final) {
     link->nack_reply_.schedule(); // timer will invoke send_nack_replies()
   }
@@ -3330,6 +3353,26 @@ RtpsUdpDataLink::RtpsWriter::check_leader_lagger() const
 }
 
 void
+RtpsUdpDataLink::RtpsWriter::record_directed(const RepoId& reader_id, SequenceNumber seq)
+{
+  ACE_UNUSED_ARG(reader_id);
+  ACE_UNUSED_ARG(seq);
+#ifdef OPENDDS_SECURITY
+  if (!is_pvs_writer_) {
+    return;
+  }
+
+  const ReaderInfoMap::iterator iter = remote_readers_.find(reader_id);
+  if (iter == remote_readers_.end()) {
+    return;
+  }
+
+  const ReaderInfo_rch& reader = iter->second;
+  reader->pvs_outstanding_.insert(seq);
+#endif
+}
+
+void
 RtpsUdpDataLink::RtpsWriter::process_acked_by_all()
 {
   TqeSet to_deliver;
@@ -3358,7 +3401,7 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
     return;
   }
 
-  // Prevent changes to the send buffer so new readers can ge
+  // Prevent changes to the send buffer so new readers can get
   // associated and find the start of their reliable range.
   if (!preassociation_readers_.empty()) {
     return;
@@ -3381,24 +3424,11 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
   ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
 
   if (!elems_not_acked_.empty()) {
-
-    OPENDDS_SET(SequenceNumber) sns_to_release;
-    iter_t it = elems_not_acked_.begin();
-    while (it != elems_not_acked_.end()) {
-      if (it->first < all_readers_ack) {
-        to_deliver.insert(it->second);
-        sns_to_release.insert(it->first);
-        iter_t last = it;
-        ++it;
-        elems_not_acked_.erase(last);
-      } else {
-        break;
-      }
-    }
-    OPENDDS_SET(SequenceNumber)::iterator sns_it = sns_to_release.begin();
-    while (sns_it != sns_to_release.end()) {
-      send_buff_->release_acked(*sns_it);
-      ++sns_it;
+    for (iter_t it = elems_not_acked_.begin(), limit = elems_not_acked_.end();
+         it != limit && it->first < all_readers_ack;) {
+      send_buff_->release_acked(it->first);
+      to_deliver.insert(it->second);
+      elems_not_acked_.erase(it++);
     }
   }
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -306,6 +306,7 @@ private:
     MonotonicTimePoint durable_timestamp_;
 #ifdef OPENDDS_SECURITY
     SequenceNumber max_pvs_sn_;
+    DisjointSequence pvs_outstanding_;
 #endif
 
     ReaderInfo(const RepoId& id, bool durable)
@@ -405,6 +406,7 @@ private:
     void make_lagger_leader(const ReaderInfo_rch& reader, const SequenceNumber previous_acked_sn);
     bool is_lagging(const ReaderInfo_rch& reader) const;
     void check_leader_lagger() const;
+    void record_directed(const RepoId& reader, SequenceNumber seq);
     void expire_durable_data(const ReaderInfo_rch& reader,
                              const RtpsUdpInst& cfg,
                              const MonotonicTimePoint& now,


### PR DESCRIPTION
Problem
-------

The maxiumum expected sequence number is tracked for each reader of a
volatile writer.  The maximum sequence number doesn't advance unless a
message is sent to the reader.  At steady state, there will be one
reader whose maximum expected sequence number is lower than every
other reader.  This places a bound on what can be released by the
`acked_by_all_helper_i` function.  Consequently, the send buffer for
the volatile writer will accumulate messages in a long-running
process.

Solution
--------

Track the sequence numbers that send to each volatile reader and use
these to free elements in the send buffer using the assumption that
each sample is directed at a single reader.