### PR TITLE
Log instance_state as readable string

### DIFF
--- a/tests/DCPS/C++11/Messenger/Subscriber/subscriber.cpp
+++ b/tests/DCPS/C++11/Messenger/Subscriber/subscriber.cpp
@@ -69,7 +69,7 @@ struct DataReaderListenerImpl
 
       if (status == DDS::RETCODE_OK) {
         std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-        std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+        std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
         if (si.valid_data) {
           if (!counts_.insert(message.count()).second) {

--- a/tests/DCPS/DPFactoryQos/DataReaderListener.cpp
+++ b/tests/DCPS/DPFactoryQos/DataReaderListener.cpp
@@ -43,9 +43,8 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     }
 
     if (status == DDS::RETCODE_OK) {
-
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data == 1)
       {

--- a/tests/DCPS/FooTest3_0/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest3_0/DataReaderListener.cpp
@@ -49,7 +49,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
       ++samples_read_;
       std::cout << "SampleInfo.valid_data = " << si.valid_data << std::endl;
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance %d is disposed\n"), foo.a_long_value));

--- a/tests/DCPS/GroupPresentation/SubscriberListener.cpp
+++ b/tests/DCPS/GroupPresentation/SubscriberListener.cpp
@@ -197,7 +197,7 @@ SubscriberListenerImpl::verify (const Messenger::Message& msg,
                                 const bool reset_last_timestamp)
 {
   std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-  std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+  std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
   if (si.valid_data) {
     std::cout << "Message: subject    = " << msg.subject.in() << std::endl

--- a/tests/DCPS/Monitor/DPMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DPMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void DPMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "DomainParticipantReport:" << endl

--- a/tests/DCPS/Monitor/DRMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DRMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void DRMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "DataReaderReport:" << endl

--- a/tests/DCPS/Monitor/DRPerMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DRPerMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void DRPerMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "DataReaderPeriodicReport:" << endl

--- a/tests/DCPS/Monitor/DWMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DWMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void DWMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "DataWriterReport:" << endl

--- a/tests/DCPS/Monitor/DWPerMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DWPerMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void DWPerMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "DataWriterPeriodicReport:" << endl

--- a/tests/DCPS/Monitor/DataReaderListener.cpp
+++ b/tests/DCPS/Monitor/DataReaderListener.cpp
@@ -48,7 +48,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         std::cout << "Message: subject    = " << message.subject.in() << std::endl

--- a/tests/DCPS/Monitor/PublisherMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/PublisherMDataReaderListener.cpp
@@ -45,7 +45,7 @@ void PublisherMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr rea
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         std::cout << "PublisherReport:" << std::endl

--- a/tests/DCPS/Monitor/SPMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/SPMDataReaderListener.cpp
@@ -45,7 +45,7 @@ void SPMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         std::cout << "ServiceParticipantReport:" << std::endl

--- a/tests/DCPS/Monitor/SubscriberMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/SubscriberMDataReaderListener.cpp
@@ -45,7 +45,7 @@ void SubscriberMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr re
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         std::cout << "SubscriberReport:" << std::endl

--- a/tests/DCPS/Monitor/TopicMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/TopicMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void TopicMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "TopicReport:" << endl

--- a/tests/DCPS/Monitor/TransportMDataReaderListener.cpp
+++ b/tests/DCPS/Monitor/TransportMDataReaderListener.cpp
@@ -48,7 +48,7 @@ void TransportMDataReaderListenerImpl::on_data_available(DDS::DataReader_ptr rea
 
     if (status == DDS::RETCODE_OK) {
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data) {
         cout << "TransportReport:" << endl

--- a/tests/DCPS/NotifyTest/DataReaderListener.cpp
+++ b/tests/DCPS/NotifyTest/DataReaderListener.cpp
@@ -42,7 +42,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     if (status == DDS::RETCODE_OK) {
 
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data == 1)
       {

--- a/tests/DCPS/RtiSerialization/DataReaderListener.cpp
+++ b/tests/DCPS/RtiSerialization/DataReaderListener.cpp
@@ -59,7 +59,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         if (!counts_.insert(message.count).second) {

--- a/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
@@ -48,7 +48,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
 

--- a/tests/DCPS/SetQosDeadline/DataReaderListener.cpp
+++ b/tests/DCPS/SetQosDeadline/DataReaderListener.cpp
@@ -41,7 +41,7 @@ DataReaderListenerImpl::on_data_available (DDS::DataReader_ptr reader)
     if (status == DDS::RETCODE_OK) {
 
       cerr << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cerr << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data == 1)
       {

--- a/tests/DCPS/SetQosPartition/DataReaderListener.cpp
+++ b/tests/DCPS/SetQosPartition/DataReaderListener.cpp
@@ -40,7 +40,7 @@ DataReaderListenerImpl::on_data_available (DDS::DataReader_ptr reader)
     if (status == DDS::RETCODE_OK) {
 
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
 
       if (si.valid_data == 1)
       {

--- a/tests/DCPS/SharedTransport/TestCase.cpp
+++ b/tests/DCPS/SharedTransport/TestCase.cpp
@@ -153,7 +153,7 @@ TestCase::test()
           DDS::SampleInfo si = si_seq[0];
           TestMessage message = message_seq[0];
           std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-          std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+          std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
           if (si.valid_data) {
             std::cout << "Message: key    = " << message.key << std::endl

--- a/tests/DCPS/SkipSerialize/DataReaderListener.cpp
+++ b/tests/DCPS/SkipSerialize/DataReaderListener.cpp
@@ -57,7 +57,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
 

--- a/tests/DCPS/StringKey/DataReaderListener.cpp
+++ b/tests/DCPS/StringKey/DataReaderListener.cpp
@@ -49,7 +49,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     if (status == DDS::RETCODE_OK) {
 
       cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
-      cout << "SampleInfo.instance_state = " << si.instance_state << endl;
+      cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << endl;
       cout << "SampleInfo.instance_handle = " << si.instance_handle << endl;
       if( previous_handle != this->last_hdl_) {
         cout << "HANDLE CHANGED: previous handle = " << previous_handle << endl;

--- a/tests/DCPS/TcpReconnect/DataReaderListener.cpp
+++ b/tests/DCPS/TcpReconnect/DataReaderListener.cpp
@@ -59,7 +59,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << si.instance_state << std::endl;
+      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         if (!counts_.insert(message.count).second) {


### PR DESCRIPTION
    * tests/DCPS/C++11/Messenger/Subscriber/subscriber.cpp:
    * tests/DCPS/DPFactoryQos/DataReaderListener.cpp:
    * tests/DCPS/FooTest3_0/DataReaderListener.cpp:
    * tests/DCPS/GroupPresentation/SubscriberListener.cpp:
    * tests/DCPS/Monitor/DPMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DRMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DRPerMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DWMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DWPerMDataReaderListener.cpp:
    * tests/DCPS/Monitor/DataReaderListener.cpp:
    * tests/DCPS/Monitor/PublisherMDataReaderListener.cpp:
    * tests/DCPS/Monitor/SPMDataReaderListener.cpp:
    * tests/DCPS/Monitor/SubscriberMDataReaderListener.cpp:
    * tests/DCPS/Monitor/TopicMDataReaderListener.cpp:
    * tests/DCPS/Monitor/TransportMDataReaderListener.cpp:
    * tests/DCPS/NotifyTest/DataReaderListener.cpp:
    * tests/DCPS/RtiSerialization/DataReaderListener.cpp:
    * tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp:
    * tests/DCPS/SetQosDeadline/DataReaderListener.cpp:
    * tests/DCPS/SetQosPartition/DataReaderListener.cpp:
    * tests/DCPS/SharedTransport/TestCase.cpp:
    * tests/DCPS/SkipSerialize/DataReaderListener.cpp:
    * tests/DCPS/StringKey/DataReaderListener.cpp:
    * tests/DCPS/TcpReconnect/DataReaderListener.cpp: