### PR TITLE
Participant BIT and location BIT not populated

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -787,9 +787,11 @@ Spdp::handle_participant_data(DCPS::MessageId id,
 #endif /* DDS_HAS_MINIMUM_BIT */
         // Perform search again, so iterator becomes valid
         iter = participants_.find(guid);
+#ifndef DDS_HAS_MINIMUM_BIT
         if (iter != participants_.end()) {
           iter->second.bit_ih_ = bit_instance_handle;
         }
+#endif /* DDS_HAS_MINIMUM_BIT */
       }
       // Participant may have been removed while lock released
       if (iter != participants_.end()) {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -196,6 +196,7 @@ protected:
 #ifndef DDS_HAS_MINIMUM_BIT
   void enqueue_location_update_i(DiscoveredParticipantIter iter, DCPS::ParticipantLocation mask, const ACE_INET_Addr& from);
   void process_location_updates_i(DiscoveredParticipantIter iter, bool force_publish = false);
+  void publish_location_update_i(DiscoveredParticipantIter iter);
 #endif
 
   bool announce_domain_participant_qos();


### PR DESCRIPTION
Problem
-------

A secure remote participant was never published to the participant BIT
and, consequently, the location topic was never published.

Solution
--------

When security is enabled, publish the participant in the BIT when the
secure SPDP message arrives.  Add the ability to publish the location
topic even when there are no updates.