### PR TITLE
Reauthentication fails

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1131,6 +1131,12 @@ void Sedp::associate_volatile(Security::SPDPdiscoveredParticipantData& pdata)
   }
 }
 
+void Sedp::cleanup_volatile_crypto(const DCPS::RepoId& remote)
+{
+  remove_remote_crypto_handle(remote, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
+  remove_remote_crypto_handle(remote, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
+}
+
 void Sedp::disassociate_volatile(Security::SPDPdiscoveredParticipantData& pdata)
 {
   using namespace DDS::Security;
@@ -5244,7 +5250,7 @@ Sedp::generate_remote_matched_writer_crypto_handle(const RepoId& writer,
   Spdp::ParticipantCryptoInfoPair info = spdp_.lookup_participant_crypto_info(writer_part);
 
   if (info.first != DDS::HANDLE_NIL && info.second) {
-    const DDS::Security::DatawriterCryptoHandle drch =
+    const DDS::Security::DatareaderCryptoHandle drch =
       get_handle_registry()->get_local_datareader_crypto_handle(reader);
     const DDS::Security::EndpointSecurityAttributes attribs =
       get_handle_registry()->get_local_datareader_security_attributes(reader);

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -99,6 +99,7 @@ public:
 #ifdef OPENDDS_SECURITY
   void associate_preauth(Security::SPDPdiscoveredParticipantData& pdata);
   void associate_volatile(Security::SPDPdiscoveredParticipantData& pdata);
+  void cleanup_volatile_crypto(const DCPS::RepoId& remote);
   void disassociate_volatile(Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_endpoints(Security::SPDPdiscoveredParticipantData& pdata,
                                   const DDS::Security::ParticipantSecurityAttributes& participant_sec_attr);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1611,10 +1611,12 @@ Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
 bool
 Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileMessageSecure& msg)
 {
+  const RepoId src_participant = make_id(msg.message_identity.source_guid, DCPS::ENTITYID_PARTICIPANT);
+
   if (DCPS::security_debug.auth_debug) {
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) Spdp::handle_participant_crypto_tokens() from %C\n"),
-               DCPS::LogGuid(msg.source_endpoint_guid).c_str()));
+               DCPS::LogGuid(src_participant).c_str()));
   }
 
   DDS::Security::SecurityException se = {"", 0, 0};
@@ -1624,8 +1626,6 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
   if (msg.destination_participant_guid != guid_ || !msg.message_data.length()) {
     return false;
   }
-
-  const RepoId src_participant = make_id(msg.message_identity.source_guid, DCPS::ENTITYID_PARTICIPANT);
 
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
 
@@ -1727,6 +1727,7 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
     }
 
     sedp_->disassociate_volatile(iter->second.pdata_);
+    sedp_->cleanup_volatile_crypto(iter->first);
     sedp_->associate_volatile(iter->second.pdata_);
 
     if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {


### PR DESCRIPTION
Problem
-------

The main challenge in reauthentication is re-keying the volatile
reader and writer.  The existing approach of disassociating and
associating does not work with the new and improved handling of crypto
tokens.  Specifically, the association does not result in the new
shared secret being installed.

Solution
--------

After disassociating, remove the crypto tokens for the remote volatile
reader and writer so that the call to associate will install the new
shared secret.