### PR TITLE
Authentication gets into a message shootout

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1280,8 +1280,8 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
   // we don't need to send the auth req.
   dp.have_auth_req_msg_ = false;
 
-  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_DONE) {
-    // Remote is still sending (reply), so resend (the final).
+  if (dp.handshake_state_ == DCPS::HANDSHAKE_STATE_DONE && !dp.is_requester_) {
+    // Remote is still sending a reply, so resend the final.
     const RepoId reader = make_id(iter->first, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER);
     if (sedp_->write_stateless_message(dp.handshake_msg_, reader) != DDS::RETCODE_OK) {
       if (DCPS::security_debug.auth_debug) {


### PR DESCRIPTION
Problem
-------

Suppose a request authenticates and sends the final.  The replier gets
the final to complete authentication.  If a message is duplicated or
resent for any reason, then the receiving participant will resend,
causing the other to resend, etc.

Solution
--------

Break the symmetry by only allow the request to resend when
authentication is complete.