### PR TITLE
EndpointSecurityAttributes not initialized

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1717,9 +1717,9 @@ namespace OpenDDS {
       {
         DDS::Security::CryptoKeyExchange_var keyexg = get_crypto_key_exchange();
         if (call_reader) {
-          DDS::Security::DatareaderCryptoHandle drch =
+          const DDS::Security::DatareaderCryptoHandle drch =
             get_handle_registry()->get_local_datareader_crypto_handle(reader);
-          DDS::Security::EndpointSecurityAttributes attribs =
+          const DDS::Security::EndpointSecurityAttributes attribs =
             get_handle_registry()->get_local_datareader_security_attributes(reader);
 
           // It might not exist due to security attributes, and that's OK
@@ -1747,9 +1747,9 @@ namespace OpenDDS {
         }
 
         if (call_writer) {
-          DDS::Security::DatawriterCryptoHandle dwch =
+          const DDS::Security::DatawriterCryptoHandle dwch =
             get_handle_registry()->get_local_datawriter_crypto_handle(writer);
-          DDS::Security::EndpointSecurityAttributes attribs =
+          const DDS::Security::EndpointSecurityAttributes attribs =
             get_handle_registry()->get_local_datawriter_security_attributes(writer);
 
           // It might not exist due to security attributes, and that's OK

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -532,15 +532,7 @@ DDS::ReturnCode_t Sedp::init_security(DDS::Security::IdentityHandle /* id_handle
   bool ok = acl->get_participant_sec_attributes(perm_handle, participant_sec_attr_, ex);
   if (ok) {
 
-    EndpointSecurityAttributes default_sec_attr;
-    default_sec_attr.base.is_read_protected = false;
-    default_sec_attr.base.is_write_protected = false;
-    default_sec_attr.base.is_discovery_protected = false;
-    default_sec_attr.base.is_liveliness_protected = false;
-    default_sec_attr.is_submessage_protected = false;
-    default_sec_attr.is_payload_protected = false;
-    default_sec_attr.is_key_protected = false;
-    default_sec_attr.plugin_endpoint_attributes = 0;
+    const EndpointSecurityAttributes default_sec_attr = get_handle_registry()->default_endpoint_security_attributes();
 
     NativeCryptoHandle h = DDS::HANDLE_NIL;
 

--- a/dds/DCPS/security/framework/HandleRegistry.cpp
+++ b/dds/DCPS/security/framework/HandleRegistry.cpp
@@ -16,6 +16,18 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace Security {
 
+HandleRegistry::HandleRegistry()
+{
+  default_endpoint_security_attributes_.base.is_read_protected = false;
+  default_endpoint_security_attributes_.base.is_write_protected = false;
+  default_endpoint_security_attributes_.base.is_discovery_protected = false;
+  default_endpoint_security_attributes_.base.is_liveliness_protected = false;
+  default_endpoint_security_attributes_.is_submessage_protected = false;
+  default_endpoint_security_attributes_.is_payload_protected = false;
+  default_endpoint_security_attributes_.is_key_protected = false;
+  default_endpoint_security_attributes_.plugin_endpoint_attributes = 0;
+}
+
 HandleRegistry::~HandleRegistry()
 {
   if (DCPS::security_debug.bookkeeping) {
@@ -33,7 +45,7 @@ HandleRegistry::~HandleRegistry()
 void
 HandleRegistry::insert_local_datareader_crypto_handle(const DCPS::RepoId& id,
                                                       DDS::Security::DatareaderCryptoHandle handle,
-                                                      DDS::Security::EndpointSecurityAttributes attributes)
+                                                      const DDS::Security::EndpointSecurityAttributes& attributes)
 {
   if (handle != DDS::HANDLE_NIL) {
     ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
@@ -60,15 +72,15 @@ HandleRegistry::get_local_datareader_crypto_handle(const DCPS::RepoId& id) const
   return DDS::HANDLE_NIL;
 }
 
-DDS::Security::EndpointSecurityAttributes
+const DDS::Security::EndpointSecurityAttributes&
 HandleRegistry::get_local_datareader_security_attributes(const DCPS::RepoId& id) const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, DDS::Security::EndpointSecurityAttributes());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, default_endpoint_security_attributes_);
   DatareaderCryptoHandleMap::const_iterator pos = local_datareader_crypto_handles_.find(id);
   if (pos != local_datareader_crypto_handles_.end()) {
     return pos->second.second;
   }
-  return DDS::Security::EndpointSecurityAttributes();
+  return default_endpoint_security_attributes_;
 }
 
 void
@@ -88,7 +100,7 @@ HandleRegistry::erase_local_datareader_crypto_handle(const DCPS::RepoId& id)
 void
 HandleRegistry::insert_local_datawriter_crypto_handle(const DCPS::RepoId& id,
                                                       DDS::Security::DatawriterCryptoHandle handle,
-                                                      DDS::Security::EndpointSecurityAttributes attributes)
+                                                      const DDS::Security::EndpointSecurityAttributes& attributes)
 {
   if (handle != DDS::HANDLE_NIL) {
     ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
@@ -115,15 +127,15 @@ HandleRegistry::get_local_datawriter_crypto_handle(const DCPS::RepoId& id) const
   return DDS::HANDLE_NIL;
 }
 
-DDS::Security::EndpointSecurityAttributes
+const DDS::Security::EndpointSecurityAttributes&
 HandleRegistry::get_local_datawriter_security_attributes(const DCPS::RepoId& id) const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, DDS::Security::EndpointSecurityAttributes());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, default_endpoint_security_attributes_);
   DatawriterCryptoHandleMap::const_iterator pos = local_datawriter_crypto_handles_.find(id);
   if (pos != local_datawriter_crypto_handles_.end()) {
     return pos->second.second;
   }
-  return DDS::Security::EndpointSecurityAttributes();
+  return default_endpoint_security_attributes_;
 }
 
 void
@@ -186,7 +198,7 @@ HandleRegistry::erase_remote_participant_crypto_handle(const DCPS::RepoId& id)
 void
 HandleRegistry::insert_remote_datareader_crypto_handle(const DCPS::RepoId& id,
                                                        DDS::Security::DatareaderCryptoHandle handle,
-                                                       DDS::Security::EndpointSecurityAttributes attributes)
+                                                       const DDS::Security::EndpointSecurityAttributes& attributes)
 {
   if (handle != DDS::HANDLE_NIL) {
     ACE_GUARD(ACE_Thread_Mutex, guard, mutex_);
@@ -213,15 +225,15 @@ HandleRegistry::get_remote_datareader_crypto_handle(const DCPS::RepoId& id) cons
   return DDS::HANDLE_NIL;
 }
 
-DDS::Security::EndpointSecurityAttributes
+const DDS::Security::EndpointSecurityAttributes&
 HandleRegistry::get_remote_datareader_security_attributes(const DCPS::RepoId& id) const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, DDS::Security::EndpointSecurityAttributes());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, default_endpoint_security_attributes_);
   DatareaderCryptoHandleMap::const_iterator pos = remote_datareader_crypto_handles_.find(id);
   if (pos != remote_datareader_crypto_handles_.end()) {
     return pos->second.second;
   }
-  return DDS::Security::EndpointSecurityAttributes();
+  return default_endpoint_security_attributes_;
 }
 
 HandleRegistry::DatareaderCryptoHandleList
@@ -256,7 +268,7 @@ HandleRegistry::erase_remote_datareader_crypto_handle(const DCPS::RepoId& id)
 void
 HandleRegistry::insert_remote_datawriter_crypto_handle(const DCPS::RepoId& id,
                                                        DDS::Security::DatawriterCryptoHandle handle,
-                                                       DDS::Security::EndpointSecurityAttributes attributes)
+                                                       const DDS::Security::EndpointSecurityAttributes& attributes)
 {
   OPENDDS_ASSERT(id.entityId != DCPS::ENTITYID_UNKNOWN);
   if (handle != DDS::HANDLE_NIL) {
@@ -284,15 +296,15 @@ HandleRegistry::get_remote_datawriter_crypto_handle(const DCPS::RepoId& id) cons
   return DDS::HANDLE_NIL;
 }
 
-DDS::Security::EndpointSecurityAttributes
+const DDS::Security::EndpointSecurityAttributes&
 HandleRegistry::get_remote_datawriter_security_attributes(const DCPS::RepoId& id) const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, DDS::Security::EndpointSecurityAttributes());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, default_endpoint_security_attributes_);
   DatawriterCryptoHandleMap::const_iterator pos = remote_datawriter_crypto_handles_.find(id);
   if (pos != remote_datawriter_crypto_handles_.end()) {
     return pos->second.second;
   }
-  return DDS::Security::EndpointSecurityAttributes();
+  return default_endpoint_security_attributes_;
 }
 
 HandleRegistry::DatawriterCryptoHandleList

--- a/dds/DCPS/security/framework/HandleRegistry.h
+++ b/dds/DCPS/security/framework/HandleRegistry.h
@@ -32,20 +32,26 @@ public:
   typedef std::pair<DCPS::RepoId, DDS::Security::DatawriterCryptoHandle> RepoIdDwch;
   typedef OPENDDS_VECTOR(RepoIdDwch) DatawriterCryptoHandleList;
 
+  HandleRegistry();
   ~HandleRegistry();
+
+  const DDS::Security::EndpointSecurityAttributes& default_endpoint_security_attributes() const
+  {
+    return default_endpoint_security_attributes_;
+  }
 
   void insert_local_datareader_crypto_handle(const DCPS::RepoId& id,
                                              DDS::Security::DatareaderCryptoHandle handle,
-                                             DDS::Security::EndpointSecurityAttributes attributes);
+                                             const DDS::Security::EndpointSecurityAttributes& attributes);
   DDS::Security::DatareaderCryptoHandle get_local_datareader_crypto_handle(const DCPS::RepoId& id) const;
-  DDS::Security::EndpointSecurityAttributes get_local_datareader_security_attributes(const DCPS::RepoId& id) const;
+  const DDS::Security::EndpointSecurityAttributes& get_local_datareader_security_attributes(const DCPS::RepoId& id) const;
   void erase_local_datareader_crypto_handle(const DCPS::RepoId& id);
 
   void insert_local_datawriter_crypto_handle(const DCPS::RepoId& id,
                                              DDS::Security::DatawriterCryptoHandle handle,
-                                             DDS::Security::EndpointSecurityAttributes attributes);
+                                             const DDS::Security::EndpointSecurityAttributes& attributes);
   DDS::Security::DatawriterCryptoHandle get_local_datawriter_crypto_handle(const DCPS::RepoId& id) const;
-  DDS::Security::EndpointSecurityAttributes get_local_datawriter_security_attributes(const DCPS::RepoId& id) const;
+  const DDS::Security::EndpointSecurityAttributes& get_local_datawriter_security_attributes(const DCPS::RepoId& id) const;
   void erase_local_datawriter_crypto_handle(const DCPS::RepoId& id);
 
   void insert_remote_participant_crypto_handle(const DCPS::RepoId& id,
@@ -55,17 +61,17 @@ public:
 
   void insert_remote_datareader_crypto_handle(const DCPS::RepoId& id,
                                               DDS::Security::DatareaderCryptoHandle handle,
-                                              DDS::Security::EndpointSecurityAttributes attributes);
+                                              const DDS::Security::EndpointSecurityAttributes& attributes);
   DDS::Security::DatareaderCryptoHandle get_remote_datareader_crypto_handle(const DCPS::RepoId& id) const;
-  DDS::Security::EndpointSecurityAttributes get_remote_datareader_security_attributes(const DCPS::RepoId& id) const;
+  const DDS::Security::EndpointSecurityAttributes& get_remote_datareader_security_attributes(const DCPS::RepoId& id) const;
   DatareaderCryptoHandleList get_all_remote_datareaders(const DCPS::RepoId& prefix) const;
   void erase_remote_datareader_crypto_handle(const DCPS::RepoId& id);
 
   void insert_remote_datawriter_crypto_handle(const DCPS::RepoId& id,
                                               DDS::Security::DatawriterCryptoHandle handle,
-                                              DDS::Security::EndpointSecurityAttributes attributes);
+                                              const DDS::Security::EndpointSecurityAttributes& attributes);
   DDS::Security::DatawriterCryptoHandle get_remote_datawriter_crypto_handle(const DCPS::RepoId& id) const;
-  DDS::Security::EndpointSecurityAttributes get_remote_datawriter_security_attributes(const DCPS::RepoId& id) const;
+  const DDS::Security::EndpointSecurityAttributes& get_remote_datawriter_security_attributes(const DCPS::RepoId& id) const;
   DatawriterCryptoHandleList get_all_remote_datawriters(const DCPS::RepoId& prefix) const;
   void erase_remote_datawriter_crypto_handle(const DCPS::RepoId& id);
 
@@ -78,6 +84,8 @@ private:
   typedef std::pair<DDS::Security::DatawriterCryptoHandle, DDS::Security::EndpointSecurityAttributes> P2;
   typedef OPENDDS_MAP_CMP(DCPS::RepoId, P2, DCPS::GUID_tKeyLessThan)
     DatawriterCryptoHandleMap;
+
+  DDS::Security::EndpointSecurityAttributes default_endpoint_security_attributes_;
 
   mutable ACE_Thread_Mutex mutex_;
   ParticipantCryptoHandleMap remote_participant_crypto_handles_;


### PR DESCRIPTION
Problem
-------

The HandleRegistry returns a default constructed
EndpointSecurityAttributes object which may contain uninitialized
values.  This causes the RtpsUdpReceiveStrategy to try to decode
messages that should not be decoded.

Solution
--------

Return an initialized EndpointSecurityAttributes object.