### PR TITLE
Improper wait in ConditionVariable with no deadline

### DIFF
--- a/dds/DCPS/ConditionVariable.h
+++ b/dds/DCPS/ConditionVariable.h
@@ -59,9 +59,10 @@ public:
     return CvStatus_Error;
   }
 
+  // Blocks forever if expire_at is zero.
   CvStatus wait_until(const MonotonicTimePoint& expire_at)
   {
-    if (impl_.wait(&expire_at.value()) == 0) {
+    if (impl_.wait(expire_at.is_zero() ? 0 : &expire_at.value()) == 0) {
       return CvStatus_NoTimeout;
     } else if (errno == ETIME) {
       return CvStatus_Timeout;

--- a/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
+++ b/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
@@ -451,9 +451,9 @@ bool run_single_dispose_filter_test(const DomainParticipant_var& dp,
     return false;
   }
 
+  dr->delete_readcondition(disposed_condition);
   sub->delete_datareader(dr);
   pub->delete_datawriter(dw);
-  dr->delete_readcondition(disposed_condition);
   dp->delete_contentfilteredtopic(cft);
   dp->delete_topic(topic);
   return true;


### PR DESCRIPTION
Problem
-------

Passing a deadline of zero causes the condition to timeout immediately
instead of blocking.  This typically leads to a busy loop.

Solution
--------

Pass in null pointer when appropriate to cause the desired blocking behavior.