### PR TITLE
Simplifications for reliable RTPS readers

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -656,7 +656,7 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
           an_start = anc_it->second;
           acknack_counts_.erase(anc_it);
         }
-        RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id, local_durable, an_start);
+        RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id, an_start);
         rr = readers_.insert(RtpsReaderMap::value_type(local_id, reader)).first;
       }
       RtpsReader_rch reader = rr->second;
@@ -1786,8 +1786,7 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
 
       preassociation_writers_.erase(writer);
 
-      const SequenceNumber x = durable_ ? 1 : std::max(hb_first, hb_last);
-      const SequenceRange sr(zero, x.previous());
+      const SequenceRange sr(zero, hb_first.previous());
       writer->recvd_.insert(sr);
       while (!writer->held_.empty() && writer->held_.begin()->first <= sr.second) {
         writer->held_.erase(writer->held_.begin());

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1499,18 +1499,12 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
   seq.setValue(data.writerSN.high, data.writerSN.low);
 
   DeliverHeldData dhd;
-  bool on_start = false;
   const WriterInfoMap::iterator wi = remote_writers_.find(src);
   if (wi != remote_writers_.end()) {
     const WriterInfo_rch& writer = wi->second;
 
     DeliverHeldData dhd2(rchandle_from(this), src);
     std::swap(dhd, dhd2);
-
-    if (writer->first_activity_) {
-      on_start = true;
-      writer->first_activity_ = false;
-    }
 
     writer->frags_.erase(seq);
 
@@ -1593,12 +1587,9 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
     link->receive_strategy()->withhold_data_from(id_);
   }
 
+  // Release for delivering held data.
   guard.release();
   g.release();
-
-  if (on_start) {
-    link->invoke_on_start_callbacks(id_, src, true);
-  }
 
   return false;
 }
@@ -1771,19 +1762,10 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
 
   bool first_ever_hb = false;
 
-  if (writer->first_activity_) {
-    writer->first_activity_ = false;
-    first_ever_hb = true;
-  }
-
   // Only valid heartbeats (see spec) will be "fully" applied to writer info
   if (!(hb_first < 1 || hb_last < 0 || hb_last < hb_first.previous())) {
-    if (writer->first_valid_hb_ && (directed || !writer->sends_directed_hb())) {
+    if (writer->recvd_.empty() && (directed || !writer->sends_directed_hb())) {
       OPENDDS_ASSERT(preassociation_writers_.count(writer));
-      OPENDDS_ASSERT(writer->recvd_.empty());
-
-      writer->first_valid_hb_ = false;
-
       preassociation_writers_.erase(writer);
 
       const SequenceRange sr(zero, hb_first.previous());
@@ -1795,6 +1777,8 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
         writer->recvd_.insert(it->first);
       }
       link->receive_strategy()->remove_fragments(sr, writer->id_);
+
+      first_ever_hb = true;
     }
 
     if (!writer->recvd_.empty()) {
@@ -1981,15 +1965,13 @@ RtpsUdpDataLink::RtpsReader::gather_preassociation_ack_nacks_i(MetaSubmessageVec
   // We want a heartbeat from these writers.
   for (WriterInfoSet::const_iterator pos = preassociation_writers_.begin(), limit = preassociation_writers_.end();
        pos != limit; ++pos) {
-    const WriterInfo_rch& info = *pos;
-    const DisjointSequence& recvd = info->recvd_;
+    const WriterInfo_rch& writer = *pos;
+    const DisjointSequence& recvd = writer->recvd_;
     const CORBA::ULong num_bits = 0;
     const LongSeq8 bitmap;
     const SequenceNumber ack = recvd.empty() ? 1 : ++SequenceNumber(recvd.cumulative_ack());
     const EntityId_t reader_id = id_.entityId;
-    const EntityId_t writer_id = info->id_.entityId;
-
-    MetaSubmessage meta_submessage(id_, info->id_);
+    const EntityId_t writer_id = writer->id_.entityId;
 
     AckNackSubmessage acknack = {
       {ACKNACK,
@@ -2003,6 +1985,7 @@ RtpsUdpDataLink::RtpsReader::gather_preassociation_ack_nacks_i(MetaSubmessageVec
       },
       {++acknack_count_}
     };
+    MetaSubmessage meta_submessage(id_, writer->id_);
     meta_submessage.sm_.acknack_sm(acknack);
     meta_submessages.push_back(meta_submessage);
   }
@@ -2778,12 +2761,15 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
     return;
   }
 
+  SequenceNumber ack;
+  ack.setValue(acknack.readerSNState.bitmapBase.high,
+               acknack.readerSNState.bitmapBase.low);
+
   const bool is_final = acknack.smHeader.flags & RTPS::FLAG_F;
   const bool is_postassociation =
     is_final ||
     bitmapNonEmpty(acknack.readerSNState) ||
-    !(acknack.readerSNState.bitmapBase.high == 0 &&
-      acknack.readerSNState.bitmapBase.low == 1);
+    ack != 1;
 
   if (preassociation_readers_.count(reader) && is_postassociation) {
     preassociation_readers_.erase(reader);
@@ -2798,10 +2784,6 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
   // Process the ack.
   SequenceNumber previous_acked_sn = reader->acked_sn();
-
-  SequenceNumber ack;
-  ack.setValue(acknack.readerSNState.bitmapBase.high,
-               acknack.readerSNState.bitmapBase.low);
 
   if (Transport_debug_level > 5) {
     GuidConverter local_conv(id_), remote_conv(remote);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -489,10 +489,9 @@ private:
 
   class RtpsReader : public RcObject {
   public:
-    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable, CORBA::Long an_start)
+    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, CORBA::Long an_start)
       : link_(link)
       , id_(id)
-      , durable_(durable)
       , stopping_(false)
       , acknack_count_(an_start)
     {}
@@ -541,7 +540,6 @@ private:
     mutable ACE_Thread_Mutex mutex_;
     WeakRcHandle<RtpsUdpDataLink> link_;
     const RepoId id_;
-    const bool durable_;
     WriterInfoMap remote_writers_;
     WriterInfoSet preassociation_writers_;
     bool stopping_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -463,15 +463,12 @@ private:
     HeldMap held_;
     SequenceNumber hb_last_;
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumber_t) frags_;
-    bool first_activity_, first_valid_hb_;
     CORBA::Long heartbeat_recvd_count_, hb_frag_recvd_count_, nackfrag_count_;
     ACE_CDR::ULong participant_flags_;
 
     WriterInfo(const RepoId& id, ACE_CDR::ULong participant_flags)
       : id_(id)
       , hb_last_(SequenceNumber::ZERO())
-      , first_activity_(true)
-      , first_valid_hb_(true)
       , heartbeat_recvd_count_(0)
       , hb_frag_recvd_count_(0)
       , nackfrag_count_(0)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -484,9 +484,10 @@ private:
 
   class RtpsReader : public RcObject {
   public:
-    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, CORBA::Long an_start)
+    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable, CORBA::Long an_start)
       : link_(link)
       , id_(id)
+      , durable_(durable)
       , stopping_(false)
       , acknack_count_(an_start)
     {}
@@ -535,6 +536,7 @@ private:
     mutable ACE_Thread_Mutex mutex_;
     WeakRcHandle<RtpsUdpDataLink> link_;
     const RepoId id_;
+    const bool durable_;
     WriterInfoMap remote_writers_;
     WriterInfoSet preassociation_writers_;
     bool stopping_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -296,7 +296,6 @@ private:
 
   struct ReaderInfo : public RcObject {
     const RepoId id_;
-    SequenceNumber preassociation_heartbeat_last_;
     CORBA::Long acknack_recvd_count_, nackfrag_recvd_count_;
     DisjointSequence requests_;
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumberSet) requested_frags_;
@@ -311,7 +310,6 @@ private:
 
     ReaderInfo(const RepoId& id, bool durable)
       : id_(id)
-      , preassociation_heartbeat_last_(SequenceNumber::ZERO())
       , acknack_recvd_count_(0)
       , nackfrag_recvd_count_(0)
       , cur_cumulative_ack_(SequenceNumber::ZERO()) // Starting at zero instead of unknown makes the logic cleaner.


### PR DESCRIPTION
A reliable RTPS writer freezes heartbeatFirst until the reliable reader has completed association.  This change causes a volatile reliable reader to start at heartbeatFirst.  