### PR TITLE
Update DataSampleElement's pointers in its related lists

### DIFF
--- a/dds/DCPS/InstanceDataSampleList.cpp
+++ b/dds/DCPS/InstanceDataSampleList.cpp
@@ -11,7 +11,7 @@
 #include "Definitions.h"
 #include "PublicationInstance.h"
 
-#include "dds/DCPS/transport/framework/TransportSendListener.h"
+#include "transport/framework/TransportSendListener.h"
 
 #if !defined (__ACE_INLINE__)
 #include "InstanceDataSampleList.inl"

--- a/dds/DCPS/InstanceDataSampleList.h
+++ b/dds/DCPS/InstanceDataSampleList.h
@@ -8,10 +8,11 @@
 #ifndef OPENDDS_DCPS_INSTANCEDATASAMPLELIST_H
 #define OPENDDS_DCPS_INSTANCEDATASAMPLELIST_H
 
-#include "dds/DdsDcpsInfoUtilsC.h"
 #include "Definitions.h"
-#include "transport/framework/TransportDefs.h"
 #include "Dynamic_Cached_Allocator_With_Overflow_T.h"
+
+#include "transport/framework/TransportDefs.h"
+#include "dds/DdsDcpsInfoUtilsC.h"
 
 #include <iterator>
 
@@ -32,10 +33,9 @@ class DataSampleElement;
 * Manages DataSampleElement's next_instance_sample pointer
 */
 class OpenDDS_Dcps_Export InstanceDataSampleList {
-
- public:
+public:
   InstanceDataSampleList();
-  ~InstanceDataSampleList(){}
+  ~InstanceDataSampleList() {}
 
   /// Reset to initial state.
   void reset();
@@ -54,7 +54,7 @@ class OpenDDS_Dcps_Export InstanceDataSampleList {
 
   bool dequeue(const DataSampleElement* stale);
 
- protected:
+protected:
 
    /// The first element of the list.
    DataSampleElement* head_;
@@ -63,7 +63,7 @@ class OpenDDS_Dcps_Export InstanceDataSampleList {
    DataSampleElement* tail_;
 
    /// Number of elements in the list.
-   ssize_t                size_;
+   ssize_t size_;
    //TBD size is never negative so should be size_t but this ripples through
    // the transport code so leave it for now. SHH
 

--- a/dds/DCPS/InstanceDataSampleList.inl
+++ b/dds/DCPS/InstanceDataSampleList.inl
@@ -5,6 +5,7 @@
  * See: http://www.opendds.org/license.html
  */
 #include "DataSampleElement.h"
+
 #include <algorithm>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -78,6 +79,7 @@ InstanceDataSampleList::enqueue_tail(const DataSampleElement* sample)
   if (head_ == 0) {
     // First sample on queue.
     head_ = tail_ = mSample;
+    mSample->previous_instance_sample_ = 0;
 
   } else {
     // Another sample on an existing queue.

--- a/dds/DCPS/SendStateDataSampleList.cpp
+++ b/dds/DCPS/SendStateDataSampleList.cpp
@@ -11,7 +11,7 @@
 #include "Definitions.h"
 #include "PublicationInstance.h"
 
-#include "dds/DCPS/transport/framework/TransportSendListener.h"
+#include "transport/framework/TransportSendListener.h"
 
 #if !defined (__ACE_INLINE__)
 #include "SendStateDataSampleList.inl"
@@ -67,54 +67,38 @@ SendStateDataSampleList::dequeue(const DataSampleElement* stale)
   }
 
   if (toRemove) {
-    size_ --;
+    --size_;
     // Remove from the previous element.
-    toRemove->previous_send_sample_->next_send_sample_ = toRemove->next_send_sample_ ;
+    toRemove->previous_send_sample_->next_send_sample_ = toRemove->next_send_sample_;
 
     // Remove from the next element.
     if (toRemove->next_send_sample_ != 0) {
       // Remove from the inside of the list.
-      toRemove->next_send_sample_->previous_send_sample_ = toRemove->previous_send_sample_ ;
+      toRemove->next_send_sample_->previous_send_sample_ = toRemove->previous_send_sample_;
 
     } else {
-      toRemove->previous_send_sample_->next_send_sample_ = 0;
       // Remove from the tail of the list.
-      tail_ = toRemove->previous_send_sample_ ;
+      tail_ = toRemove->previous_send_sample_;
     }
 
     toRemove->next_send_sample_ = 0;
     toRemove->previous_send_sample_ = 0;
   }
 
-  return toRemove;
+  return toRemove != 0;
 }
 
 void
 SendStateDataSampleList::enqueue_tail(SendStateDataSampleList list)
 {
-  //// Make the appended list linked with next_send_sample_ first.
-  //DataSampleElement* cur = list.head_;
-
-  //if (list.size_ > 1 && cur->next_send_sample_ == 0)
-  // {
-  //   for (ssize_t i = 0; i < list.size_; i ++)
-  //     {
-  //       cur->next_send_sample_ = cur->next_writer_sample_;
-  //       cur = cur->next_writer_sample_;
-  //     }
-  // }
-
   if (head_ == 0) {
     head_ = list.head_;
     tail_ = list.tail_;
     size_ = list.size_;
 
   } else {
-    tail_->next_send_sample_
-    //= tail_->next_writer_sample_
-    = list.head_;
+    tail_->next_send_sample_ = list.head_;
     list.head_->previous_send_sample_ = tail_;
-    //list.head_->previous_writer_sample_ = tail_;
     tail_ = list.tail_;
     size_ = size_ + list.size_;
   }
@@ -135,8 +119,9 @@ SendStateDataSampleListIterator::SendStateDataSampleListIterator(
 SendStateDataSampleListIterator&
 SendStateDataSampleListIterator::operator++()
 {
-  if (this->current_)
+  if (this->current_) {
     this->current_ = this->current_->next_send_sample_;
+  }
 
   return *this;
 }
@@ -152,11 +137,11 @@ SendStateDataSampleListIterator::operator++(int)
 SendStateDataSampleListIterator&
 SendStateDataSampleListIterator::operator--()
 {
-  if (this->current_)
+  if (this->current_) {
     this->current_ = this->current_->previous_send_sample_;
-
-  else
+  } else {
     this->current_ = this->tail_;
+  }
 
   return *this;
 }
@@ -207,8 +192,9 @@ SendStateDataSampleListConstIterator::SendStateDataSampleListConstIterator(
 SendStateDataSampleListConstIterator&
 SendStateDataSampleListConstIterator::operator++()
 {
-  if (this->current_)
+  if (this->current_) {
     this->current_ = this->current_->next_send_sample_;
+  }
 
   return *this;
 }
@@ -224,11 +210,11 @@ SendStateDataSampleListConstIterator::operator++(int)
 SendStateDataSampleListConstIterator&
 SendStateDataSampleListConstIterator::operator--()
 {
-  if (this->current_)
+  if (this->current_) {
     this->current_ = this->current_->previous_send_sample_;
-
-  else
+  } else {
     this->current_ = this->tail_;
+  }
 
   return *this;
 }

--- a/dds/DCPS/SendStateDataSampleList.h
+++ b/dds/DCPS/SendStateDataSampleList.h
@@ -8,12 +8,14 @@
 #ifndef OPENDDS_DCPS_SENDSTATEDATASAMPLELIST_H
 #define OPENDDS_DCPS_SENDSTATEDATASAMPLELIST_H
 
-#include "dds/DdsDcpsInfoUtilsC.h"
 #include "PoolAllocator.h"
 #include "Definitions.h"
-#include "transport/framework/TransportDefs.h"
 #include "Dynamic_Cached_Allocator_With_Overflow_T.h"
-#include "ace/config-lite.h"
+
+#include "transport/framework/TransportDefs.h"
+#include "dds/DdsDcpsInfoUtilsC.h"
+
+#include <ace/config-lite.h>
 
 #include <iterator>
 
@@ -39,19 +41,18 @@ const int MAX_READERS_TO_RESEND = 5;
  * @c over the "send samples" in a @c SendStateDataSampleList.
  */
 class OpenDDS_Dcps_Export SendStateDataSampleListIterator
-  : public std::iterator<std::bidirectional_iterator_tag, DataSampleElement>
-{
+  : public std::iterator<std::bidirectional_iterator_tag, DataSampleElement> {
 public:
 
   /// Default constructor required by ForwardIterator concept
-  SendStateDataSampleListIterator(){}
+  SendStateDataSampleListIterator() {}
 
   /**
    * This constructor is used when constructing an "end" iterator.
    */
   SendStateDataSampleListIterator(DataSampleElement* head,
-                         DataSampleElement* tail,
-                         DataSampleElement* current);
+                                  DataSampleElement* tail,
+                                  DataSampleElement* current);
 
   SendStateDataSampleListIterator& operator++();
   SendStateDataSampleListIterator  operator++(int);
@@ -64,8 +65,8 @@ public:
   bool
   operator==(const SendStateDataSampleListIterator& rhs) const {
     return this->head_ == rhs.head_
-           && this->tail_ == rhs.tail_
-           && this->current_ == rhs.current_;
+      && this->tail_ == rhs.tail_
+      && this->current_ == rhs.current_;
   }
 
   bool
@@ -92,18 +93,17 @@ private:
  * @c over the "send samples" in a @c SendStateDataSampleList.
  */
 class OpenDDS_Dcps_Export SendStateDataSampleListConstIterator
-  : public std::iterator<std::bidirectional_iterator_tag, DataSampleElement>
-{
+  : public std::iterator<std::bidirectional_iterator_tag, DataSampleElement> {
 public:
   typedef const DataSampleElement* pointer;
   typedef const DataSampleElement& reference;
 
   /// Default constructor required by ForwardIterator concept
-  SendStateDataSampleListConstIterator(){}
+  SendStateDataSampleListConstIterator() {}
 
   SendStateDataSampleListConstIterator(const DataSampleElement* head,
-                                  const DataSampleElement* tail,
-                                  const DataSampleElement* current);
+                                       const DataSampleElement* tail,
+                                       const DataSampleElement* current);
 
   SendStateDataSampleListConstIterator(const SendStateDataSampleListIterator& iterator);
 
@@ -117,8 +117,8 @@ public:
   bool
   operator==(const SendStateDataSampleListConstIterator& rhs) const {
     return this->head_ == rhs.head_
-           && this->tail_ == rhs.tail_
-           && this->current_ == rhs.current_;
+      && this->tail_ == rhs.tail_
+      && this->current_ == rhs.current_;
   }
 
   bool
@@ -153,7 +153,7 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
                                  SendStateDataSampleList** begin,
                                  SendStateDataSampleList** end);
 
- public:
+public:
 
   /// STL-style bidirectional iterator and const-iterator types.
   typedef SendStateDataSampleListIterator iterator;
@@ -177,7 +177,7 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
 
   /// Default constructor clears the list.
   SendStateDataSampleList();
-  ~SendStateDataSampleList(){}
+  ~SendStateDataSampleList() {}
 
   /// Returns a pointer to the SendStateDataSampleList containing a
   /// given DataSampleElement for use in the typical situation where
@@ -226,7 +226,7 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
   reverse_iterator rend();
   const_reverse_iterator rend() const;
 
- protected:
+protected:
 
   /// The first element of the list.
   DataSampleElement* head_;
@@ -235,7 +235,7 @@ class OpenDDS_Dcps_Export SendStateDataSampleList {
   DataSampleElement* tail_;
 
   /// Number of elements in the list.
-  ssize_t                size_;
+  ssize_t size_;
   //TBD size is never negative so should be size_t but this ripples through
   // the transport code so leave it for now. SHH
 

--- a/dds/DCPS/SendStateDataSampleList.inl
+++ b/dds/DCPS/SendStateDataSampleList.inl
@@ -6,6 +6,7 @@
  */
 
 #include "DataSampleElement.h"
+
 #include <algorithm>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -130,10 +131,12 @@ ACE_INLINE
 void
 SendStateDataSampleList::remove(DataSampleElement* stale)
 {
-  if (stale->previous_send_sample_)
+  if (stale->previous_send_sample_) {
     stale->previous_send_sample_->next_send_sample_ = stale->next_send_sample_;
-  if (stale->next_send_sample_)
+  }
+  if (stale->next_send_sample_) {
     stale->next_send_sample_->previous_send_sample_ = stale->previous_send_sample_;
+  }
 }
 
 ACE_INLINE

--- a/dds/DCPS/WriterDataSampleList.cpp
+++ b/dds/DCPS/WriterDataSampleList.cpp
@@ -33,8 +33,8 @@ WriterDataSampleList::dequeue(const DataSampleElement* stale)
   // Search from head_->next_writer_sample_.
   bool found = false;
 
-  for (DataSampleElement* item = head_->next_writer_sample_ ;
-       item != 0 ;
+  for (DataSampleElement* item = head_->next_writer_sample_;
+       item != 0;
        item = item->next_writer_sample_) {
     if (item == stale) {
       found = true;
@@ -49,18 +49,7 @@ WriterDataSampleList::dequeue(const DataSampleElement* stale)
     //
     // Remove from the previous element.
     //
-    if (stale->previous_writer_sample_ != 0) {
-      // Remove from inside of the list.
-      stale->previous_writer_sample_->next_writer_sample_ = stale->next_writer_sample_ ;
-
-    } else {
-      // Remove from the head of the list.
-      head_ = stale->next_writer_sample_ ;
-
-      if (head_ != 0) {
-        head_->previous_writer_sample_ = 0;
-      }
-    }
+    stale->previous_writer_sample_->next_writer_sample_ = stale->next_writer_sample_ ;
 
     //
     // Remove from the next element.

--- a/dds/DCPS/WriterDataSampleList.h
+++ b/dds/DCPS/WriterDataSampleList.h
@@ -9,6 +9,7 @@
 #define OPENDDS_DCPS_WRITERDATASAMPLELIST_H
 
 #include "dcps_export.h"
+
 #include <cstring>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -26,12 +27,11 @@ class DataSampleElement;
 * Manages DataSampleElement's previous_writer_sample/next_writer_sample pointers
 */
 class OpenDDS_Dcps_Export WriterDataSampleList {
-
- public:
+public:
 
   /// Default constructor clears the list.
   WriterDataSampleList();
-  ~WriterDataSampleList(){}
+  ~WriterDataSampleList() {}
 
   /// Reset to initial state.
   void reset();
@@ -46,7 +46,7 @@ class OpenDDS_Dcps_Export WriterDataSampleList {
 
   bool dequeue(const DataSampleElement* stale);
 
- protected:
+protected:
 
    /// The first element of the list.
    DataSampleElement* head_;
@@ -55,7 +55,7 @@ class OpenDDS_Dcps_Export WriterDataSampleList {
    DataSampleElement* tail_;
 
    /// Number of elements in the list.
-   ssize_t                size_;
+   ssize_t size_;
    //TBD size is never negative so should be size_t but this ripples through
    // the transport code so leave it for now. SHH
 };

--- a/dds/DCPS/WriterDataSampleList.inl
+++ b/dds/DCPS/WriterDataSampleList.inl
@@ -6,6 +6,7 @@
  */
 
 #include "DataSampleElement.h"
+
 #include <algorithm>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -58,14 +59,14 @@ WriterDataSampleList::enqueue_tail(const DataSampleElement* sample)
   // changed to accommodate const-correctness throughout.
   DataSampleElement* mSample = const_cast<DataSampleElement*>(sample);
 
-  //sample->previous_writer_sample_ = 0;
-  //sample->next_writer_sample_ = 0;
+  mSample->next_writer_sample_ = 0;
 
   ++size_ ;
 
   if (head_ == 0) {
     // First sample in the list.
     head_ = tail_ = mSample ;
+    mSample->previous_writer_sample_ = 0;
 
   } else {
     // Add to existing list.


### PR DESCRIPTION
- Some enqueue/dequeue functions in the `InstanceDataSampleList`, `WriterDataSampleList`, and `SendStateDataSampleList` classes currently haven't properly updated the corresponding pointers in the affected `DataSampleElement` nodes.
- This also removes redundant logic and does reformatting for those list classes.