### PR TITLE
[xtypes] Improve Thread Monitoring

### DIFF
--- a/MPC/config/dcps_cm.mpb
+++ b/MPC/config/dcps_cm.mpb
@@ -1,4 +1,4 @@
-project : dcpsexe, dcps_test, test_root {
+project : dcps_test, test_root {
   after    += ConsolidatedMessengerIdl
   libs     += ConsolidatedMessengerIdl
   libpaths += $(TEST_ROOT)/tests/DCPS/ConsolidatedMessengerIdl

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -848,7 +848,8 @@ namespace OpenDDS {
 #endif
 
   DDS::InstanceHandle_t store_synthetic_data(const MessageType& sample,
-                                             DDS::ViewStateKind view)
+                                             DDS::ViewStateKind view,
+                                             const SystemTimePoint& timestamp = SystemTimePoint::now())
   {
     using namespace OpenDDS::DCPS;
     ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, sample_lock_,
@@ -878,7 +879,7 @@ namespace OpenDDS {
       DataSampleHeader header;
       const int msg = i ? SAMPLE_DATA : INSTANCE_REGISTRATION;
       header.message_id_ = static_cast<char>(msg);
-      const DDS::Time_t now = SystemTimePoint::now().to_dds_time();
+      const DDS::Time_t now = timestamp.to_dds_time();
       header.source_timestamp_sec_ = now.sec;
       header.source_timestamp_nanosec_ = now.nanosec;
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1618,8 +1618,7 @@ DDS::ReturnCode_t take_next_instance_i(MessageSequenceType& received_data,
   return DDS::RETCODE_NO_DATA;
 }
 
-void store_instance_data(
-                         unique_ptr<MessageTypeWithAllocator> instance_data,
+void store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_data,
                          const OpenDDS::DCPS::DataSampleHeader& header,
                          OpenDDS::DCPS::SubscriptionInstance_rch& instance_ptr,
                          bool& just_registered,
@@ -1956,9 +1955,9 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
     return;
   }
 
-  ReceivedDataElement *ptr =
+  ReceivedDataElement* const ptr =
     new (*rd_allocator_.get()) ReceivedDataElementWithType<MessageTypeWithAllocator>(
-      header,instance_data.release(), &this->sample_lock_);
+      header, instance_data.release(), &this->sample_lock_);
 
   ptr->disposed_generation_count_ =
     instance_ptr->instance_state_->disposed_generation_count();
@@ -2071,11 +2070,10 @@ void notify_status_condition_no_sample_lock()
 
 
 /// Common input read* & take* input processing and precondition checks
-DDS::ReturnCode_t check_inputs (
-                                const char* method_name,
-                                MessageSequenceType & received_data,
-                                DDS::SampleInfoSeq & info_seq,
-                                ::CORBA::Long max_samples)
+DDS::ReturnCode_t check_inputs(const char* method_name,
+                               MessageSequenceType& received_data,
+                               DDS::SampleInfoSeq& info_seq,
+                               ::CORBA::Long max_samples)
 {
   typename MessageSequenceType::PrivateMemberAccess received_data_p (received_data);
 

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -126,14 +126,13 @@ namespace OpenDDS {
 
               case CvStatus_Timeout:
                 {
-                  const MonotonicTimePoint now = MonotonicTimePoint::now();
-                  expire = now + interval_;
+                  expire = MonotonicTimePoint::now() + interval_;
                   if (status_) {
                     if (DCPS_debug_level > 4) {
                       ACE_DEBUG((LM_DEBUG,
                                  "(%P|%t) DcpsUpcalls::svc. Updating thread status.\n"));
                     }
-                    if (!status_->update(thread_key_, now)) {
+                    if (!status_->update(thread_key_)) {
                       if (DCPS_debug_level) {
                         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DcpsUpcalls::svc: "
                           "update failed\n"));
@@ -174,13 +173,12 @@ namespace OpenDDS {
 
         wait(); // ACE_Task_Base::wait does not accept a timeout
 
-        const MonotonicTimePoint now = MonotonicTimePoint::now();
-        if (status_ && has_timeout() && now > expire) {
+        if (status_ && has_timeout() && MonotonicTimePoint::now() > expire) {
           if (DCPS_debug_level > 4) {
             ACE_DEBUG((LM_DEBUG,
                        "(%P|%t) DcpsUpcalls::writer_done. Updating thread status.\n"));
           }
-          if (!status_->update(thread_key_, now) && DCPS_debug_level) {
+          if (!status_->update(thread_key_) && DCPS_debug_level) {
             ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DcpsUpcalls::writer_done: "
               "update failed\n"));
           }

--- a/dds/DCPS/GuidUtils.h
+++ b/dds/DCPS/GuidUtils.h
@@ -200,9 +200,7 @@ inline void assign(GUID_t& dest, const GUID_t& src)
 
 inline void assign(OctetArray16& dest, const GUID_t& src)
 {
-  std::memcpy(&dest[0], &src.guidPrefix, sizeof(GuidPrefix_t));
-  std::memcpy(&dest[sizeof(GuidPrefix_t)], &src.entityId.entityKey, sizeof(EntityKey_t));
-  dest[sizeof(GuidPrefix_t) + sizeof(EntityKey_t)] = src.entityId.entityKind;
+  std::memcpy(&dest[0], &src, sizeof(src));
 }
 
 inline RepoId make_id(const GuidPrefix_t& prefix, const EntityId_t& entity)

--- a/dds/DCPS/GuidUtils.h
+++ b/dds/DCPS/GuidUtils.h
@@ -193,17 +193,29 @@ inline void assign(GuidPrefix_t& dest, const GuidPrefix_t& src)
   std::memcpy(&dest[0], &src[0], sizeof(GuidPrefix_t));
 }
 
-inline DCPS::RepoId make_id(const GuidPrefix_t& prefix, const EntityId_t& entity)
+inline void assign(GUID_t& dest, const GUID_t& src)
 {
-  DCPS::RepoId id;
+  std::memcpy(&dest, &src, sizeof(GUID_t));
+}
+
+inline void assign(OctetArray16& dest, const GUID_t& src)
+{
+  std::memcpy(&dest[0], &src.guidPrefix, sizeof(GuidPrefix_t));
+  std::memcpy(&dest[sizeof(GuidPrefix_t)], &src.entityId.entityKey, sizeof(EntityKey_t));
+  dest[sizeof(GuidPrefix_t) + sizeof(EntityKey_t)] = src.entityId.entityKind;
+}
+
+inline RepoId make_id(const GuidPrefix_t& prefix, const EntityId_t& entity)
+{
+  RepoId id;
   assign(id.guidPrefix, prefix);
   id.entityId = entity;
   return id;
 }
 
-inline DCPS::RepoId make_id(const DCPS::RepoId& participant_id, const EntityId_t& entity)
+inline RepoId make_id(const RepoId& participant_id, const EntityId_t& entity)
 {
-  DCPS::RepoId id = participant_id;
+  RepoId id = participant_id;
   id.entityId = entity;
   return id;
 }

--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -1,7 +1,19 @@
 #ifndef OPENDDS_DCPS_POOL_ALLOCATOR_H
 #define OPENDDS_DCPS_POOL_ALLOCATOR_H
 
-#include "ace/config-macros.h"
+#include <ace/config-macros.h>
+#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#  define OPENDDS_POOL_ALLOCATOR 1
+#else
+#  define OPENDDS_POOL_ALLOCATOR 0
+#endif
+
+#if OPENDDS_POOL_ALLOCATOR
+#  include "dcps_export.h"
+#  include "SafetyProfilePool.h"
+#endif
+#include <dds/Versioned_Namespace.h>
+
 #include <limits>
 #include <string>
 #include <map>
@@ -10,14 +22,12 @@
 #include <queue>
 #include <set>
 
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
-#include "dcps_export.h"
-#include "SafetyProfilePool.h"
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace DCPS {
+
+#if OPENDDS_POOL_ALLOCATOR
 
 OpenDDS_Dcps_Export void* pool_alloc_memory(size_t size);
 
@@ -97,15 +107,11 @@ bool operator!=(const PoolAllocator<T>&, const PoolAllocator<U>&)
 template <typename T>
 struct add_const { typedef const T type; };
 
-}}
-
-OPENDDS_END_VERSIONED_NAMESPACE_DECL
-
+// TODO(iguessthislldo): Rewrite with using in C++11
 #define OPENDDS_ALLOCATOR(T) OpenDDS::DCPS::PoolAllocator<T >
-#define OPENDDS_STRING std::basic_string<char, std::char_traits<char>, \
-                                         OPENDDS_ALLOCATOR(char) >
-#define OPENDDS_WSTRING std::basic_string<wchar_t, std::char_traits<wchar_t>, \
-                                          OPENDDS_ALLOCATOR(wchar_t) >
+typedef std::basic_string<char, std::char_traits<char>, OPENDDS_ALLOCATOR(char)> String;
+typedef std::basic_string<wchar_t, std::char_traits<wchar_t>, OPENDDS_ALLOCATOR(wchar_t)>
+  WString;
 #define OPENDDS_MAP(K, V) std::map<K, V, std::less<K >, \
           OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MAP_CMP(K, V, C) std::map<K, V, C, \
@@ -137,10 +143,10 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #define OPENDDS_QUEUE(T) std::queue<T, std::deque<T, \
           OpenDDS::DCPS::PoolAllocator<T > > >
 
-#else
+#else // (!OPENDDS_POOL_ALLOCATOR)
 #define OPENDDS_ALLOCATOR(T) std::allocator<T >
-#define OPENDDS_STRING std::string
-#define OPENDDS_WSTRING std::wstring
+typedef std::string String;
+typedef std::wstring WString;
 #define OPENDDS_MAP(K, V) std::map<K, V >
 #define OPENDDS_MAP_CMP(K, V, C) std::map<K, V, C >
 #define OPENDDS_MULTIMAP(K, T) std::multimap<K, T >
@@ -157,7 +163,14 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #define OPENDDS_DEQUE(T) std::deque<T >
 #define OPENDDS_QUEUE(T) std::queue<T >
 
-#endif // OPENDDS_SAFETY_PROFILE && ACE_HAS_ALLOC_HOOKS
+#endif // OPENDDS_POOL_ALLOCATOR
 
+#define OPENDDS_STRING OpenDDS::DCPS::String
+#define OPENDDS_WSTRING OpenDDS::DCPS::WString
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #endif // OPENDDS_DCPS_POOL_ALLOCATOR_H

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3830,11 +3830,10 @@ void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& /*n
       for (DCPS::ThreadStatus::Map::const_iterator i = thread_status_->map.begin();
           i != thread_status_->map.end(); ++i) {
         DCPS::InternalThreadBuiltinTopicData data;
-        assign(data.guid, guid);
+        assign(data.participant_guid, guid);
         data.thread_id = i->first.c_str();
-        data.timestamp = i->second.timestamp.to_dds_time();
 
-        bit->store_synthetic_data(data, DDS::NEW_VIEW_STATE);
+        bit->store_synthetic_data(data, DDS::NEW_VIEW_STATE, i->second.timestamp);
       }
     } else {
       // Not necessarily an error. App could be shutting down.

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -8,6 +8,7 @@
 #include "Spdp.h"
 
 #include "BaseMessageTypes.h"
+#include "BaseMessageUtils.h"
 #include "MessageTypes.h"
 #include "ParameterListConverter.h"
 #include "RtpsDiscovery.h"
@@ -3826,19 +3827,18 @@ void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& /*n
   if (TheServiceParticipant->get_thread_status_interval() > TimeDuration(0)) {
     if (thread_status_ && bit) {
       ACE_READ_GUARD(ACE_Thread_Mutex, g, thread_status_->lock);
-
-      for (OPENDDS_MAP(OPENDDS_STRING, MonotonicTimePoint)::const_iterator i = thread_status_->map.begin(); i != thread_status_->map.end(); ++i) {
-        const MonotonicTimePoint t = i->second;
+      for (DCPS::ThreadStatus::Map::const_iterator i = thread_status_->map.begin();
+          i != thread_status_->map.end(); ++i) {
         DCPS::InternalThreadBuiltinTopicData data;
-        ACE_OS::memcpy(&(data.guid), &(guid), 16);
+        assign(data.guid, guid);
         data.thread_id = i->first.c_str();
-        data.timestamp.sec = static_cast<CORBA::Long>(t.value().sec());
-        data.timestamp.nanosec = t.value().usec() * 1000;
+        data.timestamp = i->second.timestamp.to_dds_time();
+        data.since_last_update = i->second.since_last_update.to_dds_duration();
 
         bit->store_synthetic_data(data, DDS::NEW_VIEW_STATE);
       }
     } else {
-      // Not necessarily and error. App could be shutting down.
+      // Not necessarily an error. App could be shutting down.
       ACE_DEBUG((LM_DEBUG,
                  "(%P|%t) Spdp::ThreadStatusHandler: Could not get thread data reader.\n"));
     }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3833,7 +3833,6 @@ void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& /*n
         assign(data.guid, guid);
         data.thread_id = i->first.c_str();
         data.timestamp = i->second.timestamp.to_dds_time();
-        data.since_last_update = i->second.since_last_update.to_dds_duration();
 
         bit->store_synthetic_data(data, DDS::NEW_VIEW_STATE);
       }

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -262,13 +262,13 @@ bool ThreadStatus::update(
   return true;
 }
 
-String ThreadStatus::get_key(const char* fallback_tid, const String& name)
+String ThreadStatus::get_key(const char* safety_profile_tid, const String& name)
 {
-  ACE_UNUSED_ARG(fallback_tid);
   String key;
 #ifdef OPENDDS_SAFETY_PROFILE
-  key = fallback_tid;
+  key = safety_profile_tid;
 #else
+  ACE_UNUSED_ARG(safety_profile_tid);
 #  ifdef ACE_HAS_MAC_OSX
   unsigned long tid = 0;
   uint64_t u64_tid;

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -245,19 +245,12 @@ bool ThreadStatus::update(
   const bool is_new = it == map.end();
   if (is_new) {
     it = map.insert(Map::value_type(thread_key, Thread())).first;
-  } else {
-    it->second.since_last_update = timestamp - it->second.timestamp;
   }
   it->second.timestamp = timestamp;
   if (DCPS_debug_level > 4) {
-    if (is_new) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) ThreadStatus::update: first update for "
-        "thread \"%C\"\n", thread_key.c_str()));
-    } else {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) ThreadStatus::update: last update for "
-        "thread \"%C\" was %#T seconds ago\n",
-        thread_key.c_str(), &it->second.since_last_update.value()));
-    }
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) ThreadStatus::update: "
+      "%Cupdate for thread \"%C\"\n @ %d",
+      is_new ? "first " : "", thread_key.c_str(), it->second.timestamp.value().sec()));
   }
   return true;
 }

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -17,6 +17,7 @@
 #include <ace/Proactor.h>
 #include <ace/Proactor_Impl.h>
 #include <ace/WIN32_Proactor.h>
+#include <ace/OS_NS_Thread.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -276,6 +277,8 @@ String ThreadStatus::get_key(const char* fallback_tid, const String& name)
   } else if (DCPS_debug_level) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: pthread_threadid_np failed\n")));
   }
+#  elif defined ACE_HAS_GETTID
+  pid_t tid = ACE_OS::thr_gettid();
 #  else
   ACE_thread_t tid = ACE_OS::thr_self();
 #  endif

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -20,7 +20,10 @@
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
-OpenDDS::DCPS::ReactorTask::ReactorTask(bool useAsyncSend)
+namespace OpenDDS {
+namespace DCPS {
+
+ReactorTask::ReactorTask(bool useAsyncSend)
   : barrier_(2)
   , state_(STATE_NOT_RUNNING)
   , condition_(lock_)
@@ -34,7 +37,7 @@ OpenDDS::DCPS::ReactorTask::ReactorTask(bool useAsyncSend)
 {
 }
 
-OpenDDS::DCPS::ReactorTask::~ReactorTask()
+ReactorTask::~ReactorTask()
 {
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) || defined (ACE_HAS_AIO_CALLS)
   if (proactor_) {
@@ -49,8 +52,7 @@ OpenDDS::DCPS::ReactorTask::~ReactorTask()
   delete timer_queue_;
 }
 
-int
-OpenDDS::DCPS::ReactorTask::open_reactor_task(void*, TimeDuration timeout, ThreadStatus* thread_stat, OPENDDS_STRING name)
+int ReactorTask::open_reactor_task(void*, TimeDuration timeout, ThreadStatus* thread_stat, String name)
 {
   // thread status reporting support
   timeout_ = timeout;
@@ -111,8 +113,7 @@ OpenDDS::DCPS::ReactorTask::open_reactor_task(void*, TimeDuration timeout, Threa
   return 0;
 }
 
-int
-OpenDDS::DCPS::ReactorTask::svc()
+int ReactorTask::svc()
 {
   // First off - We need to obtain our own reference to ourselves such
   // that we don't get deleted while still running in our own thread.
@@ -158,27 +159,7 @@ OpenDDS::DCPS::ReactorTask::svc()
     if (timeout_ == TimeDuration(0)) {
       reactor_->run_reactor_event_loop();
     } else {
-#ifdef ACE_HAS_MAC_OSX
-      unsigned long tid = 0;
-      uint64_t osx_tid;
-      if (!pthread_threadid_np(0, &osx_tid)) {
-        tid = static_cast<unsigned long>(osx_tid);
-      } else {
-        tid = 0;
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ReactorTask::svc. Error getting OSX thread id\n")));
-      }
-#elif !defined (OPENDDS_SAFETY_PROFILE)
-      ACE_thread_t tid = ACE_OS::thr_self();
-#endif /* ACE_HAS_MAC_OSX */
-
-#ifndef OPENDDS_SAFETY_PROFILE
-      OPENDDS_STRING key = to_dds_string(tid);
-#else
-      OPENDDS_STRING key = "ReactorTask";
-#endif
-      if (name_ != "") {
-        key += " (" + name_ + ")";
-      }
+      const String thread_key = ThreadStatus::get_key("ReactorTask", name_);
 
       while (state_ == STATE_RUNNING) {
         ACE_Time_Value t = timeout_.value();
@@ -188,8 +169,7 @@ OpenDDS::DCPS::ReactorTask::svc()
             ACE_DEBUG((LM_DEBUG,
                        "(%P|%t) ReactorTask::svc. Updating thread status.\n"));
           }
-          ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, thread_status_->lock, -1);
-          thread_status_->map[key] = MonotonicTimePoint::now();
+          thread_status_->update(thread_key);
         }
       }
     }
@@ -205,8 +185,7 @@ OpenDDS::DCPS::ReactorTask::svc()
   return 0;
 }
 
-int
-OpenDDS::DCPS::ReactorTask::close(u_long flags)
+int ReactorTask::close(u_long flags)
 {
   ACE_UNUSED_ARG(flags);
   // This is called after the reactor threads exit.
@@ -224,8 +203,7 @@ OpenDDS::DCPS::ReactorTask::close(u_long flags)
   return 0;
 }
 
-void
-OpenDDS::DCPS::ReactorTask::stop()
+void ReactorTask::stop()
 {
 
   {
@@ -257,5 +235,62 @@ OpenDDS::DCPS::ReactorTask::stop()
   // Reset the thread manager in case it goes away before the next open.
   this->thr_mgr(0);
 }
+
+bool ThreadStatus::update(
+  const String& thread_key, const MonotonicTimePoint& timestamp)
+{
+  ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, lock, false);
+  Map::iterator it = map.find(thread_key);
+  const bool is_new = it == map.end();
+  if (is_new) {
+    it = map.insert(Map::value_type(thread_key, Thread())).first;
+  } else {
+    it->second.since_last_update = timestamp - it->second.timestamp;
+  }
+  it->second.timestamp = timestamp;
+  if (DCPS_debug_level > 4) {
+    if (is_new) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) ThreadStatus::update: first update for "
+        "thread \"%C\"\n", thread_key.c_str()));
+    } else {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) ThreadStatus::update: last update for "
+        "thread \"%C\" was %#T seconds ago\n",
+        thread_key.c_str(), &it->second.since_last_update.value()));
+    }
+  }
+  return true;
+}
+
+String ThreadStatus::get_key(const char* fallback_tid, const String& name)
+{
+  ACE_UNUSED_ARG(fallback_tid);
+  String key;
+#ifdef OPENDDS_SAFETY_PROFILE
+  key = fallback_tid;
+#else
+#  ifdef ACE_HAS_MAC_OSX
+  unsigned long tid = 0;
+  uint64_t u64_tid;
+  if (!pthread_threadid_np(0, &u64_tid)) {
+    tid = static_cast<unsigned long>(u64_tid);
+  } else if (DCPS_debug_level) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: pthread_threadid_np failed\n")));
+  }
+#  else
+  ACE_thread_t tid = ACE_OS::thr_self();
+#  endif
+
+  key = to_dds_string(tid);
+#endif
+
+  if (name.length()) {
+    key += " (" + name + ")";
+  }
+
+  return key;
+}
+
+} // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -238,7 +238,7 @@ void ReactorTask::stop()
 }
 
 bool ThreadStatus::update(
-  const String& thread_key, const MonotonicTimePoint& timestamp)
+  const String& thread_key, const SystemTimePoint& timestamp)
 {
   ACE_WRITE_GUARD_RETURN(ACE_Thread_Mutex, g, lock, false);
   Map::iterator it = map.find(thread_key);

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -269,9 +269,9 @@ String ThreadStatus::get_key(const char* safety_profile_tid, const String& name)
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: pthread_threadid_np failed\n")));
   }
 #  elif defined ACE_HAS_GETTID
-  pid_t tid = ACE_OS::thr_gettid();
+  const pid_t tid = gettid();
 #  else
-  ACE_thread_t tid = ACE_OS::thr_self();
+  const ACE_thread_t tid = ACE_OS::thr_self();
 #  endif
 
   key = to_dds_string(tid);

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -41,9 +41,10 @@ struct OpenDDS_Dcps_Export ThreadStatus {
   ACE_Thread_Mutex lock;
   Map map;
 
-  /// Get key for map and update. fallback_tid is mostly for safety profile.
+  /// Get key for map and update.
+  /// safety_profile_tid is the thread id under safety profile, otherwise unused.
   /// name is for a more human-friendly name that will be appended to the key.
-  static String get_key(const char* fallback_tid = "", const String& name = "");
+  static String get_key(const char* safety_profile_tid = "", const String& name = "");
 
   /// Update the status of a thread to indicate it was able to check in at the
   /// given time. Returns false if failed.

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -49,6 +49,13 @@ struct OpenDDS_Dcps_Export ThreadStatus {
   /// Update the status of a thread to indicate it was able to check in at the
   /// given time. Returns false if failed.
   bool update(const String& key);
+
+#ifdef ACE_HAS_GETTID
+  static inline pid_t gettid()
+  {
+    return syscall(SYS_gettid);
+  }
+#endif
 };
 
 class OpenDDS_Dcps_Export ReactorTask : public virtual ACE_Task_Base,

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -34,6 +34,7 @@ namespace DCPS {
 struct OpenDDS_Dcps_Export ThreadStatus {
   struct Thread {
     SystemTimePoint timestamp;
+    // TODO(iguessthislldo): Add Participant GUID
   };
   typedef OPENDDS_MAP(String, Thread) Map;
 
@@ -47,8 +48,7 @@ struct OpenDDS_Dcps_Export ThreadStatus {
 
   /// Update the status of a thread to indicate it was able to check in at the
   /// given time. Returns false if failed.
-  bool update(const String& key,
-    const SystemTimePoint& timestamp = SystemTimePoint::now());
+  bool update(const String& key);
 };
 
 class OpenDDS_Dcps_Export ReactorTask : public virtual ACE_Task_Base,
@@ -60,7 +60,8 @@ public:
   virtual ~ReactorTask();
 
 public:
-  int open_reactor_task(void*, TimeDuration timeout = TimeDuration(0), ThreadStatus* thread_stat = 0, String name = "");
+  int open_reactor_task(void*, TimeDuration timeout = TimeDuration(0),
+    ThreadStatus* thread_stat = 0, const String& name = "");
   virtual int open(void* ptr) {
     return open_reactor_task(ptr);
   }

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -33,7 +33,7 @@ namespace DCPS {
 
 struct OpenDDS_Dcps_Export ThreadStatus {
   struct Thread {
-    MonotonicTimePoint timestamp;
+    SystemTimePoint timestamp;
   };
   typedef OPENDDS_MAP(String, Thread) Map;
 
@@ -48,7 +48,7 @@ struct OpenDDS_Dcps_Export ThreadStatus {
   /// Update the status of a thread to indicate it was able to check in at the
   /// given time. Returns false if failed.
   bool update(const String& key,
-    const MonotonicTimePoint& timestamp = MonotonicTimePoint::now());
+    const SystemTimePoint& timestamp = SystemTimePoint::now());
 };
 
 class OpenDDS_Dcps_Export ReactorTask : public virtual ACE_Task_Base,

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -34,7 +34,6 @@ namespace DCPS {
 struct OpenDDS_Dcps_Export ThreadStatus {
   struct Thread {
     MonotonicTimePoint timestamp;
-    TimeDuration since_last_update;
   };
   typedef OPENDDS_MAP(String, Thread) Map;
 

--- a/dds/DCPS/ReactorTask.inl
+++ b/dds/DCPS/ReactorTask.inl
@@ -5,39 +5,42 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "ace/Reactor.h"
-#include "debug.h"
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
-ACE_INLINE ACE_Reactor*
-OpenDDS::DCPS::ReactorTask::get_reactor()
+namespace OpenDDS {
+namespace DCPS {
+
+ACE_INLINE
+ACE_Reactor* ReactorTask::get_reactor()
 {
   return reactor_;
 }
 
-ACE_INLINE const ACE_Reactor*
-OpenDDS::DCPS::ReactorTask::get_reactor() const
+ACE_INLINE
+const ACE_Reactor* ReactorTask::get_reactor() const
 {
   return reactor_;
 }
 
-ACE_INLINE ACE_thread_t
-OpenDDS::DCPS::ReactorTask::get_reactor_owner() const
+ACE_INLINE
+ACE_thread_t ReactorTask::get_reactor_owner() const
 {
   return reactor_owner_;
 }
 
-ACE_INLINE ACE_Proactor*
-OpenDDS::DCPS::ReactorTask::get_proactor()
+ACE_INLINE
+ACE_Proactor* ReactorTask::get_proactor()
 {
   return proactor_;
 }
 
-ACE_INLINE const ACE_Proactor*
-OpenDDS::DCPS::ReactorTask::get_proactor() const
+ACE_INLINE
+const ACE_Proactor* ReactorTask::get_proactor() const
 {
   return proactor_;
 }
+
+} // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -135,7 +135,7 @@ public:
   /// This is needed to know if delete DataReader should fail with
   /// PRECONDITION_NOT_MET because there are outstanding loans.
 #ifdef ACE_HAS_CPP11
-    std::atomic<long> zero_copy_cnt_;
+  std::atomic<long> zero_copy_cnt_;
 #else
   ACE_Atomic_Op<ACE_Thread_Mutex, long> zero_copy_cnt_;
 #endif
@@ -155,7 +155,7 @@ public:
 
 private:
 #ifdef ACE_HAS_CPP11
-    std::atomic<long> ref_count_;
+  std::atomic<long> ref_count_;
 #else
   ACE_Atomic_Op<ACE_Thread_Mutex, long> ref_count_;
 #endif

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -192,7 +192,7 @@ Service_Participant::Service_Participant()
     federation_initial_backoff_seconds_(DEFAULT_FEDERATION_INITIAL_BACKOFF_SECONDS),
     federation_backoff_multiplier_(DEFAULT_FEDERATION_BACKOFF_MULTIPLIER),
     federation_liveliness_(DEFAULT_FEDERATION_LIVELINESS),
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#if OPENDDS_POOL_ALLOCATOR
     pool_size_(1024*1024*16),
     pool_granularity_(8),
 #endif
@@ -422,7 +422,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
         }
       }
 
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#if OPENDD_POOL_ALLOCATOR
       // For non-FACE tests, configure pool
       configure_pool();
 #endif
@@ -1854,7 +1854,7 @@ Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationBackoffMultiplier"), this->federation_backoff_multiplier_, int)
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationLivelinessDuration"), this->federation_liveliness_, int)
 
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#if OPENDD_POOL_ALLOCATOR
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_size"), pool_size_, size_t)
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_granularity"), pool_granularity_, size_t)
 #endif
@@ -2603,7 +2603,7 @@ Service_Participant::is_discovery_template(const OPENDDS_STRING& name)
   return false;
 }
 
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#if OPENDD_POOL_ALLOCATOR
 void
 Service_Participant::configure_pool()
 {

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -422,7 +422,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
         }
       }
 
-#if OPENDD_POOL_ALLOCATOR
+#if OPENDDS_POOL_ALLOCATOR
       // For non-FACE tests, configure pool
       configure_pool();
 #endif
@@ -1854,7 +1854,7 @@ Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationBackoffMultiplier"), this->federation_backoff_multiplier_, int)
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationLivelinessDuration"), this->federation_liveliness_, int)
 
-#if OPENDD_POOL_ALLOCATOR
+#if OPENDDS_POOL_ALLOCATOR
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_size"), pool_size_, size_t)
     GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_granularity"), pool_granularity_, size_t)
 #endif
@@ -2603,7 +2603,7 @@ Service_Participant::is_discovery_template(const OPENDDS_STRING& name)
   return false;
 }
 
-#if OPENDD_POOL_ALLOCATOR
+#if OPENDDS_POOL_ALLOCATOR
 void
 Service_Participant::configure_pool()
 {

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -674,7 +674,7 @@ private:
   /// Scheduler time slice from configuration file.
   TimeDuration schedulerQuantum_;
 
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#if OPENDDS_POOL_ALLOCATOR
   /// Pool size from configuration file.
   size_t pool_size_;
 

--- a/dds/DCPS/TopicDescriptionImpl.h
+++ b/dds/DCPS/TopicDescriptionImpl.h
@@ -89,7 +89,7 @@ protected:
 
   /// The number of entities using this topic
 #ifdef ACE_HAS_CPP11
-    std::atomic<uint32_t> entity_refs_;
+  std::atomic<uint32_t> entity_refs_;
 #else
   ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> entity_refs_;
 #endif

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -136,7 +136,10 @@ public:
                     ACE_DEBUG((LM_DEBUG,
                                "(%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
                   }
-                  status->update(thread_key, now);
+                  if (!status->update(thread_key) && DCPS_debug_level) {
+                    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: QueueTaskBase::svc: "
+                      "thread update failed\n"));
+                  }
                 }
               }
             } while (this->queue_.is_empty() && !shutdown_initiated_);

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -614,12 +614,8 @@ module OpenDDS {
     BUILT_IN_TOPIC_TYPE
     struct InternalThreadBuiltinTopicData {
       BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
-      string thread_id;
-      /// Timestamp for this update.
-      DDS::Time_t timestamp;
-      /// Time since last internal update, which might not have been
-      /// published.
-      DDS::Duration_t since_last_update;
+      BUILT_IN_TOPIC_KEY string thread_id;
+      BUILT_IN_TOPIC_KEY DDS::Time_t timestamp;
     };
 
   };// End of module DCPS

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -613,9 +613,13 @@ module OpenDDS {
     // status monitoring.
     BUILT_IN_TOPIC_TYPE
     struct InternalThreadBuiltinTopicData {
-            BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
-            string thread_id;
-            DDS::Time_t timestamp;
+      BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
+      string thread_id;
+      /// Timestamp for this update.
+      DDS::Time_t timestamp;
+      /// Time since last internal update, which might not have been
+      /// published.
+      DDS::Duration_t since_last_update;
     };
 
   };// End of module DCPS

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -613,9 +613,8 @@ module OpenDDS {
     // status monitoring.
     BUILT_IN_TOPIC_TYPE
     struct InternalThreadBuiltinTopicData {
-      BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
       BUILT_IN_TOPIC_KEY string thread_id;
-      BUILT_IN_TOPIC_KEY DDS::Time_t timestamp;
+      DDS::OctetArray16 participant_guid;
     };
 
   };// End of module DCPS

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -80,7 +80,7 @@ void Initialize(const CONFIGURATION_RESOURCE configuration_file,
       return_code = INVALID_PARAM;
     } else {
       return_code = RC_NO_ERROR;
-#if defined OPENDDS_SAFETY_PROFILE && defined ACE_HAS_ALLOC_HOOKS
+#if OPENDD_POOL_ALLOCATOR
       TheServiceParticipant->configure_pool();
 #endif
     }

--- a/dds/FACE/FaceTSS.cpp
+++ b/dds/FACE/FaceTSS.cpp
@@ -80,7 +80,7 @@ void Initialize(const CONFIGURATION_RESOURCE configuration_file,
       return_code = INVALID_PARAM;
     } else {
       return_code = RC_NO_ERROR;
-#if OPENDD_POOL_ALLOCATOR
+#if OPENDDS_POOL_ALLOCATOR
       TheServiceParticipant->configure_pool();
 #endif
     }

--- a/java/tests/internal_thread_status/InternalThreadListener.java
+++ b/java/tests/internal_thread_status/InternalThreadListener.java
@@ -29,15 +29,14 @@ public class InternalThreadListener extends DDS._DataReaderListenerLocalBase {
   public synchronized void on_data_available(DDS.DataReader reader) {
     InternalThreadBuiltinTopicDataDataReader bitDataReader =
       InternalThreadBuiltinTopicDataDataReaderHelper.narrow(reader);
-    if (bitDataReader == null)
-    {
+    if (bitDataReader == null) {
       System.err.println("InternalThreadStatusListener on_data_available: narrow failed.");;
       System.exit(1);
     }
 
     InternalThreadBuiltinTopicDataHolder info =
       new InternalThreadBuiltinTopicDataHolder(
-        new InternalThreadBuiltinTopicData(new byte[16], "", new DDS.Time_t()));
+        new InternalThreadBuiltinTopicData(new byte[16], ""));
 
     SampleInfoHolder si = new SampleInfoHolder(new SampleInfo(0, 0, 0,
       new DDS.Time_t(), 0, 0, 0, 0, 0, 0, 0, false, 0));
@@ -47,10 +46,10 @@ public class InternalThreadListener extends DDS._DataReaderListenerLocalBase {
       status = bitDataReader.read_next_sample(info, si)) {
 
       System.out.println("== " + id + " Thread Info ==");
-      String guid = guidFormatter(info.value.guid);
+      String guid = guidFormatter(info.value.participant_guid);
       System.out.println("  guid: " + guid);
       System.out.println("   tid: " + info.value.thread_id);
-      System.out.println("  time: " + info.value.timestamp.sec);
+      System.out.println("  time: " + si.source_timestamp.sec);
     }
   }
 

--- a/java/tests/internal_thread_status/InternalThreadListener.java
+++ b/java/tests/internal_thread_status/InternalThreadListener.java
@@ -36,7 +36,7 @@ public class InternalThreadListener extends DDS._DataReaderListenerLocalBase {
 
     InternalThreadBuiltinTopicDataHolder info =
       new InternalThreadBuiltinTopicDataHolder(
-        new InternalThreadBuiltinTopicData(new byte[16], ""));
+        new InternalThreadBuiltinTopicData("", new byte[16]));
 
     SampleInfoHolder si = new SampleInfoHolder(new SampleInfo(0, 0, 0,
       new DDS.Time_t(), 0, 0, 0, 0, 0, 0, 0, false, 0));
@@ -49,7 +49,7 @@ public class InternalThreadListener extends DDS._DataReaderListenerLocalBase {
       String guid = guidFormatter(info.value.participant_guid);
       System.out.println("  guid: " + guid);
       System.out.println("   tid: " + info.value.thread_id);
-      System.out.println("  time: " + si.source_timestamp.sec);
+      System.out.println("  time: " + si.value.source_timestamp.sec);
     }
   }
 

--- a/java/tests/internal_thread_status/internal_thread_status_test.mpc
+++ b/java/tests/internal_thread_status/internal_thread_status_test.mpc
@@ -1,4 +1,4 @@
-project: dcps_tcp, dcps_test_java {
+project: dcps_rtps_udp, dcps_test_java {
     requires    += built_in_topics
     after       += messenger_idl_test
     javacflags  += -classpath ../messenger/messenger_idl/messenger_idl_test.jar

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatus.mpc
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatus.mpc
@@ -1,4 +1,4 @@
-project(InternalThreadStatusPublisher): dcpsexe, dcps_test, dcps_cm, dcps_transports_for_test, dcps_rtps {
+project(InternalThreadStatusPublisher): dcps_test, dcps_cm, dcps_rtps_udp {
 
   requires += no_opendds_safety_profile
   exename   = publisher
@@ -13,7 +13,7 @@ project(InternalThreadStatusPublisher): dcpsexe, dcps_test, dcps_cm, dcps_transp
   }
 }
 
-project(InternalThreadStatusSubscriber): dcpsexe, dcps_test, dcps_cm, dcps_transports_for_test, dcps_rtps {
+project(InternalThreadStatusSubscriber): dcps_test, dcps_cm, dcps_rtps_udp {
 
   requires += no_opendds_safety_profile
   exename   = subscriber

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
@@ -6,8 +6,13 @@
  */
 
 #include "InternalThreadStatusListenerImpl.h"
+
+#include <dds/DCPS/ReactorTask.h>
+
 #include <dds/DdsDcpsCoreTypeSupportImpl.h>
+
 #include <ace/streams.h>
+
 #include <string>
 
 // Implementation skeleton constructor
@@ -45,9 +50,18 @@ void InternalThreadStatusListenerImpl::on_data_available(DDS::DataReader_ptr rea
 
     std::cout << "== " << id_ << " Thread Info ==" << std::endl;
     std::cout
-    << "  guid: " << guid << std::endl
-    << "   tid: " << thread_info.thread_id << std::endl
-    << "  time: " << thread_info.timestamp.sec << std::endl;
+      << " guid: " << guid << std::endl
+      << "  tid: " << thread_info.thread_id << std::endl
+      << " time: " << thread_info.timestamp.sec << std::endl
+      << " prev: " << thread_info.since_last_update.sec << std::endl;
+
+    const CORBA::Long limit = 5;
+    const CORBA::Long exceeded = thread_info.since_last_update.sec > limit ?
+      thread_info.since_last_update.sec - limit : 0;
+    if (exceeded) {
+      std::cerr << "ERROR: Thread " << thread_info.thread_id << " was " <<
+        exceeded << "seconds late" << std::endl;
+    }
 
     ++count_;
   }

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
@@ -52,16 +52,7 @@ void InternalThreadStatusListenerImpl::on_data_available(DDS::DataReader_ptr rea
     std::cout
       << " guid: " << guid << std::endl
       << "  tid: " << thread_info.thread_id << std::endl
-      << " time: " << thread_info.timestamp.sec << std::endl
-      << " prev: " << thread_info.since_last_update.sec << std::endl;
-
-    const CORBA::Long limit = 5;
-    const CORBA::Long exceeded = thread_info.since_last_update.sec > limit ?
-      thread_info.since_last_update.sec - limit : 0;
-    if (exceeded) {
-      std::cerr << "ERROR: Thread " << thread_info.thread_id << " was " <<
-        exceeded << "seconds late" << std::endl;
-    }
+      << " time: " << thread_info.timestamp.sec << std::endl;
 
     ++count_;
   }

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
@@ -46,13 +46,13 @@ void InternalThreadStatusListenerImpl::on_data_available(DDS::DataReader_ptr rea
 
     // copy octet[] to guid
     OpenDDS::DCPS::RepoId guid;
-    std::memcpy(&guid, &thread_info.guid, sizeof(guid));
+    std::memcpy(&guid, &thread_info.participant_guid, sizeof(guid));
 
     std::cout << "== " << id_ << " Thread Info ==" << std::endl;
     std::cout
       << " guid: " << guid << std::endl
       << "  tid: " << thread_info.thread_id << std::endl
-      << " time: " << thread_info.timestamp.sec << std::endl;
+      << " time: " << si.source_timestamp.sec << std::endl;
 
     ++count_;
   }

--- a/tests/DCPS/InternalThreadStatus/publisher.cpp
+++ b/tests/DCPS/InternalThreadStatus/publisher.cpp
@@ -133,8 +133,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     // Get the Built-In Subscriber for Built-In Topics
     DDS::Subscriber_var bit_subscriber = participant->get_builtin_subscriber();
 
-    DDS::DataReader_var pub_loc_dr = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC);
-    if (0 == pub_loc_dr) {
+    DDS::DataReader_var thread_reader =
+      bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC);
+    if (!thread_reader) {
       std::cerr << "Could not get " << OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC
                 << " DataReader." << std::endl;
       ACE_OS::exit(EXIT_FAILURE);
@@ -143,9 +144,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     InternalThreadStatusListenerImpl* listener = new InternalThreadStatusListenerImpl("Publisher");
     DDS::DataReaderListener_var listener_var(listener);
 
-    CORBA::Long retcode =
-      pub_loc_dr->set_listener(listener,
-                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    const DDS::ReturnCode_t retcode =
+      thread_reader->set_listener(listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (retcode != DDS::RETCODE_OK) {
       std::cerr << "set_listener for " << OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC << " failed." << std::endl;
       ACE_OS::exit(EXIT_FAILURE);

--- a/tests/DCPS/UnitTests/.gitignore
+++ b/tests/DCPS/UnitTests/.gitignore
@@ -17,3 +17,4 @@
 /UnitTests_TimeTSubtraction
 /UnitTests_XTypesAssignability
 /UnitTests_Serializer
+/UnitTests_GuidUtils

--- a/tests/DCPS/UnitTests/GuidUtils.cpp
+++ b/tests/DCPS/UnitTests/GuidUtils.cpp
@@ -1,0 +1,21 @@
+#include <dds/DCPS/GuidUtils.h>
+
+#include <gtest/gtest.h>
+
+using namespace OpenDDS::DCPS;
+
+/**
+ * Test that assign(OctetArray16& dest, const GUID_t& src) will work since dest
+ * is an array and src is an unpacked struct, so theoretically the compiler
+ * could add padding to GUID_t, even though this is unlikely.
+ */
+TEST(guid_utils_test, guid_t_vs_octet_array16_size_test)
+{
+  ASSERT_EQ(sizeof(OctetArray16), sizeof(GUID_t));
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/DCPS/UnitTests/UnitTests.mpc
+++ b/tests/DCPS/UnitTests/UnitTests.mpc
@@ -146,3 +146,10 @@ project(*Serializer): dcps_test, googletest {
     Serializer.cpp
   }
 }
+
+project(*GuidUtils): dcps_test, googletest {
+  exename = *
+  Source_Files {
+    GuidUtils.cpp
+  }
+}


### PR DESCRIPTION
When using internal thread status BIT with conditions it's possible for one publish thread status to knock out the previous one before it can be read because the history depth is one and they are in the same instance.

Also:
- Refactor thread monitoring code by making common functions for generating the thread key and updating thread status.
- Create `OpenDDS::DCPS::String` to eventually replace `OPENDDS_STRING`.
- Other minor miscellaneous fixes.