### PR TITLE
max_bundle_size is unnecessary

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -82,7 +82,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
   , heartbeat_(reactor_task->interceptor(), config.heartbeat_period_, *this, &RtpsUdpDataLink::send_heartbeats)
   , heartbeat_reply_(reactor_task->interceptor(), config.heartbeat_period_, *this, &RtpsUdpDataLink::send_heartbeat_replies)
   , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
-  , max_bundle_size_(config.max_bundle_size_)
+  , max_bundle_size_(config.max_message_size_ - RTPS::RTPSHDR_SZ) // default maximum bundled message size is max udp message size (see TransportStrategy) minus RTPS header
   , quick_heartbeat_delay_(config.heartbeat_period_ * config.quick_reply_ratio_)
   , normal_heartbeat_response_delay_(config.heartbeat_response_delay_)
   , quick_heartbeat_response_delay_(config.heartbeat_response_delay_ * config.quick_reply_ratio_)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -35,7 +35,6 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , ttl_(1)
   , max_message_size_(RtpsUdpSendStrategy::UDP_MAX_MESSAGE_SIZE)
   , nak_depth_(0)
-  , max_bundle_size_(TransportSendStrategy::UDP_MAX_MESSAGE_SIZE - RTPS::RTPSHDR_SZ) // default maximum bundled message size is max udp message size (see TransportStrategy) minus RTPS header
   , quick_reply_ratio_(0.1)
   , nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
   , heartbeat_period_(1) // no default in RTPS spec
@@ -98,8 +97,6 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("max_message_size"), max_message_size_, size_t);
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("nak_depth"), nak_depth_, size_t);
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("max_bundle_size"), max_bundle_size_, size_t);
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("quick_reply_ratio"), quick_reply_ratio_, double);
 
@@ -173,7 +170,7 @@ RtpsUdpInst::dump_to_str() const
       + ':' + to_dds_string(multicast_group_address_.get_port_number()) + '\n';
   ret += formatNameForDump("multicast_interface") + multicast_interface_ + '\n';
   ret += formatNameForDump("nak_depth") + to_dds_string(unsigned(nak_depth_)) + '\n';
-  ret += formatNameForDump("max_bundle_size") + to_dds_string(unsigned(max_bundle_size_)) + '\n';
+  ret += formatNameForDump("max_message_size") + to_dds_string(unsigned(max_message_size_)) + '\n';
   ret += formatNameForDump("nak_response_delay") + to_dds_string(nak_response_delay_.value().msec()) + '\n';
   ret += formatNameForDump("heartbeat_period") + to_dds_string(heartbeat_period_.value().msec()) + '\n';
   ret += formatNameForDump("heartbeat_response_delay") + to_dds_string(heartbeat_response_delay_.value().msec()) + '\n';

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -38,7 +38,6 @@ public:
 
   size_t max_message_size_;
   size_t nak_depth_;
-  size_t max_bundle_size_;
   double quick_reply_ratio_;
   TimeDuration nak_response_delay_, heartbeat_period_,
     heartbeat_response_delay_, handshake_timeout_, durable_data_timeout_;


### PR DESCRIPTION
Problem
-------

Applications setting max_message_size should set max_bundle_size.
Consequently, max_bundle_size should just be derived from
max_message_size to eliminate a configuration variable.

Solution
--------

Derive max_bundle_size from max_message_size.