### PR TITLE
WCHAR test relocation for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,12 +126,9 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      Release64WChar:
+      Release64:
         BuildPlatform: x64
         BuildConfiguration: Release
-      Debug64:
-        BuildPlatform: x64
-        BuildConfiguration: Debug
   variables:
     VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
   steps:
@@ -161,12 +158,13 @@ jobs:
       arguments: 'C:\Strawberry\perl\bin'
       modifyEnvironment: true
   - script: |
-      if %BuildConfiguration%==Release set OPT=--no-debug --optimize --features=uses_wchar=1
+      if %BuildConfiguration%==Release set OPT=--no-tests --no-debug --optimize
+      if %BuildConfiguration%==Debug set OPT=--features=uses_wchar=1
       set SEC=--security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst)
       if %BuildConfiguration%==Debug if %BuildPlatform%==x64 set SEC=
       call configure -v --ace-github-latest --tests %SEC% %OPT%
       perl tools\scripts\show_build_config.pl
-      set SLN=DDS_TAOv2_all.sln
+      if %BuildConfiguration%==Release (set SLN=DDS_TAOv2.sln) else set SLN=DDS_TAOv2_all.sln
       echo ##vso[task.setvariable variable=BuildSolution]%SLN%
     failOnStderr: #
     displayName: Run configure script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ jobs:
       if %BuildConfiguration%==Debug if %BuildPlatform%==x64 set SEC=
       call configure -v --ace-github-latest --tests %SEC% %OPT%
       perl tools\scripts\show_build_config.pl
-      if %BuildConfiguration%==Release (set SLN=DDS_TAOv2.sln) else set SLN=DDS_TAOv2_all.sln
+      set SLN=DDS_TAOv2_all.sln
       echo ##vso[task.setvariable variable=BuildSolution]%SLN%
     failOnStderr: #
     displayName: Run configure script

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,10 +126,10 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      Release64:
+      Release64WChar:
         BuildPlatform: x64
         BuildConfiguration: Release
-      Debug64WChar:
+      Debug64:
         BuildPlatform: x64
         BuildConfiguration: Debug
   variables:
@@ -161,8 +161,7 @@ jobs:
       arguments: 'C:\Strawberry\perl\bin'
       modifyEnvironment: true
   - script: |
-      if %BuildConfiguration%==Release set OPT=--no-tests --no-debug --optimize
-      if %BuildConfiguration%==Debug set OPT=--features=uses_wchar=1
+      if %BuildConfiguration%==Release set OPT=--no-debug --optimize --features=uses_wchar=1
       set SEC=--security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst)
       if %BuildConfiguration%==Debug if %BuildPlatform%==x64 set SEC=
       call configure -v --ace-github-latest --tests %SEC% %OPT%


### PR DESCRIPTION
For Azure pipelines tests moved wchar option from Debug to Release for VS 2017, as the test was running out of space