### PR TITLE
Participant location updates ignored

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -2176,10 +2176,12 @@ namespace OpenDDS {
         struct LocationUpdate {
           ParticipantLocation mask_;
           ACE_INET_Addr from_;
+          SystemTimePoint timestamp_;
           LocationUpdate() {}
           LocationUpdate(ParticipantLocation mask,
-                         const ACE_INET_Addr& from)
-            : mask_(mask), from_(from) {}
+                         const ACE_INET_Addr& from,
+                         const SystemTimePoint& timestamp)
+            : mask_(mask), from_(from), timestamp_(timestamp) {}
         };
         typedef OPENDDS_VECTOR(LocationUpdate) LocationUpdateList;
         LocationUpdateList location_updates_;


### PR DESCRIPTION
Problem
-------

Participant location updates are enqueued and processed but not
published until the participant appears in the BITs.  This is
problematic when using discovery since the participant will only
appear in the BITs after secure discovery.  Consquently, the location
may never get published or get published with an incorrect mask.

Solution
--------

Don't process the queue until the participant appears in the BITs.