### PR TITLE
Security plugins leak resources

### DIFF
--- a/dds/DCPS/security/AccessControlBuiltInImpl.h
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.h
@@ -263,8 +263,10 @@ private:
                           AccessControlBuiltInImpl& impl);
     virtual ~RevokePermissionsTask();
     void insert(DDS::Security::PermissionsHandle pm_handle, const time_t& expiration);
+    void erase(DDS::Security::PermissionsHandle pm_handle);
 
   private:
+    typedef OPENDDS_MAP(DDS::Security::PermissionsHandle, time_t) HandleToExpiration;
     typedef OPENDDS_MULTIMAP(time_t, DDS::Security::PermissionsHandle) ExpirationToHandle;
 
     virtual void execute(const DCPS::MonotonicTimePoint& now);
@@ -272,6 +274,7 @@ private:
     AccessControlBuiltInImpl& impl_;
 
     mutable ACE_Thread_Mutex lock_;
+    HandleToExpiration handle_to_expiration_;
     ExpirationToHandle expiration_to_handle_;
   };
   typedef DCPS::RcHandle<RevokePermissionsTask> RevokePermissionsTask_rch;

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -83,7 +83,12 @@ AuthenticationBuiltInImpl::AuthenticationBuiltInImpl()
 
 AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
 {
-
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl local_participants_ %B handshake_data_ %B\n"),
+               local_participants_.size(),
+               handshake_data_.size()));
+  }
 }
 
 ::DDS::Security::ValidationResult_t AuthenticationBuiltInImpl::validate_local_identity(
@@ -123,6 +128,12 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
         {
           ACE_Guard<ACE_Thread_Mutex> identity_data_guard(identity_mutex_);
           local_participants_[local_identity_handle] = local_participant;
+
+          if (DCPS::security_debug.bookkeeping) {
+            ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                       ACE_TEXT("AuthenticationBuiltInImpl::validate_local_identity local_participants_ (total %B)\n"),
+                       local_participants_.size()));
+          }
         }
 
         result = DDS::Security::VALIDATION_OK;
@@ -272,6 +283,12 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
 
     remote_identity_handle = get_next_handle();
     found = local_data->validated_remotes.insert(std::make_pair(remote_identity_handle, remote_participant)).first;
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("AuthenticationBuiltInImpl::validate_remote_identity validated_remotes (total %B)\n"),
+                 local_data->validated_remotes.size()));
+    }
   }
 
   // Update the remote token.
@@ -393,6 +410,12 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
   {
     ACE_Guard<ACE_Thread_Mutex> identity_data_guard(handshake_mutex_);
     handshake_data_[handshake_handle] = handshake_data;
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("AuthenticationBuiltInImpl::begin_handshake_request handshake_data_ (total %B)\n"),
+                 handshake_data_.size()));
+    }
   }
 
   return DDS::Security::VALIDATION_PENDING_HANDSHAKE_MESSAGE;
@@ -790,6 +813,12 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
   {
     ACE_Guard<ACE_Thread_Mutex> guard(handshake_mutex_);
     handshake_data_[handshake_handle] = handshake_data;
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("AuthenticationBuiltInImpl::begin_handshake_reply handshake_data_ (total %B)\n"),
+                 handshake_data_.size()));
+    }
   }
 
   return Pending;
@@ -949,6 +978,13 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
   HandshakeDataMap::iterator found = handshake_data_.find(handshake_handle);
   if (found != handshake_data_.end()) {
     handshake_data_.erase(found);
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("AuthenticationBuiltInImpl::return_handshake_handle handshake_data_ (total %B)\n"),
+                 handshake_data_.size()));
+    }
+
     return true;
   }
 
@@ -965,6 +1001,13 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
   LocalParticipantMap::iterator local = local_participants_.find(identity_handle);
   if (local != local_participants_.end()) {
     local_participants_.erase(local);
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("AuthenticationBuiltInImpl::return_identity_handle local_participants_ (total %B)\n"),
+                 local_participants_.size()));
+    }
+
     return true;
   }
 
@@ -973,6 +1016,13 @@ static void make_final_signature_sequence(const DDS::OctetSeq& hash_c1,
 
   if (local != local_participants_.end()) {
     local->second->validated_remotes.erase(identity_handle);
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("AuthenticationBuiltInImpl::return_identity_handle validated_remotes (total %B)\n"),
+                 local->second->validated_remotes.size()));
+    }
+
     return true;
   }
 
@@ -1285,6 +1335,15 @@ AuthenticationBuiltInImpl::get_local_participant(DDS::Security::IdentityHandle h
   }
 
   return LocalParticipantData::shared_ptr();
+}
+
+AuthenticationBuiltInImpl::LocalParticipantData::~LocalParticipantData()
+{
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("LocalParticipantData::~LocalParticipantData validated_remotes %B\n"),
+               validated_remotes.size()));
+  }
 }
 
 AuthenticationBuiltInImpl::HandshakeDataPair

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.h
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.h
@@ -200,6 +200,7 @@ private:
       , handshake_debug(false)
     {
     }
+    ~LocalParticipantData();
   };
   typedef std::map<DDS::Security::IdentityHandle, LocalParticipantData::shared_ptr> LocalParticipantMap;
   LocalParticipantMap local_participants_;

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -56,6 +56,16 @@ CryptoBuiltInImpl::CryptoBuiltInImpl()
 
 CryptoBuiltInImpl::~CryptoBuiltInImpl()
 {
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::~CryptoBuiltInImpl keys_ %B encrypt_options_ %B participant_to_entity_ %B sessions_ %B derived_key_handles_ %B\n"),
+               keys_.size(),
+               encrypt_options_.size(),
+               participant_to_entity_.size(),
+               sessions_.size(),
+               derived_key_handles_.size()));
+  }
+
   openssl_cleanup();
 }
 
@@ -163,6 +173,11 @@ ParticipantCryptoHandle CryptoBuiltInImpl::register_local_participant(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   keys_[h] = keys;
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_local_participant keys_ (total %B)\n"),
+               keys_.size()));
+  }
   return h;
 }
 
@@ -359,11 +374,26 @@ DatawriterCryptoHandle CryptoBuiltInImpl::register_local_datawriter(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   keys_[h] = keys;
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_local_datawriter keys_ (total %B)\n"),
+               keys_.size()));
+  }
   encrypt_options_[h] = security_attributes;
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_local_datawriter encrypt_options_ (total %B)\n"),
+               encrypt_options_.size()));
+  }
 
   if (participant_crypto != DDS::HANDLE_NIL) {
     const EntityInfo e(DATAWRITER_SUBMESSAGE, h);
     participant_to_entity_.insert(std::make_pair(participant_crypto, e));
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::register_local_datawriter participant_to_entity_ (total %B)\n"),
+                 participant_to_entity_.size()));
+    }
   }
 
   return h;
@@ -431,16 +461,41 @@ DatareaderCryptoHandle CryptoBuiltInImpl::register_matched_remote_datareader(
         to_dds_string(dr_keys[0]).c_str()));
     }
     keys_[h] = dr_keys;
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader keys_ (total %B)\n"),
+                 keys_.size()));
+    }
     if (existing_handle_iter != derived_key_handles_.end()) {
       sessions_.erase(std::make_pair(h, submessage_key_index));
+      if (DCPS::security_debug.bookkeeping) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                   ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader sessions_ (total %B)\n"),
+                   sessions_.size()));
+      }
       return h;
     }
     derived_key_handles_[input_handles] = h;
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader derived_key_handles_ (total %B)\n"),
+                 derived_key_handles_.size()));
+    }
   }
 
   const EntityInfo e(DATAREADER_SUBMESSAGE, h);
   participant_to_entity_.insert(std::make_pair(remote_participant_crypto, e));
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader participant_to_entity_ (total %B)\n"),
+               participant_to_entity_.size()));
+  }
   encrypt_options_[h] = encrypt_options_[local_datawriter_crypto_handle];
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datareader encrypt_options_ (total %B)\n"),
+               encrypt_options_.size()));
+  }
   return h;
 }
 
@@ -474,11 +529,26 @@ DatareaderCryptoHandle CryptoBuiltInImpl::register_local_datareader(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   keys_[h] = keys;
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_local_datareader keys_ (total %B)\n"),
+               keys_.size()));
+  }
   encrypt_options_[h] = security_attributes;
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_local_datareader encrypt_options_ (total %B)\n"),
+               encrypt_options_.size()));
+  }
 
   if (participant_crypto != DDS::HANDLE_NIL) {
     const EntityInfo e(DATAREADER_SUBMESSAGE, h);
     participant_to_entity_.insert(std::make_pair(participant_crypto, e));
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::register_local_datareader participant_to_entity_ (total %B)\n"),
+                 participant_to_entity_.size()));
+    }
   }
 
   return h;
@@ -545,16 +615,41 @@ DatawriterCryptoHandle CryptoBuiltInImpl::register_matched_remote_datawriter(
         to_dds_string(dw_keys[0]).c_str()));
     }
     keys_[h] = dw_keys;
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter keys_ (total %B)\n"),
+                 keys_.size()));
+    }
     if (existing_handle_iter != derived_key_handles_.end()) {
       sessions_.erase(std::make_pair(h, submessage_key_index));
+      if (DCPS::security_debug.bookkeeping) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                   ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter sessions_ (total %B)\n"),
+                   sessions_.size()));
+      }
       return h;
     }
     derived_key_handles_[input_handles] = h;
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter derived_key_handles_ (total %B)\n"),
+                 derived_key_handles_.size()));
+    }
   }
 
   const EntityInfo e(DATAWRITER_SUBMESSAGE, h);
   participant_to_entity_.insert(std::make_pair(remote_participant_crypto, e));
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter participant_to_entity_ (total %B)\n"),
+               participant_to_entity_.size()));
+  }
   encrypt_options_[h] = encrypt_options_[local_datareader_crypto_handle];
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::register_matched_remote_datawriter encrypt_options_ (total %B)\n"),
+               encrypt_options_.size()));
+  }
   return h;
 }
 
@@ -568,6 +663,11 @@ bool CryptoBuiltInImpl::unregister_participant(ParticipantCryptoHandle handle, S
   clear_common_data(handle);
   for (DerivedKeyIndex_t::iterator it = derived_key_handles_.lower_bound(std::make_pair(handle, 0));
        it != derived_key_handles_.end() && it->first.first == handle; derived_key_handles_.erase(it++)) {
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::unregister_participant derived_key_handles_ (total %B)\n"),
+                 derived_key_handles_.size()));
+    }
   }
   return true;
 }
@@ -575,9 +675,19 @@ bool CryptoBuiltInImpl::unregister_participant(ParticipantCryptoHandle handle, S
 void CryptoBuiltInImpl::clear_common_data(NativeCryptoHandle handle)
 {
   keys_.erase(handle);
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::clear_common_data keys_ (total %B)\n"),
+               keys_.size()));
+  }
   for (SessionTable_t::iterator st_iter = sessions_.lower_bound(std::make_pair(handle, 0));
        st_iter != sessions_.end() && st_iter->first.first == handle;
        sessions_.erase(st_iter++)) {
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("CryptoBuiltInImpl::clear_common_data sessions_ (total %B)\n"),
+                 sessions_.size()));
+    }
   }
 }
 
@@ -585,11 +695,21 @@ void CryptoBuiltInImpl::clear_endpoint_data(NativeCryptoHandle handle)
 {
   clear_common_data(handle);
   encrypt_options_.erase(handle);
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::clear_endpoint_data encrypt_options_ (total %B)\n"),
+               encrypt_options_.size()));
+  }
 
   typedef std::multimap<ParticipantCryptoHandle, EntityInfo>::iterator iter_t;
   for (iter_t it = participant_to_entity_.begin(); it != participant_to_entity_.end();) {
     if (it->second.handle_ == handle) {
       participant_to_entity_.erase(it++);
+      if (DCPS::security_debug.bookkeeping) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                   ACE_TEXT("CryptoBuiltInImpl::clear_endpoint_data participant_to_entity_ (total %B)\n"),
+                   participant_to_entity_.size()));
+      }
     } else {
       ++it;
     }
@@ -722,6 +842,11 @@ bool CryptoBuiltInImpl::set_remote_participant_crypto_tokens(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   keys_[remote_participant_crypto] = tokens_to_keys(remote_participant_tokens);
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::set_remote_participant_crypto_tokens keys_ (total %B)\n"),
+               keys_.size()));
+  }
   return true;
 }
 
@@ -764,6 +889,11 @@ bool CryptoBuiltInImpl::set_remote_datawriter_crypto_tokens(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   keys_[remote_datawriter_crypto] = tokens_to_keys(remote_datawriter_tokens);
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::set_remote_datawriter_crypto_tokens keys_ (total %B)\n"),
+               keys_.size()));
+  }
   return true;
 }
 
@@ -806,6 +936,11 @@ bool CryptoBuiltInImpl::set_remote_datareader_crypto_tokens(
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   keys_[remote_datareader_crypto] = tokens_to_keys(remote_datareader_tokens);
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("CryptoBuiltInImpl::set_remote_datareader_crypto_tokens keys_ (total %B)\n"),
+               keys_.size()));
+  }
   return true;
 }
 
@@ -869,13 +1004,15 @@ bool CryptoBuiltInImpl::encode_serialized_payload(
   }
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-  const KeyTable_t::const_iterator iter = keys_.find(sending_datawriter_crypto);
-  if (iter == keys_.end() || !encrypt_options_[sending_datawriter_crypto].payload_) {
+  const KeyTable_t::const_iterator keys_iter = keys_.find(sending_datawriter_crypto);
+  const EncryptOptions_t::const_iterator eo_iter = encrypt_options_.find(sending_datawriter_crypto);
+  OPENDDS_ASSERT(eo_iter != encrypt_options_.end());
+  if (keys_iter == keys_.end() || !eo_iter->second.payload_) {
     encoded_buffer = plain_buffer;
     return true;
   }
 
-  const KeySeq& keyseq = iter->second;
+  const KeySeq& keyseq = keys_iter->second;
   if (!keyseq.length()) {
     encoded_buffer = plain_buffer;
     return true;
@@ -1257,7 +1394,10 @@ bool CryptoBuiltInImpl::encode_datawriter_submessage(
 
   NativeCryptoHandle encode_handle = sending_datawriter_crypto;
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-  if (!encrypt_options_[encode_handle].submessage_) {
+  const EncryptOptions_t::const_iterator eo_iter = encrypt_options_.find(encode_handle);
+  OPENDDS_ASSERT(eo_iter != encrypt_options_.end());
+
+  if (!eo_iter->second.submessage_) {
     encoded_rtps_submessage = plain_rtps_submessage;
     receiving_datareader_crypto_list_index = len;
     return true;
@@ -1904,7 +2044,9 @@ bool CryptoBuiltInImpl::decode_submessage(
   }
 
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-  const KeySeq& keyseq = keys_[sender_handle];
+  const KeyTable_t::const_iterator keys_iter = keys_.find(sender_handle);
+  OPENDDS_ASSERT(keys_iter != keys_.end());
+  const KeySeq& keyseq = keys_iter->second;
   for (unsigned int i = 0; i < keyseq.length(); ++i) {
     if (matches(keyseq[i], ch)) {
       const KeyId_t sKey = std::make_pair(sender_handle, i);
@@ -2012,7 +2154,9 @@ bool CryptoBuiltInImpl::decode_serialized_payload(
   if (iter == keys_.end()) {
     return CommonUtilities::set_security_error(ex, -1, 1, "No key for DataWriter crypto handle");
   }
-  if (!encrypt_options_[sending_datawriter_crypto].payload_) {
+  const EncryptOptions_t::const_iterator eo_iter = encrypt_options_.find(sending_datawriter_crypto);
+  OPENDDS_ASSERT(eo_iter != encrypt_options_.end());
+  if (!eo_iter->second.payload_) {
     plain_buffer = encoded_buffer;
     if (security_debug.encdec_debug) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {encdec_debug} CryptoBuiltInImpl::decode_serialized_payload ")

--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -1006,7 +1006,9 @@ bool CryptoBuiltInImpl::encode_serialized_payload(
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   const KeyTable_t::const_iterator keys_iter = keys_.find(sending_datawriter_crypto);
   const EncryptOptions_t::const_iterator eo_iter = encrypt_options_.find(sending_datawriter_crypto);
-  OPENDDS_ASSERT(eo_iter != encrypt_options_.end());
+  if (eo_iter == encrypt_options_.end()) {
+    return CommonUtilities::set_security_error(ex, -1, 0, "Datawriter handle lacks encrypt options");
+  }
   if (keys_iter == keys_.end() || !eo_iter->second.payload_) {
     encoded_buffer = plain_buffer;
     return true;
@@ -1395,7 +1397,9 @@ bool CryptoBuiltInImpl::encode_datawriter_submessage(
   NativeCryptoHandle encode_handle = sending_datawriter_crypto;
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   const EncryptOptions_t::const_iterator eo_iter = encrypt_options_.find(encode_handle);
-  OPENDDS_ASSERT(eo_iter != encrypt_options_.end());
+  if (eo_iter == encrypt_options_.end()) {
+    return CommonUtilities::set_security_error(ex, -1, 0, "Datawriter handle lacks encrypt options");
+  }
 
   if (!eo_iter->second.submessage_) {
     encoded_rtps_submessage = plain_rtps_submessage;
@@ -2155,7 +2159,9 @@ bool CryptoBuiltInImpl::decode_serialized_payload(
     return CommonUtilities::set_security_error(ex, -1, 1, "No key for DataWriter crypto handle");
   }
   const EncryptOptions_t::const_iterator eo_iter = encrypt_options_.find(sending_datawriter_crypto);
-  OPENDDS_ASSERT(eo_iter != encrypt_options_.end());
+  if (eo_iter == encrypt_options_.end()) {
+    return CommonUtilities::set_security_error(ex, -1, 0, "Datawriter handle lacks encrypt options");
+  }
   if (!eo_iter->second.payload_) {
     plain_buffer = encoded_buffer;
     if (security_debug.encdec_debug) {

--- a/dds/DCPS/security/framework/SecurityConfig.cpp
+++ b/dds/DCPS/security/framework/SecurityConfig.cpp
@@ -41,11 +41,13 @@ SecurityConfig::SecurityConfig(const OPENDDS_STRING& name,
 
 SecurityConfig::~SecurityConfig()
 {
+#ifdef OPENDDS_SECURITY
   if (DCPS::security_debug.bookkeeping) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
                ACE_TEXT("SecurityConfig::~SecurityConfig handle_registry_map_ %B\n"),
                handle_registry_map_.size()));
   }
+#endif
 }
 
 void SecurityConfig::get_properties(DDS::PropertyQosPolicy& out_properties) const

--- a/dds/DCPS/security/framework/SecurityConfig.cpp
+++ b/dds/DCPS/security/framework/SecurityConfig.cpp
@@ -40,7 +40,13 @@ SecurityConfig::SecurityConfig(const OPENDDS_STRING& name,
 {}
 
 SecurityConfig::~SecurityConfig()
-{}
+{
+  if (DCPS::security_debug.bookkeeping) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+               ACE_TEXT("SecurityConfig::~SecurityConfig handle_registry_map_ %B\n"),
+               handle_registry_map_.size()));
+  }
+}
 
 void SecurityConfig::get_properties(DDS::PropertyQosPolicy& out_properties) const
 {

--- a/dds/DCPS/security/framework/SecurityConfig.h
+++ b/dds/DCPS/security/framework/SecurityConfig.h
@@ -81,10 +81,16 @@ class OpenDDS_Dcps_Export SecurityConfig : public DCPS::RcObject {
     return utility_plugin_;
   }
 
-  void insert_handle_registry(const DCPS::RepoId& particpant_id,
+  void insert_handle_registry(const DCPS::RepoId& participant_id,
                               const HandleRegistry_rch& handle_registry)
   {
-    handle_registry_map_[particpant_id] = handle_registry;
+    handle_registry_map_[participant_id] = handle_registry;
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("SecurityConfig::insert_handle_registry handle_registry_map_ (total %B)\n"),
+                 handle_registry_map_.size()));
+    }
   }
 
   HandleRegistry_rch get_handle_registry(const DCPS::RepoId& participant_id)
@@ -97,9 +103,15 @@ class OpenDDS_Dcps_Export SecurityConfig : public DCPS::RcObject {
     return HandleRegistry_rch();
   }
 
-  void erase_handle_registry(const DCPS::RepoId& particpant_id)
+  void erase_handle_registry(const DCPS::RepoId& participant_id)
   {
-    handle_registry_map_.erase(particpant_id);
+    handle_registry_map_.erase(participant_id);
+
+    if (DCPS::security_debug.bookkeeping) {
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {bookkeeping} ")
+                 ACE_TEXT("SecurityConfig::erase_handle_registry handle_registry_map_ (total %B)\n"),
+                 handle_registry_map_.size()));
+    }
   }
 
 #endif

--- a/tests/security/unit_tests/CryptoTransformTest.cpp
+++ b/tests/security/unit_tests/CryptoTransformTest.cpp
@@ -110,20 +110,31 @@ TEST_F(CryptoTransformTest, encode_serialized_payload_NullHandle)
 
 TEST_F(CryptoTransformTest, encode_serialized_payload_EmptyBuffer)
 {
+  using namespace DDS::Security;
+  CryptoKeyFactory& kef = dynamic_cast<CryptoKeyFactory&>(get_inst());
+
   DDS::OctetSeq inline_qos;
   DDS::OctetSeq output;
-  DDS::Security::SecurityException ex;
-  DDS::Security::DatawriterCryptoHandle handle = 1;
+  DDS::PropertySeq no_properties;
+  EndpointSecurityAttributes esa = {{false, false, false, false}, false, false, false, 0, no_properties};
+  SecurityException ex;
+  const DatawriterCryptoHandle handle = kef.register_local_datawriter(0, no_properties, esa, ex);
+
   EXPECT_TRUE(get_inst().encode_serialized_payload(output, inline_qos, get_buffer(), handle, ex));
   EXPECT_EQ(get_buffer(), output);
 }
 
 TEST_F(CryptoTransformTest, encode_serialized_payload_WithData)
 {
+  using namespace DDS::Security;
+  CryptoKeyFactory& kef = dynamic_cast<CryptoKeyFactory&>(get_inst());
+
   DDS::OctetSeq inline_qos;
   DDS::OctetSeq output;
-  DDS::Security::SecurityException ex;
-  DDS::Security::DatawriterCryptoHandle handle = 1;
+  DDS::PropertySeq no_properties;
+  EndpointSecurityAttributes esa = {{false, false, false, false}, false, false, false, 0, no_properties};
+  SecurityException ex;
+  const DatawriterCryptoHandle handle = kef.register_local_datawriter(0, no_properties, esa, ex);
 
   // Create a buffer of non-zero size with non-zero data
   init_buffer(50U, 3);
@@ -191,9 +202,14 @@ TEST_F(CryptoTransformTest, encode_datawriter_submessage_NilReaderAtN)
 
 TEST_F(CryptoTransformTest, encode_datawriter_submessage_MultiPass)
 {
-  ::DDS::OctetSeq output;
-  ::DDS::Security::SecurityException ex;
-  ::DDS::Security::DatawriterCryptoHandle handle = 1;
+  using namespace DDS::Security;
+  CryptoKeyFactory& kef = dynamic_cast<CryptoKeyFactory&>(get_inst());
+
+  DDS::OctetSeq output;
+  DDS::PropertySeq no_properties;
+  EndpointSecurityAttributes esa = {{false, false, false, false}, false, false, false, 0, no_properties};
+  SecurityException ex;
+  const DatawriterCryptoHandle handle = kef.register_local_datawriter(0, no_properties, esa, ex);
 
   // Provide a valid list of reader handles
   const ::CORBA::Long NUM_READERS = 10;


### PR DESCRIPTION
Problem
-------

The security plugins can't use reference counting for cleanup which
makes it more susceptible to resource leaks.

Solution
--------

This commit adds logging to monitor the growth of security related
data structures.  Additionally, a resource leak related to revoking
permissions was identified and fixed.