### PR TITLE
Suppress ACE warnings for android and idl2jni boolean switch warning

### DIFF
--- a/configure
+++ b/configure
@@ -1048,11 +1048,6 @@ sub write_platform_macros {
         print $PMG 'TAO_IDL_DEP = $(TAO_IDL)$(HOST_EXE_EXT)', "\n";
         if ($has_host_compiler) {
           print $PMG 'TAO_IDL_PREPROCESSOR = ', $opts{'compiler'}, "\n";
-          if($opts{'target'} eq 'android') {
-            print $PMG 'ifeq (,$(findstring -I$(ACE_ROOT),$(INCLDIRS)))', "\n";
-            print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
-            print $PMG 'endif', "\n";
-          }
         }
         print $PMG 'TAO_IDLFLAGS += -g $(HOST_ACE)/bin/ace_gperf', "\n";
         print $PMG 'build_tao_idl_be = 0', "\n";
@@ -1075,6 +1070,11 @@ sub write_platform_macros {
             $opts{'nonstdcompiler'} = $tcomp;
             print $PMG 'LDFLAGS += -Wl,-rpath-link,$(ACE_ROOT)/lib', "\n";
           }
+        }
+        if($opts{'target'} eq 'android') {
+          print $PMG 'ifeq (,$(findstring -I$(ACE_ROOT),$(INCLDIRS)))', "\n";
+          print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
+          print $PMG 'endif', "\n";
         }
       }
     }

--- a/configure
+++ b/configure
@@ -1072,7 +1072,7 @@ sub write_platform_macros {
           }
         }
         if($opts{'target'} eq 'android') {
-          print $PMG 'ifeq (,$(findstring -I$(ACE_ROOT),$(INCLDIRS)))', "\n";
+          print $PMG 'ifeq (,$(findstring -isystem$(ACE_ROOT),$(INCLDIRS)))', "\n";
           print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
           print $PMG 'endif', "\n";
         }

--- a/configure
+++ b/configure
@@ -1048,9 +1048,11 @@ sub write_platform_macros {
         print $PMG 'TAO_IDL_DEP = $(TAO_IDL)$(HOST_EXE_EXT)', "\n";
         if ($has_host_compiler) {
           print $PMG 'TAO_IDL_PREPROCESSOR = ', $opts{'compiler'}, "\n";
-          print $PMG 'ifeq (,$(findstring -I$(ACE_ROOT),$(INCLDIRS)))', "\n";
-          print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
-          print $PMG 'endif', "\n";
+          if($opts{'target'} eq 'android') {
+            print $PMG 'ifeq (,$(findstring -I$(ACE_ROOT),$(INCLDIRS)))', "\n";
+            print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
+            print $PMG 'endif', "\n";
+          }
         }
         print $PMG 'TAO_IDLFLAGS += -g $(HOST_ACE)/bin/ace_gperf', "\n";
         print $PMG 'build_tao_idl_be = 0', "\n";

--- a/configure
+++ b/configure
@@ -1048,6 +1048,9 @@ sub write_platform_macros {
         print $PMG 'TAO_IDL_DEP = $(TAO_IDL)$(HOST_EXE_EXT)', "\n";
         if ($has_host_compiler) {
           print $PMG 'TAO_IDL_PREPROCESSOR = ', $opts{'compiler'}, "\n";
+          print $PMG 'ifeq (,$(findstring -I$(ACE_ROOT),$(INCLDIRS)))', "\n";
+          print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
+          print $PMG 'endif', "\n";
         }
         print $PMG 'TAO_IDLFLAGS += -g $(HOST_ACE)/bin/ace_gperf', "\n";
         print $PMG 'build_tao_idl_be = 0', "\n";

--- a/configure
+++ b/configure
@@ -1071,9 +1071,9 @@ sub write_platform_macros {
             print $PMG 'LDFLAGS += -Wl,-rpath-link,$(ACE_ROOT)/lib', "\n";
           }
         }
-        if($opts{'target'} eq 'android') {
+        if ($opts{'target'} eq 'android') {
           print $PMG 'ifeq (,$(findstring -isystem$(ACE_ROOT),$(INCLDIRS)))', "\n";
-          print $PMG '  INCLDIRS        += -isystem$(ACE_ROOT)', "\n";
+          print $PMG '  INCLDIRS += -isystem $(ACE_ROOT)', "\n";
           print $PMG 'endif', "\n";
         }
       }

--- a/java/idl2jni/codegen/im_jni.cpp
+++ b/java/idl2jni/codegen/im_jni.cpp
@@ -1812,6 +1812,11 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   commonSetup c(name);
   string unionJVMsig = scoped_helper(name, "/");
   bool disc_is_enum(disc_meth == "Object");
+  bool disc_is_bool = false;
+  AST_PredefinedType *pd = dynamic_cast<AST_PredefinedType*>(discriminator);
+  if (pd) {
+    disc_is_bool = (pd->pt() == AST_PredefinedType::PredefinedType::PT_boolean);
+  }
   string disc_name = disc_is_enum ? "disc_val" : "disc",
     extra_enum1 = disc_is_enum ?
     "  jmethodID mid_disc_val = jni->GetMethodID (jni->GetObjectClass "
@@ -1873,7 +1878,7 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   "  " << disc_ty << " disc = jni->Call" << disc_meth << "Method (source, "
   "mid_disc);\n" <<
   extra_enum1 <<
-  "  switch (" << disc_name << ")\n"
+  "  switch (" << (disc_is_bool ? "(int)" : "") << disc_name << ")\n"
   "    {\n" <<
   branchesToCxx <<
   "    }\n"
@@ -1893,7 +1898,7 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   "      clazz = jni->GetObjectClass (target);\n"
   "    }\n" <<
   explicitDiscSetup <<
-  "  switch (source._d ())\n"
+  "  switch (" << (disc_is_bool ? "(int)" : "") << "source._d ())\n"
   "    {\n" <<
   branchesToJava <<
   "    }\n" <<


### PR DESCRIPTION
Remaining warning is: 

/home/calabresec/3_16/testandroid/OpenDDS/build/target/ACE_wrappers/ace/Stack_Trace.cpp:55:1: warning: unused function 'determine_starting_frame' [-Wunused-function]

This has been a warning dealt with in the past and probably requires changes to ace.  It was fixed by us in the past to silence the warning on a different platform: https://github.com/DOCGroup/ACE_TAO/blob/6ac224067c083571fd1b00940e066e9ad3e2d582/ACE/ace/Stack_Trace.cpp#L746