### PR TITLE
Register TypeSupport.idl and don't use <%gendir%> in TypeSupport

### DIFF
--- a/MPC/config/dcps_ts_defaults.mpb
+++ b/MPC/config/dcps_ts_defaults.mpb
@@ -22,6 +22,12 @@ project : dds_macros, taobaseidldefaults {
     optional(header_pre_extension) {
       commandflags(-Lspcpp) += C
     }
+    optional(generic_pre_extension) {
+      commandflags(!-SI) += TypeSupport
+    }
+    optional(generic_outputext) {
+      commandflags(!-SI) = .idl
+    }
 
     // See $DDS_ROOT/MPC/modules/TYPESUPPORTHelper.pm for .idl and .java output
     // files and additional source and header files due to the -Gface option.

--- a/MPC/config/dcps_ts_defaults.mpb
+++ b/MPC/config/dcps_ts_defaults.mpb
@@ -16,7 +16,8 @@ project : dds_macros, taobaseidldefaults {
     dependent = $(OPENDDS_IDL_DEP) $(DDS_ROOT)/dds/idl/IDLTemplate.txt
     keyword dcps_ts_flags = commandflags
     inputext              = .idl
-    pre_extension         = TypeSupportImpl
+    source_pre_extension  = TypeSupportImpl
+    header_pre_extension  = TypeSupportImpl
     source_outputext      = .cpp
     header_outputext      = .h
     optional(header_pre_extension) {

--- a/MPC/config/dcps_ts_subdir.mpb
+++ b/MPC/config/dcps_ts_subdir.mpb
@@ -7,10 +7,6 @@
 
 project: dcps_ts_defaults, taobaseidldefaults {
 
-  Modify_Custom(TypeSupport) {
-    commandflags += -o <%gendir%>
-  }
-
   Modify_Custom(IDL) {
     output_follows_input = 1
     // In general, the setting in current versions of taobaseidldefaults.mpb

--- a/MPC/modules/TYPESUPPORTHelper.pm
+++ b/MPC/modules/TYPESUPPORTHelper.pm
@@ -19,8 +19,8 @@ sub get_output {
     return \@out;
   }
 
-  #my $tsidl = $file;
-  #$tsidl =~ s/\.idl$/TypeSupport.idl/;
+  my $tsidl = $file;
+  $tsidl =~ s/\.idl$/TypeSupport.idl/;
   #push(@out, $dir . basename($tsidl));
 
   my $deps;

--- a/MPC/modules/TYPESUPPORTHelper.pm
+++ b/MPC/modules/TYPESUPPORTHelper.pm
@@ -19,12 +19,11 @@ sub get_output {
     return \@out;
   }
 
-  my $tsidl = $file;
-  $tsidl =~ s/\.idl$/TypeSupport.idl/;
-  #push(@out, $dir . basename($tsidl));
-
   my $deps;
   if ($flags =~ /-Wb,java/) {
+
+    my $tsidl = $file;
+    $tsidl =~ s/\.idl$/TypeSupport.idl/;
 
     my $i2j = CommandHelper::get('idl2jni_files');
     $i2j->do_cached_parse($file, $flags);

--- a/MPC/modules/TYPESUPPORTHelper.pm
+++ b/MPC/modules/TYPESUPPORTHelper.pm
@@ -19,9 +19,9 @@ sub get_output {
     return \@out;
   }
 
-  my $tsidl = $file;
-  $tsidl =~ s/\.idl$/TypeSupport.idl/;
-  push(@out, $dir . basename($tsidl));
+  #my $tsidl = $file;
+  #$tsidl =~ s/\.idl$/TypeSupport.idl/;
+  #push(@out, $dir . basename($tsidl));
 
   my $deps;
   if ($flags =~ /-Wb,java/) {

--- a/tests/DCPS/ReadCondition/ReadCondition.mpc
+++ b/tests/DCPS/ReadCondition/ReadCondition.mpc
@@ -1,8 +1,9 @@
-project: dcpsexe, dcps_test, dcps_transports_for_test, dcps_ts_subdir {
+project: dcpsexe, dcps_test, dcps_transports_for_test, dcps_ts_defaults, taobaseidldefaults {
   exename = ReadConditionTest
   idlflags += -SS -o GeneratedCode
 
   TypeSupport_Files {
+    dcps_ts_flags += -o
     gendir = GeneratedCode
     Messenger.idl
   }

--- a/tests/DCPS/ReadCondition/ReadCondition.mpc
+++ b/tests/DCPS/ReadCondition/ReadCondition.mpc
@@ -1,9 +1,9 @@
-project: dcpsexe, dcps_test, dcps_transports_for_test, dcps_ts_defaults, taobaseidldefaults {
+project: dcpsexe, dcps_test, dcps_transports_for_test, dcps_ts_subdir {
   exename = ReadConditionTest
   idlflags += -SS -o GeneratedCode
 
   TypeSupport_Files {
-    dcps_ts_flags += -o
+    dcps_ts_flags += -o GeneratedCode
     gendir = GeneratedCode
     Messenger.idl
   }


### PR DESCRIPTION
* Using `<%gendir%>` in the dcps_ts_subdir doesn't work as expected, the value `<%gendir%>` isn't expanded, it is stored as is.
* Regiser TypeSupport.idl through dcps_ts_defaults instead of doing that manually in the TypeSupportHelper