### PR TITLE
Fix RTPS Writer Shutdown Race Condition

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -821,14 +821,14 @@ void RtpsUdpDataLink::client_stop(const RepoId& localId)
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop)
+RtpsUdpDataLink::RtpsWriter::pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop, bool true_stop)
 {
   typedef SnToTqeMap::iterator iter_t;
 
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
 
-  stopping_ = true;
+  stopping_ = true_stop;
 
   if (!elems_not_acked_.empty()) {
     OPENDDS_SET(SequenceNumber) sns_to_release;
@@ -859,7 +859,7 @@ RtpsUdpDataLink::pre_stop_i()
     RtpsWriterMap::iterator iter = writers_.begin();
     while (iter != writers_.end()) {
       RtpsWriter_rch writer = iter->second;
-      writer->pre_stop_helper(to_drop);
+      writer->pre_stop_helper(to_drop, true);
       RtpsWriterMap::iterator last = iter;
       ++iter;
       heartbeat_counts_.erase(last->first.entityId);
@@ -902,7 +902,7 @@ RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
       g.release();
       writer->remove_reader(remote_id);
       if (writer->reader_count() == 0) {
-        writer->pre_stop_helper(to_drop);
+        writer->pre_stop_helper(to_drop, false);
       }
       writer->process_acked_by_all();
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -828,6 +828,8 @@ RtpsUdpDataLink::RtpsWriter::pre_stop_helper(OPENDDS_VECTOR(TransportQueueElemen
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   ACE_GUARD(ACE_Thread_Mutex, g2, elems_not_acked_mutex_);
 
+  stopping_ = true;
+
   if (!elems_not_acked_.empty()) {
     OPENDDS_SET(SequenceNumber) sns_to_release;
     iter_t iter = elems_not_acked_.begin();
@@ -1056,7 +1058,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, 0);
 
   RtpsUdpDataLink_rch link = link_.lock();
-  if (!link) {
+  if (stopping_ || !link) {
     return 0;
   }
 
@@ -3971,6 +3973,7 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
  , link_(link)
  , id_(id)
  , durable_(durable)
+ , stopping_(false)
  , heartbeat_count_(heartbeat_count)
 #ifdef OPENDDS_SECURITY
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -378,6 +378,7 @@ private:
     WeakRcHandle<RtpsUdpDataLink> link_;
     const RepoId id_;
     const bool durable_;
+    bool stopping_;
     CORBA::Long heartbeat_count_;
 #ifdef OPENDDS_SECURITY
     const bool is_pvs_writer_; // Participant Volatile Secure writer

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -453,7 +453,7 @@ private:
     size_t reader_count() const;
     CORBA::Long inc_heartbeat_count();
 
-    void pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop);
+    void pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop, bool true_stop);
     TransportQueueElement* customize_queue_element_helper(TransportQueueElement* element,
                                                           bool requires_inline_qos,
                                                           MetaSubmessageVec& meta_submessages,


### PR DESCRIPTION
Fix a SEGV caused by race condition in customize_queue_element_helper that causes a sample to be 'delivered' after its allocator has been destroyed.