### PR TITLE
Using `<%gendir%>` in the dcps_ts_subdir doesn't work as expected, th…

### DIFF
--- a/MPC/config/dcps_ts_subdir.mpb
+++ b/MPC/config/dcps_ts_subdir.mpb
@@ -3,13 +3,11 @@
 // In the project, both IDL_Files and TypeSupport_Files sections must appear
 // with the gendir = <dir> setting and the name of the non-generated IDL file.
 // Also in the project (at project scope) include idlflags += -o <dir> where
-// <dir> is replaced by the subdirectory name.
+// <dir> is replaced by the subdirectory name. And with the TypeSupport_Files
+// add dcps_ts_flags += -o <dir> to let the opendds_idl compiler write the
+// generated files in the correct directory
 
 project: dcps_ts_defaults, taobaseidldefaults {
-
-  Modify_Custom(TypeSupport) {
-    commandflags += -o <%gendir%>
-  }
 
   Modify_Custom(IDL) {
     output_follows_input = 1

--- a/tests/DCPS/ReadCondition/ReadCondition.mpc
+++ b/tests/DCPS/ReadCondition/ReadCondition.mpc
@@ -3,6 +3,7 @@ project: dcpsexe, dcps_test, dcps_transports_for_test, dcps_ts_subdir {
   idlflags += -SS -o GeneratedCode
 
   TypeSupport_Files {
+    dcps_ts_flags += -o GeneratedCode
     gendir = GeneratedCode
     Messenger.idl
   }


### PR DESCRIPTION
…e value `<%gendir%>` isn't expanded, it is stored as is.

    * MPC/config/dcps_ts_subdir.mpb:
    * tests/DCPS/ReadCondition/ReadCondition.mpc: