### PR TITLE
DomainRange test fails on flea

### DIFF
--- a/tests/DCPS/DomainRange/DomainRangeTest.cpp
+++ b/tests/DCPS/DomainRange/DomainRangeTest.cpp
@@ -31,7 +31,7 @@
 
 const int MSGS_PER_WRITER = 10;
 const int TOTAL_WRITERS = 1;
-const int TOTAL_READERS = 5;
+const int TOTAL_READERS = 2;
 
 #define DEFAULT_FLAGS (THR_NEW_LWP | THR_JOINABLE | THR_INHERIT_SCHED)
 

--- a/tests/DCPS/DomainRange/DomainRangeTest.cpp
+++ b/tests/DCPS/DomainRange/DomainRangeTest.cpp
@@ -31,7 +31,7 @@
 
 const int MSGS_PER_WRITER = 10;
 const int TOTAL_WRITERS = 1;
-const int TOTAL_READERS = 2;
+const int TOTAL_READERS = 4;
 
 #define DEFAULT_FLAGS (THR_NEW_LWP | THR_JOINABLE | THR_INHERIT_SCHED)
 

--- a/tests/DCPS/DomainRange/run_test.pl
+++ b/tests/DCPS/DomainRange/run_test.pl
@@ -22,17 +22,17 @@ sub runTest {
     $test->enable_console_logging();
 
     print "*********************************\n";
-    print "DomainRangeTest creates a single process with 1 DW and 2 DRs.\n\n";
+    print "DomainRangeTest creates a single process with 1 DW and 4 DRs.\n\n";
     print "Domains and transports are dynamically configured from the \n";
     print "templates in config.ini. The DW in each domain sends 10 \n";
     print "messages to its DRs.\n";
     print "*********************************\n";
 
-    $test->process("alpha", 'DomainRangeTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl $arg -domain 2 -domain 11 -domain 20 -domain 50 -domain 11");
+    $test->process("alpha", 'DomainRangeTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl $arg -domain 2 -domain 8 -domain 20 -domain 50 -domain 8");
 
     $test->start_process("alpha");
 
-    my $res = $test->finish(150);
+    my $res = $test->finish(40);
     if ($res != 0) {
         print STDERR "ERROR: test returned $res\n";
         $result += $res;

--- a/tests/DCPS/DomainRange/run_test.pl
+++ b/tests/DCPS/DomainRange/run_test.pl
@@ -28,7 +28,7 @@ sub runTest {
     print "messages to its DRs.\n";
     print "*********************************\n";
 
-    $test->process("alpha", 'DomainRangeTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl $arg -domain 2 -domain 11 -domain 20 -domain 50");
+    $test->process("alpha", 'DomainRangeTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl $arg -domain 2 -domain 11 -domain 20 -domain 50 -domain 11");
 
     $test->start_process("alpha");
 

--- a/tests/DCPS/DomainRange/run_test.pl
+++ b/tests/DCPS/DomainRange/run_test.pl
@@ -22,13 +22,13 @@ sub runTest {
     $test->enable_console_logging();
 
     print "*********************************\n";
-    print "DomainRangeTest creates a single process with 1 DW and 4 DRs.\n\n";
+    print "DomainRangeTest creates a single process with 1 DW and 2 DRs.\n\n";
     print "Domains and transports are dynamically configured from the \n";
     print "templates in config.ini. The DW in each domain sends 10 \n";
     print "messages to its DRs.\n";
     print "*********************************\n";
 
-    $test->process("alpha", 'DomainRangeTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl $arg -domain 2 -domain 10 -domain 20 -domain 50 -domain 10");
+    $test->process("alpha", 'DomainRangeTest', "-DCPSConfigFile config.ini -DCPSDebugLevel $dcps_debug_lvl $arg -domain 2 -domain 11 -domain 20 -domain 50");
 
     $test->start_process("alpha");
 


### PR DESCRIPTION
Domain 10 is problematic no matter what on Flea, I couldn't find why, and even after a restart it still fails if domain 10 is attempted to be used. It also appears domain 11 is problematic.

Additionally, having at least 5 readers with 5 domains fails on Flea.

