### PR TITLE
Reinstate RTPS Submessage Bundling Using Per-Thread Submessage Queues

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -177,11 +177,13 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
     return 0;
   }
 
+  begin_transport_header_processing();
   while (bytes_remaining > 0) {
     data_sample_header_.pdu_remaining(bytes_remaining);
     data_sample_header_ = *cur_rb;
     bytes_remaining -= data_sample_header_.get_serialized_size();
     if (!check_header(data_sample_header_)) {
+      end_transport_header_processing();
       return 0;
     }
     const size_t dsh_ml = data_sample_header_.message_length();
@@ -220,7 +222,7 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
     // applies to the first DataSampleHeader in the TransportHeader
     receive_transport_header_.last_fragment(false);
   }
-
+  end_transport_header_processing();
 
   if (cur_rb->data_block()->reference_count() > 1) {
     ACE_DES_FREE(

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -77,6 +77,12 @@ protected:
   /// Check the data sample header for suitability.
   virtual bool check_header(const DSH& header);
 
+  /// Begin Current Transport Header Processing
+  virtual void begin_transport_header_processing() {}
+
+  /// End Current Transport Header Processing
+  virtual void end_transport_header_processing() {}
+
   /// Called when there is a ReceivedDataSample to be delivered.
   virtual void deliver_sample(ReceivedDataSample&  sample,
                               const ACE_INET_Addr& remote_address) = 0;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2394,7 +2394,7 @@ RtpsUdpDataLink::disable_response_queue()
   SubmessageQueue_rch queue;
   {
     ACE_GUARD(ACE_Thread_Mutex, g, send_queues_lock_);
-    ThreadSendQueueMap::const_iterator it = thread_send_queues_.find(ACE_Thread::self());
+    ThreadSendQueueMap::iterator it = thread_send_queues_.find(ACE_Thread::self());
     if (it != thread_send_queues_.end()) {
       queue = it->second;
       thread_send_queues_.erase(it);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -671,7 +671,7 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
         }
         CountMapType::iterator nfc_it = nackfrag_counts_.find(local_id.entityId);
         if (nfc_it != nackfrag_counts_.end()) {
-          an_start = nfc_it->second;
+          nf_start = nfc_it->second;
           nackfrag_counts_.erase(nfc_it);
         }
         RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id, local_durable, an_start, nf_start);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -592,7 +592,7 @@ private:
   void queue_or_send_submessages(MetaSubmessageVec& meta_submessages);
   void bundle_and_send_submessages(MetaSubmessageVec& meta_submessages);
 
-  struct SubmessageQueue: public RcObject, public MetaSubmessageVec {
+  struct SubmessageQueue: RcObject, MetaSubmessageVec {
   };
   typedef RcHandle<SubmessageQueue> SubmessageQueue_rch;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -847,6 +847,16 @@ RtpsUdpReceiveStrategy::check_header(const RtpsSampleHeader& header)
   return header.valid();
 }
 
+void
+RtpsUdpReceiveStrategy::begin_transport_header_processing() {
+  link_->enable_response_queue();
+}
+
+void
+RtpsUdpReceiveStrategy::end_transport_header_processing() {
+  link_->disable_response_queue();
+}
+
 const ReceivedDataSample*
 RtpsUdpReceiveStrategy::withhold_data_from(const RepoId& sub_id)
 {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -78,6 +78,9 @@ public:
                                       RtpsUdpTransport& tport,
                                       bool& stop);
 
+  virtual void begin_transport_header_processing();
+  virtual void end_transport_header_processing();
+
 private:
   bool getDirectedWriteReaders(RepoIdSet& directedWriteReaders, const RTPS::DataSubmessage& ds) const;
 


### PR DESCRIPTION
This implements the ability for threads to enable / disable per-thread submessage queueing, which then allows the bundling algorithm to work more effectively across several calls to send responses. This is most important, for example, when responding to an incoming packet.