### PR TITLE
Fix Workflow Permissions Issues and Add ACE_TAO Artifact Caching

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,19 +43,19 @@ jobs:
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -99,17 +99,17 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -125,7 +125,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -196,17 +196,17 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -222,7 +222,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -328,19 +328,19 @@ jobs:
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -384,17 +384,17 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -410,7 +410,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -481,17 +481,17 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -507,7 +507,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -612,19 +612,19 @@ jobs:
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       with:
         repository: DOCGroup/ACE_TAO
@@ -669,17 +669,17 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -695,7 +695,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -766,17 +766,17 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -792,7 +792,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -902,26 +902,26 @@ jobs:
         vcpkgTriplet: x64-windows
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: set up msvc env
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: ilammy/msvc-dev-cmd@v1.5.0
     - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
@@ -968,22 +968,22 @@ jobs:
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x64-windows
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1000,7 +1000,7 @@ jobs:
         tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
         rm -f windows-2019_defaults_ACE_TAO.tar.xz
     - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: ilammy/msvc-dev-cmd@v1.5.0
     - name: configure OpenDDS
       shell: cmd
       run: |
@@ -1080,22 +1080,22 @@ jobs:
         vcpkgArguments: --recurse xerces-c
         vcpkgTriplet: x64-windows
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1112,7 +1112,7 @@ jobs:
         tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
         rm -f windows-2019_defaults_ACE_TAO.tar.xz
     - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: ilammy/msvc-dev-cmd@v1.5.0
     - name: configure OpenDDS
       shell: cmd
       run: |
@@ -1200,26 +1200,26 @@ jobs:
         vcpkgTriplet: x64-windows
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: set up msvc env
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: ilammy/msvc-dev-cmd@v1.5.0
     - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
@@ -1266,22 +1266,22 @@ jobs:
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x64-windows
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1298,7 +1298,7 @@ jobs:
         tar xvfJ windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
         rm -f windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
     - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: ilammy/msvc-dev-cmd@v1.5.0
     - name: configure OpenDDS
       shell: cmd
       run: |
@@ -1378,22 +1378,22 @@ jobs:
         vcpkgArguments: --recurse xerces-c
         vcpkgTriplet: x64-windows
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1410,7 +1410,7 @@ jobs:
         tar xvfJ windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
         rm -f windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
     - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.4.1
+      uses: ilammy/msvc-dev-cmd@v1.5.0
     - name: configure OpenDDS
       shell: cmd
       run: |
@@ -1495,19 +1495,19 @@ jobs:
 #        brew install xerces-c
 #    - name: checkout MPC
 #      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/MPC
 #        path: MPC
 #    - name: checkout OpenDDS
 #      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        path: OpenDDS
 #        submodules: true
 #    - name: checkout ACE_TAO
 #      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/ACE_TAO
 #        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
@@ -1552,17 +1552,17 @@ jobs:
 #      run: |
 #        brew install xerces-c
 #    - name: checkout MPC
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/MPC
 #        path: MPC
 #    - name: checkout autobuild
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/autobuild
 #        path: autobuild
 #    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/ACE_TAO
 #        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
@@ -1578,7 +1578,7 @@ jobs:
 #        cd ACE_TAO
 #        tar xvfJ macos-11_0_defaults_ACE_TAO.tar.xz
 #    - name: checkout OpenDDS
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        path: OpenDDS
 #        submodules: true
@@ -1650,17 +1650,17 @@ jobs:
 #      run: |
 #        brew install xerces-c
 #    - name: checkout MPC
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/MPC
 #        path: MPC
 #    - name: checkout autobuild
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/autobuild
 #        path: autobuild
 #    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        repository: DOCGroup/ACE_TAO
 #        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
@@ -1676,7 +1676,7 @@ jobs:
 #        cd ACE_TAO
 #        tar xvfJ macos-11_0_defaults_ACE_TAO.tar.xz
 #    - name: checkout OpenDDS
-#      uses: actions/checkout@v2
+#      uses: actions/checkout@v2.3.4
 #      with:
 #        path: OpenDDS
 #        submodules: true
@@ -1783,19 +1783,19 @@ jobs:
         brew install xerces-c
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1840,17 +1840,17 @@ jobs:
       run: |
         brew install xerces-c
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1866,7 +1866,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
@@ -1938,17 +1938,17 @@ jobs:
       run: |
         brew install xerces-c
     - name: checkout MPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout autobuild
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/autobuild
         path: autobuild
     - name: checkout ACE_TAO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
@@ -1964,7 +1964,7 @@ jobs:
         cd ACE_TAO
         tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
     - name: checkout OpenDDS
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,6 @@ on:
     branches:
       - master
       - branch-DDS-3.*
-      - gh_workflow*
     paths:
       - '**'
       - '!docs/**'
@@ -33,29 +32,41 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: ubuntu-20_04_defaults_ACE_TAO.tar.xz
+        key: ${{ github.job }}_ace6tao2
     - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         . setenv.sh
@@ -64,6 +75,7 @@ jobs:
         cd ../TAO
         make -j4
     - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
@@ -305,29 +317,41 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: ubuntu-18_04_defaults_ACE_TAO.tar.xz
+        key: ${{ github.job }}_ace6tao2
     - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         . setenv.sh
@@ -336,6 +360,7 @@ jobs:
         cd ../TAO
         make -j4
     - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
@@ -577,29 +602,41 @@ jobs:
     runs-on: ubuntu-16.04
 
     steps:
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: ubuntu-16_04_defaults_ACE_TAO.tar.xz
+        key: ${{ github.job }}_ace6tao2
     - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
       uses: actions/checkout@v2
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
       uses: actions/checkout@v2
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
       uses: actions/checkout@v2
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         . setenv.sh
@@ -608,6 +645,7 @@ jobs:
         cd ../TAO
         make -j4
     - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
@@ -849,36 +887,49 @@ jobs:
     runs-on: windows-2019
 
     steps:
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: windows-2019_defaults_ACE_TAO.tar.xz
+        key: ${{ github.job }}_ace6tao2
     - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: lukka/run-vcpkg@v6
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x64-windows
     - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: ilammy/msvc-dev-cmd@v1.4.1
     - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         cd OpenDDS
         configure --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
     - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         cd OpenDDS
@@ -888,6 +939,7 @@ jobs:
         cd ..\TAO
         msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
     - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
@@ -1133,36 +1185,49 @@ jobs:
     runs-on: windows-2016
 
     steps:
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
+        key: ${{ github.job }}_ace6tao2
     - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: lukka/run-vcpkg@v6
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x64-windows
     - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: ilammy/msvc-dev-cmd@v1.4.1
     - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         cd OpenDDS
         configure --tests --no-debug --no-inline --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
     - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         cd OpenDDS
@@ -1172,6 +1237,7 @@ jobs:
         cd ..\TAO
         msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
     - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
@@ -1417,30 +1483,42 @@ jobs:
 #    runs-on: macos-11.0
 #
 #    steps:
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: macos-11_0_defaults_ACE_TAO.tar.xz
+#        key: ${{ github.job }}_ace6tao2
 #    - name: install xerces-c
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      run: |
 #        brew install xerces-c
 #    - name: checkout MPC
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      uses: actions/checkout@v2
 #      with:
 #        repository: DOCGroup/MPC
 #        path: MPC
 #    - name: checkout OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      uses: actions/checkout@v2
 #      with:
 #        path: OpenDDS
 #        submodules: true
 #    - name: checkout ACE_TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      uses: actions/checkout@v2
 #      with:
 #        repository: DOCGroup/ACE_TAO
 #        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
 #        path: OpenDDS/ACE_TAO
 #    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      run: |
 #        cd OpenDDS
 #        ./configure --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
 #    - name: build ACE and TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
@@ -1449,6 +1527,7 @@ jobs:
 #        cd ../TAO
 #        make -j4
 #    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      shell: bash
 #      run: |
 #        cd OpenDDS/ACE_TAO
@@ -1692,30 +1771,42 @@ jobs:
     runs-on: macos-10.15
 
     steps:
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: macos-10_15_defaults_ACE_TAO.tar.xz
+        key: ${{ github.job }}_ace6tao2
     - name: install xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         brew install xerces-c
     - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/MPC
         path: MPC
     - name: checkout OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
     - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         ./configure --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
     - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
         . setenv.sh
@@ -1724,6 +1815,7 @@ jobs:
         cd ../TAO
         make -j4
     - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,6 +16,7 @@ on:
     branches:
       - master
       - branch-DDS-3.*
+      - gh_workflow*
     paths:
       - '**'
       - '!docs/**'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - branch-DDS-3.*
-      - gh_workflow
+      - gh_workflow*
     paths:
       - '**'
       - '!docs/**'
@@ -25,23 +25,11 @@ on:
 
 jobs:
 
-  # Cancel Previous Runs
-
-  cancel-previous-runs:
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v1
-    - uses: n1hility/cancel-previous-runs@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
   # Ubuntu 20.04
 
   ubuntu-20_04_defaults_artifact:
 
     runs-on: ubuntu-20.04
-
-    needs: cancel-previous-runs
 
     steps:
     - name: install xerces
@@ -88,7 +76,7 @@ jobs:
         name: ubuntu-20_04_defaults_ace_artifact
         path: ubuntu-20_04_defaults_ACE_TAO.tar.xz
 
-  ubuntu-20_04_security:
+  ubuntu-20_04_defaults_security:
 
     runs-on: ubuntu-20.04
 
@@ -149,15 +137,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir ubuntu-20_04_defaults_security_autobuild_workspace
+        cd ubuntu-20_04_defaults_security_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="ubuntu-20_04_security_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/ubuntu-20_04_defaults_security_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/ubuntu-20_04_defaults_security_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -172,26 +161,19 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-20_04_security_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/ubuntu-20_04_security_autobuild_output.log_Full.html
+        name: ubuntu-20_04_defaults_security_autobuild_output
+        path: OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-20_04_security"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
+        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace/latest.txt"
 
-  ubuntu-20_04_java_no-bit:
+  ubuntu-20_04_defaults_java_no-bit:
 
     runs-on: ubuntu-20.04
 
@@ -279,15 +261,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir ubuntu-20_04_defaults_java_no-bit_autobuild_workspace
+        cd ubuntu-20_04_defaults_java_no-bit_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="ubuntu-20_04_java_no-bit_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -302,23 +285,23 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-20_04_java_no-bit_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/ubuntu-20_04_java_no-bit_autobuild_output.log_Full.html
+        name: ubuntu-20_04_defaults_java_no-bit_autobuild_output
+        path: OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-20_04_java_no-bit"
+        check_name: "Test Results: ubuntu-20_04_defaults_java_no-bit"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Ubuntu 18.04
@@ -326,8 +309,6 @@ jobs:
   ubuntu-18_04_defaults_artifact:
 
     runs-on: ubuntu-18.04
-
-    needs: cancel-previous-runs
 
     steps:
     - name: install xerces
@@ -374,7 +355,7 @@ jobs:
         name: ubuntu-18_04_defaults_ace_artifact
         path: ubuntu-18_04_defaults_ACE_TAO.tar.xz
 
-  ubuntu-18_04_security:
+  ubuntu-18_04_defaults_security:
 
     runs-on: ubuntu-18.04
 
@@ -435,15 +416,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir ubuntu-18_04_defaults_security_autobuild_workspace
+        cd ubuntu-18_04_defaults_security_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="ubuntu-18_04_security_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/ubuntu-18_04_defaults_security_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/ubuntu-18_04_defaults_security_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -458,26 +440,26 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-18_04_security_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/ubuntu-18_04_security_autobuild_output.log_Full.html
+        name: ubuntu-18_04_defaults_security_autobuild_output
+        path: OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-18_04_security"
+        check_name: "Test Results: ubuntu-18_04_defaults_security"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
-  ubuntu-18_04_java_no-bit:
+  ubuntu-18_04_defaults_java_no-bit:
 
     runs-on: ubuntu-18.04
 
@@ -565,15 +547,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir ubuntu-18_04_defaults_java_no-bit_autobuild_workspace
+        cd ubuntu-18_04_defaults_java_no-bit_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="ubuntu-18_04_java_no-bit_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -588,23 +571,23 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-18_04_java_no-bit_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/ubuntu-18_04_java_no-bit_autobuild_output.log_Full.html
+        name: ubuntu-18_04_defaults_java_no-bit_autobuild_output
+        path: OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-18_04_java_no-bit"
+        check_name: "Test Results: ubuntu-18_04_defaults_java_no-bit"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Ubuntu 16.04
@@ -612,8 +595,6 @@ jobs:
   ubuntu-16_04_defaults_artifact:
 
     runs-on: ubuntu-16.04
-
-    needs: cancel-previous-runs
 
     steps:
     - name: install xerces
@@ -660,7 +641,7 @@ jobs:
         name: ubuntu-16_04_defaults_ace_artifact
         path: ubuntu-16_04_defaults_ACE_TAO.tar.xz
 
-  ubuntu-16_04_security:
+  ubuntu-16_04_defaults_security:
 
     runs-on: ubuntu-16.04
 
@@ -721,15 +702,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir ubuntu-16_04_defaults_security_autobuild_workspace
+        cd ubuntu-16_04_defaults_security_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="ubuntu-16_04_security_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/ubuntu-16_04_defaults_security_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/ubuntu-16_04_defaults_security_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -744,26 +726,26 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-16_04_security_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/ubuntu-16_04_security_autobuild_output.log_Full.html
+        name: ubuntu-16_04_defaults_security_autobuild_output
+        path: OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-16_04_security"
+        check_name: "Test Results: ubuntu-16_04_defaults_security"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
-  ubuntu-16_04_java_no-bit:
+  ubuntu-16_04_defaults_java_no-bit:
 
     runs-on: ubuntu-16.04
 
@@ -851,15 +833,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir ubuntu-16_04_defaults_java_no-bit_autobuild_workspace
+        cd ubuntu-16_04_defaults_java_no-bit_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="ubuntu-16_04_java_no-bit_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -874,23 +857,23 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-16_04_java_no-bit_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/ubuntu-16_04_java_no-bit_autobuild_output.log_Full.html
+        name: ubuntu-16_04_defaults_java_no-bit_autobuild_output
+        path: OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-16_04_java_no-bit"
+        check_name: "Test Results: ubuntu-16_04_defaults_java_no-bit"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Windows 2019
@@ -898,8 +881,6 @@ jobs:
   windows-2019_defaults_artifact:
 
     runs-on: windows-2019
-
-    needs: cancel-previous-runs
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -1023,16 +1004,17 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        mkdir workspace
-        cd workspace
+        mkdir windows-2019_defaults_security_autobuild_workspace
+        cd windows-2019_defaults_security_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="windows-2019_security_autobuild_output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_security_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_security_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1053,24 +1035,24 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\workspace\config.xml"
-    - name: upload Full log output
+        cd windows-2019_defaults_security_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2019_defaults_security_autobuild_workspace\config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2019_security_autobuild_output.log_Full.html
-        path: OpenDDS\workspace\windows-2019_security_autobuild_output.log_Full.html
+        name: windows-2019_defaults_security_autobuild_output
+        path: OpenDDS\windows-2019_defaults_security_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_security_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_security_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2019_security"
+        check_name: "Test Results: windows-2019_defaults_security"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   windows-2019_defaults_java_no-bit:
@@ -1141,16 +1123,17 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        mkdir workspace
-        cd workspace
+        mkdir windows-2019_defaults_java_no-bit_autobuild_workspace
+        cd windows-2019_defaults_java_no-bit_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="windows-2019_java_no-bit_autobuild_output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1171,24 +1154,24 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\workspace\config.xml"
-    - name: upload Full log output
+        cd windows-2019_defaults_java_no-bit_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2019_defaults_java_no-bit_autobuild_workspace\config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2019_java_no-bit_autobuild_output.log_Full.html
-        path: OpenDDS\workspace\windows-2019_java_no-bit_autobuild_output.log_Full.html
+        name: windows-2019_defaults_java_no-bit_autobuild_output
+        path: OpenDDS\windows-2019_defaults_java_no-bit_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_java_no-bit_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2019_java_no-bit"
+        check_name: "Test Results: windows-2019_defaults_java_no-bit"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Windows 2016
@@ -1196,8 +1179,6 @@ jobs:
   windows-2016_no_debug_no_inline_artifact:
 
     runs-on: windows-2016
-
-    needs: cancel-previous-runs
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -1321,16 +1302,17 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        mkdir workspace
-        cd workspace
+        mkdir windows-2016_no_debug_no_inline_security_autobuild_workspace
+        cd windows-2016_no_debug_no_inline_security_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="windows-2016_security_autobuild_output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_security_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_security_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1351,24 +1333,24 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\workspace\config.xml"
-    - name: upload Full log output
+        cd windows-2016_no_debug_no_inline_security_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2016_no_debug_no_inline_security_autobuild_workspace\config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2016_security_autobuild_output.log_Full.html
-        path: OpenDDS\workspace\windows-2016_security_autobuild_output.log_Full.html
+        name: windows-2016_no_debug_no_inline_security_autobuild_output
+        path: OpenDDS\windows-2016_no_debug_no_inline_security_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_security_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_security_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2016_security"
+        check_name: "Test Results: windows-2016_no_debug_no_inline_security"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   windows-2016_no_debug_no_inline_java_no-bit:
@@ -1439,16 +1421,17 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        mkdir workspace
-        cd workspace
+        mkdir windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
+        cd windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="windows-2016_java_no-bit_autobuild_output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1469,24 +1452,24 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\workspace\config.xml"
-    - name: upload Full log output
+        cd windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace\config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2016_java_no-bit_autobuild_output.log_Full.html
-        path: OpenDDS\workspace\windows-2016_java_no-bit_autobuild_output.log_Full.html
+        name: windows-2016_no_debug_no_inline_java_no-bit_autobuild_output
+        path: OpenDDS\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2016_java_no-bit"
+        check_name: "Test Results: windows-2016_no_debug_no_inline_java_no-bit"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # macOS 11.0
@@ -1494,8 +1477,6 @@ jobs:
 #  macos-11_0_defaults_artifact:
 #
 #    runs-on: macos-11.0
-#
-#    needs: cancel-previous-runs
 #
 #    steps:
 #    - name: install xerces-c
@@ -1543,7 +1524,7 @@ jobs:
 #        name: macos-11_0_defaults_ace_artifact
 #        path: macos-11_0_defaults_ACE_TAO.tar.xz
 #
-#  macos-11_0_security:
+#  macos-11_0_defaults_security:
 #
 #    runs-on: macos-11.0
 #
@@ -1607,13 +1588,14 @@ jobs:
 #        . setenv.sh
 #        mkdir workspace
 #        cd workspace
+#        echo $GITHUB_SHA > ./SHA
 #        cat > config.xml <<EOF
 #        <autobuild>
 #        <configuration>
-#        <variable name="log_file" value="macos-11_0_security_autobuild_output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/macos-11_0_defaults_security_autobuild_workspace"/>
 #        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/workspace"/>
+#        <variable name="root" value="$DDS_ROOT/macos-11_0_defaults_security_autobuild_workspace"/>
 #        <variable name="junit_xml_output" value="Tests"/>
 #        </configuration>
 #        <command name="log" options="on"/>
@@ -1628,26 +1610,26 @@ jobs:
 #        <command name="process_logs" options="prettify"/>
 #        </autobuild>
 #        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-#    - name: upload Full log output
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
 #      uses: actions/upload-artifact@v2
 #      with:
-#        name: macos-11_0_security_autobuild_output.log_Full.html
-#        path: OpenDDS/workspace/macos-11_0_security_autobuild_output.log_Full.html
+#        name: macos-11_0_defaults_security_autobuild_output
+#        path: OpenDDS/macos-11_0_defaults_security_autobuild_workspace
 #    - name: check results
 #      shell: bash
 #      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+#        cat "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/latest.txt"
 #    - name: Publish Unit Test Results
 #      uses: simpsont-oci/action-junit-report@v1.2.1
 #      if: always()
 #      with:
 #        github_token: ${{ secrets.GITHUB_TOKEN }}
-#        check_name: "Test Results: macos-11_0_security"
+#        check_name: "Test Results: macos-11_0_defaults_security"
 #        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 #
-#  macos-11_0_java_no-bit:
+#  macos-11_0_defaults_java_no-bit:
 #
 #    runs-on: macos-11.0
 #
@@ -1736,15 +1718,16 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
-#        mkdir workspace
-#        cd workspace
+#        mkdir macos-11_0_defaults_java_no-bit_autobuild_workspace
+#        cd macos-11_0_defaults_java_no-bit_autobuild_workspace
+#        echo $GITHUB_SHA > ./SHA
 #        cat > config.xml <<EOF
 #        <autobuild>
 #        <configuration>
-#        <variable name="log_file" value="macos-11_0_java_no-bit_autobuild_output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/macos-11_0_defaults_java_no-bit_autobuild_workspace"/>
 #        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/workspace"/>
+#        <variable name="root" value="$DDS_ROOT/macos-11_0_defaults_java_no-bit_autobuild_workspace"/>
 #        <variable name="junit_xml_output" value="Tests"/>
 #        </configuration>
 #        <command name="log" options="on"/>
@@ -1759,23 +1742,23 @@ jobs:
 #        <command name="process_logs" options="prettify"/>
 #        </autobuild>
 #        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-#    - name: upload Full log output
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
 #      uses: actions/upload-artifact@v2
 #      with:
-#        name: macos-11_0_java_no-bit_autobuild_output.log_Full.html
-#        path: OpenDDS/workspace/macos-11_0_java_no-bit_autobuild_output.log_Full.html
+#        name: macos-11_0_defaults_java_no-bit_autobuild_output
+#        path: OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace
 #    - name: check results
 #      shell: bash
 #      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+#        cat "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/latest.txt"
 #    - name: Publish Unit Test Results
 #      uses: simpsont-oci/action-junit-report@v1.2.1
 #      if: always()
 #      with:
 #        github_token: ${{ secrets.GITHUB_TOKEN }}
-#        check_name: "Test Results: macos-11_0_java_no-bit"
+#        check_name: "Test Results: macos-11_0_defaults_java_no-bit"
 #        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # macOS 10.15
@@ -1783,8 +1766,6 @@ jobs:
   macos-10_15_defaults_artifact:
 
     runs-on: macos-10.15
-
-    needs: cancel-previous-runs
 
     steps:
     - name: install xerces-c
@@ -1832,7 +1813,7 @@ jobs:
         name: macos-10_15_defaults_ace_artifact
         path: macos-10_15_defaults_ACE_TAO.tar.xz
 
-  macos-10_15_security:
+  macos-10_15_defaults_security:
 
     runs-on: macos-10.15
 
@@ -1894,15 +1875,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir macos-10_15_defaults_security_autobuild_workspace
+        cd macos-10_15_defaults_security_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="macos-10_15_security_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/macos-10_15_defaults_security_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/macos-10_15_defaults_security_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1917,26 +1899,26 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: macos-10_15_security_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/macos-10_15_security_autobuild_output.log_Full.html
+        name: macos-10_15_defaults_security_autobuild_output
+        path: OpenDDS/macos-10_15_defaults_security_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: macos-10_15_security"
+        check_name: "Test Results: macos-10_15_defaults_security"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
-  macos-10_15_java_no-bit:
+  macos-10_15_defaults_java_no-bit:
 
     runs-on: macos-10.15
 
@@ -2025,15 +2007,16 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir workspace
-        cd workspace
+        mkdir macos-10_15_defaults_java_no-bit_autobuild_workspace
+        cd macos-10_15_defaults_java_no-bit_autobuild_workspace
+        echo $GITHUB_SHA > ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
-        <variable name="log_file" value="macos-10_15_java_no-bit_autobuild_output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/workspace"/>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/macos-10_15_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/workspace"/>
+        <variable name="root" value="$DDS_ROOT/macos-10_15_defaults_java_no-bit_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -2048,21 +2031,21 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/workspace/config.xml"
-    - name: upload Full log output
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/config.xml"
+    - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: macos-10_15_java_no-bit_autobuild_output.log_Full.html
-        path: OpenDDS/workspace/macos-10_15_java_no-bit_autobuild_output.log_Full.html
+        name: macos-10_15_defaults_java_no-bit_autobuild_output
+        path: OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/latest.txt"
     - name: Publish Unit Test Results
       uses: simpsont-oci/action-junit-report@v1.2.1
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: macos-10_15_java_no-bit"
+        check_name: "Test Results: macos-10_15_defaults_java_no-bit"
         report_paths: OpenDDS/workspace/Tests_JUnit.xml

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -296,13 +296,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-20_04_defaults_java_no-bit"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Ubuntu 18.04
 
@@ -451,13 +444,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-18_04_defaults_security"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   ubuntu-18_04_defaults_java_no-bit:
 
@@ -582,13 +568,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-18_04_defaults_java_no-bit"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Ubuntu 16.04
 
@@ -737,13 +716,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-16_04_defaults_security"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   ubuntu-16_04_defaults_java_no-bit:
 
@@ -868,13 +840,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: ubuntu-16_04_defaults_java_no-bit"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Windows 2019
 
@@ -1047,13 +1012,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_security_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_security_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2019_defaults_security"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   windows-2019_defaults_java_no-bit:
 
@@ -1166,13 +1124,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_java_no-bit_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_java_no-bit_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2019_defaults_java_no-bit"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # Windows 2016
 
@@ -1345,13 +1296,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_security_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_security_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2016_no_debug_no_inline_security"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   windows-2016_no_debug_no_inline_java_no-bit:
 
@@ -1464,13 +1408,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: windows-2016_no_debug_no_inline_java_no-bit"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # macOS 11.0
 
@@ -1621,13 +1558,6 @@ jobs:
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/latest.txt"
 #        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/latest.txt"
-#    - name: Publish Unit Test Results
-#      uses: simpsont-oci/action-junit-report@v1.2.1
-#      if: always()
-#      with:
-#        github_token: ${{ secrets.GITHUB_TOKEN }}
-#        check_name: "Test Results: macos-11_0_defaults_security"
-#        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 #
 #  macos-11_0_defaults_java_no-bit:
 #
@@ -1753,13 +1683,6 @@ jobs:
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/latest.txt"
 #        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/latest.txt"
-#    - name: Publish Unit Test Results
-#      uses: simpsont-oci/action-junit-report@v1.2.1
-#      if: always()
-#      with:
-#        github_token: ${{ secrets.GITHUB_TOKEN }}
-#        check_name: "Test Results: macos-11_0_defaults_java_no-bit"
-#        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   # macOS 10.15
 
@@ -1910,13 +1833,6 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: macos-10_15_defaults_security"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml
 
   macos-10_15_defaults_java_no-bit:
 
@@ -2042,10 +1958,3 @@ jobs:
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/latest.txt"
-    - name: Publish Unit Test Results
-      uses: simpsont-oci/action-junit-report@v1.2.1
-      if: always()
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        check_name: "Test Results: macos-10_15_defaults_java_no-bit"
-        report_paths: OpenDDS/workspace/Tests_JUnit.xml

--- a/.github/workflows/cancel_previous_runs.yml
+++ b/.github/workflows/cancel_previous_runs.yml
@@ -3,10 +3,11 @@ on:
   schedule:
     - cron: '*/15 * * * *'
 
-cancel-previous-runs:
-  runs-on: ubuntu-20.04
-  steps:
-  - uses: n1hility/cancel-previous-runs@v2
-    with:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      workflow: build_and_test.yml
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        workflow: build_and_test.yml

--- a/.github/workflows/cancel_previous_runs.yml
+++ b/.github/workflows/cancel_previous_runs.yml
@@ -1,13 +1,18 @@
-name: Cancel Previous Runs
+name: Cancel Duplicate Workflow Runs
+
 on:
-  schedule:
-    - cron: '*/15 * * * *'
+  workflow_run:
+    workflows: ["Build & Test"]
+    types: ['requested']
 
 jobs:
-  cancel-previous-runs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel Duplicate Workflow Runs"
     runs-on: ubuntu-20.04
     steps:
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: potiuk/cancel-workflow-runs@v4_7
+      name: "Cancel Duplicate Workflow Runs"
       with:
+        cancelMode: allDuplicates
         token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: build_and_test.yml
+        sourceRunId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/cancel_previous_runs.yml
+++ b/.github/workflows/cancel_previous_runs.yml
@@ -1,0 +1,12 @@
+name: Cancel Previous Runs
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+
+cancel-previous-runs:
+  runs-on: ubuntu-20.04
+  steps:
+  - uses: n1hility/cancel-previous-runs@v2
+    with:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      workflow: build_and_test.yml

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -39,7 +39,8 @@ jobs:
       - name: 'Setup'
         shell: bash
         run: |
-          ls -1 *.zip | xargs -I {} unzip -q -o {}
+          echo "mkdir \${1} && cp \${1}.zip \${1} && cd \${1} && unzip \${1}.zip" > helper.sh
+          ls -1 *.zip | sed 's/\(.*\)\.zip$/\1/g' | xargs -I {} ./helper.sh {}
           export PR_SHA=$(cat */SHA | sort -u | head -n 1)
           echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
 
@@ -49,7 +50,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-20_04_defaults_security"
-          report_paths: ubuntu-20_04_defaults_security_workspace/Tests_JUnit.xml
+          report_paths: ubuntu-20_04_defaults_security_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -58,7 +59,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-20_04_defaults_java_no-bit"
-          report_paths: ubuntu-20_04_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          report_paths: ubuntu-20_04_defaults_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -67,7 +68,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-18_04_defaults_security"
-          report_paths: ubuntu-18_04_defaults_security_workspace/Tests_JUnit.xml
+          report_paths: ubuntu-18_04_defaults_security_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -76,7 +77,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-18_04_defaults_java_no-bit"
-          report_paths: ubuntu-18_04_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          report_paths: ubuntu-18_04_defaults_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -85,7 +86,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-16_04_defaults_security"
-          report_paths: ubuntu-16_04_defaults_security_workspace/Tests_JUnit.xml
+          report_paths: ubuntu-16_04_defaults_security_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -94,7 +95,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-16_04_defaults_java_no-bit"
-          report_paths: ubuntu-16_04_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          report_paths: ubuntu-16_04_defaults_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -103,7 +104,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2019_defaults_security"
-          report_paths: windows-2019_defaults_security_workspace/Tests_JUnit.xml
+          report_paths: windows-2019_defaults_security_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -112,7 +113,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2019_defaults_java_no-bit"
-          report_paths: windows-2019_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          report_paths: windows-2019_defaults_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -121,7 +122,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2016_no_debug_no_inline_security"
-          report_paths: windows-2016_no_debug_no_inline_security_workspace/Tests_JUnit.xml
+          report_paths: windows-2016_no_debug_no_inline_security_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -130,7 +131,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2016_no_debug_no_inline_java_no-bit"
-          report_paths: windows-2016_no_debug_no_inline_java_no-bit_workspace/Tests_JUnit.xml
+          report_paths: windows-2016_no_debug_no_inline_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -139,7 +140,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: macos-10_15_defaults_security"
-          report_paths: macos-10_15_defaults_security_workspace/Tests_JUnit.xml
+          report_paths: macos-10_15_defaults_security_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 
       - name: 'Publish Unit Test Results'
@@ -148,6 +149,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: macos-10_15_defaults_java_no-bit"
-          report_paths: macos-10_15_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          report_paths: macos-10_15_defaults_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
 

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   download_and_publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
       - name: 'Download Autobuild Artifacts'
@@ -40,6 +40,7 @@ jobs:
         shell: bash
         run: |
           echo "mkdir \${1} && cp \${1}.zip \${1} && cd \${1} && unzip \${1}.zip" > helper.sh
+          chmod +x helper.sh
           ls -1 *.zip | sed 's/\(.*\)\.zip$/\1/g' | xargs -I {} ./helper.sh {}
           export PR_SHA=$(cat */SHA | sort -u | head -n 1)
           echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -1,0 +1,141 @@
+name: Check Test Results
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Build & Test"]
+    types:
+      - completed
+
+jobs:
+  download_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download Autobuild Artifacts'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var matchArtifacts = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.indexOf("_autobuild_output") > -1;
+            });
+            var fs = require('fs');
+            for (var i = 0; i < matchArtifacts.length; i++) {
+              var download = await github.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchArtifacts[i].id,
+                 archive_format: 'zip',
+              });
+              fs.writeFileSync('${{ github.workspace }}/' + matchArtifacts[i].name + '.zip', Buffer.from(download.data));
+            }
+
+      - name: Setup
+        shell: bash
+        run: |
+          unzip *.zip
+          export PR_SHA=$(cat */SHA | sort -u | head -n 1)
+          echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
+      - run: |
+        cat */SHA | 
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: ubuntu-20_04_defaults_security"
+          report_paths: ubuntu-20_04_defaults_security_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: ubuntu-20_04_defaults_java_no-bit"
+          report_paths: ubuntu-20_04_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: ubuntu-18_04_defaults_security"
+          report_paths: ubuntu-18_04_defaults_security_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: ubuntu-18_04_defaults_java_no-bit"
+          report_paths: ubuntu-18_04_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: ubuntu-16_04_defaults_security"
+          report_paths: ubuntu-16_04_defaults_security_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: ubuntu-16_04_defaults_java_no-bit"
+          report_paths: ubuntu-16_04_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: windows-2019_defaults_security"
+          report_paths: windows-2019_defaults_security_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: windows-2019_defaults_java_no-bit"
+          report_paths: windows-2019_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: windows-2016_no_debug_no_inline_security"
+          report_paths: windows-2016_no_debug_no_inline_security_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: windows-2016_no_debug_no_inline_java_no-bit"
+          report_paths: windows-2016_no_debug_no_inline_java_no-bit_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: macos-10_15_defaults_security"
+          report_paths: macos-10_15_defaults_security_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+
+      - name: 'Publish Unit Test Results'
+        uses: simpsont-oci/action-junit-report@v1.2.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          check_name: "Test Results: macos-10_15_defaults_java_no-bit"
+          report_paths: macos-10_15_defaults_java_no-bit_workspace/Tests_JUnit.xml
+          commit: ${{ env.PR_SHA }}
+

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   download_and_publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
       - name: 'Download Autobuild Artifacts'
         uses: actions/github-script@v3.1.0
@@ -38,12 +39,13 @@ jobs:
       - name: 'Setup'
         shell: bash
         run: |
-          unzip *.zip
+          ls -1 *.zip | xargs -I {} unzip -q -o {}
           export PR_SHA=$(cat */SHA | sort -u | head -n 1)
           echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-20_04_defaults_security"
@@ -52,6 +54,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-20_04_defaults_java_no-bit"
@@ -60,6 +63,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-18_04_defaults_security"
@@ -68,6 +72,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-18_04_defaults_java_no-bit"
@@ -76,6 +81,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-16_04_defaults_security"
@@ -84,6 +90,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: ubuntu-16_04_defaults_java_no-bit"
@@ -92,6 +99,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2019_defaults_security"
@@ -100,6 +108,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2019_defaults_java_no-bit"
@@ -108,6 +117,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2016_no_debug_no_inline_security"
@@ -116,6 +126,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: windows-2016_no_debug_no_inline_java_no-bit"
@@ -124,6 +135,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: macos-10_15_defaults_security"
@@ -132,6 +144,7 @@ jobs:
 
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
+        if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: "Test Results: macos-10_15_defaults_java_no-bit"

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -151,4 +151,3 @@ jobs:
           check_name: "Test Results: macos-10_15_defaults_java_no-bit"
           report_paths: macos-10_15_defaults_java_no-bit_autobuild_output/Tests_JUnit.xml
           commit: ${{ env.PR_SHA }}
-

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -35,14 +35,13 @@ jobs:
               fs.writeFileSync('${{ github.workspace }}/' + matchArtifacts[i].name + '.zip', Buffer.from(download.data));
             }
 
-      - name: Setup
+      - name: 'Setup'
         shell: bash
         run: |
           unzip *.zip
           export PR_SHA=$(cat */SHA | sort -u | head -n 1)
           echo "PR_SHA=$PR_SHA" >> $GITHUB_ENV
-      - run: |
-        cat */SHA | 
+
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v1.2.1
         with:


### PR DESCRIPTION
The permissions for the previous round of GitHub actions workflows didn't work for pull requests, and according to [this article](https://securitylab.github.com/research/github-actions-preventing-pwn-requests), switching to pull_request_target was problematic for other reasons. This PR adjusts the workflows to avoid security vulnerabilities by splitting it into three separate workflows (cancel previous, build & test, and check results). It also adds ACE_TAO artifact caching for a small performance improvement.