### PR TITLE
Define "tmp" variable for sequence and array as first branch in unions

### DIFF
--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -3915,6 +3915,11 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
               (ev->et == AST_Expression::EV_octet && ev->u.oval == 0) ||
               (ev->et == AST_Expression::EV_bool && ev->u.bval == 0))
           {
+            AST_Type* br = resolveActualType(branch->field_type());
+            Classification br_cls = classify(br);
+            if (br_cls & (CL_SEQUENCE | CL_ARRAY)) {
+              be_global->impl_ << scoped(branch->field_type()->name()) << " " << getWrapper("tmp", branch->field_type(), WD_INPUT) << ";\n";
+            }
             be_global->impl_ << type_to_default("  ", branch->field_type(), string("uni.")
               + branch->local_name()->get_string(), false, true);
             found = true;

--- a/tests/DCPS/Compiler/TryConstruct/TryConstruct.idl
+++ b/tests/DCPS/Compiler/TryConstruct/TryConstruct.idl
@@ -74,6 +74,10 @@ typedef sequence <ShortSeqBound2> SeqShortSeqBoundUnbound2;
 typedef sequence <@try_construct(TRIM) ShortSeqBound, 2> SeqShortSeqBoundBound;
 typedef sequence <ShortSeqBound2, 3> SeqShortSeqBoundBound2;
 
+union NestedUnionDefaultSeq switch (EnumType) {
+  case VALUE1: ShortSeqUnbound ss_ub;
+  case VALUE2: short u_s;
+};
 
 //arrays
 //enum
@@ -91,6 +95,11 @@ typedef short ShortArrThreeDim[3][3][3];
 //sequence
 typedef ShortSeqUnbound ArrSeqUnbound[3];
 typedef ShortSeqBound ArrSeqBound[3];
+
+union NestedUnionDefaultArr switch (EnumType) {
+  case VALUE1: UnsignedShortArr u_sa;
+  case VALUE2: short u_s;
+};
 
 //anon seq
 //enum


### PR DESCRIPTION
If there were a sequence or array in the 1st branch of the union it was causing an idl error because tmp would be undefined but used.  This fixes that.