### PR TITLE
Prevent TryConstruct test from building or running for safety builds.

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -65,8 +65,8 @@ tests/DCPS/Compiler/C++11/idl_test3_main/run_test.pl: !DCPS_MIN CXX11
 tests/DCPS/Compiler/key_annotation/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11
-tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN
-tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11
+tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Compiler/xcdr/run_test.pl
 tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN
 

--- a/tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct_C++11.mpc
+++ b/tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct_C++11.mpc
@@ -1,4 +1,5 @@
 project(Compiler*): dcps_test, googletest, msvc_bigobj, opendds_cxx11 {
+  requires += no_opendds_safety_profile
   exename = *
   idlflags += -I..
 

--- a/tests/DCPS/Compiler/TryConstruct/Compiler.mpc
+++ b/tests/DCPS/Compiler/TryConstruct/Compiler.mpc
@@ -1,4 +1,5 @@
 project(*TryConstruct): dcps_test, googletest, msvc_bigobj{
+  requires += no_opendds_safety_profile
   exename = *
   Source_Files {
     TryConstruct.cpp


### PR DESCRIPTION
TC Test utilizes std strings and widestrings meaning it is incompatible with safety profile.  The test would require a good deal of changes to make it compliant, so for now we will just block it from being used with safety profile.