### PR TITLE
Update "Build & Test" Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3418,8 +3418,8 @@ jobs:
     - name: Move ACE and MPC to C Drive
       shell: bash
       run: |
-        mv OpenDDS/ACE_TAO /
-        mv MPC /
+        mv OpenDDS/ACE_TAO /c/
+        mv MPC /c/
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3427,7 +3427,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --rapidjson --security --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
     - name: check build configuration
       shell: cmd
       run: |
@@ -3614,8 +3614,8 @@ jobs:
     - name: Move ACE and MPC to C Drive
       shell: bash
       run: |
-        mv OpenDDS/ACE_TAO /
-        mv MPC /
+        mv OpenDDS/ACE_TAO /c/
+        mv MPC /c/
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3623,7 +3623,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
+        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
     - name: check build configuration
       shell: cmd
       run: |
@@ -3889,8 +3889,8 @@ jobs:
 #    - name: Move ACE and MPC to C Drive
 #      shell: bash
 #      run: |
-#        mv OpenDDS/ACE_TAO /
-#        mv MPC /
+#        mv OpenDDS/ACE_TAO /c/
+#        mv MPC /c/
 #    - uses: ammaraskar/msvc-problem-matcher@0.1
 #    - name: set up msvc env
 #      uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3898,7 +3898,7 @@ jobs:
 #      shell: cmd
 #      run: |
 #        cd OpenDDS
-#        configure --tests --rapidjson --security --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+#        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
 #    - name: check build configuration
 #      shell: cmd
 #      run: |
@@ -4086,8 +4086,8 @@ jobs:
 #    - name: Move ACE and MPC to C Drive
 #      shell: bash
 #      run: |
-#        mv OpenDDS/ACE_TAO /
-#        mv MPC /
+#        mv OpenDDS/ACE_TAO /c/
+#        mv MPC /c/
 #    - uses: ammaraskar/msvc-problem-matcher@0.1
 #    - name: set up msvc env
 #      uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4095,7 +4095,7 @@ jobs:
 #      shell: cmd
 #      run: |
 #        cd OpenDDS
-#        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
+#        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
 #    - name: check build configuration
 #      shell: cmd
 #      run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3436,7 +3436,6 @@ jobs:
 #      run: |
 #        mv OpenDDS/ACE_TAO /c/
 #        mv MPC /c/
-#        echo $VCPKG_ROOT
 #    - uses: ammaraskar/msvc-problem-matcher@0.1
 #    - name: set up msvc env
 #      uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3635,7 +3634,6 @@ jobs:
 #      run: |
 #        mv OpenDDS/ACE_TAO /c/
 #        mv MPC /c/
-#        echo $VCPKG_ROOT
 #    - uses: ammaraskar/msvc-problem-matcher@0.1
 #    - name: set up msvc env
 #      uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3915,7 +3913,6 @@ jobs:
       run: |
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
-        echo $VCPKG_ROOT
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3998,6 +3995,12 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
         rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+    - name: Move ACE and MPC to C Drive
+      shell: bash
+      run: |
+        mv OpenDDS/ACE_TAO /c/
+        mv MPC /c/
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
@@ -4116,7 +4119,6 @@ jobs:
       run: |
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
-        echo $VCPKG_ROOT
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4200,6 +4202,11 @@ jobs:
         tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
         rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+    - name: Move ACE and MPC to C Drive
+      shell: bash
+      run: |
+        mv OpenDDS/ACE_TAO /c/
+        mv MPC /c/
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2523,7 +2523,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -2606,7 +2606,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -2709,7 +2709,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -2792,7 +2792,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -2973,7 +2973,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: build OpenDDS
 #      shell: cmd
 #      run: |
@@ -3056,7 +3056,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -3159,7 +3159,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: build OpenDDS
 #      shell: cmd
 #      run: |
@@ -3242,7 +3242,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -3435,7 +3435,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: build OpenDDS
 #      shell: cmd
 #      run: |
@@ -3518,7 +3518,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -3633,7 +3633,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: build OpenDDS
 #      shell: cmd
 #      run: |
@@ -3717,7 +3717,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -3914,7 +3914,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -3997,7 +3997,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -4005,6 +4005,7 @@ jobs:
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
         echo using commit $TRIGGERING_COMMIT for SHA
         echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
@@ -4023,7 +4024,7 @@ jobs:
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
+        <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4114,7 +4115,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -4198,7 +4199,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        tools\scripts\show_build_config.pl
+        perl tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -4206,6 +4207,7 @@ jobs:
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
         echo using commit $TRIGGERING_COMMIT for SHA
         echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
@@ -4224,7 +4226,7 @@ jobs:
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4389,7 +4391,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: build OpenDDS
 #      shell: cmd
 #      run: |
@@ -4473,7 +4475,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -4586,7 +4588,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: build OpenDDS
 #      shell: cmd
 #      run: |
@@ -4670,7 +4672,7 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        call setenv.cmd
-#        tools\scripts\show_build_config.pl
+#        perl tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3418,7 +3418,7 @@ jobs:
     - name: Move ACE and MPC to C Drive
       shell: bash
       run: |
-        mv ACE_TAO /
+        mv OpenDDS/ACE_TAO /
         mv MPC /
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
@@ -3614,7 +3614,7 @@ jobs:
     - name: Move ACE and MPC to C Drive
       shell: bash
       run: |
-        mv ACE_TAO /
+        mv OpenDDS/ACE_TAO /
         mv MPC /
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
@@ -3889,7 +3889,7 @@ jobs:
 #    - name: Move ACE and MPC to C Drive
 #      shell: bash
 #      run: |
-#        mv ACE_TAO /
+#        mv OpenDDS/ACE_TAO /
 #        mv MPC /
 #    - uses: ammaraskar/msvc-problem-matcher@0.1
 #    - name: set up msvc env
@@ -4086,7 +4086,7 @@ jobs:
 #    - name: Move ACE and MPC to C Drive
 #      shell: bash
 #      run: |
-#        mv ACE_TAO /
+#        mv OpenDDS/ACE_TAO /
 #        mv MPC /
 #    - uses: ammaraskar/msvc-problem-matcher@0.1
 #    - name: set up msvc env

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3420,6 +3420,8 @@ jobs:
       run: |
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
+        echo $VCPKG_ROOT
+        mv $VCPKG_ROOT /c/
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3427,7 +3429,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x64-windows" --openssl="C:\vcpkg\installed\x64-windows"
     - name: check build configuration
       shell: cmd
       run: |
@@ -3616,6 +3618,8 @@ jobs:
       run: |
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
+        echo $VCPKG_ROOT
+        mv $VCPKG_ROOT /c/
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3623,7 +3627,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
+        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x64-windows"
     - name: check build configuration
       shell: cmd
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3414,6 +3414,12 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
         rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+    - name: Move ACE and MPC to C Drive
+      shell: bash
+      run: |
+        mv ACE_TAO /
+        mv MPC /
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3421,7 +3427,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --no-debug --no-inline --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+        configure --tests --rapidjson --security --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
     - name: check build configuration
       shell: cmd
       run: |
@@ -3605,6 +3611,11 @@ jobs:
         tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
         rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+    - name: Move ACE and MPC to C Drive
+      shell: bash
+      run: |
+        mv ACE_TAO /
+        mv MPC /
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3612,7 +3623,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --no-debug --no-inline --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
+        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
     - name: check build configuration
       shell: cmd
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2602,11 +2602,11 @@ jobs:
         tar xvfJ windows-2019_defaults_security_build.tar.xz
         rm -f windows-2019_defaults_security_build.tar.xz
     - name: check build configuration
-      shell: bash
+      shell: cmd
       run: |
         cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -2788,11 +2788,11 @@ jobs:
         tar xvfJ windows-2019_defaults_java_no-bit_build.tar.xz
         rm -f windows-2019_defaults_java_no-bit_build.tar.xz
     - name: check build configuration
-      shell: bash
+      shell: cmd
       run: |
         cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -3052,11 +3052,11 @@ jobs:
 #        tar xvfJ windows-2019_wchar_security_build.tar.xz
 #        rm -f windows-2019_wchar_security_build.tar.xz
 #    - name: check build configuration
-#      shell: bash
+#      shell: cmd
 #      run: |
 #        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -3238,11 +3238,11 @@ jobs:
 #        tar xvfJ windows-2019_wchar_java_no-bit_build.tar.xz
 #        rm -f windows-2019_wchar_java_no-bit_build.tar.xz
 #    - name: check build configuration
-#      shell: bash
+#      shell: cmd
 #      run: |
 #        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -3514,11 +3514,11 @@ jobs:
         tar xvfJ windows-2016_no-debug_no-inline_security_build.tar.xz
         rm -f windows-2016_no-debug_no-inline_security_build.tar.xz
     - name: check build configuration
-      shell: bash
+      shell: cmd
       run: |
         cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -3713,11 +3713,11 @@ jobs:
         tar xvfJ windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
         rm -f windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
     - name: check build configuration
-      shell: bash
+      shell: cmd
       run: |
         cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
@@ -3988,11 +3988,11 @@ jobs:
 #        tar xvfJ windows-2016_ipv6_no-debug_no-inline_security_build.tar.xz
 #        rm -f windows-2016_ipv6_no-debug_no-inline_security_build.tar.xz
 #    - name: check build configuration
-#      shell: bash
+#      shell: cmd
 #      run: |
 #        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |
@@ -4185,11 +4185,11 @@ jobs:
 #        tar xvfJ windows-2016_ipv6_no-debug_no-inline_java_no-bit_build.tar.xz
 #        rm -f windows-2016_ipv6_no-debug_no-inline_java_no-bit_build.tar.xz
 #    - name: check build configuration
-#      shell: bash
+#      shell: cmd
 #      run: |
 #        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
 #    - name: create autobuild config
 #      shell: bash
 #      run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4036,6 +4036,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd ${{ github.job }}_autobuild_workspace
+        set PERL5LIB=%ACE_ROOT%\bin
         perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
@@ -4238,6 +4239,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd ${{ github.job }}_autobuild_workspace
+        set PERL5LIB=%ACE_ROOT%\bin
         perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3383,6 +3383,7 @@ jobs:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x64-windows
+        vcpkgDirectory: '/c/vcpkg'
     - name: Clean Up VCPKG
       shell: bash
       run: |
@@ -3421,7 +3422,6 @@ jobs:
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
         echo $VCPKG_ROOT
-        mv $VCPKG_ROOT /c/
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -3581,6 +3581,7 @@ jobs:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse xerces-c
         vcpkgTriplet: x64-windows
+        vcpkgDirectory: '/c/vcpkg'
     - name: Clean Up VCPKG
       shell: bash
       run: |
@@ -3619,7 +3620,6 @@ jobs:
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
         echo $VCPKG_ROOT
-        mv $VCPKG_ROOT /c/
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3294,7 +3294,482 @@ jobs:
 
   # Windows 2016 - No Debug, No Inline
 
-  windows-2016_no-debug_no-inline_ACE_TAO:
+#  windows-2016_no-debug_no-inline_ACE_TAO:
+#
+#    runs-on: windows-2016
+#
+#    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+#    - name: install openssl-windows & xerces-c
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: set up msvc env
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+#    - name: build ACE & TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ACE_TAO\ACE
+#        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+#        cd ..\TAO
+#        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+#    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+#        find . -iname "*\.obj" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
+#    - name: upload ACE_TAO artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2016_no-debug_no-inline_security_build:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_no-debug_no-inline_ACE_TAO
+#
+#    steps:
+#    - name: install openssl-windows & xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#        vcpkgDirectory: 'C:\vcpkg'
+#    - name: Clean Up VCPKG
+#      shell: bash
+#      run: |
+#        rm -rf $VCPKG_ROOT/downloads $VCPKG_ROOT/buildtrees $VCPKG_ROOT/packages
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: Move ACE and MPC to C Drive
+#      shell: bash
+#      run: |
+#        mv OpenDDS/ACE_TAO /c/
+#        mv MPC /c/
+#        echo $VCPKG_ROOT
+#    - uses: ammaraskar/msvc-problem-matcher@0.1
+#    - name: set up msvc env
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x64-windows" --openssl="C:\vcpkg\installed\x64-windows"
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: build OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.cmd
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2016_no-debug_no-inline_security_test:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_no-debug_no-inline_security_build
+#
+#    steps:
+#    - name: install openssl-windows & xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_no-debug_no-inline_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ windows-2016_no-debug_no-inline_security_build.tar.xz
+#        rm -f windows-2016_no-debug_no-inline_security_build.tar.xz
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: create autobuild config
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
+#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        cat config.xml
+#    - name: run OpenDDS tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ${{ github.job }}_autobuild_workspace
+#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS\${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#
+#  windows-2016_no-debug_no-inline_java_no-bit_build:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_no-debug_no-inline_ACE_TAO
+#
+#    steps:
+#    - name: install xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse xerces-c
+#        vcpkgTriplet: x64-windows
+#        vcpkgDirectory: 'C:\vcpkg'
+#    - name: Clean Up VCPKG
+#      shell: bash
+#      run: |
+#        rm -rf $VCPKG_ROOT/downloads $VCPKG_ROOT/buildtrees $VCPKG_ROOT/packages
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: Move ACE and MPC to C Drive
+#      shell: bash
+#      run: |
+#        mv OpenDDS/ACE_TAO /c/
+#        mv MPC /c/
+#        echo $VCPKG_ROOT
+#    - uses: ammaraskar/msvc-problem-matcher@0.1
+#    - name: set up msvc env
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x64-windows"
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: build OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.cmd
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2016_no-debug_no-inline_java_no-bit_test:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_no-debug_no-inline_java_no-bit_build
+#
+#    steps:
+#    - name: install xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_no-debug_no-inline_java_no-bit_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
+#        rm -f windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: create autobuild config
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
+#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        cat config.xml
+#    - name: run OpenDDS tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ${{ github.job }}_autobuild_workspace
+#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS\${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # Windows 2016 - x86, No Debug, No Inline
+
+  windows-2016_x86_no-debug_no-inline_ACE_TAO:
 
     runs-on: windows-2016
 
@@ -3328,7 +3803,7 @@ jobs:
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
+        vcpkgTriplet: x86-windows
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2.3.4
@@ -3338,12 +3813,14 @@ jobs:
     - name: set up msvc env
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: ilammy/msvc-dev-cmd@v1.5.0
+      with:
+        arch: x86
     - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
       run: |
         cd OpenDDS
-        configure --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+        configure --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x86-windows --openssl=%VCPKG_ROOT%/installed/x86-windows --mpcopts=-hierarchy
     - name: build ACE & TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
@@ -3351,9 +3828,9 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd ACE_TAO\ACE
-        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+        msbuild -p:Configuration=Debug,Platform=Win32 -m ace.sln
         cd ..\TAO
-        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+        msbuild -p:Configuration=Debug,Platform=Win32 -m tao.sln
     - name: create ACE_TAO tar.xz artifact
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: bash
@@ -3370,11 +3847,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2016_no-debug_no-inline_security_build:
+  windows-2016_x86_no-debug_no-inline_security_build:
 
     runs-on: windows-2016
 
-    needs: windows-2016_no-debug_no-inline_ACE_TAO
+    needs: windows-2016_x86_no-debug_no-inline_ACE_TAO
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -3382,7 +3859,7 @@ jobs:
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
+        vcpkgTriplet: x86-windows
         vcpkgDirectory: 'C:\vcpkg'
     - name: Clean Up VCPKG
       shell: bash
@@ -3407,14 +3884,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -3425,11 +3902,13 @@ jobs:
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
+      with:
+        arch: x86
     - name: configure OpenDDS
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x64-windows" --openssl="C:\vcpkg\installed\x64-windows"
+        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x86-windows" --openssl="C:\vcpkg\installed\x86-windows"
     - name: check build configuration
       shell: cmd
       run: |
@@ -3441,7 +3920,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        msbuild -p:Configuration=Debug,Platform=Win32 -m DDS.sln
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -3457,11 +3936,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2016_no-debug_no-inline_security_test:
+  windows-2016_x86_no-debug_no-inline_security_test:
 
     runs-on: windows-2016
 
-    needs: windows-2016_no-debug_no-inline_security_build
+    needs: windows-2016_x86_no-debug_no-inline_security_build
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -3469,7 +3948,7 @@ jobs:
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
+        vcpkgTriplet: x86-windows
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:
@@ -3494,25 +3973,25 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no-debug_no-inline_security_build_artifact
+        name: windows-2016_x86_no-debug_no-inline_security_build_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ windows-2016_no-debug_no-inline_security_build.tar.xz
-        rm -f windows-2016_no-debug_no-inline_security_build.tar.xz
+        tar xvfJ windows-2016_x86_no-debug_no-inline_security_build.tar.xz
+        rm -f windows-2016_x86_no-debug_no-inline_security_build.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -3568,11 +4047,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  windows-2016_no-debug_no-inline_java_no-bit_build:
+  windows-2016_x86_no-debug_no-inline_java_no-bit_build:
 
     runs-on: windows-2016
 
-    needs: windows-2016_no-debug_no-inline_ACE_TAO
+    needs: windows-2016_x86_no-debug_no-inline_ACE_TAO
 
     steps:
     - name: install xerces-c
@@ -3580,7 +4059,7 @@ jobs:
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse xerces-c
-        vcpkgTriplet: x64-windows
+        vcpkgTriplet: x86-windows
         vcpkgDirectory: 'C:\vcpkg'
     - name: Clean Up VCPKG
       shell: bash
@@ -3605,14 +4084,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -3623,11 +4102,13 @@ jobs:
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
+      with:
+        arch: x86
     - name: configure OpenDDS
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x64-windows"
+        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="C:\vcpkg\installed\x86-windows"
     - name: check build configuration
       shell: cmd
       run: |
@@ -3639,7 +4120,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        msbuild -p:Configuration=Debug,Platform=Win32 -m DDS.sln
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -3655,11 +4136,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2016_no-debug_no-inline_java_no-bit_test:
+  windows-2016_x86_no-debug_no-inline_java_no-bit_test:
 
     runs-on: windows-2016
 
-    needs: windows-2016_no-debug_no-inline_java_no-bit_build
+    needs: windows-2016_x86_no-debug_no-inline_java_no-bit_build
 
     steps:
     - name: install xerces-c
@@ -3667,7 +4148,7 @@ jobs:
       with:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse xerces-c
-        vcpkgTriplet: x64-windows
+        vcpkgTriplet: x86-windows
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:
@@ -3692,26 +4173,26 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no-debug_no-inline_java_no-bit_build_artifact
+        name: windows-2016_x86_no-debug_no-inline_java_no-bit_build_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
-        rm -f windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
+        tar xvfJ windows-2016_x86_no-debug_no-inline_java_no-bit_build.tar.xz
+        rm -f windows-2016_x86_no-debug_no-inline_java_no-bit_build.tar.xz
     - name: check build configuration
       shell: cmd
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3383,7 +3383,7 @@ jobs:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x64-windows
-        vcpkgDirectory: '/c/vcpkg'
+        vcpkgDirectory: 'C:\vcpkg'
     - name: Clean Up VCPKG
       shell: bash
       run: |
@@ -3581,7 +3581,7 @@ jobs:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse xerces-c
         vcpkgTriplet: x64-windows
-        vcpkgDirectory: '/c/vcpkg'
+        vcpkgDirectory: 'C:\vcpkg'
     - name: Clean Up VCPKG
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -244,6 +244,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -436,6 +437,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -670,6 +672,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
         <command name="log" options="off"/>
@@ -862,6 +865,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
@@ -1096,6 +1100,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -1288,6 +1293,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -1522,6 +1528,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
         <command name="log" options="off"/>
@@ -1714,6 +1721,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config RTPS -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
@@ -1948,6 +1956,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
         <command name="log" options="off"/>
@@ -2140,6 +2149,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
@@ -2374,6 +2384,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -2613,16 +2624,16 @@ jobs:
         cd OpenDDS
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace
-        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
         echo using commit $TRIGGERING_COMMIT for SHA
         echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -2631,8 +2642,9 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
+        <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2799,16 +2811,16 @@ jobs:
         cd OpenDDS
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace
-        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
         echo using commit $TRIGGERING_COMMIT for SHA
         echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -2817,8 +2829,9 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -3081,6 +3094,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config WCHAR -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -3267,6 +3281,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config WCHAR -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
 #        <command name="log" options="off"/>
@@ -3543,6 +3558,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -3742,6 +3758,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
 #        <command name="log" options="off"/>
@@ -4004,7 +4021,6 @@ jobs:
         cd OpenDDS
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace
-        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
         export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
         echo using commit $TRIGGERING_COMMIT for SHA
         echo $TRIGGERING_COMMIT >> ./SHA
@@ -4012,9 +4028,9 @@ jobs:
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -4023,8 +4039,9 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
+        <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4206,7 +4223,6 @@ jobs:
         cd OpenDDS
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace
-        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
         export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
         echo using commit $TRIGGERING_COMMIT for SHA
         echo $TRIGGERING_COMMIT >> ./SHA
@@ -4214,9 +4230,9 @@ jobs:
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -4225,6 +4241,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
         <command name="log" options="off"/>
@@ -4500,6 +4517,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config IPV6 -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -4697,6 +4715,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config IPV6 -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
 #        <command name="log" options="off"/>
@@ -4941,6 +4960,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -5135,6 +5155,7 @@ jobs:
 #        <command name="print_ace_config"/>
 #        <command name="print_make_version"/>
 #        <command name="check_compiler" options="gcc"/>
+#        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
 #        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
 #        <command name="log" options="off"/>
@@ -5372,6 +5393,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
         <command name="log" options="off"/>
@@ -5566,6 +5588,7 @@ jobs:
         <command name="print_ace_config"/>
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - branch-DDS-3.*
-      - gh_workflow*
+      - gh_wf_*
     paths:
       - '**'
       - '!docs/**'
@@ -23,21 +23,467 @@ on:
       - '!INSTALL.md'
       - '!NEWS.md'
 
+env:
+  TRIGGERING_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+
 jobs:
 
-  # Ubuntu 20.04
+  # Ubuntu 20.04 - Defaults
 
-  ubuntu-20_04_defaults_artifact:
+#  ubuntu-20_04_defaults_ACE_TAO:
+#
+#    runs-on: ubuntu-20.04
+#
+#    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+#    - name: install xerces
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: |
+#        cd OpenDDS
+#        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: build ACE and TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        cd ACE_TAO/ACE
+#        make -j4
+#        cd ../TAO
+#        make -j4
+#    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
+#    - name: upload ACE_TAO artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-20_04_defaults_security_build:
+#
+#    runs-on: ubuntu-20.04
+#
+#    needs: ubuntu-20_04_defaults_ACE_TAO
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: configure OpenDDS
+#      run: |
+#        cd OpenDDS
+#        ./configure --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
+#    - name: build OpenDDS
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-20_04_defaults_security_test:
+#
+#    runs-on: ubuntu-20.04
+#
+#    needs: ubuntu-20_04_defaults_security_build
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-20_04_defaults_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ ubuntu-20_04_defaults_security_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: run OpenDDS tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DDS_ROOT"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt" then echo ::error file=latest.txt,line=0,col=0::Test Failures
+#
+#  ubuntu-20_04_defaults_java_no-bit_build:
+#
+#    runs-on: ubuntu-20.04
+#
+#    needs: ubuntu-20_04_defaults_ACE_TAO
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: configure OpenDDS
+#      run: |
+#        cd OpenDDS
+#        ./configure --tests --java=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64 --no-built-in-topics --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
+#    - name: build OpenDDS
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4
+#    - name: set up TAO Hello test
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
+#    - name: build TAO Hello test
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4 dir=$TAO_ROOT/tests/Hello
+#    - name: set up Modeling tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        cd tools/modeling/tests
+#        ./setup.pl
+#        cd -
+#        mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
+#    - name: build Modeling tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4 -C tools/modeling/tests
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-20_04_defaults_java_no-bit_test:
+#
+#    runs-on: ubuntu-20.04
+#
+#    needs: ubuntu-20_04_defaults_java_no-bit_build
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-20_04_defaults_java_no-bit_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ ubuntu-20_04_defaults_java_no-bit_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: run OpenDDS tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DDS_ROOT"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # Ubuntu 20.04 - IPv6
+
+  ubuntu-20_04_ipv6_ACE_TAO:
 
     runs-on: ubuntu-20.04
 
     steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
       uses: actions/cache@v2
       with:
-        path: ubuntu-20_04_defaults_ACE_TAO.tar.xz
-        key: ${{ github.job }}_ace6tao2
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -47,24 +493,11 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
     - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
-        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+        ./configure --ipv6 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: build ACE and TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -80,20 +513,21 @@ jobs:
       run: |
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        tar cvf ../../ubuntu-20_04_defaults_ACE_TAO.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../ubuntu-20_04_defaults_ACE_TAO.tar
-        xz ../../ubuntu-20_04_defaults_ACE_TAO.tar
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-20_04_defaults_ace_artifact
-        path: ubuntu-20_04_defaults_ACE_TAO.tar.xz
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  ubuntu-20_04_defaults_security:
+  ubuntu-20_04_ipv6_security_build:
 
     runs-on: ubuntu-20.04
 
-    needs: ubuntu-20_04_defaults_artifact
+    needs: ubuntu-20_04_ipv6_ACE_TAO
 
     steps:
     - name: install xerces
@@ -103,11 +537,6 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v2.3.4
       with:
@@ -117,13 +546,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_defaults_ace_artifact
+        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
+        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -139,58 +568,33 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build OpenDDS
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: run OpenDDS tests
+    - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
         cd OpenDDS
-        . setenv.sh
-        mkdir ubuntu-20_04_defaults_security_autobuild_workspace
-        cd ubuntu-20_04_defaults_security_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/ubuntu-20_04_defaults_security_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/ubuntu-20_04_defaults_security_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace/config.xml"
-    - name: upload autobuild output
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-20_04_defaults_security_autobuild_output
-        path: OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_security_autobuild_workspace/latest.txt"
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  ubuntu-20_04_defaults_java_no-bit:
+  ubuntu-20_04_ipv6_security_test:
 
     runs-on: ubuntu-20.04
 
-    needs: ubuntu-20_04_defaults_artifact
+    needs: ubuntu-20_04_ipv6_security_build
 
     steps:
     - name: install xerces
@@ -214,13 +618,106 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_defaults_ace_artifact
+        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
+        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-20_04_ipv6_security_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ ubuntu-20_04_ipv6_security_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  ubuntu-20_04_ipv6_java_no-bit_build:
+
+    runs-on: ubuntu-20.04
+
+    needs: ubuntu-20_04_ipv6_ACE_TAO
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -236,6 +733,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build OpenDDS
       shell: bash
       run: |
@@ -247,13 +745,13 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mwc.pl -type gnuace $TAO_ROOT/tests/Hello
+        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
     - name: build TAO Hello test
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        make -j2 dir=$TAO_ROOT/tests/Hello
+        make -j4 dir=$TAO_ROOT/tests/Hello
     - name: set up Modeling tests
       shell: bash
       run: |
@@ -262,28 +760,100 @@ jobs:
         cd tools/modeling/tests
         ./setup.pl
         cd -
-        mwc.pl -type gnuace -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
+        mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
     - name: build Modeling tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        make -j2 -C tools/modeling/tests
+        make -j4 -C tools/modeling/tests
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  ubuntu-20_04_ipv6_java_no-bit_test:
+
+    runs-on: ubuntu-20.04
+
+    needs: ubuntu-20_04_ipv6_java_no-bit_build
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-20_04_ipv6_java_no-bit_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ ubuntu-20_04_ipv6_java_no-bit_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: run OpenDDS tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir ubuntu-20_04_defaults_java_no-bit_autobuild_workspace
-        cd ubuntu-20_04_defaults_java_no-bit_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -293,36 +863,479 @@ jobs:
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/config.xml"
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-20_04_defaults_java_no-bit_autobuild_output
-        path: OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-20_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # Ubuntu 18.04
+  # Ubuntu 18.04 - Defaults
 
-  ubuntu-18_04_defaults_artifact:
+#  ubuntu-18_04_defaults_ACE_TAO:
+#
+#    runs-on: ubuntu-18.04
+#
+#    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+#    - name: install xerces
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: |
+#        cd OpenDDS
+#        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: build ACE and TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        cd ACE_TAO/ACE
+#        make -j4
+#        cd ../TAO
+#        make -j4
+#    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
+#    - name: upload ACE_TAO artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-18_04_defaults_security_build:
+#
+#    runs-on: ubuntu-18.04
+#
+#    needs: ubuntu-18_04_defaults_ACE_TAO
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: configure OpenDDS
+#      run: |
+#        cd OpenDDS
+#        ./configure --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
+#    - name: build OpenDDS
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-18_04_defaults_security_test:
+#
+#    runs-on: ubuntu-18.04
+#
+#    needs: ubuntu-18_04_defaults_security_build
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-18_04_defaults_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ ubuntu-18_04_defaults_security_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: run OpenDDS tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DDS_ROOT"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#
+#  ubuntu-18_04_defaults_java_no-csp_build:
+#
+#    runs-on: ubuntu-18.04
+#
+#    needs: ubuntu-18_04_defaults_ACE_TAO
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: configure OpenDDS
+#      run: |
+#        cd OpenDDS
+#        ./configure --tests --java --no-content-subscription --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
+#    - name: build OpenDDS
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4
+#    - name: set up TAO Hello test
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
+#    - name: build TAO Hello test
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4 dir=$TAO_ROOT/tests/Hello
+#    - name: set up Modeling tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        cd tools/modeling/tests
+#        ./setup.pl
+#        cd -
+#        mwc.pl -type gnuace -workers 4 -features content_subscription=0 tools/modeling/tests/modeling_tests.mwc
+#    - name: build Modeling tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4 -C tools/modeling/tests
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-18_04_defaults_java_no-csp_test:
+#
+#    runs-on: ubuntu-18.04
+#
+#    needs: ubuntu-18_04_defaults_java_no-csp_build
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-18_04_defaults_java_no-csp_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ ubuntu-18_04_defaults_java_no-csp_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: run OpenDDS tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DDS_ROOT"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # Ubuntu 18.04 - WChar
+
+  ubuntu-18_04_wchar_ACE_TAO:
 
     runs-on: ubuntu-18.04
 
     steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
       uses: actions/cache@v2
       with:
-        path: ubuntu-18_04_defaults_ACE_TAO.tar.xz
-        key: ${{ github.job }}_ace6tao2
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -332,19 +1345,432 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout OpenDDS
+    - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --features=uses_wchar=1 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  ubuntu-18_04_wchar_security_build:
+
+    runs-on: ubuntu-18.04
+
+    needs: ubuntu-18_04_wchar_ACE_TAO
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --features=uses_wchar=1 --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  ubuntu-18_04_wchar_security_test:
+
+    runs-on: ubuntu-18.04
+
+    needs: ubuntu-18_04_wchar_security_build
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-18_04_wchar_security_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ ubuntu-18_04_wchar_security_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  ubuntu-18_04_wchar_java_no-csp_build:
+
+    runs-on: ubuntu-18.04
+
+    needs: ubuntu-18_04_wchar_ACE_TAO
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --features=uses_wchar=1 --tests --java --no-content-subscription --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: set up TAO Hello test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
+    - name: build TAO Hello test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 dir=$TAO_ROOT/tests/Hello
+    - name: set up Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tools/modeling/tests
+        ./setup.pl
+        cd -
+        mwc.pl -type gnuace -workers 4 -features content_subscription=0 tools/modeling/tests/modeling_tests.mwc
+    - name: build Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 -C tools/modeling/tests
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  ubuntu-18_04_wchar_java_no-csp_test:
+
+    runs-on: ubuntu-18.04
+
+    needs: ubuntu-18_04_wchar_java_no-csp_build
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-18_04_wchar_java_no-csp_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ ubuntu-18_04_wchar_java_no-csp_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config RTPS -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # Ubuntu 16.04 - Defaults
+
+  ubuntu-16_04_defaults_ACE_TAO:
+
+    runs-on: ubuntu-16.04
+
+    steps:
+    - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
         path: OpenDDS
         submodules: true
     - name: checkout ACE_TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2.3.4
       with:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
     - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -365,305 +1791,21 @@ jobs:
       run: |
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        tar cvf ../../ubuntu-18_04_defaults_ACE_TAO.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../ubuntu-18_04_defaults_ACE_TAO.tar
-        xz ../../ubuntu-18_04_defaults_ACE_TAO.tar
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-18_04_defaults_ace_artifact
-        path: ubuntu-18_04_defaults_ACE_TAO.tar.xz
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  ubuntu-18_04_defaults_security:
-
-    runs-on: ubuntu-18.04
-
-    needs: ubuntu-18_04_defaults_artifact
-
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ubuntu-18_04_defaults_ace_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j4
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ubuntu-18_04_defaults_security_autobuild_workspace
-        cd ubuntu-18_04_defaults_security_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/ubuntu-18_04_defaults_security_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/ubuntu-18_04_defaults_security_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ubuntu-18_04_defaults_security_autobuild_output
-        path: OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_security_autobuild_workspace/latest.txt"
-
-  ubuntu-18_04_defaults_java_no-bit:
-
-    runs-on: ubuntu-18.04
-
-    needs: ubuntu-18_04_defaults_artifact
-
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ubuntu-18_04_defaults_ace_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --tests --java --no-built-in-topics --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j4
-    - name: set up TAO Hello test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mwc.pl -type gnuace $TAO_ROOT/tests/Hello
-    - name: build TAO Hello test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j2 dir=$TAO_ROOT/tests/Hello
-    - name: set up Modeling tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tools/modeling/tests
-        ./setup.pl
-        cd -
-        mwc.pl -type gnuace -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
-    - name: build Modeling tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j2 -C tools/modeling/tests
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ubuntu-18_04_defaults_java_no-bit_autobuild_workspace
-        cd ubuntu-18_04_defaults_java_no-bit_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ubuntu-18_04_defaults_java_no-bit_autobuild_output
-        path: OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-18_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-
-  # Ubuntu 16.04
-
-  ubuntu-16_04_defaults_artifact:
+  ubuntu-16_04_defaults_security_build:
 
     runs-on: ubuntu-16.04
 
-    steps:
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2
-      with:
-        path: ubuntu-16_04_defaults_ACE_TAO.tar.xz
-        key: ${{ github.job }}_ace6tao2
-    - name: install xerces
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: build ACE and TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd ACE_TAO/ACE
-        make -j4
-        cd ../TAO
-        make -j4
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        tar cvf ../../ubuntu-16_04_defaults_ACE_TAO.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../ubuntu-16_04_defaults_ACE_TAO.tar
-        xz ../../ubuntu-16_04_defaults_ACE_TAO.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ubuntu-16_04_defaults_ace_artifact
-        path: ubuntu-16_04_defaults_ACE_TAO.tar.xz
-
-  ubuntu-16_04_defaults_security:
-
-    runs-on: ubuntu-16.04
-
-    needs: ubuntu-16_04_defaults_artifact
+    needs: ubuntu-16_04_defaults_ACE_TAO
 
     steps:
     - name: install xerces
@@ -673,11 +1815,6 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v2.3.4
       with:
@@ -687,7 +1824,7 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_ace_artifact
+        name: ubuntu-16_04_defaults_ACE_TAO_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
@@ -709,27 +1846,100 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build OpenDDS
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
         make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  ubuntu-16_04_defaults_security_test:
+
+    runs-on: ubuntu-16.04
+
+    needs: ubuntu-16_04_defaults_security_build
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-16_04_defaults_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-16_04_defaults_security_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ ubuntu-16_04_defaults_security_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: run OpenDDS tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir ubuntu-16_04_defaults_security_autobuild_workspace
-        cd ubuntu-16_04_defaults_security_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/ubuntu-16_04_defaults_security_autobuild_workspace"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/ubuntu-16_04_defaults_security_autobuild_workspace"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -744,23 +1954,117 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/config.xml"
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_security_autobuild_output
-        path: OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_security_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ubuntu-16_04_defaults_java_no-bit:
+  ubuntu-16_04_defaults_java_no-cft_build:
 
     runs-on: ubuntu-16.04
 
-    needs: ubuntu-16_04_defaults_artifact
+    needs: ubuntu-16_04_defaults_ACE_TAO
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-16_04_defaults_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --tests --java --no-content-filtered-topic --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: set up TAO Hello test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
+    - name: build TAO Hello test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 dir=$TAO_ROOT/tests/Hello
+    - name: set up Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tools/modeling/tests
+        ./setup.pl
+        cd -
+        mwc.pl -type gnuace -workers 4 -features content_filtered_topic=0 tools/modeling/tests/modeling_tests.mwc
+    - name: build Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 -C tools/modeling/tests
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  ubuntu-16_04_defaults_java_no-cft_test:
+
+    runs-on: ubuntu-16.04
+
+    needs: ubuntu-16_04_defaults_java_no-cft_build
 
     steps:
     - name: install xerces
@@ -784,7 +2088,7 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_ace_artifact
+        name: ubuntu-16_04_defaults_ACE_TAO_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
@@ -796,64 +2100,38 @@ jobs:
       with:
         path: OpenDDS
         submodules: true
-    - name: configure OpenDDS
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ubuntu-16_04_defaults_java_no-cft_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
       run: |
         cd OpenDDS
-        ./configure --tests --java --no-built-in-topics --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+        tar xvfJ ubuntu-16_04_defaults_java_no-cft_build.tar.xz
     - name: check build configuration
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j4
-    - name: set up TAO Hello test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mwc.pl -type gnuace $TAO_ROOT/tests/Hello
-    - name: build TAO Hello test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j2 dir=$TAO_ROOT/tests/Hello
-    - name: set up Modeling tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tools/modeling/tests
-        ./setup.pl
-        cd -
-        mwc.pl -type gnuace -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
-    - name: build Modeling tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j2 -C tools/modeling/tests
     - name: run OpenDDS tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir ubuntu-16_04_defaults_java_no-bit_autobuild_workspace
-        cd ubuntu-16_04_defaults_java_no-bit_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -863,36 +2141,287 @@ jobs:
         <command name="print_make_version"/>
         <command name="check_compiler" options="gcc"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/config.xml"
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_java_no-bit_autobuild_output
-        path: OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/ubuntu-16_04_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # Windows 2019
+  # Ubuntu 16.04 - Static
 
-  windows-2019_defaults_artifact:
+#  ubuntu-16_04_static_ACE_TAO:
+#
+#    runs-on: ubuntu-16.04
+#
+#    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+#    - name: install xerces
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: |
+#        cd OpenDDS
+#        ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: build ACE and TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        cd ACE_TAO/ACE
+#        make -j4
+#        cd ../TAO
+#        make -j4
+#    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
+#    - name: upload ACE_TAO artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-16_04_static_security_build:
+#
+#    runs-on: ubuntu-16.04
+#
+#    needs: ubuntu-16_04_static_ACE_TAO
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-16_04_static_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-16_04_static_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: configure OpenDDS
+#      run: |
+#        cd OpenDDS
+#        ./configure --static --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
+#    - name: build OpenDDS
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        make -j4
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  ubuntu-16_04_static_security_test:
+#
+#    runs-on: ubuntu-16.04
+#
+#    needs: ubuntu-16_04_static_security_build
+#
+#    steps:
+#    - name: install xerces
+#      run: sudo apt-get -y install libxerces-c-dev
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-16_04_static_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ ubuntu-16_04_static_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: ubuntu-16_04_static_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ ubuntu-16_04_static_security_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: run OpenDDS tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DDS_ROOT"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # Windows 2019 - Defaults
+
+  windows-2019_defaults_ACE_TAO:
 
     runs-on: windows-2019
 
     steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
       uses: actions/cache@v2
       with:
-        path: windows-2019_defaults_ACE_TAO.tar.xz
-        key: ${{ github.job }}_ace6tao2
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
     - name: install openssl-windows & xerces-c
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: lukka/run-vcpkg@v6
@@ -906,19 +2435,6 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
     - name: set up msvc env
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -944,21 +2460,96 @@ jobs:
       run: |
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find -iname "*\.obj" | xargs rm
-        tar cvf ../../windows-2019_defaults_ACE_TAO.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../windows-2019_defaults_ACE_TAO.tar
-        xz ../../windows-2019_defaults_ACE_TAO.tar
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2019_defaults_ace_artifact
-        path: windows-2019_defaults_ACE_TAO.tar.xz
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  windows-2019_defaults_security:
+  windows-2019_defaults_security_build:
 
     runs-on: windows-2019
 
-    needs: windows-2019_defaults_artifact
+    needs: windows-2019_defaults_ACE_TAO
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2019_defaults_ACE_TAO_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
+        rm -f windows-2019_defaults_ACE_TAO.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  windows-2019_defaults_security_test:
+
+    runs-on: windows-2019
+
+    needs: windows-2019_defaults_security_build
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -991,7 +2582,7 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_ace_artifact
+        name: windows-2019_defaults_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
@@ -999,40 +2590,39 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
         rm -f windows-2019_defaults_ACE_TAO.tar.xz
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2019_defaults_security_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
       run: |
         cd OpenDDS
-        configure --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+        tar xvfJ windows-2019_defaults_security_build.tar.xz
+        rm -f windows-2019_defaults_security_build.tar.xz
     - name: check build configuration
-      shell: cmd
+      shell: bash
       run: |
         cd OpenDDS
-        call setenv.cmd
-        tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
         cd OpenDDS
-        mkdir windows-2019_defaults_security_autobuild_workspace
-        cd windows-2019_defaults_security_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_security_autobuild_workspace"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_security_autobuild_workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1053,24 +2643,99 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd windows-2019_defaults_security_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2019_defaults_security_autobuild_workspace\config.xml"
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2019_defaults_security_autobuild_output
-        path: OpenDDS\windows-2019_defaults_security_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_security_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_security_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  windows-2019_defaults_java_no-bit:
+  windows-2019_defaults_java_no-bit_build:
 
     runs-on: windows-2019
 
-    needs: windows-2019_defaults_artifact
+    needs: windows-2019_defaults_ACE_TAO
+
+    steps:
+    - name: install xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2019_defaults_ACE_TAO_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
+        rm -f windows-2019_defaults_ACE_TAO.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  windows-2019_defaults_java_no-bit_test:
+
+    runs-on: windows-2019
+
+    needs: windows-2019_defaults_java_no-bit_build
 
     steps:
     - name: install xerces-c
@@ -1103,7 +2768,7 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_ace_artifact
+        name: windows-2019_defaults_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
@@ -1111,40 +2776,39 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
         rm -f windows-2019_defaults_ACE_TAO.tar.xz
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2019_defaults_java_no-bit_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
       run: |
         cd OpenDDS
-        configure --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
+        tar xvfJ windows-2019_defaults_java_no-bit_build.tar.xz
+        rm -f windows-2019_defaults_java_no-bit_build.tar.xz
     - name: check build configuration
-      shell: cmd
+      shell: bash
       run: |
         cd OpenDDS
-        call setenv.cmd
-        tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
         cd OpenDDS
-        mkdir windows-2019_defaults_java_no-bit_autobuild_workspace
-        cd windows-2019_defaults_java_no-bit_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2019_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1165,32 +2829,499 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd windows-2019_defaults_java_no-bit_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2019_defaults_java_no-bit_autobuild_workspace\config.xml"
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2019_defaults_java_no-bit_autobuild_output
-        path: OpenDDS\windows-2019_defaults_java_no-bit_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_java_no-bit_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2019_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # Windows 2016
+  # Windows 2019 - WChar
 
-  windows-2016_no_debug_no_inline_artifact:
+#  windows-2019_wchar_ACE_TAO:
+#
+#    runs-on: windows-2019
+#
+#    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+#    - name: install openssl-windows & xerces-c
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: set up msvc env
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --features=uses_wchar=1 --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+#    - name: build ACE & TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ACE_TAO\ACE
+#        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+#        cd ..\TAO
+#        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+#    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+#        find . -iname "*\.obj" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
+#    - name: upload ACE_TAO artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2019_wchar_security_build:
+#
+#    runs-on: windows-2019
+#
+#    needs: windows-2019_wchar_ACE_TAO
+#
+#    steps:
+#    - name: install openssl-windows & xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2019_wchar_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
+#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
+#    - uses: ammaraskar/msvc-problem-matcher@0.1
+#    - name: set up msvc env
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --features=uses_wchar=1 --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: build OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.cmd
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2019_wchar_security_test:
+#
+#    runs-on: windows-2019
+#
+#    needs: windows-2019_wchar_security_build
+#
+#    steps:
+#    - name: install openssl-windows & xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2019_wchar_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
+#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2019_wchar_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ windows-2019_wchar_security_build.tar.xz
+#        rm -f windows-2019_wchar_security_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: create autobuild config
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
+#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config WCHAR -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        cat config.xml
+#    - name: run OpenDDS tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ${{ github.job }}_autobuild_workspace
+#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS\${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#
+#  windows-2019_wchar_java_no-bit_build:
+#
+#    runs-on: windows-2019
+#
+#    needs: windows-2019_wchar_ACE_TAO
+#
+#    steps:
+#    - name: install xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2019_wchar_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
+#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
+#    - uses: ammaraskar/msvc-problem-matcher@0.1
+#    - name: set up msvc env
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --features=uses_wchar=1e --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: build OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.cmd
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2019_wchar_java_no-bit_test:
+#
+#    runs-on: windows-2019
+#
+#    needs: windows-2019_wchar_java_no-bit_build
+#
+#    steps:
+#    - name: install xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2019_wchar_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
+#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2019_wchar_java_no-bit_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ windows-2019_wchar_java_no-bit_build.tar.xz
+#        rm -f windows-2019_wchar_java_no-bit_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: create autobuild config
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
+#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config WCHAR -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        cat config.xml
+#    - name: run OpenDDS tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ${{ github.job }}_autobuild_workspace
+#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS\${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # Windows 2016 - No Debug, No Inline
+
+  windows-2016_no-debug_no-inline_ACE_TAO:
 
     runs-on: windows-2016
 
     steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
       uses: actions/cache@v2
       with:
-        path: windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
-        key: ${{ github.job }}_ace6tao2
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
     - name: install openssl-windows & xerces-c
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: lukka/run-vcpkg@v6
@@ -1204,19 +3335,6 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
     - name: set up msvc env
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -1225,7 +3343,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --no-debug --no-inline --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+        configure --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
     - name: build ACE & TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
@@ -1242,21 +3360,100 @@ jobs:
       run: |
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find -iname "*\.obj" | xargs rm
-        tar cvf ../../windows-2016_no_debug_no_inline_ACE_TAO.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../windows-2016_no_debug_no_inline_ACE_TAO.tar
-        xz ../../windows-2016_no_debug_no_inline_ACE_TAO.tar
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2016_no_debug_no_inline_artifact
-        path: windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  windows-2016_no_debug_no_inline_security:
+  windows-2016_no-debug_no-inline_security_build:
 
     runs-on: windows-2016
 
-    needs: windows-2016_no_debug_no_inline_artifact
+    needs: windows-2016_no-debug_no-inline_ACE_TAO
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: Clean Up VCPKG
+      shell: bash
+      run: |
+        rm -rf $VCPKG_ROOT/downloads $VCPKG_ROOT/buildtrees $VCPKG_ROOT/packages
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --no-debug --no-inline --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  windows-2016_no-debug_no-inline_security_test:
+
+    runs-on: windows-2016
+
+    needs: windows-2016_no-debug_no-inline_security_build
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -1289,48 +3486,47 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no_debug_no_inline_artifact
+        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
-        rm -f windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
+        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2016_no-debug_no-inline_security_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
       run: |
         cd OpenDDS
-        configure --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+        tar xvfJ windows-2016_no-debug_no-inline_security_build.tar.xz
+        rm -f windows-2016_no-debug_no-inline_security_build.tar.xz
     - name: check build configuration
-      shell: cmd
+      shell: bash
       run: |
         cd OpenDDS
-        call setenv.cmd
-        tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
         cd OpenDDS
-        mkdir windows-2016_no_debug_no_inline_security_autobuild_workspace
-        cd windows-2016_no_debug_no_inline_security_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_security_autobuild_workspace"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_security_autobuild_workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1351,24 +3547,104 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd windows-2016_no_debug_no_inline_security_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2016_no_debug_no_inline_security_autobuild_workspace\config.xml"
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2016_no_debug_no_inline_security_autobuild_output
-        path: OpenDDS\windows-2016_no_debug_no_inline_security_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_security_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_security_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  windows-2016_no_debug_no_inline_java_no-bit:
+  windows-2016_no-debug_no-inline_java_no-bit_build:
 
     runs-on: windows-2016
 
-    needs: windows-2016_no_debug_no_inline_artifact
+    needs: windows-2016_no-debug_no-inline_ACE_TAO
+
+    steps:
+    - name: install xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse xerces-c
+        vcpkgTriplet: x64-windows
+    - name: Clean Up VCPKG
+      shell: bash
+      run: |
+        rm -rf $VCPKG_ROOT/downloads $VCPKG_ROOT/buildtrees $VCPKG_ROOT/packages
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --no-debug --no-inline --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  windows-2016_no-debug_no-inline_java_no-bit_test:
+
+    runs-on: windows-2016
+
+    needs: windows-2016_no-debug_no-inline_java_no-bit_build
 
     steps:
     - name: install xerces-c
@@ -1401,48 +3677,48 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_no_debug_no_inline_artifact
+        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
-        rm -f windows-2016_no_debug_no_inline_ACE_TAO.tar.xz
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
+        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: windows-2016_no-debug_no-inline_java_no-bit_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
       run: |
         cd OpenDDS
-        configure --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
+        tar xvfJ windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
+        rm -f windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
     - name: check build configuration
-      shell: cmd
+      shell: bash
       run: |
         cd OpenDDS
-        call setenv.cmd
-        tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: create autobuild config
       shell: bash
       run: |
         cd OpenDDS
-        mkdir windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
-        cd windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
         export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace"/>
+        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-        <variable name="root" value="$DBS_GHW\\OpenDDS\\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace"/>
+        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -1463,32 +3739,521 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace\config.xml"
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: windows-2016_no_debug_no_inline_java_no-bit_autobuild_output
-        path: OpenDDS\windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/windows-2016_no_debug_no_inline_java_no-bit_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # macOS 11.0
+  # Windows 2016 - IPv6, No Debug, No Inline
 
-#  macos-11_0_defaults_artifact:
+#  windows-2016_ipv6_no-debug_no-inline_ACE_TAO:
 #
-#    runs-on: macos-11.0
+#    runs-on: windows-2016
 #
 #    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
 #    - name: Cache Artifact
 #      id: cache-artifact
 #      uses: actions/cache@v2
 #      with:
-#        path: macos-11_0_defaults_ACE_TAO.tar.xz
-#        key: ${{ github.job }}_ace6tao2
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+#    - name: install openssl-windows & xerces-c
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: set up msvc env
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --ipv6 --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+#    - name: build ACE & TAO
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ACE_TAO\ACE
+#        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+#        cd ..\TAO
+#        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+#    - name: create ACE_TAO tar.xz artifact
+#      if: steps.cache-artifact.outputs.cache-hit != 'true'
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+#        find . -iname "*\.obj" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
+#    - name: upload ACE_TAO artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2016_ipv6_no-debug_no-inline_security_build:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_ipv6_no-debug_no-inline_ACE_TAO
+#
+#    steps:
+#    - name: install openssl-windows & xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: Clean Up VCPKG
+#      shell: bash
+#      run: |
+#        rm -rf $VCPKG_ROOT/downloads $VCPKG_ROOT/buildtrees $VCPKG_ROOT/packages
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: Move ACE and MPC to C Drive
+#      shell: bash
+#      run: |
+#        mv ACE_TAO /
+#        mv MPC /
+#    - uses: ammaraskar/msvc-problem-matcher@0.1
+#    - name: set up msvc env
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --tests --rapidjson --security --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: build OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.cmd
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2016_ipv6_no-debug_no-inline_security_test:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_ipv6_no-debug_no-inline_security_build
+#
+#    steps:
+#    - name: install openssl-windows & xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse openssl-windows xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_ipv6_no-debug_no-inline_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_security_build.tar.xz
+#        rm -f windows-2016_ipv6_no-debug_no-inline_security_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: create autobuild config
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
+#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config IPV6 -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        cat config.xml
+#    - name: run OpenDDS tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ${{ github.job }}_autobuild_workspace
+#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS\${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#
+#  windows-2016_ipv6_no-debug_no-inline_java_no-bit_build:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_ipv6_no-debug_no-inline_ACE_TAO
+#
+#    steps:
+#    - name: install xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: Clean Up VCPKG
+#      shell: bash
+#      run: |
+#        rm -rf $VCPKG_ROOT/downloads $VCPKG_ROOT/buildtrees $VCPKG_ROOT/packages
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: Move ACE and MPC to C Drive
+#      shell: bash
+#      run: |
+#        mv ACE_TAO /
+#        mv MPC /
+#    - uses: ammaraskar/msvc-problem-matcher@0.1
+#    - name: set up msvc env
+#      uses: ilammy/msvc-dev-cmd@v1.5.0
+#    - name: configure OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\Program Files\GIT\ACE_TAO\ACE" --tao="C:\Program Files\GIT\ACE_TAO\TAO" --mpc="C:\Program Files\GIT\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
+#    - name: check build configuration
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        tools\scripts\show_build_config.pl
+#    - name: build OpenDDS
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.cmd
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  windows-2016_ipv6_no-debug_no-inline_java_no-bit_test:
+#
+#    runs-on: windows-2016
+#
+#    needs: windows-2016_ipv6_no-debug_no-inline_java_no-bit_build
+#
+#    steps:
+#    - name: install xerces-c
+#      uses: lukka/run-vcpkg@v6
+#      with:
+#        vcpkgGitCommitId: ec6fe06
+#        vcpkgArguments: --recurse xerces-c
+#        vcpkgTriplet: x64-windows
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: ace6tao2
+#        path: OpenDDS/ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
+#        path: OpenDDS/ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
+#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: windows-2016_ipv6_no-debug_no-inline_java_no-bit_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_java_no-bit_build.tar.xz
+#        rm -f windows-2016_ipv6_no-debug_no-inline_java_no-bit_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: create autobuild config
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
+#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$DBS_GHW\\OpenDDS -Config IPV6 -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        cat config.xml
+#    - name: run OpenDDS tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        cd ${{ github.job }}_autobuild_workspace
+#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS\${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  # macOS 11.0
+
+#  macos-11_0_defaults_ACE_TAO:
+#
+#    runs-on: macos-11.0
+#
+#    steps:
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
+#        path: OpenDDS/ACE_TAO
+#    - name: get ACE_TAO commit
+#      shell: bash
+#      run: |
+#        cd OpenDDS/ACE_TAO
+#        export ACE_COMMIT=$(git rev-parse HEAD)
+#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+#    - name: Cache Artifact
+#      id: cache-artifact
+#      uses: actions/cache@v2
+#      with:
+#        path: ${{ github.job }}.tar.xz
+#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
 #    - name: install xerces-c
 #      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      run: |
@@ -1499,19 +4264,6 @@ jobs:
 #      with:
 #        repository: DOCGroup/MPC
 #        path: MPC
-#    - name: checkout OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
-#        path: OpenDDS/ACE_TAO
 #    - name: configure OpenDDS
 #      if: steps.cache-artifact.outputs.cache-hit != 'true'
 #      run: |
@@ -1532,20 +4284,21 @@ jobs:
 #      run: |
 #        cd OpenDDS/ACE_TAO
 #        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        tar cvf ../../macos-11_0_defaults_ACE_TAO.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../macos-11_0_defaults_ACE_TAO.tar
-#        xz ../../macos-11_0_defaults_ACE_TAO.tar
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+#        xz -3 ../../${{ github.job }}.tar
 #    - name: upload ACE_TAO artifact
 #      uses: actions/upload-artifact@v2
 #      with:
-#        name: macos-11_0_defaults_ace_artifact
-#        path: macos-11_0_defaults_ACE_TAO.tar.xz
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
 #
-#  macos-11_0_defaults_security:
+#  macos-11_0_defaults_security_build:
 #
 #    runs-on: macos-11.0
 #
-#    needs: macos-11_0_defaults_artifact
+#    needs: macos-11_0_defaults_ACE_TAO
 #
 #    steps:
 #    - name: install xerces-c
@@ -1556,11 +4309,6 @@ jobs:
 #      with:
 #        repository: DOCGroup/MPC
 #        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
 #    - name: checkout ACE_TAO
 #      uses: actions/checkout@v2.3.4
 #      with:
@@ -1570,7 +4318,7 @@ jobs:
 #    - name: download ACE_TAO artifact
 #      uses: actions/download-artifact@v2
 #      with:
-#        name: macos-11_0_defaults_ace_artifact
+#        name: macos-11_0_defaults_ACE_TAO_artifact
 #        path: ACE_TAO
 #    - name: extract ACE_TAO artifact
 #      shell: bash
@@ -1592,58 +4340,33 @@ jobs:
 #        cd OpenDDS
 #        . setenv.sh
 #        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
 #    - name: build OpenDDS
 #      shell: bash
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
 #        make -j4
-#    - name: run OpenDDS tests
+#    - name: create OpenDDS tar.xz artifact
 #      shell: bash
 #      run: |
 #        cd OpenDDS
-#        . setenv.sh
-#        mkdir workspace
-#        cd workspace
-#        echo $GITHUB_SHA > ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/macos-11_0_defaults_security_autobuild_workspace"/>
-#        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/macos-11_0_defaults_security_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/config.xml"
-#    - name: upload autobuild output
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
 #      uses: actions/upload-artifact@v2
 #      with:
-#        name: macos-11_0_defaults_security_autobuild_output
-#        path: OpenDDS/macos-11_0_defaults_security_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_security_autobuild_workspace/latest.txt"
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
 #
-#  macos-11_0_defaults_java_no-bit:
+#  macos-11_0_defaults_security_test:
 #
 #    runs-on: macos-11.0
 #
-#    needs: macos-11_0_defaults_artifact
+#    needs: macos-11_0_defaults_security_build
 #
 #    steps:
 #    - name: install xerces-c
@@ -1668,7 +4391,101 @@ jobs:
 #    - name: download ACE_TAO artifact
 #      uses: actions/download-artifact@v2
 #      with:
-#        name: macos-11_0_defaults_ace_artifact
+#        name: macos-11_0_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ macos-11_0_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: macos-11_0_defaults_security_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ macos-11_0_defaults_security_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
+#    - name: run OpenDDS tests
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
+#        cat > config.xml <<EOF
+#        <autobuild>
+#        <configuration>
+#        <variable name="log_file" value="output.log"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="project_root" value="$DDS_ROOT"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+#        <variable name="junit_xml_output" value="Tests"/>
+#        </configuration>
+#        <command name="log" options="on"/>
+#        <command name="print_os_version"/>
+#        <command name="print_env_vars"/>
+#        <command name="print_ace_config"/>
+#        <command name="print_make_version"/>
+#        <command name="check_compiler" options="gcc"/>
+#        <command name="print_autobuild_config"/>
+#        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+#        <command name="log" options="off"/>
+#        <command name="process_logs" options="prettify"/>
+#        </autobuild>
+#        EOF
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+#    - name: upload autobuild output
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
+#    - name: check results
+#      shell: bash
+#      run: |
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#
+#  macos-11_0_defaults_java_no-bit_build:
+#
+#    runs-on: macos-11.0
+#
+#    needs: macos-11_0_defaults_ACE_TAO
+#
+#    steps:
+#    - name: install xerces-c
+#      run: |
+#        brew install xerces-c
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: macos-11_0_defaults_ACE_TAO_artifact
 #        path: ACE_TAO
 #    - name: extract ACE_TAO artifact
 #      shell: bash
@@ -1690,6 +4507,7 @@ jobs:
 #        cd OpenDDS
 #        . setenv.sh
 #        tools/scripts/show_build_config.pl
+#    - uses: ammaraskar/gcc-problem-matcher@0.1
 #    - name: build OpenDDS
 #      shell: bash
 #      run: |
@@ -1701,13 +4519,13 @@ jobs:
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
-#        mwc.pl -type gnuace $TAO_ROOT/tests/Hello
+#        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
 #    - name: build TAO Hello test
 #      shell: bash
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
-#        make -j2 dir=$TAO_ROOT/tests/Hello
+#        make -j4 dir=$TAO_ROOT/tests/Hello
 #    - name: set up Modeling tests
 #      shell: bash
 #      run: |
@@ -1716,28 +4534,101 @@ jobs:
 #        cd tools/modeling/tests
 #        ./setup.pl
 #        cd -
-#        mwc.pl -type gnuace -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
+#        mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
 #    - name: build Modeling tests
 #      shell: bash
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
-#        make -j2 -C tools/modeling/tests
+#        make -j4 -C tools/modeling/tests
+#    - name: create OpenDDS tar.xz artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        rm -rf ACE_TAO
+#        find . -iname "*\.o" | xargs rm
+#        tar cvf ../${{ github.job }}.tar setenv.sh
+#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+#        xz -3 ../${{ github.job }}.tar
+#    - name: upload OpenDDS artifact
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: ${{ github.job }}_artifact
+#        path: ${{ github.job }}.tar.xz
+#
+#  macos-11_0_defaults_java_no-bit_test:
+#
+#    runs-on: macos-11.0
+#
+#    needs: macos-11_0_defaults_java_no-bit_build
+#
+#    steps:
+#    - name: install xerces-c
+#      run: |
+#        brew install xerces-c
+#    - name: checkout MPC
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/MPC
+#        path: MPC
+#    - name: checkout autobuild
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/autobuild
+#        path: autobuild
+#    - name: checkout ACE_TAO
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        repository: DOCGroup/ACE_TAO
+#        ref: 9eae9c11f1bcd07b48c74820d8cb4c67aca9ef23 # Update to 6_5_13 when available
+#        path: ACE_TAO
+#    - name: download ACE_TAO artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: macos-11_0_defaults_ACE_TAO_artifact
+#        path: ACE_TAO
+#    - name: extract ACE_TAO artifact
+#      shell: bash
+#      run: |
+#        cd ACE_TAO
+#        tar xvfJ macos-11_0_defaults_ACE_TAO.tar.xz
+#    - name: checkout OpenDDS
+#      uses: actions/checkout@v2.3.4
+#      with:
+#        path: OpenDDS
+#        submodules: true
+#    - name: download OpenDDS artifact
+#      uses: actions/download-artifact@v2
+#      with:
+#        name: macos-11_0_defaults_java_no-bit_build_artifact
+#        path: OpenDDS
+#    - name: extract OpenDDS artifact
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        tar xvfJ macos-11_0_defaults_java_no-bit_build.tar.xz
+#    - name: check build configuration
+#      shell: bash
+#      run: |
+#        cd OpenDDS
+#        . setenv.sh
+#        tools/scripts/show_build_config.pl
 #    - name: run OpenDDS tests
 #      shell: bash
 #      run: |
 #        cd OpenDDS
 #        . setenv.sh
-#        mkdir macos-11_0_defaults_java_no-bit_autobuild_workspace
-#        cd macos-11_0_defaults_java_no-bit_autobuild_workspace
-#        echo $GITHUB_SHA > ./SHA
+#        mkdir ${{ github.job }}_autobuild_workspace
+#        cd ${{ github.job }}_autobuild_workspace
+#        echo using commit $TRIGGERING_COMMIT for SHA
+#        echo $TRIGGERING_COMMIT >> ./SHA
 #        cat > config.xml <<EOF
 #        <autobuild>
 #        <configuration>
 #        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/macos-11_0_defaults_java_no-bit_autobuild_workspace"/>
+#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
 #        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/macos-11_0_defaults_java_no-bit_autobuild_workspace"/>
+#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
 #        <variable name="junit_xml_output" value="Tests"/>
 #        </configuration>
 #        <command name="log" options="on"/>
@@ -1752,31 +4643,48 @@ jobs:
 #        <command name="process_logs" options="prettify"/>
 #        </autobuild>
 #        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/config.xml"
+#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
 #    - name: upload autobuild output
 #      uses: actions/upload-artifact@v2
 #      with:
-#        name: macos-11_0_defaults_java_no-bit_autobuild_output
-#        path: OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace
+#        name: ${{ github.job }}_autobuild_output
+#        path: OpenDDS/${{ github.job }}_autobuild_workspace
 #    - name: check results
 #      shell: bash
 #      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-11_0_defaults_java_no-bit_autobuild_workspace/latest.txt"
+#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   # macOS 10.15
 
-  macos-10_15_defaults_artifact:
+  macos-10_15_defaults_ACE_TAO:
 
     runs-on: macos-10.15
 
     steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
       uses: actions/cache@v2
       with:
-        path: macos-10_15_defaults_ACE_TAO.tar.xz
-        key: ${{ github.job }}_ace6tao2
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
     - name: install xerces-c
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -1787,19 +4695,6 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
     - name: configure OpenDDS
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -1820,20 +4715,21 @@ jobs:
       run: |
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        tar cvf ../../macos-10_15_defaults_ACE_TAO.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../macos-10_15_defaults_ACE_TAO.tar
-        xz ../../macos-10_15_defaults_ACE_TAO.tar
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v2
       with:
-        name: macos-10_15_defaults_ace_artifact
-        path: macos-10_15_defaults_ACE_TAO.tar.xz
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  macos-10_15_defaults_security:
+  macos-10_15_defaults_security_build:
 
     runs-on: macos-10.15
 
-    needs: macos-10_15_defaults_artifact
+    needs: macos-10_15_defaults_ACE_TAO
 
     steps:
     - name: install xerces-c
@@ -1844,11 +4740,6 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v2.3.4
       with:
@@ -1858,7 +4749,7 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_ace_artifact
+        name: macos-10_15_defaults_ACE_TAO_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
@@ -1880,58 +4771,33 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build OpenDDS
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: run OpenDDS tests
+    - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
         cd OpenDDS
-        . setenv.sh
-        mkdir macos-10_15_defaults_security_autobuild_workspace
-        cd macos-10_15_defaults_security_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/macos-10_15_defaults_security_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/macos-10_15_defaults_security_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/config.xml"
-    - name: upload autobuild output
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
       uses: actions/upload-artifact@v2
       with:
-        name: macos-10_15_defaults_security_autobuild_output
-        path: OpenDDS/macos-10_15_defaults_security_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_security_autobuild_workspace/latest.txt"
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  macos-10_15_defaults_java_no-bit:
+  macos-10_15_defaults_security_test:
 
     runs-on: macos-10.15
 
-    needs: macos-10_15_defaults_artifact
+    needs: macos-10_15_defaults_security_build
 
     steps:
     - name: install xerces-c
@@ -1956,7 +4822,101 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_ace_artifact
+        name: macos-10_15_defaults_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: macos-10_15_defaults_security_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ macos-10_15_defaults_security_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  macos-10_15_defaults_java_no-bit_build:
+
+    runs-on: macos-10.15
+
+    needs: macos-10_15_defaults_ACE_TAO
+
+    steps:
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: macos-10_15_defaults_ACE_TAO_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
@@ -1978,6 +4938,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build OpenDDS
       shell: bash
       run: |
@@ -1989,13 +4950,13 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        mwc.pl -type gnuace $TAO_ROOT/tests/Hello
+        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
     - name: build TAO Hello test
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        make -j2 dir=$TAO_ROOT/tests/Hello
+        make -j4 dir=$TAO_ROOT/tests/Hello
     - name: set up Modeling tests
       shell: bash
       run: |
@@ -2004,28 +4965,101 @@ jobs:
         cd tools/modeling/tests
         ./setup.pl
         cd -
-        mwc.pl -type gnuace -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
+        mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
     - name: build Modeling tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        make -j2 -C tools/modeling/tests
+        make -j4 -C tools/modeling/tests
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  macos-10_15_defaults_java_no-bit_test:
+
+    runs-on: macos-10.15
+
+    needs: macos-10_15_defaults_java_no-bit_build
+
+    steps:
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: macos-10_15_defaults_ACE_TAO_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: macos-10_15_defaults_java_no-bit_build_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ macos-10_15_defaults_java_no-bit_build.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
     - name: run OpenDDS tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        mkdir macos-10_15_defaults_java_no-bit_autobuild_workspace
-        cd macos-10_15_defaults_java_no-bit_autobuild_workspace
-        echo $GITHUB_SHA > ./SHA
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
         cat > config.xml <<EOF
         <autobuild>
         <configuration>
         <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/macos-10_15_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/macos-10_15_defaults_java_no-bit_autobuild_workspace"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
         <variable name="junit_xml_output" value="Tests"/>
         </configuration>
         <command name="log" options="on"/>
@@ -2040,14 +5074,14 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/config.xml"
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
       with:
-        name: macos-10_15_defaults_java_no-bit_autobuild_output
-        path: OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
     - name: check results
       shell: bash
       run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/macos-10_15_defaults_java_no-bit_autobuild_workspace/latest.txt"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -260,7 +260,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt" then echo ::error file=latest.txt,line=0,col=0::Test Failures
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 #
 #  ubuntu-20_04_defaults_java_no-bit_build:
 #
@@ -452,7 +452,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Ubuntu 20.04 - IPv6
 
@@ -686,7 +686,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   ubuntu-20_04_ipv6_java_no-bit_build:
 
@@ -878,7 +878,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Ubuntu 18.04 - Defaults
 
@@ -1112,7 +1112,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 #
 #  ubuntu-18_04_defaults_java_no-csp_build:
 #
@@ -1304,7 +1304,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Ubuntu 18.04 - WChar
 
@@ -1538,7 +1538,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   ubuntu-18_04_wchar_java_no-csp_build:
 
@@ -1730,7 +1730,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Ubuntu 16.04 - Defaults
 
@@ -1964,7 +1964,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   ubuntu-16_04_defaults_java_no-cft_build:
 
@@ -2156,7 +2156,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Ubuntu 16.04 - Static
 
@@ -2390,7 +2390,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Windows 2019 - Defaults
 
@@ -2654,7 +2654,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   windows-2019_defaults_java_no-bit_build:
 
@@ -2840,7 +2840,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Windows 2019 - WChar
 
@@ -3104,7 +3104,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 #
 #  windows-2019_wchar_java_no-bit_build:
 #
@@ -3290,7 +3290,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Windows 2016 - No Debug, No Inline
 
@@ -3566,7 +3566,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 #
 #  windows-2016_no-debug_no-inline_java_no-bit_build:
 #
@@ -3765,7 +3765,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Windows 2016 - x86, No Debug, No Inline
 
@@ -4036,7 +4036,6 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd ${{ github.job }}_autobuild_workspace
-        set PERL5LIB=%ACE_ROOT%\bin
         perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
@@ -4047,7 +4046,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   windows-2016_x86_no-debug_no-inline_java_no-bit_build:
 
@@ -4239,7 +4238,6 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd ${{ github.job }}_autobuild_workspace
-        set PERL5LIB=%ACE_ROOT%\bin
         perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v2
@@ -4250,7 +4248,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Windows 2016 - IPv6, No Debug, No Inline
 
@@ -4525,7 +4523,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 #
 #  windows-2016_ipv6_no-debug_no-inline_java_no-bit_build:
 #
@@ -4722,7 +4720,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # macOS 11.0
 
@@ -4959,7 +4957,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 #
 #  macos-11_0_defaults_java_no-bit_build:
 #
@@ -5153,7 +5151,7 @@ jobs:
 #      shell: bash
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # macOS 10.15
 
@@ -5390,7 +5388,7 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   macos-10_15_defaults_java_no-bit_build:
 
@@ -5584,4 +5582,4 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi

--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -2,6 +2,8 @@
 # This module contains a few miscellaneous functions and some
 # startup ARGV processing that is used by all tests.
 
+use lib "$ENV{ACE_ROOT}/bin";
+use lib "$ENV{DDS_ROOT}/bin";
 use PerlACE::Run_Test;
 use PerlDDS::Process;
 use PerlDDS::ProcessFactory;

--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -2,8 +2,6 @@
 # This module contains a few miscellaneous functions and some
 # startup ARGV processing that is used by all tests.
 
-use lib "$ENV{ACE_ROOT}/bin";
-use lib "$ENV{DDS_ROOT}/bin";
 use PerlACE::Run_Test;
 use PerlDDS::Process;
 use PerlDDS::ProcessFactory;

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -429,8 +429,8 @@ tests/DCPS/XTypes/run_test.pl: !DCPS_MIN
 tests/DCPS/UnregisterType/run_test.pl: !DCPS_MIN
 
 performance-tests/bench_2/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench_2/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench_2/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench_2/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+performance-tests/bench_2/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 performance-tests/bench_2/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON

--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -438,4 +438,4 @@ performance-tests/bench_2/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS 
 tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN
 tests/DCPS/DataRepresentation/run_test.pl rtps_disc: !DCPS_MIN RTPS
 
-performance-tests/bench_2/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench_2/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -617,7 +617,9 @@ Spdp::handle_participant_data(DCPS::MessageId id,
   }
 
   const bool from_relay = from == config_->spdp_rtps_relay_address();
+#ifndef DDS_HAS_MINIMUM_BIT
   const DCPS::ParticipantLocation location_mask = compute_location_mask(from, from_relay);
+#endif
 
   // Find the participant - iterator valid only as long as we hold the lock
   DiscoveredParticipantIter iter = participants_.find(guid);
@@ -920,6 +922,8 @@ Spdp::match_unauthenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter&
       }
     }
   }
+#else
+  ACE_UNUSED_ARG(guid);
 #endif /* DDS_HAS_MINIMUM_BIT */
 
   // notify Sedp of association

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -65,6 +65,7 @@ namespace {
     return false;
   }
 
+#ifndef DDS_HAS_MINIMUM_BIT
   DCPS::ParticipantLocation compute_location_mask(const ACE_INET_Addr& address, bool from_relay)
   {
     if (address.get_type() == AF_INET6) {
@@ -72,6 +73,7 @@ namespace {
     }
     return from_relay ? DCPS::LOCATION_RELAY : DCPS::LOCATION_LOCAL;
   }
+#endif
 
 #ifdef OPENDDS_SECURITY
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -81,6 +81,9 @@ StaticEndpointManager::StaticEndpointManager(const RepoId& participant_id,
   , participant_(participant)
 #endif
 {
+#ifndef DDS_HAS_MINIMUM_BIT
+  ACE_UNUSED_ARG(participant);
+#endif
   type_lookup_init(TheServiceParticipant->interceptor());
 }
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -81,7 +81,7 @@ StaticEndpointManager::StaticEndpointManager(const RepoId& participant_id,
   , participant_(participant)
 #endif
 {
-#ifndef DDS_HAS_MINIMUM_BIT
+#ifdef DDS_HAS_MINIMUM_BIT
   ACE_UNUSED_ARG(participant);
 #endif
   type_lookup_init(TheServiceParticipant->interceptor());

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -77,7 +77,9 @@ StaticEndpointManager::StaticEndpointManager(const RepoId& participant_id,
                                              StaticParticipant& participant)
   : EndpointManager<StaticDiscoveredParticipantData>(participant_id, lock)
   , registry_(registry)
+#ifndef DDS_HAS_MINIMUM_BIT
   , participant_(participant)
+#endif
 {
   type_lookup_init(TheServiceParticipant->interceptor());
 }

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -205,7 +205,9 @@ public:
 
 private:
   const EndpointRegistry& registry_;
+#ifndef DDS_HAS_MINIMUM_BIT
   StaticParticipant& participant_;
+#endif
 };
 
 class StaticParticipant : public LocalParticipant<StaticEndpointManager> {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3891,6 +3891,7 @@ RtpsUdpDataLink::RtpsWriter::heartbeat_high(const ReaderInfo_rch& ri) const
 void
 RtpsUdpDataLink::RtpsWriter::update_max_sn(SequenceNumber seq)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(mutex_);
   max_sn_ = std::max(max_sn_, seq);
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -644,7 +644,7 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
       }
       RtpsWriter_rch writer = rw->second;
       g.release();
-      writer->update_max_sn(max_sn);
+      writer->update_max_sn(remote_id, max_sn);
       writer->add_reader(make_rch<ReaderInfo>(remote_id, remote_durable));
       enable_heartbeat = true;
     }
@@ -1075,6 +1075,9 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     }
   }
 
+  make_leader_lagger(element->subscription_id(), previous_max_sn);
+  check_leader_lagger();
+
   TransportSendElement* tse = dynamic_cast<TransportSendElement*>(element);
   TransportCustomizedElement* tce =
     dynamic_cast<TransportCustomizedElement*>(element);
@@ -1095,8 +1098,6 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
       // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
       RtpsSampleHeader::populate_data_control_submessages(
         subm, *tsce, requires_inline_qos);
-      make_leader_lagger(element->subscription_id(), previous_max_sn);
-      check_leader_lagger();
       record_directed(element->subscription_id(), seq);
     } else if (tsce->header().message_id_ == END_HISTORIC_SAMPLES) {
       end_historic_samples_i(tsce->header(), msg->cont());
@@ -1120,8 +1121,6 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
-    make_leader_lagger(element->subscription_id(), previous_max_sn);
-    check_leader_lagger();
     record_directed(element->subscription_id(), seq);
     durable = dsle->get_header().historic_sample_;
 
@@ -1132,8 +1131,6 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
-    make_leader_lagger(element->subscription_id(), previous_max_sn);
-    check_leader_lagger();
     record_directed(element->subscription_id(), seq);
     durable = dsle->get_header().historic_sample_;
 
@@ -3889,10 +3886,13 @@ RtpsUdpDataLink::RtpsWriter::heartbeat_high(const ReaderInfo_rch& ri) const
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::update_max_sn(SequenceNumber seq)
+RtpsUdpDataLink::RtpsWriter::update_max_sn(const RepoId& reader, SequenceNumber seq)
 {
   ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+  SequenceNumber previous_max_sn = max_sn_;
   max_sn_ = std::max(max_sn_, seq);
+  make_leader_lagger(reader, previous_max_sn);
+  check_leader_lagger();
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -416,7 +416,7 @@ private:
                SequenceNumber max_sn, CORBA::Long heartbeat_count, size_t capacity);
     ~RtpsWriter();
     SequenceNumber heartbeat_high(const ReaderInfo_rch&) const;
-    void update_max_sn(SequenceNumber seq);
+    void update_max_sn(const RepoId& reader, SequenceNumber seq);
     void add_elem_awaiting_ack(TransportQueueElement* element);
 
     RemoveResult remove_sample(const DataSampleElement* sample);

--- a/dds/InfoRepo/DCPSInfo_i.cpp
+++ b/dds/InfoRepo/DCPSInfo_i.cpp
@@ -2208,6 +2208,9 @@ int TAO_DDS_DCPSInfo_i::init_transport(int listen_address_given,
     // beyond this point.
     status = 1;
   }
+#else
+  ACE_UNUSED_ARG(listen_address_given);
+  ACE_UNUSED_ARG(listen_str);
 #endif
 
   return status;

--- a/performance-tests/bench_2/builder/DataReader.cpp
+++ b/performance-tests/bench_2/builder/DataReader.cpp
@@ -106,6 +106,8 @@ DataReader::DataReader(const DataReaderConfig& config, DataReaderReport& report,
     }
 
     datareader_ = subscriber_->create_datareader(content_filtered_topic, qos_, listener_, listener_status_mask_);
+#else
+  ACE_UNUSED_ARG(cft_map);
 #endif
   }
 

--- a/performance-tests/bench_2/builder/Topic.cpp
+++ b/performance-tests/bench_2/builder/Topic.cpp
@@ -97,6 +97,8 @@ Topic::Topic(const TopicConfig& config, DDS::DomainParticipant_var& participant,
 
     content_filtered_topics_map[content_filtered_topics_[i].cft_name.in()] = cft;
   }
+#else
+  ACE_UNUSED_ARG(content_filtered_topics_map);
 #endif
 
   // Bind Transport Config

--- a/performance-tests/bench_2/builder/Topic.h
+++ b/performance-tests/bench_2/builder/Topic.h
@@ -14,7 +14,7 @@ namespace Builder {
   {
   public:
 
-    inline bool operator < (const ContentFilteredTopic_var_stub& t) const {
+    inline bool operator < (const ContentFilteredTopic_var_stub&) const {
       return true;
     }
   };

--- a/performance-tests/bench_2/node_controller/ProcessStatsCollector.cpp
+++ b/performance-tests/bench_2/node_controller/ProcessStatsCollector.cpp
@@ -167,6 +167,8 @@ ProcessStatsCollector::ProcessStatsCollector(const int process_id) noexcept
   }
   read_total_cpu_usage(last_time_);
   read_process_cpu_usage(process_id_, last_user_time_, last_sys_time_);
+#else
+  ACE_UNUSED_ARG(process_id);
 #endif
 }
 

--- a/performance-tests/bench_2/node_controller/ProcessStatsCollector.h
+++ b/performance-tests/bench_2/node_controller/ProcessStatsCollector.h
@@ -24,8 +24,8 @@ private:
 #ifndef ACE_HAS_MAC_OSX
   int process_id_;
   size_t num_processors_;
-  size_t total_virtual_mem_;
-  size_t total_mem_;
+  uint64_t total_virtual_mem_;
+  uint64_t total_mem_;
 #endif
 #ifdef ACE_WIN32
   HANDLE process_handle_;

--- a/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
+++ b/performance-tests/bench_2/worker/WorkerDataReaderListener.cpp
@@ -336,7 +336,7 @@ WorkerDataReaderListener::unset_datareader(Builder::DataReader& datareader)
         auto psr = it->second.out_of_order_data_received_.present_sequence_ranges();
         for (auto it2 = psr.begin(); it2 != psr.end(); ++it2) {
           if (new_writer) {
-            size_t low = it->second.data_received_.low().getValue() == 0 ? 1 : it->second.data_received_.low().getValue();
+            uint64_t low = it->second.data_received_.low().getValue() == 0 ? 1 : it->second.data_received_.low().getValue();
             out_of_order_data_details << " [PH: " << it->first << " (" << low << "-" << it->second.data_received_.high().getValue() << ")] " << std::flush;
             new_writer = false;
           } else {
@@ -362,7 +362,7 @@ WorkerDataReaderListener::unset_datareader(Builder::DataReader& datareader)
         auto psr = it->second.duplicate_data_received_.present_sequence_ranges();
         for (auto it2 = psr.begin(); it2 != psr.end(); ++it2) {
           if (new_writer) {
-            size_t low = it->second.data_received_.low().getValue() == 0 ? 1 : it->second.data_received_.low().getValue();
+            uint64_t low = it->second.data_received_.low().getValue() == 0 ? 1 : it->second.data_received_.low().getValue();
             duplicate_data_details << " [PH: " << it->first << " (" << low << "-" << it->second.data_received_.high().getValue() << ")] " << std::flush;
             new_writer = false;
           } else {
@@ -388,7 +388,7 @@ WorkerDataReaderListener::unset_datareader(Builder::DataReader& datareader)
         for (auto it2 = msr.begin(); it2 != msr.end(); ++it2) {
           missing_data_count += static_cast<ptrdiff_t>(it2->second.getValue() - (it2->first.getValue() - 1)); // update count
           if (new_writer) {
-            size_t low = it->second.data_received_.low().getValue() == 0 ? 1 : it->second.data_received_.low().getValue();
+            uint64_t low = it->second.data_received_.low().getValue() == 0 ? 1 : it->second.data_received_.low().getValue();
             missing_data_details << " [PH: " << it->first << " (" << low << "-" << it->second.data_received_.high().getValue() << ")] " << std::flush;
             new_writer = false;
           } else {

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -238,7 +238,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   Builder::ConstPropertyIndex max_decimal_places_prop =
     get_property(config.properties, "max_decimal_places", Builder::PVK_ULL);
   if (max_decimal_places_prop) {
-    max_decimal_places = max_decimal_places_prop->value.ull_prop();
+    max_decimal_places = static_cast<int>(max_decimal_places_prop->value.ull_prop());
   }
 
   size_t redirect_ace_log = 1;

--- a/performance-tests/bench_2/worker/main.cpp
+++ b/performance-tests/bench_2/worker/main.cpp
@@ -245,7 +245,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   Builder::ConstPropertyIndex redirect_ace_log_prop =
     get_property(config.properties, "redirect_ace_log", Builder::PVK_ULL);
   if (redirect_ace_log_prop) {
-    redirect_ace_log = redirect_ace_log_prop->value.ull_prop();
+    redirect_ace_log = static_cast<size_t>(redirect_ace_log_prop->value.ull_prop());
   }
 
   if (redirect_ace_log && !log_file_path.empty()) {

--- a/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
+++ b/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
@@ -147,7 +147,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   // read durable data from dr
   if (!Utils::waitForSample(dr)) return false;
 #ifdef ACE_HAS_CPP11
-  if (takeSamples(dr, bind(greater<CORBA::Long>(), _1, 98)) != 1) {
+  if (takeSamples(dr, bind(greater<CORBA::Long>(), placeholders::_1, 98)) != 1) {
 #else
   if (takeSamples(dr, bind2nd(greater<CORBA::Long>(), 98)) != 1) {
 #endif
@@ -203,7 +203,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   if (!Utils::waitForSample(dr)) return false;
 
 #ifdef ACE_HAS_CPP11
-  size_t taken = takeSamples(dr, bind(greater<CORBA::Long>(), _1, 1));
+  size_t taken = takeSamples(dr, bind(greater<CORBA::Long>(), placeholders::_1, 1));
 #else
   size_t taken = takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
 #endif
@@ -211,7 +211,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
     cout << "INFO: partial read on DataReader \"dr\"\n";
     if (!Utils::waitForSample(dr)) return false;
 #ifdef ACE_HAS_CPP11
-    taken += takeSamples(dr, bind(greater<CORBA::Long>(), _1, 1));
+    taken += takeSamples(dr, bind(greater<CORBA::Long>(), placeholders::_1, 1));
 #else
     taken += takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
 #endif
@@ -225,7 +225,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   if (!Utils::waitForSample(sub2_dr2)) return false;
 
 #ifdef ACE_HAS_CPP11
-  if (takeSamples(sub2_dr2, bind(greater<CORBA::Long>(), _1, 2)) != 1) {
+  if (takeSamples(sub2_dr2, bind(greater<CORBA::Long>(), placeholders::_1, 2)) != 1) {
 #else
   if (takeSamples(sub2_dr2, bind2nd(greater<CORBA::Long>(), 2)) != 1) {
 #endif

--- a/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
+++ b/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
@@ -20,6 +20,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <functional>
 
 #if defined __GNUC__ && __GNUC__ == 4 && __GNUC_MINOR__ <= 1
 # define INT64_LITERAL_SUFFIX(X) X ## ll
@@ -145,7 +146,11 @@ bool run_filtering_test(const DomainParticipant_var& dp,
 
   // read durable data from dr
   if (!Utils::waitForSample(dr)) return false;
+#ifdef ACE_HAS_CPP11
   if (takeSamples(dr, bind2nd(greater<CORBA::Long>(), 98)) != 1) {
+#else
+  if (takeSamples(dr, bind(greater<CORBA::Long>(), _1, 98)) != 1) {
+#endif
     cout << "ERROR: take() should have returned a valid durable sample (99)"
          << endl;
     return false;
@@ -197,11 +202,19 @@ bool run_filtering_test(const DomainParticipant_var& dp,
 
   if (!Utils::waitForSample(dr)) return false;
 
+#ifdef ACE_HAS_CPP11
   size_t taken = takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
+#else
+  size_t taken = takeSamples(dr, bind(greater<CORBA::Long>(), _1, 1));
+#endif
   if (taken == 1) {
     cout << "INFO: partial read on DataReader \"dr\"\n";
     if (!Utils::waitForSample(dr)) return false;
+#ifdef ACE_HAS_CPP11
     taken += takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
+#else
+    taken += takeSamples(dr, bind(greater<CORBA::Long>(), _1, 1));
+#endif
   }
 
   if (taken != 2) {
@@ -211,7 +224,11 @@ bool run_filtering_test(const DomainParticipant_var& dp,
 
   if (!Utils::waitForSample(sub2_dr2)) return false;
 
+#ifdef ACE_HAS_CPP11
   if (takeSamples(sub2_dr2, bind2nd(greater<CORBA::Long>(), 2)) != 1) {
+#else
+  if (takeSamples(sub2_dr2, bind(greater<CORBA::Long>(), _1, 2)) != 1) {
+#endif
     cout << "ERROR: take() should have returned one valid sample" << endl;
     return false;
   }

--- a/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
+++ b/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
@@ -19,8 +19,8 @@
 #include "tests/Utils/WaitForSample.h"
 
 #include <cstdlib>
-#include <iostream>
 #include <functional>
+#include <iostream>
 
 #if defined __GNUC__ && __GNUC__ == 4 && __GNUC_MINOR__ <= 1
 # define INT64_LITERAL_SUFFIX(X) X ## ll
@@ -147,9 +147,9 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   // read durable data from dr
   if (!Utils::waitForSample(dr)) return false;
 #ifdef ACE_HAS_CPP11
-  if (takeSamples(dr, bind2nd(greater<CORBA::Long>(), 98)) != 1) {
-#else
   if (takeSamples(dr, bind(greater<CORBA::Long>(), _1, 98)) != 1) {
+#else
+  if (takeSamples(dr, bind2nd(greater<CORBA::Long>(), 98)) != 1) {
 #endif
     cout << "ERROR: take() should have returned a valid durable sample (99)"
          << endl;
@@ -203,17 +203,17 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   if (!Utils::waitForSample(dr)) return false;
 
 #ifdef ACE_HAS_CPP11
-  size_t taken = takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
-#else
   size_t taken = takeSamples(dr, bind(greater<CORBA::Long>(), _1, 1));
+#else
+  size_t taken = takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
 #endif
   if (taken == 1) {
     cout << "INFO: partial read on DataReader \"dr\"\n";
     if (!Utils::waitForSample(dr)) return false;
 #ifdef ACE_HAS_CPP11
-    taken += takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
-#else
     taken += takeSamples(dr, bind(greater<CORBA::Long>(), _1, 1));
+#else
+    taken += takeSamples(dr, bind2nd(greater<CORBA::Long>(), 1));
 #endif
   }
 
@@ -225,9 +225,9 @@ bool run_filtering_test(const DomainParticipant_var& dp,
   if (!Utils::waitForSample(sub2_dr2)) return false;
 
 #ifdef ACE_HAS_CPP11
-  if (takeSamples(sub2_dr2, bind2nd(greater<CORBA::Long>(), 2)) != 1) {
-#else
   if (takeSamples(sub2_dr2, bind(greater<CORBA::Long>(), _1, 2)) != 1) {
+#else
+  if (takeSamples(sub2_dr2, bind2nd(greater<CORBA::Long>(), 2)) != 1) {
 #endif
     cout << "ERROR: take() should have returned one valid sample" << endl;
     return false;

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -27,8 +27,10 @@ public:
     , expected_samples_(expected_samples)
     , received_samples_(0)
     , done_callback_(done_callback)
-    , check_bits_(check_bits)
     , builtin_read_error_(false)
+#ifndef DDS_HAS_MINIMUM_BIT
+    , check_bits_(check_bits)
+#endif
   {
     ACE_UNUSED_ARG(subscriber);
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Starting DataReader %C\n", id.c_str()));
@@ -78,10 +80,10 @@ private:
   const int expected_samples_;
   int received_samples_;
   callback_t done_callback_;
-  bool check_bits_;
   bool builtin_read_error_;
 #ifndef DDS_HAS_MINIMUM_BIT
-  DDS::DataReader_var     builtin_;
+  bool check_bits_;
+  DDS::DataReader_var builtin_;
 #endif /* DDS_HAS_MINIMUM_BIT */
 };
 

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -33,6 +33,9 @@ public:
 #endif
   {
     ACE_UNUSED_ARG(subscriber);
+#ifndef DDS_HAS_MINIMUM_BIT
+    ACE_UNUSED_ARG(check_bits);
+#endif
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Starting DataReader %C\n", id.c_str()));
   }
 

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -27,10 +27,10 @@ public:
     , expected_samples_(expected_samples)
     , received_samples_(0)
     , done_callback_(done_callback)
-    , subscriber_(subscriber)
     , check_bits_(check_bits)
     , builtin_read_error_(false)
   {
+    ACE_UNUSED_ARG(subscriber);
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Starting DataReader %C\n", id.c_str()));
   }
 
@@ -78,7 +78,6 @@ private:
   const int expected_samples_;
   int received_samples_;
   callback_t done_callback_;
-  DDS::Subscriber_ptr subscriber_;
   bool check_bits_;
   bool builtin_read_error_;
 #ifndef DDS_HAS_MINIMUM_BIT

--- a/tools/modeling/codegen/model/Service_T.cpp
+++ b/tools/modeling/codegen/model/Service_T.cpp
@@ -135,18 +135,28 @@ OpenDDS::Model::Service< ModelName, InstanceTraits>::createTopicDescription(
   typename Topics::Values       topic
 )
 {
+#ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
   typename ContentFilteredTopics::Values cfTopic =
                this->modelData_.contentFilteredTopic(topic);
+#endif
+#ifndef OPENDDS_NO_MULTI_TOPIC
   typename MultiTopics::Values multiTopic =
                this->modelData_.multiTopic(topic);
+#endif
+#ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
   // If this is a content-filtered topic
   if (cfTopic != ContentFilteredTopics::LAST_INDEX) {
     createContentFilteredTopic(participant, topic, cfTopic);
   // Else if this is a multitopic
-  } else if (multiTopic != MultiTopics::LAST_INDEX) {
+  } else
+#endif
+#ifndef OPENDDS_NO_MULTI_TOPIC
+  if (multiTopic != MultiTopics::LAST_INDEX) {
     createMultiTopic(participant, topic, multiTopic);
   // Else this is a standard topic
-  } else {
+  } else
+#endif
+  {
     createTopic(participant, topic);
   }
 }
@@ -192,12 +202,14 @@ OpenDDS::Model::Service< ModelName, InstanceTraits>::createContentFilteredTopic(
   DDS::Topic_var related_topic = DDS::Topic::_narrow(this->topic(participant, target_topic));
   const char* filter_expression = this->modelData_.filterExpression(cfTopic);
   DDS::DomainParticipant_var domain_participant = this->participant(participant);
+#ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
   // TODO: Should this be moved to Delegate?
   this->topics_[participant][topic] =
         domain_participant->create_contentfilteredtopic(topicName,
                                                         related_topic,
                                                         filter_expression,
                                                         DDS::StringSeq());
+#endif
 }
 
 template< typename ModelName, class InstanceTraits>
@@ -213,7 +225,7 @@ OpenDDS::Model::Service< ModelName, InstanceTraits>::createMultiTopic(
   typename Types::Values type = this->modelData_.type(topic);
   DDS::DomainParticipant_var domain_participant = this->participant(participant);
   const char* topicExpression = this->modelData_.topicExpression(multiTopic);
-
+#ifndef OPENDDS_NO_MULTI_TOPIC
   if(!this->types_[participant][type]) {
     this->modelData_.registerType(type, this->participants_[ participant]);
     this->types_[participant][type] = true;
@@ -224,6 +236,7 @@ OpenDDS::Model::Service< ModelName, InstanceTraits>::createMultiTopic(
                                               this->modelData_.typeName(type),
                                               topicExpression,
                                               DDS::StringSeq());
+#endif
 }
 
 template< typename ModelName, class InstanceTraits>

--- a/tools/modeling/tests/modeling_tests.lst
+++ b/tools/modeling/tests/modeling_tests.lst
@@ -29,8 +29,8 @@ tools/modeling/tests/ReferExternalProj/run_test.pl
 tools/modeling/tests/Deep/Down/Reference/run_test.pl
 tools/modeling/tests/EmptyLibs/run_test.pl
 tools/modeling/tests/MessengerSimpleTypes/run_test.pl
-tools/modeling/tests/CfTopic/run_test.pl: !DDS_NO_CONTENT_FILTERED_TOPIC
-tools/modeling/tests/MultiTopic/run_test.pl: !DDS_NO_MULTI_TOPIC
+tools/modeling/tests/CfTopic/run_test.pl: !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_CONTENT_FILTERED_TOPIC
+tools/modeling/tests/MultiTopic/run_test.pl: !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_MULTI_TOPIC
 tools/modeling/tests/Exchange/run_test.pl: COMPILE_ONLY
 tools/modeling/tests/RemoteInstHandles/run_test.pl: !NO_BUILT_IN_TOPICS
 tools/modeling/tests/Comments/run_test.pl
@@ -39,6 +39,6 @@ tools/modeling/tests/ReusedExtTypes/run_test.pl
 tools/modeling/tests/StockQuoter/run_test.pl
 tools/modeling/tests/Looped/run_test.pl: COMPILE_ONLY
 tools/modeling/tests/ModuleNameConflict/run_test.pl
-tools/modeling/tests/Chained/run_test.pl: !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_MULTI_TOPIC
+tools/modeling/tests/Chained/run_test.pl: !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_MULTI_TOPIC
 tools/modeling/tests/Chained_Topic/run_test.pl: COMPILE_ONLY
 tools/modeling/tests/Chained_Data/run_test.pl: COMPILE_ONLY

--- a/tools/modeling/tests/modeling_tests.lst
+++ b/tools/modeling/tests/modeling_tests.lst
@@ -29,8 +29,8 @@ tools/modeling/tests/ReferExternalProj/run_test.pl
 tools/modeling/tests/Deep/Down/Reference/run_test.pl
 tools/modeling/tests/EmptyLibs/run_test.pl
 tools/modeling/tests/MessengerSimpleTypes/run_test.pl
-tools/modeling/tests/CfTopic/run_test.pl
-tools/modeling/tests/MultiTopic/run_test.pl
+tools/modeling/tests/CfTopic/run_test.pl: !DDS_NO_CONTENT_FILTERED_TOPIC
+tools/modeling/tests/MultiTopic/run_test.pl: !DDS_NO_MULTI_TOPIC
 tools/modeling/tests/Exchange/run_test.pl: COMPILE_ONLY
 tools/modeling/tests/RemoteInstHandles/run_test.pl: !NO_BUILT_IN_TOPICS
 tools/modeling/tests/Comments/run_test.pl
@@ -39,6 +39,6 @@ tools/modeling/tests/ReusedExtTypes/run_test.pl
 tools/modeling/tests/StockQuoter/run_test.pl
 tools/modeling/tests/Looped/run_test.pl: COMPILE_ONLY
 tools/modeling/tests/ModuleNameConflict/run_test.pl
-tools/modeling/tests/Chained/run_test.pl
+tools/modeling/tests/Chained/run_test.pl: !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_MULTI_TOPIC
 tools/modeling/tests/Chained_Topic/run_test.pl: COMPILE_ONLY
 tools/modeling/tests/Chained_Data/run_test.pl: COMPILE_ONLY

--- a/tools/rtpsrelay/lib/QosIndex.h
+++ b/tools/rtpsrelay/lib/QosIndex.h
@@ -141,7 +141,7 @@ public:
   void erase(WriterPtr writer)
   {
     const auto pos = writers_.find(writer);
-    for (const auto reader : pos->second) {
+    for (const auto& reader : pos->second) {
       readers_[reader].erase(writer);
     }
     writers_.erase(writer);
@@ -167,7 +167,7 @@ public:
   void erase(ReaderPtr reader)
   {
     const auto pos = readers_.find(reader);
-    for (const auto writer : pos->second) {
+    for (const auto& writer : pos->second) {
       writers_[writer].erase(reader);
     }
     readers_.erase(reader);
@@ -191,7 +191,7 @@ public:
   {
     const auto pos = writers_.find(writer);
     if (pos != writers_.end()) {
-      for (const auto reader : pos->second) {
+      for (const auto& reader : pos->second) {
         to.insert(reader->participant_guid());
       }
     }
@@ -209,7 +209,7 @@ public:
   {
     const auto pos = readers_.find(reader);
     if (pos != readers_.end()) {
-      for (const auto writer : pos->second) {
+      for (const auto& writer : pos->second) {
         to.insert(writer->participant_guid());
       }
     }

--- a/tools/rtpsrelay/lib/QosIndex.h
+++ b/tools/rtpsrelay/lib/QosIndex.h
@@ -349,7 +349,7 @@ public:
 
   static void remove_from_literals(PatternPtr pattern)
   {
-    for (const auto literal : pattern->literals_) {
+    for (const auto& literal : pattern->literals_) {
       literal->erase(pattern);
     }
     pattern->literals_.clear();
@@ -360,10 +360,10 @@ public:
   {
     pattern->literals_.insert(literal);
     literal->insert(pattern);
-    for (const auto writer : pattern->writers_) {
+    for (const auto& writer : pattern->writers_) {
       literal->insert_pattern(writer, guids);
     }
-    for (const auto reader : pattern->readers_) {
+    for (const auto& reader : pattern->readers_) {
       literal->insert_pattern(reader, guids);
     }
   }
@@ -377,7 +377,7 @@ public:
               GuidSet& guids)
   {
     writers_.insert(writer);
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->insert_pattern(writer, guids);
     }
   }
@@ -386,14 +386,14 @@ public:
                 const WriterEntry& writer_entry,
                 GuidSet& guids)
   {
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->reinsert(writer, writer_entry, guids);
     }
   }
 
   void erase(WriterPtr writer)
   {
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->erase_pattern(writer);
     }
     writers_.erase(writer);
@@ -403,7 +403,7 @@ public:
               GuidSet& guids)
   {
     readers_.insert(reader);
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->insert_pattern(reader, guids);
     }
   }
@@ -412,14 +412,14 @@ public:
                 const ReaderEntry& reader_entry,
                 GuidSet& guids)
   {
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->reinsert(reader, reader_entry, guids);
     }
   }
 
   void erase(ReaderPtr reader)
   {
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->erase_pattern(reader);
     }
     readers_.erase(reader);
@@ -432,14 +432,14 @@ public:
 
   void get_readers(WriterPtr writer, ReaderSet& readers) const
   {
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->get_readers(writer, readers);
     }
   }
 
   void get_writers(ReaderPtr reader, WriterSet& writers) const
   {
-    for (const auto literal : literals_) {
+    for (const auto& literal : literals_) {
       literal->get_writers(reader, writers);
     }
   }
@@ -650,7 +650,7 @@ private:
 
     const auto& literal_atom = *begin;
 
-    for (const auto p : node->children_) {
+    for (const auto& p : node->children_) {
       const auto& pattern_atom = p.first;
       const auto next_node = p.second;
 
@@ -738,7 +738,7 @@ public:
         if (literal == nullptr) {
           literal = LiteralPtr(new LiteralType());
           NodeType::insert(node_, name, literal);
-          for (const auto pattern : NodeType::find_patterns(node_, name)) {
+          for (const auto& pattern : NodeType::find_patterns(node_, name)) {
             PatternType::insert(pattern, literal, guids);
           }
         }
@@ -748,7 +748,7 @@ public:
         if (pattern == nullptr) {
           pattern = PatternPtr(new PatternType());
           NodeType::insert(node_, name, pattern);
-          for (const auto literal : NodeType::find_literals(node_, name)) {
+          for (const auto& literal : NodeType::find_literals(node_, name)) {
             PatternType::insert(pattern, literal, guids);
           }
         }
@@ -819,7 +819,7 @@ public:
           if (literal == nullptr) {
             literal = LiteralPtr(new LiteralType());
             NodeType::insert(node_, name, literal);
-            for (const auto pattern : NodeType::find_patterns(node_, name)) {
+            for (const auto& pattern : NodeType::find_patterns(node_, name)) {
               PatternType::insert(pattern, literal, guids);
             }
           }
@@ -829,7 +829,7 @@ public:
           if (pattern == nullptr) {
             pattern = PatternPtr(new PatternType());
             NodeType::insert(node_, name, pattern);
-            for (const auto literal : NodeType::find_literals(node_, name)) {
+            for (const auto& literal : NodeType::find_literals(node_, name)) {
               PatternType::insert(pattern, literal, guids);
             }
           }
@@ -882,7 +882,7 @@ public:
         if (literal == nullptr) {
           literal = LiteralPtr(new LiteralType());
           NodeType::insert(node_, name, literal);
-          for (const auto pattern : NodeType::find_patterns(node_, name)) {
+          for (const auto& pattern : NodeType::find_patterns(node_, name)) {
             PatternType::insert(pattern, literal, guids);
           }
         }
@@ -892,7 +892,7 @@ public:
         if (pattern == nullptr) {
           pattern = PatternPtr(new PatternType());
           NodeType::insert(node_, name, pattern);
-          for (const auto literal : NodeType::find_literals(node_, name)) {
+          for (const auto& literal : NodeType::find_literals(node_, name)) {
             PatternType::insert(pattern, literal, guids);
           }
         }
@@ -964,7 +964,7 @@ public:
           if (literal == nullptr) {
             literal = LiteralPtr(new LiteralType());
             NodeType::insert(node_, name, literal);
-            for (const auto pattern : NodeType::find_patterns(node_, name)) {
+            for (const auto& pattern : NodeType::find_patterns(node_, name)) {
               PatternType::insert(pattern, literal, guids);
             }
           }
@@ -974,7 +974,7 @@ public:
           if (pattern == nullptr) {
             pattern = PatternPtr(new PatternType());
             NodeType::insert(node_, name, pattern);
-            for (const auto literal : NodeType::find_literals(node_, name)) {
+            for (const auto& literal : NodeType::find_literals(node_, name)) {
               PatternType::insert(pattern, literal, guids);
             }
           }


### PR DESCRIPTION
Several Updates:
- Split "build" and "test" jobs into two parts for greater flexibility
- Update output format to use correct "triggering commit" SHA for the "Check Test Results" action
- Add build warning annotations for build jobs
- Small improvements in build flag coverage