### PR TITLE
Static Libs in DataRepresentation test need linking

### DIFF
--- a/tests/DCPS/DataRepresentation/DataRepresentation.cpp
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.cpp
@@ -17,6 +17,7 @@
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/DCPS_Utils.h>
 #ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/transport/tcp/Tcp.h>
 #  include <dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h>
 #  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>

--- a/tests/DCPS/DataRepresentation/DataRepresentation.mpc
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, dcps_rtps, dcps_rtps_udp {
+project: dcps_test, dcps_rtps, dcps_rtps_udp, dcps_transports_for_test, dcps_inforepodiscovery {
   exename = *
   TypeSupport_Files {
     DataRepresentation.idl


### PR DESCRIPTION
Sorry, I misunderstood how static libraries interacted with includes.  This should fix the problems on spider and bee regarding the Data Representation test.