### PR TITLE
type_to_default patch for long double

### DIFF
--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -332,11 +332,13 @@ string type_to_default(const std::string& indent, AST_Type* type, const string& 
       if (use_cxx11) {
         def_val = "0.0L";
       } else {
+		    string temp_val = "ACE_CDR::LongDouble val = ACE_CDR_LONG_DOUBLE_INITIALIZER";
         if (is_union) {
-          def_val = "0";
+          def_val = "val";
+		  return indent + temp_val + ";\n" + indent + name + pre + def_val + post + ";\n";
         } else {
-          def_val = "ACE_CDR_LONG_DOUBLE_ASSIGNMENT(" + name + ", 0)";
-          return indent + def_val + ";\n";
+          def_val += "ACE_CDR_LONG_DOUBLE_ASSIGNMENT(" + name + ", val)";
+          return indent + "{\n  " + indent + temp_val + ";\n  " + indent + def_val + ";\n" + indent + "}\n";
         }
       }
     } else {

--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -335,13 +335,14 @@ string type_to_default(const std::string& indent, AST_Type* type, const string& 
         string temp_val = "ACE_CDR::LongDouble val = ACE_CDR_LONG_DOUBLE_INITIALIZER";
         if (is_union) {
           def_val = "val";
-          return indent + temp_val + ";\n" + indent + name + pre + def_val + post + ";\n";
+          return indent + temp_val + ";\n" +
+            indent + name + pre + def_val + post + ";\n";
         } else {
           def_val = "ACE_CDR_LONG_DOUBLE_ASSIGNMENT(" + name + ", val)";
           return indent + "{\n"
-          "  " + indent + temp_val + ";\n"
-          "  " + indent + def_val + ";\n" +
-          indent + "}\n";
+            "  " + indent + temp_val + ";\n"
+            "  " + indent + def_val + ";\n" +
+            indent + "}\n";
         }
       }
     } else {

--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -332,13 +332,16 @@ string type_to_default(const std::string& indent, AST_Type* type, const string& 
       if (use_cxx11) {
         def_val = "0.0L";
       } else {
-		    string temp_val = "ACE_CDR::LongDouble val = ACE_CDR_LONG_DOUBLE_INITIALIZER";
+        string temp_val = "ACE_CDR::LongDouble val = ACE_CDR_LONG_DOUBLE_INITIALIZER";
         if (is_union) {
           def_val = "val";
-		  return indent + temp_val + ";\n" + indent + name + pre + def_val + post + ";\n";
+          return indent + temp_val + ";\n" + indent + name + pre + def_val + post + ";\n";
         } else {
-          def_val += "ACE_CDR_LONG_DOUBLE_ASSIGNMENT(" + name + ", val)";
-          return indent + "{\n  " + indent + temp_val + ";\n  " + indent + def_val + ";\n" + indent + "}\n";
+          def_val = "ACE_CDR_LONG_DOUBLE_ASSIGNMENT(" + name + ", val)";
+          return indent + "{\n"
+          "  " + indent + temp_val + ";\n"
+          "  " + indent + def_val + ";\n" +
+          indent + "}\n";
         }
       }
     } else {

--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -333,7 +333,7 @@ string type_to_default(const std::string& indent, AST_Type* type, const string& 
         def_val = "0.0L";
       } else {
         if (is_union) {
-          def_val = "ACE_CDR_LONG_DOUBLE_INITIALIZER";
+          def_val = "0";
         } else {
           def_val = "ACE_CDR_LONG_DOUBLE_ASSIGNMENT(" + name + ", 0)";
           return indent + def_val + ";\n";


### PR DESCRIPTION
Now creates a temp var that is initialized then assigned to the member.  Context is needed for non unions to prevent multiple declarations.