### PR TITLE
completed MPC project file refactoring for transport tests

### DIFF
--- a/tests/transport/TestMsg/TestMsg.mpb
+++ b/tests/transport/TestMsg/TestMsg.mpb
@@ -1,0 +1,6 @@
+project {
+  after += DDS_tests_transport_testmsg
+  libs += transport_testmsg
+  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
+  includes += $(TEST_ROOT)/tests/transport/TestMsg
+}

--- a/tests/transport/TestMsg/TestMsg.mpc
+++ b/tests/transport/TestMsg/TestMsg.mpc
@@ -1,3 +1,4 @@
-project(tests_transport_testmsg): dcps_test {
+project(DDS_tests_transport_testmsg): dcps_test {
+  sharedname = transport_testmsg
   dynamicflags += TESTMSG_BUILD_DLL
 }

--- a/tests/transport/best_effort_reader/best_effort_reader.mpc
+++ b/tests/transport/best_effort_reader/best_effort_reader.mpc
@@ -1,11 +1,6 @@
-project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp {
+project(DDS_tests_transport*pub) : dcpsexe, dcps_test, dcps_rtps_udp, ../TestMsg/TestMsg {
 
   exename = publisher
-
-  after += opendds_tests_transport_testmsg
-  libs += opendds_tests_transport_testmsg
-  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
-  includes += $(TEST_ROOT)/tests/transport/TestMsg
 
   Source_Files {
     AppConfig.cpp
@@ -14,14 +9,9 @@ project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp {
   }
 }
 
-project(*sub) : dcpsexe, dcps_test, dcps_rtps_udp {
+project(DDS_tests_transport*sub) : dcpsexe, dcps_test, dcps_rtps_udp, ../TestMsg/TestMsg {
 
   exename = subscriber
-
-  after += opendds_tests_transport_testmsg
-  libs += opendds_tests_transport_testmsg
-  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
-  includes += $(TEST_ROOT)/tests/transport/TestMsg
 
   Source_Files {
     AppConfig.cpp

--- a/tests/transport/rtps/DDS_transport_rtps.mpc
+++ b/tests/transport/rtps/DDS_transport_rtps.mpc
@@ -1,25 +1,15 @@
-project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp {
+project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp, ../TestMsg/TestMsg {
 
   exename = publisher
-
-  after += opendds_tests_transport_testmsg
-  libs += opendds_tests_transport_testmsg
-  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
-  includes += $(TEST_ROOT)/tests/transport/TestMsg
 
   Source_Files {
     publisher.cpp
   }
 }
 
-project(*sub) : dcpsexe, dcps_test, dcps_rtps_udp {
+project(*sub) : dcpsexe, dcps_test, dcps_rtps_udp, ../TestMsg/TestMsg {
 
   exename = subscriber
-
-  after += opendds_tests_transport_testmsg
-  libs += opendds_tests_transport_testmsg
-  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
-  includes += $(TEST_ROOT)/tests/transport/TestMsg
 
   Source_Files {
     subscriber.cpp

--- a/tests/transport/rtps_directed_write/DDS_transport_rtps_directed_write.mpc
+++ b/tests/transport/rtps_directed_write/DDS_transport_rtps_directed_write.mpc
@@ -1,11 +1,6 @@
-project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp {
+project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp, ../TestMsg/TestMsg {
 
   exename = publisher
-
-  after += opendds_tests_transport_testmsg
-  libs += opendds_tests_transport_testmsg
-  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
-  includes += $(TEST_ROOT)/tests/transport/TestMsg
 
   Source_Files {
     AppConfig.cpp
@@ -13,14 +8,9 @@ project(*pub) : dcpsexe, dcps_test, dcps_rtps_udp {
   }
 }
 
-project(*sub) : dcpsexe, dcps_test, dcps_rtps_udp {
+project(*sub) : dcpsexe, dcps_test, dcps_rtps_udp, ../TestMsg/TestMsg {
 
   exename = subscriber
-
-  after += opendds_tests_transport_testmsg
-  libs += opendds_tests_transport_testmsg
-  libpaths += $(TEST_ROOT)/tests/transport/TestMsg
-  includes += $(TEST_ROOT)/tests/transport/TestMsg
 
   Source_Files {
     AppConfig.cpp


### PR DESCRIPTION
- fixed mistake from earlier today
- use a base project to reduce duplication
- a little more consistency in project naming