### PR TITLE
Init Remote Associated Endpoints to Zero

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -867,6 +867,8 @@ Spdp::data_received(const DataSubmessage& data,
   ParticipantData_t pdata;
 
   pdata.participantProxy.domainId = domain_;
+  pdata.associated_endpoints = 0;
+  pdata.extended_associated_endpoints = 0;
 
   if (!ParameterListConverter::from_param_list(plist, pdata)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::data_received - ")
@@ -3992,13 +3994,13 @@ void Spdp::process_participant_ice(const ParameterList& plist,
 
 const ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid) const
 {
-  DiscoveredParticipantConstIter iter = participants_.find(make_id(guid, DCPS::ENTITYID_PARTICIPANT));
+  DiscoveredParticipantConstIter iter = participants_.find(make_part_guid(guid));
   return iter->second.pdata_;
 }
 
 ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid)
 {
-  DiscoveredParticipantIter iter = participants_.find(make_id(guid, DCPS::ENTITYID_PARTICIPANT));
+  DiscoveredParticipantIter iter = participants_.find(make_part_guid(guid));
   return iter->second.pdata_;
 }
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -868,7 +868,9 @@ Spdp::data_received(const DataSubmessage& data,
 
   pdata.participantProxy.domainId = domain_;
   pdata.associated_endpoints = 0;
+#ifdef OPENDDS_SECURITY
   pdata.extended_associated_endpoints = 0;
+#endif
 
   if (!ParameterListConverter::from_param_list(plist, pdata)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::data_received - ")


### PR DESCRIPTION
To fix issue where type lookup service writer thinks it's already associated with a reader when it tries to associate, so it fails to fully associate.

Also clear deferred builtin samples that are send and other more minor changes.