### PR TITLE
Data Representation test Safety Profile compatibility

### DIFF
--- a/bin/dcps_tests.lst
+++ b/bin/dcps_tests.lst
@@ -438,7 +438,7 @@ performance-tests/bench_2/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !
 performance-tests/bench_2/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench_2/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 
-tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN
+tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DataRepresentation/run_test.pl rtps_disc: !DCPS_MIN RTPS
 
 performance-tests/bench_2/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON

--- a/tests/DCPS/DataRepresentation/DataRepresentation.cpp
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.cpp
@@ -17,12 +17,15 @@
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/DCPS_Utils.h>
 #ifdef ACE_AS_STATIC_LIBS
-#  include <dds/DCPS/transport/tcp/Tcp.h>
+# include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+# include <dds/DCPS/RTPS/RtpsDiscovery.h>
+# ifdef OPENDDS_SAFETY_PROFILE
+#  include <dds/DCPS/StaticDiscovery.h>
+# else
 #  include <dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h>
-#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
-#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#  include <dds/DCPS/transport/tcp/Tcp.h>
+# endif
 #endif
-
 #include <vector>
 #include <sstream>
 

--- a/tests/DCPS/DataRepresentation/DataRepresentation.cpp
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.cpp
@@ -25,6 +25,7 @@
 #  include <dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h>
 #  include <dds/DCPS/transport/tcp/Tcp.h>
 # endif
+
 #endif
 #include <vector>
 #include <sstream>

--- a/tests/DCPS/DataRepresentation/DataRepresentation.cpp
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.cpp
@@ -25,8 +25,8 @@
 #  include <dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h>
 #  include <dds/DCPS/transport/tcp/Tcp.h>
 # endif
-
 #endif
+
 #include <vector>
 #include <sstream>
 

--- a/tests/DCPS/DataRepresentation/DataRepresentation.cpp
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.cpp
@@ -17,14 +17,14 @@
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/DCPS_Utils.h>
 #ifdef ACE_AS_STATIC_LIBS
-# include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
-# include <dds/DCPS/RTPS/RtpsDiscovery.h>
-# ifdef OPENDDS_SAFETY_PROFILE
-#  include <dds/DCPS/StaticDiscovery.h>
-# else
-#  include <dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h>
-#  include <dds/DCPS/transport/tcp/Tcp.h>
-# endif
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  ifdef OPENDDS_SAFETY_PROFILE
+#    include <dds/DCPS/StaticDiscovery.h>
+#  else
+#    include <dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h>
+#    include <dds/DCPS/transport/tcp/Tcp.h>
+#  endif
 #endif
 
 #include <vector>

--- a/tests/DCPS/DataRepresentation/DataRepresentation.mpc
+++ b/tests/DCPS/DataRepresentation/DataRepresentation.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, dcps_rtps, dcps_rtps_udp, dcps_transports_for_test, dcps_inforepodiscovery {
+project: dcpsexe, dcps_test, dcps_rtps, dcps_rtps_udp, dcps_transports_for_test {
   exename = *
   TypeSupport_Files {
     DataRepresentation.idl


### PR DESCRIPTION
DR test without args is blocked in the tests list because it tries to use info repo.  Other fixes are to allow the test to compile on safety builds.