### PR TITLE
Changed XType test flow to event driven, removing Sleep statements.

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -387,6 +387,17 @@ sub new {
   return $self;
 }
 
+sub wait_kill {
+  my $self = shift;
+  my $name = shift;
+  my $wait_time = shift;
+  my $verbose = shift;
+
+  my $process = $self->{processes}->{process}->{$name}->{process};
+
+  return PerlDDS::wait_kill($process, $wait_time, $name, $verbose);
+}
+
 sub default_transport {
   my $self = shift;
   my $transport = shift;

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -263,7 +263,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   DDS::ConditionSeq conditions;
   DDS::Duration_t timeout = { 10, 0 };
-  if ((ws->wait(conditions, timeout) != DDS::RETCODE_OK) && expect_to_match) {
+  if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, "ERROR: %C condition wait failed for type %C\n",
       expect_to_match ? "PUBLICATION_MATCHED_STATUS" : "INCONSISTENT_TOPIC_STATUS", type.c_str()));
     failed = 1;

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -237,7 +237,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     AppendableStructWithDependencyTypeSupport_var ts = new AppendableStructWithDependencyTypeSupportImpl;
     failed = !get_topic(ts, dp, topic_name, topic, registered_type_name);
   } else {
-    ACE_ERROR((LM_ERROR, "ERROR: Type %s is not supported\n", type.c_str()));
+    ACE_ERROR((LM_ERROR, "ERROR: Type %C is not supported\n", type.c_str()));
     return 1;
   }
 
@@ -264,7 +264,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::ConditionSeq conditions;
   DDS::Duration_t timeout = { 10, 0 };
   if ((ws->wait(conditions, timeout) != DDS::RETCODE_OK) && expect_to_match) {
-    ACE_ERROR((LM_ERROR, "ERROR: %s condition wait failed for type %s\n",
+    ACE_ERROR((LM_ERROR, "ERROR: %C condition wait failed for type %C\n",
       expect_to_match ? "PUBLICATION_MATCHED_STATUS" : "INCONSISTENT_TOPIC_STATUS", type.c_str()));
     failed = 1;
   }
@@ -276,7 +276,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   if (failed) {
-    ACE_ERROR((LM_ERROR, "ERROR: Writer failed for type %s\n", type.c_str()));
+    ACE_ERROR((LM_ERROR, "ERROR: Writer failed for type %C\n", type.c_str()));
   } else if (expect_to_match) {
     if (type == "PlainCdrStruct") {
       write_plain_cdr_struct(dw);

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -264,7 +264,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::ConditionSeq conditions;
   DDS::Duration_t timeout = { 10, 0 };
   if ((ws->wait(conditions, timeout) != DDS::RETCODE_OK) && expect_to_match) {
-    ACE_ERROR((LM_ERROR, "ERROR: wait failed for type %s\n", type.c_str()));
+    ACE_ERROR((LM_ERROR, "ERROR: %s condition wait failed for type %s\n",
+      expect_to_match ? "PUBLICATION_MATCHED_STATUS" : "INCONSISTENT_TOPIC_STATUS", type.c_str()));
     failed = 1;
   }
 

--- a/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
+++ b/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
@@ -255,7 +255,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     Trim20StructTypeSupport_var ts = new Trim20StructTypeSupportImpl;
     failed = !get_topic(ts, dp, topic_name, topic, registered_type_name);
   } else {
-    ACE_ERROR((LM_ERROR, "ERROR: Type %s is not supported\n", type.c_str()));
+    ACE_ERROR((LM_ERROR, "ERROR: Type %C is not supported\n", type.c_str()));
     return 1;
   }
 
@@ -283,7 +283,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::ConditionSeq conditions;
   DDS::Duration_t timeout = { 10, 0 };
   if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, "ERROR: %s condition wait failed for type %s\n",
+    ACE_ERROR((LM_ERROR, "ERROR: %C condition wait failed for type %C\n",
       expect_to_match ? "SUBSCRIPTION_MATCHED_STATUS" : "INCONSISTENT_TOPIC_STATUS", type.c_str()));
     failed = 1;
   }
@@ -295,7 +295,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   if (failed) {
-    ACE_ERROR((LM_ERROR, "ERROR: Reader failed for type %s\n", type.c_str()));
+    ACE_ERROR((LM_ERROR, "ERROR: Reader failed for type %C\n", type.c_str()));
   } else if (expect_to_match) {
     if (type == "PlainCdrStruct") {
       failed = !(read_plain_cdr_struct(dr) == RETCODE_OK);

--- a/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
+++ b/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
@@ -298,19 +298,19 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     ACE_ERROR((LM_ERROR, "ERROR: Reader failed for type %C\n", type.c_str()));
   } else if (expect_to_match) {
     if (type == "PlainCdrStruct") {
-      failed = !(read_plain_cdr_struct(dr) == RETCODE_OK);
+      failed = (read_plain_cdr_struct(dr) != RETCODE_OK);
     } else if (type == "AppendableStruct") {
-      failed = !(read_appendable_struct(dr) == RETCODE_OK);
+      failed = (read_appendable_struct(dr) != RETCODE_OK);
     } else if (type == "AppendableStructNoXTypes") {
-      failed = !(read_appendable_struct_no_xtypes(dr) == RETCODE_OK);
+      failed = (read_appendable_struct_no_xtypes(dr) != RETCODE_OK);
     } else if (type == "FinalStructSub") {
-      failed = !(read_final_struct(dr) == RETCODE_OK);
+      failed = (read_final_struct(dr) != RETCODE_OK);
     } else if (type == "MutableStruct") {
-      failed = !(read_mutable_struct(dr) == RETCODE_OK);
+      failed = (read_mutable_struct(dr) != RETCODE_OK);
     } else if (type == "MutableUnion") {
-      failed = !(read_mutable_union(dr) == RETCODE_OK);
+      failed = (read_mutable_union(dr) != RETCODE_OK);
     } else if (type == "Trim20Struct") {
-      failed = !(read_trim20_struct(dr) == RETCODE_OK);
+      failed = (read_trim20_struct(dr) != RETCODE_OK);
     }
   }
 

--- a/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
+++ b/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
@@ -283,7 +283,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::ConditionSeq conditions;
   DDS::Duration_t timeout = { 10, 0 };
   if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, "ERROR: wait failed for type %s\n", type.c_str()));
+    ACE_ERROR((LM_ERROR, "ERROR: %s condition wait failed for type %s\n",
+      expect_to_match ? "SUBSCRIPTION_MATCHED_STATUS" : "INCONSISTENT_TOPIC_STATUS", type.c_str()));
     failed = 1;
   }
 

--- a/tests/DCPS/XTypes/run_test.pl
+++ b/tests/DCPS/XTypes/run_test.pl
@@ -65,6 +65,7 @@ my %params = (
                                 key_val => 4, r_ini => "rtps_disc_no_xtypes.ini", w_ini => "rtps_disc.ini"},
 );
 
+my $status = 0;
 
 sub run_test {
   my @test_args;
@@ -94,17 +95,23 @@ sub run_test {
   push(@writer_args, @test_args);
   $test->process("writer_$test_name_param", './Pub/xtypes_publisher', join(' ', @writer_args));
   $test->start_process("writer_$test_name_param");
+
+  $status |= $test->wait_kill("reader_$test_name_param", 30);
+  $status |= $test->wait_kill("writer_$test_name_param", 30);
 }
 
 
 if ($test_name eq '') {
   while (my ($k, $v) = each %params) {
     run_test ($v, $k);
-    sleep(10);
   }
 }
 else {
   run_test ($params{$test_name}, $test_name);
+}
+
+if ($status) {
+  print STDERR "ERROR: test failed\n";
 }
 
 exit $test->finish(60);


### PR DESCRIPTION
Reviewed the way that run_test.pl in tests/DCPS/XTypes uses the perl test framework and what it expects in terms of timing of tests.  Sleep is not necessary since the Perl script can determine when the child process(es) exit.

In addition to the Perl part of this issue, replace sleep in the C++ test code with the use of WaitSet and Conditions.