### PR TITLE
Volatile reader may go from leader to leader

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3350,15 +3350,16 @@ RtpsUdpDataLink::RtpsWriter::make_lagger_leader(const ReaderInfo_rch& reader,
 {
   const SequenceNumber acked_sn = reader->acked_sn();
   if (previous_acked_sn == acked_sn) { return; }
-  const SequenceNumber max_sn = expected_max_sn(reader);
-
-  snris_erase(lagging_readers_, previous_acked_sn, reader);
-  snris_insert(acked_sn >= max_sn ? leading_readers_ : lagging_readers_, reader);
+  const SequenceNumber previous_max_sn = expected_max_sn(reader);
 #ifdef OPENDDS_SECURITY
-  if (is_pvs_writer_ && acked_sn > max_sn) {
+  if (is_pvs_writer_ && acked_sn > previous_max_sn) {
     reader->max_pvs_sn_ = acked_sn;
   }
 #endif
+  const SequenceNumber max_sn = expected_max_sn(reader);
+
+  snris_erase(previous_acked_sn == previous_max_sn ? leading_readers_ : lagging_readers_, previous_acked_sn, reader);
+  snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
 }
 
 bool


### PR DESCRIPTION
Problem
-------

For background see #2338.  A reader that acks beyond its expected max
sequence number may already be a leader.  The existing code only
removes it from the lagger set so it will be inserted twice into the
leader SNRIS and cause an assert.

Solution
--------

Generalize code so that the reader is removed from the correct SNRIS.