### PR TITLE
get_minimal_type_map_private call not thread safe for cpp03

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2788,9 +2788,9 @@ Service_Participant::get_thread_statuses()
 }
 
 ACE_Thread_Mutex*
-Service_Participant::get_ti_lock()
+Service_Participant::get_tm_lock()
 {
-  return &ti_lock_;
+  return &tm_lock_;
 }
 
 NetworkConfigMonitor_rch Service_Participant::network_config_monitor()

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2787,10 +2787,9 @@ Service_Participant::get_thread_statuses()
   return &thread_status_;
 }
 
-ACE_Thread_Mutex*
-Service_Participant::get_tm_lock()
+ACE_Thread_Mutex& Service_Participant::get_tm_lock()
 {
-  return &tm_lock_;
+  return tm_lock_;
 }
 
 NetworkConfigMonitor_rch Service_Participant::network_config_monitor()

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2787,6 +2787,12 @@ Service_Participant::get_thread_statuses()
   return &thread_status_;
 }
 
+ACE_Thread_Mutex*
+Service_Participant::get_ti_lock()
+{
+  return &ti_lock_;
+}
+
 NetworkConfigMonitor_rch Service_Participant::network_config_monitor()
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, network_config_monitor_lock_, NetworkConfigMonitor_rch());

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -584,6 +584,9 @@ private:
 
   bool bit_enabled_;
 
+  /// Thread mutex used to grab type information
+  ACE_Thread_Mutex ti_lock_;
+
 #if defined(OPENDDS_SECURITY)
   bool security_enabled_;
 #endif
@@ -654,6 +657,9 @@ public:
 
   /// Pointer to the monitor object for this object
   unique_ptr<Monitor> monitor_;
+
+  ACE_Thread_Mutex* get_ti_lock();
+
 
 private:
   /// The FederationRecoveryDuration value in seconds.

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -725,7 +725,7 @@ private:
 
   ThreadStatus thread_status_;
 
-  /// Thread mutex used to grab type information
+  /// Thread mutex used to grab type map
   ACE_Thread_Mutex tm_lock_;
 
   /// Enable Monitor functionality

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -584,8 +584,6 @@ private:
 
   bool bit_enabled_;
 
-  /// Thread mutex used to grab type information
-  ACE_Thread_Mutex ti_lock_;
 
 #if defined(OPENDDS_SECURITY)
   bool security_enabled_;
@@ -649,6 +647,9 @@ public:
   TimeDuration get_thread_status_interval();
   void set_thread_status_interval(TimeDuration interval);
 
+  // getter for tm_lock_ used to block get_minimal_type_map_private
+  ACE_Thread_Mutex* get_tm_lock();
+
   ThreadStatus* get_thread_statuses();
 
   /// Pointer to the monitor factory that is used to create
@@ -658,7 +659,6 @@ public:
   /// Pointer to the monitor object for this object
   unique_ptr<Monitor> monitor_;
 
-  ACE_Thread_Mutex* get_ti_lock();
 
 
 private:
@@ -724,6 +724,9 @@ private:
   TimeDuration thread_status_interval_;
 
   ThreadStatus thread_status_;
+
+  /// Thread mutex used to grab type information
+  ACE_Thread_Mutex tm_lock_;
 
   /// Enable Monitor functionality
   bool monitor_enabled_;

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -584,7 +584,6 @@ private:
 
   bool bit_enabled_;
 
-
 #if defined(OPENDDS_SECURITY)
   bool security_enabled_;
 #endif
@@ -647,8 +646,8 @@ public:
   TimeDuration get_thread_status_interval();
   void set_thread_status_interval(TimeDuration interval);
 
-  // getter for tm_lock_ used to block get_minimal_type_map_private
-  ACE_Thread_Mutex* get_tm_lock();
+  /// getter for tm_lock_ used to block get_minimal_type_map_private
+  ACE_Thread_Mutex& get_tm_lock();
 
   ThreadStatus* get_thread_statuses();
 
@@ -658,8 +657,6 @@ public:
 
   /// Pointer to the monitor object for this object
   unique_ptr<Monitor> monitor_;
-
-
 
 private:
   /// The FederationRecoveryDuration value in seconds.

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -3401,6 +3401,7 @@ marshal_generator::gen_field_getValueFromSerialized(AST_Structure* node, const s
     be_global->impl_ <<
       "    if (encoding.xcdr_version() != Encoding::XCDR_VERSION_NONE) {\n"
       "      unsigned field_id = map_name_to_id(base_field.c_str());\n"
+      "      ACE_UNUSED_ARG(field_id);\n"
       "      unsigned member_id;\n"
       "      size_t field_size;\n"
       "      const size_t end_of_struct = strm.pos() + total_size;\n"

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -939,7 +939,7 @@ typeobject_generator::gen_epilogue()
     "const XTypes::TypeMap& get_minimal_type_map()\n"
     "{\n"
     "  static XTypes::TypeMap tm;\n"
-    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, *TheServiceParticipant->get_tm_lock(), tm);\n"
+    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), tm);\n"
     "  if (tm.empty()) {\n"
     "    tm = get_minimal_type_map_private();\n"
     "  }\n"

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -934,10 +934,15 @@ typeobject_generator::gen_epilogue()
     "}\n"
     "}\n";
 
+  be_global->add_include("dds/DCPS/Service_Participant.h");
   be_global->impl_ <<
     "const XTypes::TypeMap& get_minimal_type_map()\n"
     "{\n"
-    "  static const XTypes::TypeMap tm = get_minimal_type_map_private();\n"
+    "  static XTypes::TypeMap tm;\n"
+    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, *TheServiceParticipant->get_ti_lock(), tm);\n"
+    "  if (tm.empty()) {\n"
+    "    tm = get_minimal_type_map_private();\n"
+    "  }\n"
     "  return tm;\n"
     "}\n";
 }

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -939,7 +939,7 @@ typeobject_generator::gen_epilogue()
     "const XTypes::TypeMap& get_minimal_type_map()\n"
     "{\n"
     "  static XTypes::TypeMap tm;\n"
-    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, *TheServiceParticipant->get_ti_lock(), tm);\n"
+    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, *TheServiceParticipant->get_tm_lock(), tm);\n"
     "  if (tm.empty()) {\n"
     "    tm = get_minimal_type_map_private();\n"
     "  }\n"


### PR DESCRIPTION
The get_minimal_type_map function call in typeobject_generator.cpp was not thread safe and was possibly the cause of an error occurring on bee where TLS would fail.  This is a fix to make that section of code thread safe.  I did not see the TLS error in my testing on bee.