### PR TITLE
opendds_idl fix for underscore fields

### DIFF
--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -23,6 +23,7 @@ bool dds_generator::cxx_escape(const std::string& s, size_t i)
 std::string dds_generator::valid_var_name(const std::string& str)
 {
   // Replace invalid characters with a single underscore
+  // Replace existing "_" with "_9" to prevent collision
   const std::string invalid_chars("<>()[]*.: ");
   std::string s;
   char last_char = '\0';
@@ -44,6 +45,9 @@ std::string dds_generator::valid_var_name(const std::string& str)
     if (!cxx_escape(s, 0)) {
       s.erase(0, 1);
     }
+  }
+  if (s.size() > 1 && s[s.size() - 1] == '_') {
+    s.erase(s.size() - 1, 1);
   }
   return s;
 }
@@ -299,7 +303,7 @@ string type_to_default_array(const std::string& indent, AST_Type* type, const st
       n = n.substr(0, n.rfind("::") + 2) + "AnonymousType_" + type->local_name()->get_string();
       n = (fld_cls == AST_Decl::NT_sequence) ? (n + "_seq") : n;
     }
-    val += indent + "set_default(IDL::DistinctType<" + n + ", " + dds_generator::get_tag_name(n, false) + ">(" +
+    val += indent + "set_default(IDL::DistinctType<" + n + ", " + dds_generator::get_tag_name(n) + ">(" +
       (is_union ? "tmp" : name) + "));\n";
   } else {
     string n = scoped(type->name());

--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -41,6 +41,8 @@ std::string dds_generator::valid_var_name(const std::string& str)
       last_char = '_';
     }
   }
+
+  // Remove underscores at start and end
   if (s.size() > 1 && s[0] == '_') {
     if (!cxx_escape(s, 0)) {
       s.erase(0, 1);
@@ -49,6 +51,7 @@ std::string dds_generator::valid_var_name(const std::string& str)
   if (s.size() > 1 && s[s.size() - 1] == '_') {
     s.erase(s.size() - 1, 1);
   }
+
   return s;
 }
 

--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -45,7 +45,6 @@ std::string dds_generator::valid_var_name(const std::string& str)
       s.erase(0, 1);
     }
   }
-
   return s;
 }
 

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -731,7 +731,7 @@ void generateCaseBody(
       rhs = use_cxx11 ? "tmp" : "tmp.out()";
     } else if (use_cxx11 && (br_cls & (CL_ARRAY | CL_SEQUENCE))) {  //array or seq C++11
       rhs = "IDL::DistinctType<" + brType + ", "
-        + dds_generator::get_tag_name(dds_generator::scoped_helper(branch->field_type()->name(), "_"), false)
+        + dds_generator::get_tag_name(dds_generator::scoped_helper(branch->field_type()->name(), "_"))
         + ">(tmp)";
     } else if (br_cls & CL_ARRAY) { //array classic
       forany = "    " + brType + "_forany fa = tmp;\n";

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -731,7 +731,7 @@ void generateCaseBody(
       rhs = use_cxx11 ? "tmp" : "tmp.out()";
     } else if (use_cxx11 && (br_cls & (CL_ARRAY | CL_SEQUENCE))) {  //array or seq C++11
       rhs = "IDL::DistinctType<" + brType + ", "
-        + dds_generator::get_tag_name(dds_generator::scoped_helper(branch->field_type()->name(), "_"))
+        + dds_generator::get_tag_name(dds_generator::scoped_helper(branch->field_type()->name(), "::"))
         + ">(tmp)";
     } else if (br_cls & CL_ARRAY) { //array classic
       forany = "    " + brType + "_forany fa = tmp;\n";

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -33,6 +33,12 @@ class dds_generator {
 public:
   virtual ~dds_generator() = 0;
 
+  static std::string get_tag_name(const std::string& base_name, bool nested_key_only = false);
+
+  static bool cxx_escape(const std::string& s, size_t i);
+
+  static std::string valid_var_name(const std::string& str);
+
   virtual bool do_included_files() const { return false; }
 
   virtual void gen_prologue() {}
@@ -725,8 +731,8 @@ void generateCaseBody(
       rhs = use_cxx11 ? "tmp" : "tmp.out()";
     } else if (use_cxx11 && (br_cls & (CL_ARRAY | CL_SEQUENCE))) {  //array or seq C++11
       rhs = "IDL::DistinctType<" + brType + ", "
-        + dds_generator::scoped_helper(branch->field_type()->name(), "_")
-        + "_tag>(tmp)";
+        + dds_generator::get_tag_name(dds_generator::scoped_helper(branch->field_type()->name(), "_"), false)
+        + ">(tmp)";
     } else if (br_cls & CL_ARRAY) { //array classic
       forany = "    " + brType + "_forany fa = tmp;\n";
       rhs = getWrapper("fa", br, WD_INPUT);

--- a/dds/idl/field_info.cpp
+++ b/dds/idl/field_info.cpp
@@ -8,7 +8,7 @@
 #include "field_info.h"
 
 #include <sstream>
-#include <iostream>
+
 using namespace AstTypeClassification;
 
 FieldInfo::EleLen::EleLen(const FieldInfo& af)
@@ -58,7 +58,7 @@ std::string FieldInfo::underscore(const std::string& scoped)
 
 std::string FieldInfo::ref(const std::string& scoped, const std::string& underscored, const std::string& const_s)
 {
-  return "IDL::DistinctType<" + const_s + scoped + ", " + dds_generator::get_tag_name(scoped, false) + ">";
+  return "IDL::DistinctType<" + const_s + scoped + ", " + dds_generator::get_tag_name(scoped) + ">";
 }
 
 FieldInfo::FieldInfo(AST_Field& field)

--- a/dds/idl/field_info.cpp
+++ b/dds/idl/field_info.cpp
@@ -8,7 +8,7 @@
 #include "field_info.h"
 
 #include <sstream>
-
+#include <iostream>
 using namespace AstTypeClassification;
 
 FieldInfo::EleLen::EleLen(const FieldInfo& af)
@@ -58,7 +58,7 @@ std::string FieldInfo::underscore(const std::string& scoped)
 
 std::string FieldInfo::ref(const std::string& scoped, const std::string& underscored, const std::string& const_s)
 {
-  return "IDL::DistinctType<" + const_s + scoped + ", " + underscored + "_tag>";
+  return "IDL::DistinctType<" + const_s + scoped + ", " + dds_generator::get_tag_name(scoped, false) + ">";
 }
 
 FieldInfo::FieldInfo(AST_Field& field)

--- a/dds/idl/field_info.cpp
+++ b/dds/idl/field_info.cpp
@@ -56,7 +56,7 @@ std::string FieldInfo::underscore(const std::string& scoped)
   return s;
 }
 
-std::string FieldInfo::ref(const std::string& scoped, const std::string& underscored, const std::string& const_s)
+std::string FieldInfo::ref(const std::string& scoped, const std::string& const_s)
 {
   return "IDL::DistinctType<" + const_s + scoped + ", " + dds_generator::get_tag_name(scoped) + ">";
 }
@@ -77,8 +77,8 @@ FieldInfo::FieldInfo(AST_Field& field)
   , as_cls_(as_act_ ? classify(as_act_) : CL_UNKNOWN)
   , scoped_elem_(as_base_ ? scoped(as_base_->name()) : "")
   , underscored_elem_(as_base_ ? underscore(scoped_elem_) : "")
-  , elem_ref_(as_base_ ? ref(scoped_elem_, underscored_elem_, "") : "")
-  , elem_const_ref_(as_base_ ? ref(scoped_elem_, underscored_elem_) : "")
+  , elem_ref_(as_base_ ? ref(scoped_elem_, "") : "")
+  , elem_const_ref_(as_base_ ? ref(scoped_elem_) : "")
 {
   n_elems_ = 1;
   if (arr_) {
@@ -100,8 +100,8 @@ FieldInfo::FieldInfo(AST_Field& field)
     const_unwrap_ = "  const " + unwrap_;
     unwrap_ = "  " + unwrap_;
     arg_ = "wrap";
-    ref_ = ref(scoped_type_, underscored_, "");
-    const_ref_ = ref(scoped_type_, underscored_);
+    ref_ = ref(scoped_type_, "");
+    const_ref_ = ref(scoped_type_);
     ptr_ = ref_ + '*';
   } else {
     ref_ = scoped_type_ + (arr_ ? "_forany&" : "&");

--- a/dds/idl/field_info.h
+++ b/dds/idl/field_info.h
@@ -29,7 +29,7 @@ struct FieldInfo {
   static std::string at_pfx();
   static std::string scoped_type(AST_Type& field_type, const std::string& field_name);
   static std::string underscore(const std::string& scoped);
-  static std::string ref(const std::string& scoped, const std::string& underscored, const std::string& const_s = "const ");
+  static std::string ref(const std::string& scoped, const std::string& const_s = "const ");
 
   AST_Type* type_;
   const std::string name_;

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -274,12 +274,6 @@ namespace {
       type_class & (CL_SEQUENCE | CL_ARRAY);
   }
 
-  bool cxx_escape(const std::string& s, size_t i)
-  {
-    const std::string cxx = "_cxx_";
-    return s.substr(i, cxx.size()) == cxx;
-  }
-
   const char* const shift_out = "<< ";
   const char* const shift_in = ">> ";
 
@@ -3538,7 +3532,7 @@ marshal_generator::gen_field_getValueFromSerialized(AST_Structure* node, const s
         post = "_forany";
       } else if (use_cxx11 && (fld_cls & (CL_ARRAY | CL_SEQUENCE))) {
         pre = "IDL::DistinctType<";
-        post = ", " + dds_generator::get_tag_name(scoped(field->field_type()->name()), false) + ">";
+        post = ", " + dds_generator::get_tag_name(scoped(field->field_type()->name())) + ">";
       }
       const std::string ptr = field->field_type()->anonymous() ?
         FieldInfo(*field).ptr_ : (pre + scoped(field->field_type()->name()) + post + '*');

--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -554,7 +554,7 @@ metaclass_generator::gen_struct(AST_Structure* node, UTL_ScopedName* name,
               post = "_forany";
             } else if (use_cxx11 && (elem_cls & (CL_ARRAY | CL_SEQUENCE))) {
               pre = "IDL::DistinctType<";
-              post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(elem_orig->name(), "_"), false) + ">";
+              post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(elem_orig->name(), "_")) + ">";
             }
             be_global->impl_ <<
               "    if (!gen_skip_over(ser, static_cast<" << pre << cxx_elem << post
@@ -659,7 +659,7 @@ metaclass_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
         post = "_forany";
       } else if (use_cxx11 && (elem_cls & (CL_ARRAY | CL_SEQUENCE))) {
         pre = "IDL::DistinctType<";
-        post = ", " + dds_generator::get_tag_name(clazz, false) + ">";
+        post = ", " + dds_generator::get_tag_name(clazz) + ">";
       }
       be_global->impl_ <<
         "    if (!gen_skip_over(ser, static_cast<" << pre << cxx_elem << post
@@ -703,7 +703,7 @@ func(const std::string&, const std::string&, AST_Type* br_type, const std::strin
       post = "_forany";
     } else if (use_cxx11 && (br_cls & (CL_ARRAY | CL_SEQUENCE))) {
       pre = "IDL::DistinctType<";
-      post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(br_type->name(), "_"), false) + ">";
+      post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(br_type->name(), "_")) + ">";
     }
     ss <<
       "    if (!gen_skip_over(ser, static_cast<" << pre

--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -554,7 +554,7 @@ metaclass_generator::gen_struct(AST_Structure* node, UTL_ScopedName* name,
               post = "_forany";
             } else if (use_cxx11 && (elem_cls & (CL_ARRAY | CL_SEQUENCE))) {
               pre = "IDL::DistinctType<";
-              post = ", " + dds_generator::scoped_helper(elem_orig->name(), "_") + "_tag>";
+              post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(elem_orig->name(), "_"), false) + ">";
             }
             be_global->impl_ <<
               "    if (!gen_skip_over(ser, static_cast<" << pre << cxx_elem << post
@@ -593,13 +593,13 @@ metaclass_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
   }
   const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
 
-  const std::string clazz = scoped(name), clazz_underscores = scoped_helper(name, "_");
+  const std::string clazz = scoped(name);
   ContentSubscriptionGuard csg;
   NamespaceGuard ng;
   Function f("gen_skip_over", "bool");
   f.addArg("ser", "Serializer&");
   if (use_cxx11) {
-    f.addArg("", "IDL::DistinctType<" + clazz + ", " + clazz_underscores + "_tag>*");
+    f.addArg("", "IDL::DistinctType<" + clazz + ", " + dds_generator::get_tag_name(clazz) +">*");
   } else {
     f.addArg("", clazz + (arr ? "_forany*" : "*"));
   }
@@ -659,7 +659,7 @@ metaclass_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
         post = "_forany";
       } else if (use_cxx11 && (elem_cls & (CL_ARRAY | CL_SEQUENCE))) {
         pre = "IDL::DistinctType<";
-        post = ", " + dds_generator::scoped_helper(elem_orig->name(), "_") + "_tag>";
+        post = ", " + dds_generator::get_tag_name(clazz, false) + ">";
       }
       be_global->impl_ <<
         "    if (!gen_skip_over(ser, static_cast<" << pre << cxx_elem << post
@@ -703,7 +703,7 @@ func(const std::string&, const std::string&, AST_Type* br_type, const std::strin
       post = "_forany";
     } else if (use_cxx11 && (br_cls & (CL_ARRAY | CL_SEQUENCE))) {
       pre = "IDL::DistinctType<";
-      post = ", " + dds_generator::scoped_helper(br_type->name(), "_") + "_tag>";
+      post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(br_type->name(), "_"), false) + ">";
     }
     ss <<
       "    if (!gen_skip_over(ser, static_cast<" << pre

--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -659,7 +659,7 @@ metaclass_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
         post = "_forany";
       } else if (use_cxx11 && (elem_cls & (CL_ARRAY | CL_SEQUENCE))) {
         pre = "IDL::DistinctType<";
-        post = ", " + dds_generator::get_tag_name(clazz) + ">";
+        post = ", " + dds_generator::get_tag_name(scoped_helper(elem_orig->name(), "::")) + ">";
       }
       be_global->impl_ <<
         "    if (!gen_skip_over(ser, static_cast<" << pre << cxx_elem << post
@@ -703,7 +703,7 @@ func(const std::string&, const std::string&, AST_Type* br_type, const std::strin
       post = "_forany";
     } else if (use_cxx11 && (br_cls & (CL_ARRAY | CL_SEQUENCE))) {
       pre = "IDL::DistinctType<";
-      post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(br_type->name(), "_")) + ">";
+      post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(br_type->name(), "::")) + ">";
     }
     ss <<
       "    if (!gen_skip_over(ser, static_cast<" << pre

--- a/dds/idl/metaclass_generator.h
+++ b/dds/idl/metaclass_generator.h
@@ -9,6 +9,7 @@
 #define metaclass_generator_H
 
 #include "dds_generator.h"
+#include <string>
 
 class metaclass_generator : public dds_generator {
 public:

--- a/dds/idl/metaclass_generator.h
+++ b/dds/idl/metaclass_generator.h
@@ -9,7 +9,6 @@
 #define metaclass_generator_H
 
 #include "dds_generator.h"
-#include <string>
 
 class metaclass_generator : public dds_generator {
 public:

--- a/tests/DCPS/Compiler/underscore_fields/.gitignore
+++ b/tests/DCPS/Compiler/underscore_fields/.gitignore
@@ -1,4 +1,4 @@
-/Compiler_test
+/underscore_fields
 test.cpp
 testC.h
 testC.inl

--- a/tests/DCPS/Compiler/underscore_fields/.gitignore
+++ b/tests/DCPS/Compiler/underscore_fields/.gitignore
@@ -1,0 +1,14 @@
+/Compiler_test
+test.cpp
+testC.h
+testC.inl
+testS.cpp
+testS.h
+testTypeSupportC.cpp
+testTypeSupportC.h
+testTypeSupportC.inl
+testTypeSupportImpl.cpp
+testTypeSupportImpl.h
+testTypeSupportS.cpp
+testTypeSupportS.h
+testTypeSupport.idl

--- a/tests/DCPS/Compiler/underscore_fields/test.idl
+++ b/tests/DCPS/Compiler/underscore_fields/test.idl
@@ -1,0 +1,30 @@
+// generated from rosidl_generator_dds_idl/resource/idl.idl.em
+// with input from unique_identifier_msgs:msg/UUID.idl
+// generated code does not contain a copyright notice
+
+#ifndef __unique_identifier_msgs__msg__uuid__idl__
+#define __unique_identifier_msgs__msg__uuid__idl__
+
+
+module unique_identifier_msgs {
+
+module msg {
+
+module dds_ {
+
+
+struct UUID_ {
+octet uuid_[16];
+
+
+};
+
+
+};  // module dds_
+
+};  // module msg
+
+};  // module unique_identifier_msgs
+
+
+#endif  // __unique_identifier_msgs__msg__uuid__idl__

--- a/tests/DCPS/Compiler/underscore_fields/test.idl
+++ b/tests/DCPS/Compiler/underscore_fields/test.idl
@@ -1,6 +1,6 @@
-// generated from rosidl_generator_dds_idl/resource/idl.idl.em
-// with input from unique_identifier_msgs:msg/UUID.idl
-// generated code does not contain a copyright notice
+// This test was made to catch problems with names
+// containing trailing underscores failing and colliding
+// with each other
 
 #ifndef __unique_identifier_msgs__msg__uuid__idl__
 #define __unique_identifier_msgs__msg__uuid__idl__
@@ -8,16 +8,47 @@
 
 module unique_identifier_msgs {
 
-module msg {
+module msg_ {
 
 module dds_ {
-
-
-struct UUID_ {
-octet uuid_[16];
-
-
-};
+  typedef octet td_oa[16];
+  typedef octet td_oa_[16];
+  typedef octet td_oa__[16];
+  typedef sequence<octet, 16> td_oseq;
+  typedef sequence<octet, 16> td_oseq_;
+  typedef sequence<octet, 16> td_oseq__;
+  struct str {
+    string s;
+    string s_;
+    string s__;
+    long l;
+    long l_;
+    long l__;
+    long l_laa[16];
+    long l_laa_[16];
+    long l_laa__[16];
+    td_oseq td_seq;
+    td_oseq td_seq_;
+    td_oseq td_seq__;
+    td_oa td_a;
+    td_oa td_a_;
+    td_oa td_a__;
+    octet oa[16];
+    octet oa_[16];
+    octet oa__[16];
+    sequence <long> l_lssa;
+    sequence <long, 16> l_lssa_;
+    sequence <long, 16> l_lssa__;
+  };
+  struct stru {
+    str nested_struct;
+    str nested_struct_;
+    str nested_struct__;
+  };
+  union union_final switch(long) {
+    case 0: long A;
+    case 1: long A_;
+  };
 
 
 };  // module dds_

--- a/tests/DCPS/Compiler/underscore_fields/test.idl
+++ b/tests/DCPS/Compiler/underscore_fields/test.idl
@@ -5,57 +5,51 @@
 #ifndef __unique_identifier_msgs__msg__uuid__idl__
 #define __unique_identifier_msgs__msg__uuid__idl__
 
-
 module unique_identifier_msgs {
+  module msg_ {
+    module dds_ {
+      typedef octet td_oa[16];
+      typedef octet td_oa_[16];
+      typedef octet td_oa__[16];
+      typedef sequence<octet, 16> td_oseq;
+      typedef sequence<octet, 16> td_oseq_;
+      typedef sequence<octet, 16> td_oseq__;
 
-module msg_ {
+      struct str {
+        string s;
+        string s_;
+        string s__;
+        long l;
+        long l_;
+        long l__;
+        long l_laa[16];
+        long l_laa_[16];
+        long l_laa__[16];
+        td_oseq td_seq;
+        td_oseq td_seq_;
+        td_oseq td_seq__;
+        td_oa td_a;
+        td_oa td_a_;
+        td_oa td_a__;
+        octet oa[16];
+        octet oa_[16];
+        octet oa__[16];
+        sequence <long> l_lssa;
+        sequence <long, 16> l_lssa_;
+        sequence <long, 16> l_lssa__;
+      };
 
-module dds_ {
-  typedef octet td_oa[16];
-  typedef octet td_oa_[16];
-  typedef octet td_oa__[16];
-  typedef sequence<octet, 16> td_oseq;
-  typedef sequence<octet, 16> td_oseq_;
-  typedef sequence<octet, 16> td_oseq__;
-  struct str {
-    string s;
-    string s_;
-    string s__;
-    long l;
-    long l_;
-    long l__;
-    long l_laa[16];
-    long l_laa_[16];
-    long l_laa__[16];
-    td_oseq td_seq;
-    td_oseq td_seq_;
-    td_oseq td_seq__;
-    td_oa td_a;
-    td_oa td_a_;
-    td_oa td_a__;
-    octet oa[16];
-    octet oa_[16];
-    octet oa__[16];
-    sequence <long> l_lssa;
-    sequence <long, 16> l_lssa_;
-    sequence <long, 16> l_lssa__;
-  };
-  struct stru {
-    str nested_struct;
-    str nested_struct_;
-    str nested_struct__;
-  };
-  union union_final switch(long) {
-    case 0: long A;
-    case 1: long A_;
-  };
+      struct stru {
+        str nested_struct;
+        str nested_struct_;
+        str nested_struct__;
+      };
 
-
-};  // module dds_
-
-};  // module msg
-
-};  // module unique_identifier_msgs
-
-
+      union union_final switch(long) {
+        case 0: long A;
+        case 1: long A_;
+      };
+    };  // module dds_
+  };  // module msg_
+};  // module unique_identifier_msgs_
 #endif  // __unique_identifier_msgs__msg__uuid__idl__

--- a/tests/DCPS/Compiler/underscore_fields/test.idl
+++ b/tests/DCPS/Compiler/underscore_fields/test.idl
@@ -5,7 +5,7 @@
 #ifndef __unique_identifier_msgs__msg__uuid__idl__
 #define __unique_identifier_msgs__msg__uuid__idl__
 
-module unique_identifier_msgs {
+module unique_identifier_msgs_ {
   module msg_ {
     module dds_ {
       typedef octet td_oa[16];

--- a/tests/DCPS/Compiler/underscore_fields/underscore_fields.mpc
+++ b/tests/DCPS/Compiler/underscore_fields/underscore_fields.mpc
@@ -1,0 +1,8 @@
+project: opendds_cxx11 {
+  idlflags += -Cw -aw
+  dcps_ts_flags += -Cw -aw
+
+  TypeSupport_Files {
+    test.idl
+  }
+}


### PR DESCRIPTION
ROS generates IDL with underscores appended for variable names as captured in the example `test.idl`. The current `opendds_idl` does not generate compilable C++ code. This fix creates a test to capture the expectation and remedies the issue. 