### PR TITLE
RtpsDiscovery does not expose heartbeat period

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -77,6 +77,7 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , secure_participant_user_data_(false)
   , max_type_lookup_service_reply_period_(5, 0)
   , use_xtypes_(true)
+  , sedp_heartbeat_period_(1)
 {}
 
 RtpsDiscovery::RtpsDiscovery(const RepoKey& key)

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -493,6 +493,17 @@ public:
     use_xtypes_ = use_xtypes;
   }
 
+  DCPS::TimeDuration sedp_heartbeat_period() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return sedp_heartbeat_period_;
+  }
+  void sedp_heartbeat_period(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_heartbeat_period_ = period;
+  }
+
 private:
   mutable ACE_Thread_Mutex lock_;
   DCPS::TimeDuration resend_period_;
@@ -530,6 +541,7 @@ private:
   bool secure_participant_user_data_;
   DCPS::TimeDuration max_type_lookup_service_reply_period_;
   bool use_xtypes_;
+  DCPS::TimeDuration sedp_heartbeat_period_;
 };
 
 typedef OpenDDS::DCPS::RcHandle<RtpsDiscoveryConfig> RtpsDiscoveryConfig_rch;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -363,6 +363,7 @@ Sedp::init(const RepoId& guid,
   static const double HANDSHAKE_MULTIPLIER = 5;
   rtps_inst->handshake_timeout_ = disco.resend_period() * HANDSHAKE_MULTIPLIER;
   rtps_inst->max_message_size_ = disco.config()->sedp_max_message_size();
+  rtps_inst->heartbeat_period_ = disco.config()->sedp_heartbeat_period();
 
   if (disco.sedp_multicast()) {
     // Bind to a specific multicast group


### PR DESCRIPTION
Problem
-------

RtpsDiscovery can be delayed by dropped messages.  By default, these
messages will only be retried after the default heartbeat period of 1
second.

Solution
--------

Expose the heartbeat period.