### PR TITLE
Initialization of TypeIdentifier is not thread-safe

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2796,9 +2796,9 @@ Service_Participant::get_thread_statuses()
   return &thread_status_;
 }
 
-ACE_Thread_Mutex& Service_Participant::get_tm_lock()
+ACE_Thread_Mutex& Service_Participant::get_static_xtypes_lock()
 {
-  return tm_lock_;
+  return xtypes_lock_;
 }
 
 NetworkConfigMonitor_rch Service_Participant::network_config_monitor()

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -646,8 +646,8 @@ public:
   TimeDuration get_thread_status_interval();
   void set_thread_status_interval(TimeDuration interval);
 
-  /// getter for tm_lock_ used to block get_minimal_type_map_private
-  ACE_Thread_Mutex& get_tm_lock();
+  /// getter for lock that protects the static initialization of XTypes related data structures
+  ACE_Thread_Mutex& get_static_xtypes_lock();
 
   ThreadStatus* get_thread_statuses();
 
@@ -722,8 +722,8 @@ private:
 
   ThreadStatus thread_status_;
 
-  /// Thread mutex used to grab type map
-  ACE_Thread_Mutex tm_lock_;
+  /// Thread mutex used to protect the static initialization of XTypes data structures
+  ACE_Thread_Mutex xtypes_lock_;
 
   /// Enable Monitor functionality
   bool monitor_enabled_;

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -938,7 +938,7 @@ typeobject_generator::gen_epilogue()
   be_global->impl_ <<
     "const XTypes::TypeMap& get_minimal_type_map()\n"
     "{\n"
-    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), tm);\n"
+    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), XTypes::TypeMap());\n"
     "  static XTypes::TypeMap tm;\n"
     "  if (tm.empty()) {\n"
     "    tm = get_minimal_type_map_private();\n"
@@ -1762,7 +1762,7 @@ typeobject_generator::generate(AST_Type* node, UTL_ScopedName* name)
     gti.endArgs();
     const OpenDDS::XTypes::TypeIdentifier ti = get_minimal_type_identifier(node);
     be_global->impl_ <<
-      "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), ti);\n"
+      "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), XTypes::TypeIdentifier());\n"
       "  static XTypes::TypeIdentifier ti;\n"
       "  if (ti.kind() == XTypes::TK_NONE) {\n"
       "    ti = " << ti << ";\n"

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -938,8 +938,8 @@ typeobject_generator::gen_epilogue()
   be_global->impl_ <<
     "const XTypes::TypeMap& get_minimal_type_map()\n"
     "{\n"
-    "  static XTypes::TypeMap tm;\n"
     "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), tm);\n"
+    "  static XTypes::TypeMap tm;\n"
     "  if (tm.empty()) {\n"
     "    tm = get_minimal_type_map_private();\n"
     "  }\n"
@@ -1762,8 +1762,8 @@ typeobject_generator::generate(AST_Type* node, UTL_ScopedName* name)
     gti.endArgs();
     const OpenDDS::XTypes::TypeIdentifier ti = get_minimal_type_identifier(node);
     be_global->impl_ <<
-      "  static XTypes::TypeIdentifier ti;\n"
       "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), ti);\n"
+      "  static XTypes::TypeIdentifier ti;\n"
       "  if (ti.kind() == XTypes::TK_NONE) {\n"
       "    ti = " << ti << ";\n"
       "  }\n"

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -1762,7 +1762,11 @@ typeobject_generator::generate(AST_Type* node, UTL_ScopedName* name)
     gti.endArgs();
     const OpenDDS::XTypes::TypeIdentifier ti = get_minimal_type_identifier(node);
     be_global->impl_ <<
-      "  static const XTypes::TypeIdentifier ti = " << ti << ";\n"
+      "  static XTypes::TypeIdentifier ti;\n"
+      "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), ti);\n"
+      "  if (ti.kind() == XTypes::TK_NONE) {\n"
+      "    ti = " << ti << ";\n"
+      "  }\n"
       "  return ti;\n";
   }
   {

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -938,8 +938,8 @@ typeobject_generator::gen_epilogue()
   be_global->impl_ <<
     "const XTypes::TypeMap& get_minimal_type_map()\n"
     "{\n"
-    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), XTypes::TypeMap());\n"
     "  static XTypes::TypeMap tm;\n"
+    "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_static_xtypes_lock(), tm);\n"
     "  if (tm.empty()) {\n"
     "    tm = get_minimal_type_map_private();\n"
     "  }\n"
@@ -1762,8 +1762,8 @@ typeobject_generator::generate(AST_Type* node, UTL_ScopedName* name)
     gti.endArgs();
     const OpenDDS::XTypes::TypeIdentifier ti = get_minimal_type_identifier(node);
     be_global->impl_ <<
-      "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_tm_lock(), XTypes::TypeIdentifier());\n"
       "  static XTypes::TypeIdentifier ti;\n"
+      "  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, TheServiceParticipant->get_static_xtypes_lock(), ti);\n"
       "  if (ti.kind() == XTypes::TK_NONE) {\n"
       "    ti = " << ti << ";\n"
       "  }\n"


### PR DESCRIPTION
Problem
-------

Initialization of statics is not thread-safe on all compilers.  See #2362.

Solution
--------

Add lock to serialize initialization of type identifier.