### PR TITLE
TypeLookupService is not thread-safe

### DIFF
--- a/dds/DCPS/XTypes/TypeLookupService.cpp
+++ b/dds/DCPS/XTypes/TypeLookupService.cpp
@@ -24,6 +24,7 @@ TypeLookupService::~TypeLookupService()
 void TypeLookupService::get_type_objects(const TypeIdentifierSeq& type_ids,
                                          TypeIdentifierTypeObjectPairSeq& types) const
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   for (CORBA::ULong i = 0; i < type_ids.length(); ++i) {
     TypeMap::const_iterator it_object = minimal_type_map_.find(type_ids[i]);
     if (it_object != minimal_type_map_.end()) {
@@ -34,6 +35,7 @@ void TypeLookupService::get_type_objects(const TypeIdentifierSeq& type_ids,
 
 const TypeObject& TypeLookupService::get_type_objects(const TypeIdentifier& type_id) const
 {
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, to_empty_);
   const TypeMap::const_iterator it_object = minimal_type_map_.find(type_id);
   if (it_object != minimal_type_map_.end()) {
     return it_object->second;
@@ -44,6 +46,7 @@ const TypeObject& TypeLookupService::get_type_objects(const TypeIdentifier& type
 bool TypeLookupService::get_type_dependencies(const TypeIdentifier& type_id,
   TypeIdentifierWithSizeSeq& dependencies) const
 {
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
   const TypeIdentifierWithSizeSeqMap::const_iterator it = type_dependencies_map_.find(type_id);
   if (it != type_dependencies_map_.end()) {
     dependencies = it->second;
@@ -55,6 +58,7 @@ bool TypeLookupService::get_type_dependencies(const TypeIdentifier& type_id,
 void TypeLookupService::get_type_dependencies(const TypeIdentifierSeq& type_ids,
   TypeIdentifierWithSizeSeq& dependencies) const
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   OPENDDS_SET(TypeIdentifier) tmp;
   for (unsigned i = 0; i < type_ids.length(); ++i) {
     const TypeIdentifierWithSizeSeqMap::const_iterator it = type_dependencies_map_.find(type_ids[i]);
@@ -80,6 +84,7 @@ void TypeLookupService::get_type_dependencies(const TypeIdentifierSeq& type_ids,
 
 void TypeLookupService::add_type_objects_to_cache(const TypeIdentifierTypeObjectPairSeq& types)
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   for (ACE_UINT32 i = 0; i < types.length(); ++i) {
     const TypeMap::iterator it_type_id_with_size_seq = minimal_type_map_.find(types[i].type_identifier);
     if (it_type_id_with_size_seq == minimal_type_map_.end()) {
@@ -90,6 +95,7 @@ void TypeLookupService::add_type_objects_to_cache(const TypeIdentifierTypeObject
 
 void TypeLookupService::add_type_objects_to_cache(const DCPS::TypeSupportImpl& typesupport)
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   // TODO: This populates the map N times instead of 1.
   const XTypes::TypeMap& minimal_type_map = typesupport.getMinimalTypeMap();
   minimal_type_map_.insert(minimal_type_map.begin(), minimal_type_map.end());
@@ -97,6 +103,7 @@ void TypeLookupService::add_type_objects_to_cache(const DCPS::TypeSupportImpl& t
 
 void TypeLookupService::add_type_objects_to_cache(const TypeIdentifier& ti, const TypeObject& tobj)
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   TypeMap::const_iterator it_type_id_with_size_seq = minimal_type_map_.find(ti);
   if (it_type_id_with_size_seq == minimal_type_map_.end()) {
     minimal_type_map_.insert(std::make_pair(ti, tobj));
@@ -106,6 +113,7 @@ void TypeLookupService::add_type_objects_to_cache(const TypeIdentifier& ti, cons
 void TypeLookupService::add_type_dependencies(const TypeIdentifier& type_id,
   const TypeIdentifierWithSizeSeq& dependencies)
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
   if (type_dependencies_map_.find(type_id) == type_dependencies_map_.end()) {
     type_dependencies_map_.insert(std::make_pair(type_id, dependencies));
   }
@@ -113,12 +121,14 @@ void TypeLookupService::add_type_dependencies(const TypeIdentifier& type_id,
 
 bool TypeLookupService::type_object_in_cache(const TypeIdentifier& ti) const
 {
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
   TypeMap::const_iterator it_type_id_with_size_seq = minimal_type_map_.find(ti);
   return it_type_id_with_size_seq != minimal_type_map_.end();
 }
 
 bool TypeLookupService::extensibility(TypeFlag extensibility_mask, const TypeIdentifier& type_id) const
 {
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
   bool result = false;
   TypeObject to = get_type_objects(type_id);
 

--- a/dds/DCPS/XTypes/TypeLookupService.h
+++ b/dds/DCPS/XTypes/TypeLookupService.h
@@ -12,6 +12,8 @@
 #include <dds/DCPS/SequenceNumber.h>
 #include <dds/DCPS/TypeSupportImpl.h>
 
+#include <ace/Thread_Mutex.h>
+
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
@@ -56,6 +58,8 @@ private:
   // For dependencies of local types
   typedef OPENDDS_MAP(TypeIdentifier, TypeIdentifierWithSizeSeq) TypeIdentifierWithSizeSeqMap;
   TypeIdentifierWithSizeSeqMap type_dependencies_map_;
+
+  mutable ACE_Thread_Mutex mutex_;
 
   TypeObject to_empty_;
 };

--- a/dds/DCPS/XTypes/TypeLookupService.h
+++ b/dds/DCPS/XTypes/TypeLookupService.h
@@ -52,6 +52,10 @@ public:
   bool extensibility(TypeFlag extensibility_mask, const TypeIdentifier& ti) const;
 
 private:
+  const TypeObject& get_type_objects_i(const TypeIdentifier& type_id) const;
+  void get_type_dependencies_i(const TypeIdentifierSeq& type_ids,
+    TypeIdentifierWithSizeSeq& dependencies) const;
+
   // Only minimal Type Objects for now
   TypeMap minimal_type_map_;
 


### PR DESCRIPTION
Problem
-------

A TypeLookupService object can be accessed concurrently by a user
thread and discovery.  As this access is not serialized, it may lead to
data corruption.

Solution
--------

Add locking.