### PR TITLE
Cleanup tests/DCPS/Messenger

### DIFF
--- a/tests/DCPS/Messenger/Args.h
+++ b/tests/DCPS/Messenger/Args.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -9,7 +7,6 @@
 #define MESSENGER_TEST_ARGS_H
 
 #include <dds/DCPS/transport/framework/TransportRegistry.h>
-
 #include <dds/DCPS/transport/framework/TransportConfig.h>
 #include <dds/DCPS/transport/framework/TransportInst.h>
 
@@ -24,12 +21,12 @@
 const size_t num_messages = 40;
 extern bool reliable;
 
-inline int
-parse_args(int argc, ACE_TCHAR *argv[])
+inline
+int parse_args(int argc, ACE_TCHAR* argv[])
 {
   ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("t:prw"));
 
-  OPENDDS_STRING transport_type;
+  OpenDDS::DCPS::String transport_type;
   int c;
   bool thread_per_connection = false;
   while ((c = get_opts()) != -1) {

--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -1,20 +1,19 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
-
-#include <ace/Log_Msg.h>
-#include <ace/OS_NS_stdlib.h>
-
-#include <dds/DdsDcpsSubscriptionC.h>
-#include <dds/DCPS/Service_Participant.h>
 
 #include "Args.h"
 #include "DataReaderListener.h"
 #include "MessengerTypeSupportC.h"
 #include "MessengerTypeSupportImpl.h"
+
+#include <dds/DCPS/Service_Participant.h>
+
+#include <dds/DdsDcpsSubscriptionC.h>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_stdlib.h>
 
 #include <iostream>
 #include <cstdlib>
@@ -31,8 +30,7 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 {
 }
 
-bool
-DataReaderListenerImpl::is_reliable()
+bool DataReaderListenerImpl::is_reliable()
 {
   OpenDDS::DCPS::TransportConfig_rch gc = TheTransportRegistry->global_config();
   return !(gc->instances_[0]->transport_type_ == "udp");

--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -33,7 +33,7 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 bool DataReaderListenerImpl::is_reliable()
 {
   OpenDDS::DCPS::TransportConfig_rch gc = TheTransportRegistry->global_config();
-  return !(gc->instances_[0]->transport_type_ == "udp");
+  return gc->instances_[0]->transport_type_ != "udp";
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
@@ -43,8 +43,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
   try {
     Messenger::MessageDataReader_var message_dr =
       Messenger::MessageDataReader::_narrow(reader);
-
-    if (CORBA::is_nil(message_dr.in())) {
+    if (!message_dr) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("%N:%l: on_data_available()")
                  ACE_TEXT(" ERROR: _narrow failed!\n")));
@@ -54,11 +53,12 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     Messenger::Message message;
     DDS::SampleInfo si;
 
-    const DDS::ReturnCode_t status = message_dr->take_next_sample(message, si) ;
+    const DDS::ReturnCode_t status = message_dr->take_next_sample(message, si);
 
     if (status == DDS::RETCODE_OK) {
       std::cout << "SampleInfo.sample_rank = " << si.sample_rank << std::endl;
-      std::cout << "SampleInfo.instance_state = " << OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
+      std::cout << "SampleInfo.instance_state = " <<
+        OpenDDS::DCPS::InstanceState::instance_state_string(si.instance_state) << std::endl;
 
       if (si.valid_data) {
         if (!counts_.insert(message.count).second) {
@@ -181,8 +181,7 @@ bool DataReaderListenerImpl::is_valid() const
           valid_count = false;
           continue;
         }
-      }
-      else {
+      } else {
         bool multi = false;
         while (++count != counts_.end() && *count < expected) {
           multi = true;
@@ -201,11 +200,10 @@ bool DataReaderListenerImpl::is_valid() const
   if (count != counts_.end()) {
     std::cout << "ERROR: received messages with count higher than expected values" << std::endl;
     valid_count = false;
-  }
-  // if didn't receive all the messages (for reliable transport) or didn't receive even get 1/4, then report error
-  else if (counts_.size() < num_messages &&
-           (reliable_ || (counts_.size() * 4) < num_messages)) {
-    std::cout << "ERROR: received " << counts_.size() << " messages, but expected " << num_messages << std::endl;
+  } else if (counts_.size() < num_messages &&
+      (reliable_ || (counts_.size() * 4) < num_messages)) {
+    std::cout << "ERROR: received " << counts_.size() << " messages, but expected " <<
+      num_messages << std::endl;
     valid_count = false;
   }
 

--- a/tests/DCPS/Messenger/DataReaderListener.h
+++ b/tests/DCPS/Messenger/DataReaderListener.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,7 +6,11 @@
 #ifndef DATAREADER_LISTENER_IMPL
 #define DATAREADER_LISTENER_IMPL
 
+#include <dds/DCPS/LocalObject.h>
+
 #include <dds/DdsDcpsSubscriptionC.h>
+
+#include <set>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -48,7 +50,8 @@ public:
     DDS::DataReader_ptr reader,
     const DDS::SampleLostStatus& status);
 
-  long num_reads() const {
+  long num_reads() const
+  {
     return num_reads_;
   }
 
@@ -60,10 +63,10 @@ private:
   typedef std::set<CORBA::ULong> Counts;
 
   DDS::DataReader_var reader_;
-  long                num_reads_;
-  Counts              counts_;
-  bool                valid_;
-  const bool          reliable_;
+  long num_reads_;
+  Counts counts_;
+  bool valid_;
+  const bool reliable_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/Messenger/Messenger.idl
+++ b/tests/DCPS/Messenger/Messenger.idl
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */

--- a/tests/DCPS/Messenger/Messenger.mpc
+++ b/tests/DCPS/Messenger/Messenger.mpc
@@ -1,4 +1,3 @@
-
 project(DDS*idl): dcps_test_idl_only_lib {
   idlflags      += -Wb,stub_export_include=Messenger_export.h \
                    -Wb,stub_export_macro=Messenger_Export -SS

--- a/tests/DCPS/Messenger/Writer.cpp
+++ b/tests/DCPS/Messenger/Writer.cpp
@@ -1,22 +1,21 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
+
+#include "Args.h"
+#include "MessengerTypeSupportC.h"
+#include "Writer.h"
+
+#include <dds/DCPS/WaitSet.h>
+
+#include <dds/DdsDcpsPublicationC.h>
 
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
 #include <ace/OS_NS_unistd.h>
 
-#include <dds/DdsDcpsPublicationC.h>
-#include <dds/DCPS/WaitSet.h>
-
 #include <cstdlib>
-
-#include "Args.h"
-#include "MessengerTypeSupportC.h"
-#include "Writer.h"
 
 const int num_instances_per_writer = 1;
 bool reliable = false;
@@ -27,8 +26,7 @@ Writer::Writer(DDS::DataWriter_ptr writer)
 {
 }
 
-void
-Writer::start()
+void Writer::start()
 {
   // Lanuch num_instances_per_writer threads. Each thread writes one
   // instance which uses the thread id as the key value.
@@ -40,17 +38,13 @@ Writer::start()
   }
 }
 
-void
-Writer::end()
+void Writer::end()
 {
   wait();
 }
 
-int
-Writer::svc()
+int Writer::svc()
 {
-  DDS::InstanceHandleSeq handles;
-
   try {
     // Block until Subscriber is available
     DDS::StatusCondition_var condition = writer_->get_statuscondition();
@@ -59,7 +53,7 @@ Writer::svc()
     DDS::WaitSet_var ws = new DDS::WaitSet;
     ws->attach_condition(condition);
 
-    DDS::Duration_t timeout =
+    const DDS::Duration_t timeout =
       { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
 
     DDS::ConditionSeq conditions;
@@ -87,8 +81,7 @@ Writer::svc()
     // Write samples
     Messenger::MessageDataWriter_var message_dw
       = Messenger::MessageDataWriter::_narrow(writer_.in());
-
-    if (CORBA::is_nil(message_dw.in())) {
+    if (!message_dw) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("%N:%l: svc()")
                  ACE_TEXT(" ERROR: _narrow failed!\n")));
@@ -98,12 +91,12 @@ Writer::svc()
     Messenger::Message message;
     message.subject_id = 99;
 
-    DDS::InstanceHandle_t handle = message_dw->register_instance(message);
+    const DDS::InstanceHandle_t handle = message_dw->register_instance(message);
 
-    message.from         = "Comic Book Guy";
-    message.subject      = "Review";
-    message.text         = "Worst. Movie. Ever.";
-    message.count        = 0;
+    message.from = "Comic Book Guy";
+    message.subject = "Review";
+    message.text = "Worst. Movie. Ever.";
+    message.count = 0;
 
     for (size_t i = 0; i < num_messages; i++) {
       DDS::ReturnCode_t error;
@@ -129,8 +122,7 @@ Writer::svc()
   return 0;
 }
 
-bool
-Writer::is_finished() const
+bool Writer::is_finished() const
 {
   return finished_instances_ == num_instances_per_writer;
 }

--- a/tests/DCPS/Messenger/Writer.h
+++ b/tests/DCPS/Messenger/Writer.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,8 +6,9 @@
 #ifndef WRITER_H
 #define WRITER_H
 
-#include <ace/Task.h>
 #include <dds/DdsDcpsPublicationC.h>
+
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base {
 public:

--- a/tests/DCPS/Messenger/publisher.cpp
+++ b/tests/DCPS/Messenger/publisher.cpp
@@ -1,43 +1,40 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
+
+#include "MessengerTypeSupportImpl.h"
+#include "Writer.h"
+#include "Args.h"
+
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/PublisherImpl.h>
+#include <dds/DCPS/Service_Participant.h>
+#ifdef OPENDDS_SECURITY
+#  include <dds/DCPS/security/framework/Properties.h>
+#endif
+#include <dds/DCPS/StaticIncludes.h>
+#ifdef ACE_AS_STATIC_LIBS
+#  ifndef OPENDDS_SAFETY_PROFILE
+#    include <dds/DCPS/transport/udp/Udp.h>
+#    include <dds/DCPS/transport/multicast/Multicast.h>
+#    include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#    include <dds/DCPS/transport/shmem/Shmem.h>
+#    ifdef OPENDDS_SECURITY
+#      include <dds/DCPS/security/BuiltInPlugins.h>
+#    endif
+#  endif
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
 
 #include <ace/Get_Opt.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
 #include <ace/OS_NS_unistd.h>
 
-#include <dds/DCPS/Marked_Default_Qos.h>
-#include <dds/DCPS/PublisherImpl.h>
-#include <dds/DCPS/Service_Participant.h>
-
-#include "dds/DCPS/StaticIncludes.h"
-
-#ifdef ACE_AS_STATIC_LIBS
-# ifndef OPENDDS_SAFETY_PROFILE
-#include <dds/DCPS/transport/udp/Udp.h>
-#include <dds/DCPS/transport/multicast/Multicast.h>
-#include <dds/DCPS/RTPS/RtpsDiscovery.h>
-#include <dds/DCPS/transport/shmem/Shmem.h>
-#  ifdef OPENDDS_SECURITY
-#  include "dds/DCPS/security/BuiltInPlugins.h"
-#  endif
-# endif
-#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
-#endif
-
 #include <cstdlib>
 
-#include "MessengerTypeSupportImpl.h"
-#include "Writer.h"
-#include "Args.h"
-
 #ifdef OPENDDS_SECURITY
-#include <dds/DCPS/security/framework/Properties.h>
-
 const char auth_ca_file_from_tests[] = "security/certs/identity/identity_ca_cert.pem";
 const char perm_ca_file_from_tests[] = "security/certs/permissions/permissions_ca_cert.pem";
 const char id_cert_file_from_tests[] = "security/certs/identity/test_participant_01_cert.pem";
@@ -46,9 +43,10 @@ const char governance_file[] = "file:./governance_signed.p7s";
 const char permissions_file[] = "file:./permissions_1_signed.p7s";
 #endif
 
-bool dw_reliable() {
+bool dw_reliable()
+{
   OpenDDS::DCPS::TransportConfig_rch gc = TheTransportRegistry->global_config();
-  return !(gc->instances_[0]->transport_type_ == "udp");
+  return gc->instances_[0]->transport_type_ != "udp";
 }
 
 void append(DDS::PropertySeq& props, const char* name, const char* value, bool propagate = false)
@@ -59,7 +57,7 @@ void append(DDS::PropertySeq& props, const char* name, const char* value, bool p
   props[len] = prop;
 }
 
-int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
   int status = EXIT_SUCCESS;
   DDS::DomainParticipantFactory_var dpf;
@@ -84,37 +82,39 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       append(props, "OpenDDS.RtpsRelay.Groups", "Messenger", true);
 
 #ifdef OPENDDS_SECURITY
+      using OpenDDS::DCPS::String;
       // Determine the path to the keys
-      OPENDDS_STRING path_to_tests;
+      String path_to_tests;
       const char* dds_root = ACE_OS::getenv("DDS_ROOT");
       if (dds_root && dds_root[0]) {
         // Use DDS_ROOT in case we are one of the CMake tests
-        path_to_tests = OPENDDS_STRING("file:") + dds_root + "/tests/";
+        path_to_tests = String("file:") + dds_root + "/tests/";
       } else {
         // Else if DDS_ROOT isn't defined try to do it relative to the traditional location
         path_to_tests = "file:../../";
       }
-      const OPENDDS_STRING auth_ca_file = path_to_tests + auth_ca_file_from_tests;
-      const OPENDDS_STRING perm_ca_file = path_to_tests + perm_ca_file_from_tests;
-      const OPENDDS_STRING id_cert_file = path_to_tests + id_cert_file_from_tests;
-      const OPENDDS_STRING id_key_file = path_to_tests + id_key_file_from_tests;
+      const String auth_ca_file = path_to_tests + auth_ca_file_from_tests;
+      const String perm_ca_file = path_to_tests + perm_ca_file_from_tests;
+      const String id_cert_file = path_to_tests + id_cert_file_from_tests;
+      const String id_key_file = path_to_tests + id_key_file_from_tests;
       if (TheServiceParticipant->get_security()) {
-        append(props, DDS::Security::Properties::AuthIdentityCA, auth_ca_file.c_str());
-        append(props, DDS::Security::Properties::AuthIdentityCertificate, id_cert_file.c_str());
-        append(props, DDS::Security::Properties::AuthPrivateKey, id_key_file.c_str());
-        append(props, DDS::Security::Properties::AccessPermissionsCA, perm_ca_file.c_str());
-        append(props, DDS::Security::Properties::AccessGovernance, governance_file);
-        append(props, DDS::Security::Properties::AccessPermissions, permissions_file);
+        using namespace DDS::Security::Properties;
+        append(props, AuthIdentityCA, auth_ca_file.c_str());
+        append(props, AuthIdentityCertificate, id_cert_file.c_str());
+        append(props, AuthPrivateKey, id_key_file.c_str());
+        append(props, AccessPermissionsCA, perm_ca_file.c_str());
+        append(props, AccessGovernance, governance_file);
+        append(props, AccessPermissions, permissions_file);
       }
 #endif
 
       // Create DomainParticipant
-      participant = dpf->create_participant(4,
+      participant =
+        dpf->create_participant(4,
                                 part_qos,
                                 DDS::DomainParticipantListener::_nil(),
                                 OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-      if (CORBA::is_nil(participant.in())) {
+      if (!participant) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%N:%l: main()")
                           ACE_TEXT(" ERROR: create_participant failed!\n")),
@@ -124,7 +124,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       // Register TypeSupport (Messenger::Message)
       Messenger::MessageTypeSupport_var mts =
         new Messenger::MessageTypeSupportImpl();
-
       if (mts->register_type(participant.in(), "") != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%N:%l: main()")
@@ -140,8 +139,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                                   TOPIC_QOS_DEFAULT,
                                   DDS::TopicListener::_nil(),
                                   OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-      if (CORBA::is_nil(topic.in())) {
+      if (!topic) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%N:%l: main()")
                           ACE_TEXT(" ERROR: create_topic failed!\n")),
@@ -153,8 +151,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         participant->create_publisher(PUBLISHER_QOS_DEFAULT,
                                       DDS::PublisherListener::_nil(),
                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-      if (CORBA::is_nil(pub.in())) {
+      if (!pub) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%N:%l: main()")
                           ACE_TEXT(" ERROR: create_publisher failed!\n")),
@@ -175,8 +172,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                                qos,
                                DDS::DataWriterListener::_nil(),
                                OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-      if (CORBA::is_nil(dw.in())) {
+      if (!dw) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%N:%l: main()")
                           ACE_TEXT(" ERROR: create_datawriter failed!\n")),
@@ -200,7 +196,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       if (dw_reliable()) {
         std::cout << "Writer wait for ACKS" << std::endl;
 
-        DDS::Duration_t timeout =
+        const DDS::Duration_t timeout =
           { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
         dw->wait_for_acknowledgments(timeout);
       } else {

--- a/tests/DCPS/Messenger/run_test.pl
+++ b/tests/DCPS/Messenger/run_test.pl
@@ -2,8 +2,6 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
     & eval 'exec perl -S $0 $argv:q'
     if 0;
 
-# -*- perl -*-
-
 my @original_ARGV = @ARGV;
 
 use Env (DDS_ROOT);
@@ -145,5 +143,4 @@ $test->start_process("publisher");
 
 # ignore this issue that is already being tracked in redmine
 $test->ignore_error("(Redmine Issue# 1446)");
-# start killing processes in 300 seconds
 exit $test->finish(120);

--- a/tests/DCPS/Messenger/stack_subscriber.cpp
+++ b/tests/DCPS/Messenger/stack_subscriber.cpp
@@ -1,33 +1,30 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
-
-#include <dds/DdsDcpsInfrastructureC.h>
-#include <dds/DCPS/Marked_Default_Qos.h>
-#include <dds/DCPS/Service_Participant.h>
-#include <dds/DCPS/SubscriberImpl.h>
-#include <dds/DCPS/WaitSet.h>
-
-#include "dds/DCPS/StaticIncludes.h"
-#if defined ACE_AS_STATIC_LIBS && !defined OPENDDS_SAFETY_PROFILE
-#include <dds/DCPS/transport/udp/Udp.h>
-#include <dds/DCPS/transport/multicast/Multicast.h>
-#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
-#endif
-
-#include <cstdlib>
 
 #include "DataReaderListener.h"
 #include "MessengerTypeSupportImpl.h"
 #include "Args.h"
 
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/SubscriberImpl.h>
+#include <dds/DCPS/WaitSet.h>
+#include <dds/DCPS/StaticIncludes.h>
+#if defined ACE_AS_STATIC_LIBS && !defined OPENDDS_SAFETY_PROFILE
+#  include <dds/DCPS/transport/udp/Udp.h>
+#  include <dds/DCPS/transport/multicast/Multicast.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+#include <dds/DdsDcpsInfrastructureC.h>
+
+#include <cstdlib>
+
 bool reliable = false;
 
-int
-ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
   int status = EXIT_SUCCESS;
 
@@ -46,8 +43,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                               PARTICIPANT_QOS_DEFAULT,
                               DDS::DomainParticipantListener::_nil(),
                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(participant.in())) {
+    if (!participant) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_participant() failed!\n")),
@@ -57,7 +53,6 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     // Register Type (Messenger::Message)
     Messenger::MessageTypeSupport_var ts =
       new Messenger::MessageTypeSupportImpl();
-
     if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
@@ -72,8 +67,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                                 TOPIC_QOS_DEFAULT,
                                 DDS::TopicListener::_nil(),
                                 OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(topic.in())) {
+    if (!topic) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_topic() failed!\n")),
@@ -85,8 +79,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT,
                                      DDS::SubscriberListener::_nil(),
                                      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(sub.in())) {
+    if (!sub) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_subscriber() failed!\n")),
@@ -101,8 +94,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                              DATAREADER_QOS_DEFAULT,
                              &listener,
                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(reader.in())) {
+    if (!reader) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_datareader() failed!\n")),
@@ -116,7 +108,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     DDS::WaitSet_var ws = new DDS::WaitSet;
     ws->attach_condition(condition);
 
-    DDS::Duration_t timeout =
+    const DDS::Duration_t timeout =
       { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
 
     DDS::ConditionSeq conditions;

--- a/tests/DCPS/Messenger/subscriber.cpp
+++ b/tests/DCPS/Messenger/subscriber.cpp
@@ -1,44 +1,36 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
+#include "DataReaderListener.h"
+#include "MessengerTypeSupportImpl.h"
+#include "Args.h"
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/SubscriberImpl.h>
 #include <dds/DCPS/WaitSet.h>
-
-#include "dds/DCPS/StaticIncludes.h"
+#ifdef OPENDDS_SECURITY
+#  include <dds/DCPS/security/framework/Properties.h>
+#endif
+#include <dds/DCPS/StaticIncludes.h>
 #ifdef ACE_AS_STATIC_LIBS
-# ifndef OPENDDS_SAFETY_PROFILE
-#include <dds/DCPS/transport/udp/Udp.h>
-#include <dds/DCPS/transport/multicast/Multicast.h>
-#include <dds/DCPS/RTPS/RtpsDiscovery.h>
-#include <dds/DCPS/transport/shmem/Shmem.h>
-#  ifdef OPENDDS_SECURITY
-#  include "dds/DCPS/security/BuiltInPlugins.h"
+#  ifndef OPENDDS_SAFETY_PROFILE
+#    include <dds/DCPS/transport/udp/Udp.h>
+#    include <dds/DCPS/transport/multicast/Multicast.h>
+#    include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#    include <dds/DCPS/transport/shmem/Shmem.h>
+#    ifdef OPENDDS_SECURITY
+#      include <dds/DCPS/security/BuiltInPlugins.h>
+#    endif
 #  endif
-# endif
-#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #endif
 
-#include <dds/DCPS/transport/framework/TransportRegistry.h>
-#include <dds/DCPS/transport/framework/TransportConfig.h>
-#include <dds/DCPS/transport/framework/TransportInst.h>
-
 #include <cstdlib>
-
-#include "DataReaderListener.h"
-#include "MessengerTypeSupportImpl.h"
-#include "Args.h"
-
 #ifdef OPENDDS_SECURITY
-#include <dds/DCPS/security/framework/Properties.h>
-
 const char auth_ca_file_from_tests[] = "security/certs/identity/identity_ca_cert.pem";
 const char perm_ca_file_from_tests[] = "security/certs/permissions/permissions_ca_cert.pem";
 const char id_cert_file_from_tests[] = "security/certs/identity/test_participant_02_cert.pem";
@@ -57,8 +49,7 @@ void append(DDS::PropertySeq& props, const char* name, const char* value, bool p
   props[len] = prop;
 }
 
-int
-ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
   int status = EXIT_SUCCESS;
 
@@ -78,27 +69,29 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     append(props, "OpenDDS.RtpsRelay.Groups", "Messenger", true);
 
 #ifdef OPENDDS_SECURITY
+    using OpenDDS::DCPS::String;
     // Determine the path to the keys
-    OPENDDS_STRING path_to_tests;
+    String path_to_tests;
     const char* dds_root = ACE_OS::getenv("DDS_ROOT");
     if (dds_root && dds_root[0]) {
       // Use DDS_ROOT in case we are one of the CMake tests
-      path_to_tests = OPENDDS_STRING("file:") + dds_root + "/tests/";
+      path_to_tests = String("file:") + dds_root + "/tests/";
     } else {
       // Else if DDS_ROOT isn't defined try to do it relative to the traditional location
       path_to_tests = "file:../../";
     }
-    const OPENDDS_STRING auth_ca_file = path_to_tests + auth_ca_file_from_tests;
-    const OPENDDS_STRING perm_ca_file = path_to_tests + perm_ca_file_from_tests;
-    const OPENDDS_STRING id_cert_file = path_to_tests + id_cert_file_from_tests;
-    const OPENDDS_STRING id_key_file = path_to_tests + id_key_file_from_tests;
+    const String auth_ca_file = path_to_tests + auth_ca_file_from_tests;
+    const String perm_ca_file = path_to_tests + perm_ca_file_from_tests;
+    const String id_cert_file = path_to_tests + id_cert_file_from_tests;
+    const String id_key_file = path_to_tests + id_key_file_from_tests;
     if (TheServiceParticipant->get_security()) {
-      append(props, DDS::Security::Properties::AuthIdentityCA, auth_ca_file.c_str());
-      append(props, DDS::Security::Properties::AuthIdentityCertificate, id_cert_file.c_str());
-      append(props, DDS::Security::Properties::AuthPrivateKey, id_key_file.c_str());
-      append(props, DDS::Security::Properties::AccessPermissionsCA, perm_ca_file.c_str());
-      append(props, DDS::Security::Properties::AccessGovernance, governance_file);
-      append(props, DDS::Security::Properties::AccessPermissions, permissions_file);
+      using namespace DDS::Security::Properties;
+      append(props, AuthIdentityCA, auth_ca_file.c_str());
+      append(props, AuthIdentityCertificate, id_cert_file.c_str());
+      append(props, AuthPrivateKey, id_key_file.c_str());
+      append(props, AccessPermissionsCA, perm_ca_file.c_str());
+      append(props, AccessGovernance, governance_file);
+      append(props, AccessPermissions, permissions_file);
     }
 #endif
 
@@ -108,8 +101,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                               part_qos,
                               DDS::DomainParticipantListener::_nil(),
                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(participant.in())) {
+    if (!participant) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_participant() failed!\n")),
@@ -119,7 +111,6 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     // Register Type (Messenger::Message)
     Messenger::MessageTypeSupport_var ts =
       new Messenger::MessageTypeSupportImpl();
-
     if (ts->register_type(participant.in(), "") != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
@@ -135,8 +126,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                                 TOPIC_QOS_DEFAULT,
                                 DDS::TopicListener::_nil(),
                                 OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(topic.in())) {
+    if (!topic) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_topic() failed!\n")),
@@ -148,8 +138,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT,
                                      DDS::SubscriberListener::_nil(),
                                      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(sub.in())) {
+    if (!sub) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_subscriber() failed!\n")),
@@ -172,8 +161,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                              dr_qos,
                              listener.in(),
                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-    if (CORBA::is_nil(reader.in())) {
+    if (!reader) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("%N:%l main()")
                         ACE_TEXT(" ERROR: create_datareader() failed!\n")),


### PR DESCRIPTION
Since this test always seems to get copied to make new tests, let's reduce the number of bad habits and anachronisms that will get copied in the future.

- Make includes match guidelines and added missing includes.
- Replaced var `is_nil` checks with straight checks.
- Replaced `OPENDDS_STRING` with `OpenDDS::DCPS::String`.
- Fixed style of function signatures.
- Removed blank lines of copyright notices. I still don't know the
  reason for these.
- Other misc. fixes