### PR TITLE
Removed special case encoding of ReliabilityQosPolicy's kind in SEDP

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -871,18 +871,16 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
   // For interoperability, always write the reliability info
   {
     Parameter param;
-    // Interoperability note:
-    // Spec creators for RTPS have reliability indexed at 1
-    DDS::ReliabilityQosPolicy reliability_copy =
-        writer_data.ddsPublicationData.reliability;
+    ReliabilityQosPolicyRtps reliability;
+    reliability.max_blocking_time = writer_data.ddsPublicationData.reliability.max_blocking_time;
 
-    if (reliability_copy.kind == DDS::BEST_EFFORT_RELIABILITY_QOS) {
-      reliability_copy.kind = (DDS::ReliabilityQosPolicyKind)(RTPS::BEST_EFFORT);
+    if (writer_data.ddsPublicationData.reliability.kind == DDS::BEST_EFFORT_RELIABILITY_QOS) {
+      reliability.kind.value = RTPS::BEST_EFFORT;
     } else { // default to RELIABLE for writers
-      reliability_copy.kind = (DDS::ReliabilityQosPolicyKind)(RTPS::RELIABLE);
+      reliability.kind.value = RTPS::RELIABLE;
     }
 
-    param.reliability(reliability_copy);
+    param.reliability(reliability);
     add_param(param_list, param);
   }
 
@@ -1059,12 +1057,11 @@ bool from_param_list(const ParameterList& param_list,
         normalize(writer_data.ddsPublicationData.liveliness.lease_duration);
         break;
       case PID_RELIABILITY:
-        writer_data.ddsPublicationData.reliability = param.reliability();
+        writer_data.ddsPublicationData.reliability.max_blocking_time = param.reliability().max_blocking_time;
         // Interoperability note:
         // Spec creators for RTPS have reliability indexed at 1
         {
-          const CORBA::Short rtpsKind = static_cast<CORBA::Short>(param.reliability().kind);
-          if (rtpsKind == RTPS::BEST_EFFORT) {
+          if (param.reliability().kind.value == RTPS::BEST_EFFORT) {
             writer_data.ddsPublicationData.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
           } else { // default to RELIABLE for writers
             writer_data.ddsPublicationData.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
@@ -1201,18 +1198,16 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
   // if (not_default(reader_data.ddsSubscriptionData.reliability, false))
   {
     Parameter param;
-    // Interoperability note:
-    // Spec creators for RTPS have reliability indexed at 1
-    DDS::ReliabilityQosPolicy reliability_copy =
-      reader_data.ddsSubscriptionData.reliability;
+    ReliabilityQosPolicyRtps reliability;
+    reliability.max_blocking_time = reader_data.ddsSubscriptionData.reliability.max_blocking_time;
 
-    if (reliability_copy.kind == DDS::RELIABLE_RELIABILITY_QOS) {
-      reliability_copy.kind = (DDS::ReliabilityQosPolicyKind)(RTPS::RELIABLE);
+    if (reader_data.ddsSubscriptionData.reliability.kind == DDS::BEST_EFFORT_RELIABILITY_QOS) {
+      reliability.kind.value = RTPS::RELIABLE;
     } else { // default to BEST_EFFORT for readers
-      reliability_copy.kind = (DDS::ReliabilityQosPolicyKind)(RTPS::BEST_EFFORT);
+      reliability.kind.value = RTPS::BEST_EFFORT;
     }
 
-    param.reliability(reliability_copy);
+    param.reliability(reliability);
     add_param(param_list, param);
   }
 
@@ -1402,11 +1397,11 @@ bool from_param_list(const ParameterList& param_list,
         normalize(reader_data.ddsSubscriptionData.liveliness.lease_duration);
         break;
       case PID_RELIABILITY:
-        reader_data.ddsSubscriptionData.reliability = param.reliability();
+        reader_data.ddsSubscriptionData.reliability.max_blocking_time = param.reliability().max_blocking_time;
         // Interoperability note:
         // Spec creators for RTPS have reliability indexed at 1
         {
-          const CORBA::Short rtpsKind = static_cast<CORBA::Short>(param.reliability().kind);
+          const CORBA::Short rtpsKind = param.reliability().kind.value;
           const CORBA::Short OLD_RELIABLE_VALUE = 3;
           if (rtpsKind == RTPS::RELIABLE || rtpsKind == OLD_RELIABLE_VALUE) {
             reader_data.ddsSubscriptionData.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1201,7 +1201,7 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     ReliabilityQosPolicyRtps reliability;
     reliability.max_blocking_time = reader_data.ddsSubscriptionData.reliability.max_blocking_time;
 
-    if (reader_data.ddsSubscriptionData.reliability.kind == DDS::BEST_EFFORT_RELIABILITY_QOS) {
+    if (reader_data.ddsSubscriptionData.reliability.kind == DDS::RELIABLE_RELIABILITY_QOS) {
       reliability.kind.value = RTPS::RELIABLE;
     } else { // default to BEST_EFFORT for readers
       reliability.kind.value = RTPS::BEST_EFFORT;

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -140,6 +140,11 @@ module OpenDDS {
     const short BEST_EFFORT = 1;
     const short RELIABLE = 2;
 
+    struct ReliabilityQosPolicyRtps {
+      ReliabilityKind_t kind;
+      DDS::Duration_t max_blocking_time;
+    };
+
     struct KeyHash_t {
       DCPS::OctetArray16 value;
     };
@@ -358,7 +363,7 @@ module OpenDDS {
       case PID_LIVELINESS:
         DDS::LivelinessQosPolicy liveliness;
       case PID_RELIABILITY:
-        DDS::ReliabilityQosPolicy reliability;
+        ReliabilityQosPolicyRtps reliability;
       case PID_LIFESPAN:
         DDS::LifespanQosPolicy lifespan;
       case PID_DESTINATION_ORDER:

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -584,7 +584,7 @@ RtpsSampleHeader::populate_inline_qos(
     }
 
     plist[qos_len].reliability(reliability);
-  }  
+  }
   PROCESS_INLINE_QOS(transport_priority, default_dw_qos, qos_data.dw_qos);
   PROCESS_INLINE_QOS(lifespan, default_dw_qos, qos_data.dw_qos);
   PROCESS_INLINE_QOS(destination_order, default_dw_qos, qos_data.dw_qos);

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -570,7 +570,21 @@ RtpsSampleHeader::populate_inline_qos(
   PROCESS_INLINE_QOS(ownership_strength, default_dw_qos, qos_data.dw_qos);
 #endif
   PROCESS_INLINE_QOS(liveliness, default_dw_qos, qos_data.dw_qos);
-  PROCESS_INLINE_QOS(reliability, default_dw_qos, qos_data.dw_qos);
+  if (qos_data.dw_qos.reliability != default_dw_qos.reliability) {
+    const int qos_len = plist.length();
+    plist.length(qos_len + 1);
+
+    ReliabilityQosPolicyRtps reliability;
+    reliability.max_blocking_time = qos_data.dw_qos.reliability.max_blocking_time;
+
+    if (qos_data.dw_qos.reliability.kind == DDS::BEST_EFFORT_RELIABILITY_QOS) {
+      reliability.kind.value = RTPS::BEST_EFFORT;
+    } else { // default to RELIABLE for writers
+      reliability.kind.value = RTPS::RELIABLE;
+    }
+
+    plist[qos_len].reliability(reliability);
+  }  
   PROCESS_INLINE_QOS(transport_priority, default_dw_qos, qos_data.dw_qos);
   PROCESS_INLINE_QOS(lifespan, default_dw_qos, qos_data.dw_qos);
   PROCESS_INLINE_QOS(destination_order, default_dw_qos, qos_data.dw_qos);

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -172,15 +172,11 @@ bool marshal_generator::gen_enum(AST_Enum*, UTL_ScopedName* name,
     insertion.addArg("strm", "Serializer&");
     insertion.addArg("enumval", "const " + cxx + "&");
     insertion.endArgs();
-    if (cxx != DdsNamespace + "ReliabilityQosPolicyKind") {
-      // DDS::ReliabilityQosPolicyKind needs to be able to stream values
-      // that are not valid enum values (see ParameterListConverter::to_param_list())
-      be_global->impl_ <<
-        "    if (CORBA::ULong(enumval) >= " << vals.size() << ") {\n"
-        "      ACE_DEBUG((LM_DEBUG, ACE_TEXT(\"(%P|%t) Invalid enumerated value for " << cxx << " (%u)\\n\"), enumval));\n"
-        "      return false;\n"
-        "    }\n";
-    }
+    be_global->impl_ <<
+      "    if (CORBA::ULong(enumval) >= " << vals.size() << ") {\n"
+      "      ACE_DEBUG((LM_DEBUG, ACE_TEXT(\"(%P|%t) Invalid enumerated value for " << cxx << " (%u)\\n\"), enumval));\n"
+      "      return false;\n"
+      "    }\n";
     be_global->impl_ <<
       "  return strm << static_cast<CORBA::ULong>(enumval);\n";
   }
@@ -192,15 +188,11 @@ bool marshal_generator::gen_enum(AST_Enum*, UTL_ScopedName* name,
     be_global->impl_ <<
       "  CORBA::ULong temp = 0;\n"
       "  if (strm >> temp) {\n";
-    if (cxx != DdsNamespace + "ReliabilityQosPolicyKind") {
-      // DDS::ReliabilityQosPolicyKind needs to be able to stream values
-      // that are not valid enum values (see ParameterListConverter::to_param_list())
-      be_global->impl_ <<
-        "    if (temp >= " << vals.size() << ") {\n"
-        "      strm.set_construction_status(Serializer::ElementConstructionFailure);\n"
-        "      return false;\n"
-        "    }\n";
-    }
+    be_global->impl_ <<
+      "    if (temp >= " << vals.size() << ") {\n"
+      "      strm.set_construction_status(Serializer::ElementConstructionFailure);\n"
+      "      return false;\n"
+      "    }\n";
     be_global->impl_ <<
       "    enumval = static_cast<" << cxx << ">(temp);\n"
       "    return true;\n"

--- a/tests/DCPS/UnitTests/ut_ParameterListConverter.cpp
+++ b/tests/DCPS/UnitTests/ut_ParameterListConverter.cpp
@@ -1595,8 +1595,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
       TEST_ASSERT(to_param_list(writer_data, param_list, true, type_info, map));
       TEST_ASSERT(is_present(param_list, PID_RELIABILITY));
       Parameter param = get(param_list, PID_RELIABILITY);
-      const int reliable_interop = static_cast<int>(RELIABLE_RELIABILITY_QOS) + 1;
-      TEST_ASSERT(static_cast<int>(param.reliability().kind) == reliable_interop);
+      TEST_ASSERT(static_cast<int>(param.reliability().kind.value) == RELIABLE);
       TEST_ASSERT(param.reliability().max_blocking_time.sec == 8);
       TEST_ASSERT(param.reliability().max_blocking_time.nanosec == 100);
     }
@@ -2602,8 +2601,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
       TEST_ASSERT(to_param_list(reader_data, param_list, true, type_info, map));
       TEST_ASSERT(is_present(param_list, PID_RELIABILITY));
       Parameter param = get(param_list, PID_RELIABILITY);
-      const int reliable_interop = static_cast<int>(RELIABLE_RELIABILITY_QOS) + 1;
-      TEST_ASSERT(static_cast<int>(param.reliability().kind) == reliable_interop);
+      TEST_ASSERT(static_cast<int>(param.reliability().kind.value) == RELIABLE);
       TEST_ASSERT(param.reliability().max_blocking_time.sec == 8);
       TEST_ASSERT(param.reliability().max_blocking_time.nanosec == 100);
     }

--- a/tests/DCPS/UnitTests/ut_ParameterListConverter.cpp
+++ b/tests/DCPS/UnitTests/ut_ParameterListConverter.cpp
@@ -1595,7 +1595,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
       TEST_ASSERT(to_param_list(writer_data, param_list, true, type_info, map));
       TEST_ASSERT(is_present(param_list, PID_RELIABILITY));
       Parameter param = get(param_list, PID_RELIABILITY);
-      TEST_ASSERT(static_cast<int>(param.reliability().kind.value) == RELIABLE);
+      TEST_ASSERT(param.reliability().kind.value == RELIABLE);
       TEST_ASSERT(param.reliability().max_blocking_time.sec == 8);
       TEST_ASSERT(param.reliability().max_blocking_time.nanosec == 100);
     }
@@ -2601,7 +2601,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
       TEST_ASSERT(to_param_list(reader_data, param_list, true, type_info, map));
       TEST_ASSERT(is_present(param_list, PID_RELIABILITY));
       Parameter param = get(param_list, PID_RELIABILITY);
-      TEST_ASSERT(static_cast<int>(param.reliability().kind.value) == RELIABLE);
+      TEST_ASSERT(param.reliability().kind.value == RELIABLE);
       TEST_ASSERT(param.reliability().max_blocking_time.sec == 8);
       TEST_ASSERT(param.reliability().max_blocking_time.nanosec == 100);
     }


### PR DESCRIPTION
RTPS spec version 2.3 Table 9.13 has footnote 3 that describes how the "kind" field of ReliabilityQosPolicy needs special treatment. Currently we are reusing the same struct from DCPS inside RTPS Discovery, however this is not necessary (since it goes through ParameterListConverter anyway) and causes problems for XTypes (TryConstruct is putting special-case checks into the code generator).