### PR TITLE
RtpsRelay doesn't log user data

### DIFF
--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -3,6 +3,7 @@
 #include "utility.h"
 
 #include <dds/DdsDcpsCoreTypeSupportImpl.h>
+#include <dds/DCPS/JsonValueWriter.h>
 
 namespace RtpsRelay {
 
@@ -59,7 +60,7 @@ void ParticipantListener::write_sample(const DDS::ParticipantBuiltinTopicData& d
 
   const ParticipantEntry entry(guid, data.user_data);
 
-  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::write_sample add local participant %C\n"), guid_to_string(repoid).c_str()));
+  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::write_sample add local participant %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
   DDS::ReturnCode_t ret = writer_->write(entry, DDS::HANDLE_NIL);
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::write_sample failed to write\n")));

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -2,6 +2,8 @@
 
 #include "utility.h"
 
+#include <dds/DCPS/JsonValueWriter.h>
+
 namespace RtpsRelay {
 
 PublicationListener::PublicationListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
@@ -88,7 +90,7 @@ void PublicationListener::write_sample(const DDS::PublicationBuiltinTopicData& d
     publisher_qos,
   };
 
-  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: PublicationLister::write_sample add local writer %C\n"), guid_to_string(repoid).c_str()));
+  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: PublicationLister::write_sample add local writer %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
   DDS::ReturnCode_t ret = writer_->write(entry, DDS::HANDLE_NIL);
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: PublicationListener::write_sample failed to write\n")));

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -2,6 +2,8 @@
 
 #include "utility.h"
 
+#include <dds/DCPS/JsonValueWriter.h>
+
 namespace RtpsRelay {
 
 SubscriptionListener::SubscriptionListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
@@ -85,7 +87,7 @@ void SubscriptionListener::write_sample(const DDS::SubscriptionBuiltinTopicData&
     subscriber_qos,
   };
 
-  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: SubscriptionListener::write_sample add local reader %C\n"), guid_to_string(repoid).c_str()));
+  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: SubscriptionListener::write_sample add local reader %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
   DDS::ReturnCode_t ret = writer_->write(entry, DDS::HANDLE_NIL);
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: SubscriptionListener::write_sample failed to write\n")));


### PR DESCRIPTION
Problem
-------

Users of the RtpsRelay need a way to correlate DDS guids with
application identifiers stored in user data.

Solution
--------

Log the BuiltinTopicData for discovered participants, publications,
and subscriptions.