### PR TITLE
SingleSendBuffer lacks synchronization

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -241,6 +241,7 @@ SingleSendBuffer::insert(SequenceNumber sequence,
   check_capacity_i(removed);
 
   BufferType& buffer = buffers_[sequence];
+  pre_seq_.erase(sequence);
   insert_buffer(buffer, queue, chain);
 
   if (Transport_debug_level > 5) {
@@ -308,6 +309,7 @@ SingleSendBuffer::insert_fragment(SequenceNumber sequence,
                                       static_cast<ACE_Message_Block*>(0));
 
   BufferType& buffer = fragments_[sequence][fragment];
+  pre_seq_.erase(sequence);
   insert_buffer(buffer, queue, chain);
 
   if (Transport_debug_level > 5) {
@@ -356,6 +358,7 @@ bool
 SingleSendBuffer::resend(const SequenceRange& range, DisjointSequence* gaps)
 {
   ACE_GUARD_RETURN(LockType, guard, strategy_lock(), false);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
   return resend_i(range, gaps);
 }
 
@@ -370,12 +373,12 @@ SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps,
                            const RepoId& destination)
 {
   //Special case, nak to make sure it has all history
-  const SequenceNumber lowForAllResent = range.first == SequenceNumber() ? low() : range.first;
+  if (buffers_.empty()) throw std::exception();
+  const SequenceNumber lowForAllResent = range.first == SequenceNumber() ? buffers_.begin()->first : range.first;
   const bool has_dest = destination != GUID_UNKNOWN;
 
   for (SequenceNumber sequence(range.first);
        sequence <= range.second; ++sequence) {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
     // Re-send requested sample if still buffered; missing samples
     // will be scored against the given DisjointSequence:
     BufferMap::iterator it(buffers_.find(sequence));
@@ -411,11 +414,11 @@ SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps,
     }
   }
   // Have we resent all requested data?
-  return lowForAllResent >= low() && range.second <= high();
+  return lowForAllResent >= buffers_.begin()->first && range.second <= buffers_.rbegin()->first;
 }
 
 void
-SingleSendBuffer::resend_fragments_i(const SequenceNumber& seq,
+SingleSendBuffer::resend_fragments_i(SequenceNumber seq,
                                      const DisjointSequence& requested_frags)
 {
   if (fragments_.empty() || requested_frags.empty()) {

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -185,7 +185,7 @@ public:
 
   private:
     SingleSendBuffer& ssb_;
-    Proxy(Proxy&);
+    OPENDDS_DELETED_COPY_MOVE_CTOR_ASSIGN(Proxy)
   };
 
 private:

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -87,20 +87,6 @@ public:
 
   bool resend(const SequenceRange& range, DisjointSequence* gaps = 0);
 
-  // caller must already have the send strategy lock
-  bool resend_i(const SequenceRange& range, DisjointSequence* gaps = 0);
-  bool resend_i(const SequenceRange& range, DisjointSequence* gaps,
-                const RepoId& destination);
-
-  void resend_fragments_i(const SequenceNumber& sequence,
-                          const DisjointSequence& fragments);
-
-  SequenceNumber low() const;
-  SequenceNumber high() const;
-  bool empty() const;
-  bool contains(const SequenceNumber& seq) const;
-  bool contains(const SequenceNumber& seq, RepoId& destination) const;
-
   void retain_all(const RepoId& pub_id);
   void insert(SequenceNumber sequence,
               TransportSendStrategy::QueueType* queue,
@@ -109,6 +95,98 @@ public:
                        SequenceNumber fragment,
                        TransportSendStrategy::QueueType* queue,
                        ACE_Message_Block* chain);
+
+  void pre_insert(SequenceNumber sequence);
+
+  class Proxy {
+  public:
+    Proxy(SingleSendBuffer& ssb)
+      : ssb_(ssb)
+    {
+      ssb_.mutex_.acquire();
+    }
+
+    ~Proxy()
+    {
+      ssb_.mutex_.release();
+    }
+
+    SequenceNumber low() const
+    {
+      if (ssb_.buffers_.empty()) throw std::exception();
+      return ssb_.buffers_.begin()->first;
+    }
+
+    SequenceNumber high() const
+    {
+      if (ssb_.buffers_.empty()) throw std::exception();
+      return ssb_.buffers_.rbegin()->first;
+    }
+
+    bool empty() const
+    {
+      return ssb_.buffers_.empty();
+    }
+
+    bool contains(SequenceNumber seq) const
+    {
+      return ssb_.buffers_.count(seq);
+    }
+
+    bool contains(SequenceNumber seq, RepoId& destination) const
+    {
+      if (ssb_.buffers_.count(seq)) {
+        DestinationMap::const_iterator pos = ssb_.destinations_.find(seq);
+        destination = pos == ssb_.destinations_.end() ? GUID_UNKNOWN : pos->second;
+        return true;
+      }
+      return false;
+    }
+
+    SequenceNumber pre_low() const
+    {
+      if (ssb_.pre_seq_.empty()) throw std::exception();
+      return *ssb_.pre_seq_.begin();
+    }
+
+    SequenceNumber pre_high() const
+    {
+      if (ssb_.pre_seq_.empty()) throw std::exception();
+      return *ssb_.pre_seq_.rbegin();
+    }
+
+    bool pre_empty() const
+    {
+      return ssb_.pre_seq_.empty();
+    }
+
+    bool pre_contains(SequenceNumber sequence) const
+    {
+      return ssb_.pre_seq_.count(sequence);
+    }
+
+    // caller must already have the send strategy lock
+    bool resend_i(const SequenceRange& range, DisjointSequence* gaps = 0)
+    {
+      return ssb_.resend_i(range, gaps);
+    }
+
+    bool resend_i(const SequenceRange& range, DisjointSequence* gaps,
+                  const RepoId& destination)
+    {
+      return ssb_.resend_i(range, gaps, destination);
+    }
+
+    void resend_fragments_i(SequenceNumber sequence,
+                            const DisjointSequence& fragments)
+    {
+      ssb_.resend_fragments_i(sequence, fragments);
+    }
+
+  private:
+    SingleSendBuffer& ssb_;
+    Proxy(Proxy&);
+  };
 
 private:
   void check_capacity_i(BufferVec& removed);
@@ -119,6 +197,13 @@ private:
   void insert_buffer(BufferType& buffer,
                      TransportSendStrategy::QueueType* queue,
                      ACE_Message_Block* chain);
+
+  // caller must already have the send strategy lock
+  bool resend_i(const SequenceRange& range, DisjointSequence* gaps = 0);
+  bool resend_i(const SequenceRange& range, DisjointSequence* gaps,
+                const RepoId& destination);
+  void resend_fragments_i(SequenceNumber sequence,
+                          const DisjointSequence& fragments);
 
   size_t n_chunks_;
 
@@ -135,7 +220,10 @@ private:
   typedef OPENDDS_MAP(SequenceNumber, RepoId) DestinationMap;
   DestinationMap destinations_;
 
-  ACE_Thread_Mutex mutex_;
+  typedef OPENDDS_SET(SequenceNumber) SequenceNumberSet;
+  SequenceNumberSet pre_seq_;
+
+  mutable ACE_Thread_Mutex mutex_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/TransportSendBuffer.inl
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.inl
@@ -28,45 +28,17 @@ TransportSendBuffer::bind(TransportSendStrategy* strategy)
 ACE_INLINE size_t
 SingleSendBuffer::n_chunks() const
 {
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, this->n_chunks_);
   return this->n_chunks_;
 }
 
-ACE_INLINE SequenceNumber
-SingleSendBuffer::low() const
+ACE_INLINE void
+SingleSendBuffer::pre_insert(SequenceNumber sequence)
 {
-  if (this->buffers_.empty()) throw std::exception();
-  return this->buffers_.begin()->first;
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+  pre_seq_.insert(sequence);
 }
 
-ACE_INLINE SequenceNumber
-SingleSendBuffer::high() const
-{
-  if (this->buffers_.empty()) throw std::exception();
-  return this->buffers_.rbegin()->first;
-}
-
-ACE_INLINE bool
-SingleSendBuffer::empty() const
-{
-  return this->buffers_.empty();
-}
-
-ACE_INLINE bool
-SingleSendBuffer::contains(const SequenceNumber& seq) const
-{
-  return this->buffers_.count(seq);
-}
-
-ACE_INLINE bool
-SingleSendBuffer::contains(const SequenceNumber& seq, RepoId& destination) const
-{
-  if (this->buffers_.count(seq)) {
-    DestinationMap::const_iterator pos = destinations_.find(seq);
-    destination = pos == destinations_.end() ? GUID_UNKNOWN : pos->second;
-    return true;
-  }
-  return false;
-}
 
 } // namespace DCPS
 } // namespace OpenDDS


### PR DESCRIPTION
Problem
-------

1. `max_sn_` and the send buffer are not synchronized.

   `max_sn_` is increased before the corresponding sample is place in
   the send buffer.  Between these two activities, the task for
   sending heartbeats and nack responses may access `max_sn_` and the
   send buffer and send incorrect gaps and heartbeats.

2. Various methods in SingleSendBuffer lacked synchronization.

   An inspection of the send buffer revealed that many methods are not
   synchronized.  Many of these methods are used as a group and need
   to be transactional.

Solution
--------

1. Add missing synchronization to SingleSendBuffer.

2. Introduce a proxy object for the SingleSendBuffer that holds the
   lock.

3. Extend SingleSendBuffer with a set of sequence numbers that will
   eventually be inserted.  Sequence numbers in this set cannot be
   gap'ed.

4. Refactor `send_and_gather_nack_replies` to use the proxy object.