### PR TITLE
add_on_start_callback deadlock

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -673,8 +673,8 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
       }
       RtpsReader_rch reader = rr->second;
       readers_of_writer_.insert(RtpsReaderMultiMap::value_type(remote_id, rr->second));
-      add_on_start_callback(client, remote_id);
       g.release();
+      add_on_start_callback(client, remote_id);
       reader->add_writer(make_rch<WriterInfo>(remote_id, remote_context));
       associated = false;
       enable_replies = true;


### PR DESCRIPTION
Problem
-------

The call to `add_on_start_callback` in RtpsUdpDataLink is protected by
the `readers_lock_`.  `add_on_start_callback` can eventually call
`make_reservation` which requires the same lock.

Solution
--------

Move the call to `add_on_start_callback` out of the scope of the `readers_lock_`.