### PR TITLE
Immediate replies to acknacks leads to shootout

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3618,6 +3618,7 @@ RtpsUdpDataLink::send_heartbeats(const DCPS::MonotonicTimePoint& now)
     typedef OPENDDS_MAP_CMP(RepoId, RepoIdSet, GUID_tKeyLessThan) WtaMap;
     WtaMap writers_to_advertise;
 
+    use_fixed_period |= !interesting_readers_.empty();
     for (InterestingRemoteMapType::iterator pos = interesting_readers_.begin(),
            limit = interesting_readers_.end();
          pos != limit;
@@ -3870,7 +3871,7 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats(OPENDDS_VECTOR(TransportQueueElem
   // Directed, final.
   if (!readers_expecting_heartbeat_.empty()) {
     meta_submessage.sm_.heartbeat_sm().smHeader.flags |= RTPS::FLAG_F;
-    for (ReaderInfoSet::const_iterator pos = readers_expecting_data_.begin(), limit = readers_expecting_data_.end();
+    for (ReaderInfoSet::const_iterator pos = readers_expecting_heartbeat_.begin(), limit = readers_expecting_heartbeat_.end();
          pos != limit; ++pos) {
       const ReaderInfo_rch& reader = *pos;
       if (additional_guids.count(reader->id_) == 0 &&

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -370,6 +370,8 @@ private:
     SNRIS leading_readers_;
     // These readers have sent a nack and are expecting data.
     ReaderInfoSet readers_expecting_data_;
+    // These readers have sent a non-final ack are are expecting a heartbeat.
+    ReaderInfoSet readers_expecting_heartbeat_;
     RcHandle<SingleSendBuffer> send_buff_;
     SequenceNumber max_sn_;
     typedef OPENDDS_SET(TransportQueueElement*) TqeSet;
@@ -435,14 +437,6 @@ private:
                                      MetaSubmessageVec& meta_submessages,
                                      MetaSubmessage& meta_submessage,
                                      const ReaderInfo_rch& reader);
-    void set_heartbeat_final_flag(CORBA::Octet& flags, const ReaderInfo_rch& reader) const
-    {
-      if (is_lagging(reader)) {
-        flags &= (~RTPS::FLAG_F);
-      } else {
-        flags |= RTPS::FLAG_F;
-      }
-    }
 
   public:
     RtpsWriter(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable,


### PR DESCRIPTION
Problem
-------

A heartbeat can elicit an immediate acknack from a reader.  This
acknack in turn could elicit another heartbeat.  This leads to a
downward spiral.

Solution
--------

Resurrect the `readers_expecting_heartbeat_` member and logic to defer
the response to a non-final ack.