### PR TITLE
SporadicTask schedule is on the reliable write path

### DIFF
--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -51,6 +51,7 @@ void ReactorInterceptor::process_command_queue_i()
   state_ = PROCESSING;
   if (!command_queue_.empty()) {
     cq.swap(command_queue_);
+    cq.front()->queue_flushed();
     ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rev_guard(rev_lock);
     for (Queue::const_iterator pos = cq.begin(), limit = cq.end(); pos != limit; ++pos) {
       (*pos)->execute();

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -21,7 +21,7 @@ public:
   explicit SporadicTask(RcHandle<ReactorInterceptor> interceptor)
     : interceptor_(interceptor)
     , scheduled_(false)
-    , last_command_(NONE)
+    , last_command_(SPORADIC_TASK_NONE)
   {
     reactor(interceptor->reactor());
   }
@@ -73,9 +73,9 @@ private:
   WeakRcHandle<ReactorInterceptor> interceptor_;
   bool scheduled_;
   enum {
-    NONE,
-    SCHEDULE,
-    CANCEL
+    SPORADIC_TASK_NONE,
+    SPORADIC_TASK_SCHEDULE,
+    SPORADIC_TASK_CANCEL
   } last_command_;
 
   struct ScheduleCommand : public ReactorInterceptor::Command {
@@ -85,12 +85,12 @@ private:
 
     virtual bool should_execute() const
     {
-      return sporadic_task_->last_command_ != SCHEDULE;
+      return sporadic_task_->last_command_ != SPORADIC_TASK_SCHEDULE;
     }
 
     virtual void will_execute()
     {
-      sporadic_task_->last_command_ = SCHEDULE;
+      sporadic_task_->last_command_ = SPORADIC_TASK_SCHEDULE;
     }
 
     virtual void execute()
@@ -100,7 +100,7 @@ private:
 
     virtual void queue_flushed()
     {
-      sporadic_task_->last_command_ = NONE;
+      sporadic_task_->last_command_ = SPORADIC_TASK_NONE;
     }
 
     SporadicTask* const sporadic_task_;
@@ -114,12 +114,12 @@ private:
 
     virtual bool should_execute() const
     {
-      return sporadic_task_->last_command_ != CANCEL;
+      return sporadic_task_->last_command_ != SPORADIC_TASK_CANCEL;
     }
 
     virtual void will_execute()
     {
-      sporadic_task_->last_command_ = CANCEL;
+      sporadic_task_->last_command_ = SPORADIC_TASK_CANCEL;
     }
 
     virtual void execute()
@@ -129,7 +129,7 @@ private:
 
     virtual void queue_flushed()
     {
-      sporadic_task_->last_command_ = NONE;
+      sporadic_task_->last_command_ = SPORADIC_TASK_NONE;
     }
 
     SporadicTask* const sporadic_task_;

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -21,6 +21,7 @@ public:
   explicit SporadicTask(RcHandle<ReactorInterceptor> interceptor)
     : interceptor_(interceptor)
     , scheduled_(false)
+    , last_command_(NONE)
   {
     reactor(interceptor->reactor());
   }
@@ -56,7 +57,9 @@ public:
     RcHandle<ReactorInterceptor> interceptor = interceptor_.lock();
     if (interceptor) {
       ReactorInterceptor::CommandPtr command = interceptor->execute_or_enqueue(new CancelCommand(this));
-      command->wait();
+      if (command) {
+        command->wait();
+      }
     } else if (DCPS_debug_level >= 1) {
       ACE_ERROR((LM_WARNING,
                  ACE_TEXT("(%P|%t) WARNING: SporadicTask::cancel_and_wait")
@@ -69,15 +72,35 @@ public:
 private:
   WeakRcHandle<ReactorInterceptor> interceptor_;
   bool scheduled_;
+  enum {
+    NONE,
+    SCHEDULE,
+    CANCEL
+  } last_command_;
 
   struct ScheduleCommand : public ReactorInterceptor::Command {
     ScheduleCommand(SporadicTask* hb, const TimeDuration& delay)
       : sporadic_task_(hb), delay_(delay)
     { }
 
+    virtual bool should_execute() const
+    {
+      return sporadic_task_->last_command_ != SCHEDULE;
+    }
+
+    virtual void will_execute()
+    {
+      sporadic_task_->last_command_ = SCHEDULE;
+    }
+
     virtual void execute()
     {
       sporadic_task_->schedule_i(delay_);
+    }
+
+    virtual void queue_flushed()
+    {
+      sporadic_task_->last_command_ = NONE;
     }
 
     SporadicTask* const sporadic_task_;
@@ -89,9 +112,24 @@ private:
       : sporadic_task_(hb)
     { }
 
+    virtual bool should_execute() const
+    {
+      return sporadic_task_->last_command_ != CANCEL;
+    }
+
+    virtual void will_execute()
+    {
+      sporadic_task_->last_command_ = CANCEL;
+    }
+
     virtual void execute()
     {
       sporadic_task_->cancel_i();
+    }
+
+    virtual void queue_flushed()
+    {
+      sporadic_task_->last_command_ = NONE;
     }
 
     SporadicTask* const sporadic_task_;


### PR DESCRIPTION
Problem
-------

Scheduling a SporadicTask is now in the path of writing a reliable
sample.  As the writing thread is not the same as the SporadicTask
thread, the schedule commands will be queued.

Solution
--------

Optimize by not enqueuing a schedule/cancel command when the
previously enqueued command is the same.