### PR TITLE
Minor Bundling Improvements and Logging Cleanup

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -83,6 +83,14 @@ protected:
   /// End Current Transport Header Processing
   virtual void end_transport_header_processing() {}
 
+  class ScopedHeaderProcessing {
+  public:
+    ScopedHeaderProcessing(TransportReceiveStrategy& trs) : trs_(trs) { trs_.begin_transport_header_processing(); }
+    ~ScopedHeaderProcessing() { trs_.end_transport_header_processing(); }
+  private:
+    TransportReceiveStrategy& trs_;
+  };
+
   /// Called when there is a ReceivedDataSample to be delivered.
   virtual void deliver_sample(ReceivedDataSample&  sample,
                               const ACE_INET_Addr& remote_address) = 0;

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -85,7 +85,7 @@ protected:
 
   class ScopedHeaderProcessing {
   public:
-    ScopedHeaderProcessing(TransportReceiveStrategy& trs) : trs_(trs) { trs_.begin_transport_header_processing(); }
+    explicit ScopedHeaderProcessing(TransportReceiveStrategy& trs) : trs_(trs) { trs_.begin_transport_header_processing(); }
     ~ScopedHeaderProcessing() { trs_.end_transport_header_processing(); }
   private:
     TransportReceiveStrategy& trs_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2372,9 +2372,6 @@ RtpsUdpDataLink::disable_response_queue()
 void
 RtpsUdpDataLink::queue_or_send_submessages(MetaSubmessageVec& in)
 {
-  MetaSubmessageVecVec temp;
-  MetaSubmessageVecVec* send = 0;
-
   {
     ACE_GUARD(ACE_Thread_Mutex, g, send_queues_lock_);
 
@@ -2382,16 +2379,14 @@ RtpsUdpDataLink::queue_or_send_submessages(MetaSubmessageVec& in)
     if (it != thread_send_queues_.end()) {
       it->second->push_back(MetaSubmessageVec());
       it->second->back().swap(in);
-    } else {
-      temp.push_back(MetaSubmessageVec());
-      temp.back().swap(in);
-      send = &temp;
+      return;
     }
   }
 
-  if (send) {
-    bundle_and_send_submessages(*send);
-  }
+  MetaSubmessageVecVec temp;
+  temp.push_back(MetaSubmessageVec());
+  temp.back().swap(in);
+  bundle_and_send_submessages(temp);
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1484,13 +1484,11 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
     } else if (writer->recvd_.contains(seq)) {
       if (Transport_debug_level > 5) {
-        GuidConverter wc(src);
-        GuidConverter rc(id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                              ACE_TEXT(" data seq: %q from %C being DROPPED from %C because it's ALREADY received\n"),
                              seq.getValue(),
-                             OPENDDS_STRING(wc).c_str(),
-                             OPENDDS_STRING(rc).c_str()));
+                             LogGuid(src).c_str(),
+                             LogGuid(id_).c_str()));
       }
       link->receive_strategy()->withhold_data_from(id_);
 
@@ -1506,13 +1504,11 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
     } else if (writer->recvd_.disjoint() || writer->recvd_.cumulative_ack() != seq.previous()) {
       if (Transport_debug_level > 5) {
-        GuidConverter wc(src);
-        GuidConverter rc(id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                              ACE_TEXT(" data seq: %q from %C being WITHHELD from %C because it's EXPECTING more data\n"),
                              seq.getValue(),
-                             OPENDDS_STRING(wc).c_str(),
-                             OPENDDS_STRING(rc).c_str()));
+                             LogGuid(src).c_str(),
+                             LogGuid(id_).c_str()));
       }
       const ReceivedDataSample* sample =
         link->receive_strategy()->withhold_data_from(id_);
@@ -1521,13 +1517,11 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
     } else {
       if (Transport_debug_level > 5) {
-        GuidConverter wc(src);
-        GuidConverter rc(id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                              ACE_TEXT(" data seq: %q from %C to %C OK to deliver\n"),
                              seq.getValue(),
-                             OPENDDS_STRING(wc).c_str(),
-                             OPENDDS_STRING(rc).c_str()));
+                             LogGuid(src).c_str(),
+                             LogGuid(id_).c_str()));
       }
       writer->recvd_.insert(seq);
       link->receive_strategy()->do_not_withhold_data_from(id_);
@@ -1535,13 +1529,11 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
   } else {
     if (Transport_debug_level > 5) {
-      GuidConverter wc(src);
-      GuidConverter rc(id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                            ACE_TEXT(" data seq: %q from %C to %C dropped because of unknown writer\n"),
                            to_opendds_seqnum(data.writerSN).getValue(),
-                           OPENDDS_STRING(wc).c_str(),
-                           OPENDDS_STRING(rc).c_str()));
+                           LogGuid(src).c_str(),
+                           LogGuid(id_).c_str()));
     }
     link->receive_strategy()->withhold_data_from(id_);
   }
@@ -2409,7 +2401,7 @@ RtpsUdpDataLink::bundle_and_send_submessages(MetaSubmessageVecVec& meta_submessa
 
   bool has_data = false;
   for (MetaSubmessageVecVec::const_iterator it = meta_submessages.begin(); !has_data && it != meta_submessages.end(); ++it) {
-    has_data |= !it->empty();
+    has_data = !it->empty();
   }
 
   if (!has_data) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1484,13 +1484,13 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
     } else if (writer->recvd_.contains(seq)) {
       if (Transport_debug_level > 5) {
-        GuidConverter writer(src);
-        GuidConverter reader(id_);
+        GuidConverter wc(src);
+        GuidConverter rc(id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                              ACE_TEXT(" data seq: %q from %C being DROPPED from %C because it's ALREADY received\n"),
                              seq.getValue(),
-                             OPENDDS_STRING(writer).c_str(),
-                             OPENDDS_STRING(reader).c_str()));
+                             OPENDDS_STRING(wc).c_str(),
+                             OPENDDS_STRING(rc).c_str()));
       }
       link->receive_strategy()->withhold_data_from(id_);
 
@@ -1498,7 +1498,7 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
       const ReceivedDataSample* sample =
         link->receive_strategy()->withhold_data_from(id_);
       if (Transport_debug_level > 5) {
-        ACE_DEBUG((LM_DEBUG, "RtpsUdpDataLink::process_data_i WITHHOLD %q\n", seq.getValue()));
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) WITHHOLD %q\n", seq.getValue()));
         writer->recvd_.dump();
       }
       writer->held_.insert(std::make_pair(seq, *sample));
@@ -1506,13 +1506,13 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
     } else if (writer->recvd_.disjoint() || writer->recvd_.cumulative_ack() != seq.previous()) {
       if (Transport_debug_level > 5) {
-        GuidConverter writer(src);
-        GuidConverter reader(id_);
+        GuidConverter wc(src);
+        GuidConverter rc(id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                              ACE_TEXT(" data seq: %q from %C being WITHHELD from %C because it's EXPECTING more data\n"),
                              seq.getValue(),
-                             OPENDDS_STRING(writer).c_str(),
-                             OPENDDS_STRING(reader).c_str()));
+                             OPENDDS_STRING(wc).c_str(),
+                             OPENDDS_STRING(rc).c_str()));
       }
       const ReceivedDataSample* sample =
         link->receive_strategy()->withhold_data_from(id_);
@@ -1521,13 +1521,13 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
     } else {
       if (Transport_debug_level > 5) {
-        GuidConverter writer(src);
-        GuidConverter reader(id_);
+        GuidConverter wc(src);
+        GuidConverter rc(id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                              ACE_TEXT(" data seq: %q from %C to %C OK to deliver\n"),
                              seq.getValue(),
-                             OPENDDS_STRING(writer).c_str(),
-                             OPENDDS_STRING(reader).c_str()));
+                             OPENDDS_STRING(wc).c_str(),
+                             OPENDDS_STRING(rc).c_str()));
       }
       writer->recvd_.insert(seq);
       link->receive_strategy()->do_not_withhold_data_from(id_);
@@ -1535,13 +1535,13 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 
   } else {
     if (Transport_debug_level > 5) {
-      GuidConverter writer(src);
-      GuidConverter reader(id_);
+      GuidConverter wc(src);
+      GuidConverter rc(id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::process_data_i(DataSubmessage) -")
                            ACE_TEXT(" data seq: %q from %C to %C dropped because of unknown writer\n"),
                            to_opendds_seqnum(data.writerSN).getValue(),
-                           OPENDDS_STRING(writer).c_str(),
-                           OPENDDS_STRING(reader).c_str()));
+                           OPENDDS_STRING(wc).c_str(),
+                           OPENDDS_STRING(rc).c_str()));
     }
     link->receive_strategy()->withhold_data_from(id_);
   }
@@ -2137,37 +2137,39 @@ namespace {
 #endif
 
 void
-RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVec& meta_submessages, AddrDestMetaSubmessageMap& adr_map)
+RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVecVec& meta_submessages, AddrDestMetaSubmessageMap& adr_map)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
   AddrSet addrs;
   // Sort meta_submessages by address set and destination
-  for (MetaSubmessageVec::iterator it = meta_submessages.begin(); it != meta_submessages.end(); ++it) {
-    const bool directed = it->dst_guid_ != GUID_UNKNOWN;
-    if (directed) {
-      accumulate_addresses(it->from_guid_, it->dst_guid_, addrs, true);
-    } else {
-      addrs = get_addresses_i(it->from_guid_); // This will overwrite, but addrs should always be empty here
-    }
-    for (RepoIdSet::iterator it2 = it->to_guids_.begin(); it2 != it->to_guids_.end(); ++it2) {
-      accumulate_addresses(it->from_guid_, *it2, addrs, directed);
-    }
-    if (addrs.empty()) {
-      continue;
-    }
+  for (MetaSubmessageVecVec::iterator vit = meta_submessages.begin(); vit != meta_submessages.end(); ++vit) {
+    for (MetaSubmessageVec::iterator it = vit->begin(); it != vit->end(); ++it) {
+      const bool directed = it->dst_guid_ != GUID_UNKNOWN;
+      if (directed) {
+        accumulate_addresses(it->from_guid_, it->dst_guid_, addrs, true);
+      } else {
+        addrs = get_addresses_i(it->from_guid_); // This will overwrite, but addrs should always be empty here
+      }
+      for (RepoIdSet::iterator it2 = it->to_guids_.begin(); it2 != it->to_guids_.end(); ++it2) {
+        accumulate_addresses(it->from_guid_, *it2, addrs, directed);
+      }
+      if (addrs.empty()) {
+        continue;
+      }
 
 #ifdef OPENDDS_SECURITY
-    if (local_crypto_handle() != DDS::HANDLE_NIL && separate_message(it->from_guid_.entityId)) {
-      addrs.insert(BUNDLING_PLACEHOLDER); // removed in bundle_mapped_meta_submessages
-    }
+      if (local_crypto_handle() != DDS::HANDLE_NIL && separate_message(it->from_guid_.entityId)) {
+        addrs.insert(BUNDLING_PLACEHOLDER); // removed in bundle_mapped_meta_submessages
+      }
 #endif
 
-    if (std::memcmp(&(it->dst_guid_.guidPrefix), &GUIDPREFIX_UNKNOWN, sizeof(GuidPrefix_t)) != 0) {
-      adr_map[addrs][make_unknown_guid(it->dst_guid_.guidPrefix)].push_back(it);
-    } else {
-      adr_map[addrs][GUID_UNKNOWN].push_back(it);
+      if (std::memcmp(&(it->dst_guid_.guidPrefix), &GUIDPREFIX_UNKNOWN, sizeof(GuidPrefix_t)) != 0) {
+        adr_map[addrs][make_unknown_guid(it->dst_guid_.guidPrefix)].push_back(it);
+      } else {
+        adr_map[addrs][GUID_UNKNOWN].push_back(it);
+      }
+      addrs.clear();
     }
-    addrs.clear();
   }
 }
 
@@ -2378,16 +2380,20 @@ RtpsUdpDataLink::disable_response_queue()
 void
 RtpsUdpDataLink::queue_or_send_submessages(MetaSubmessageVec& in)
 {
-  MetaSubmessageVec* send = 0;
+  MetaSubmessageVecVec temp;
+  MetaSubmessageVecVec* send = 0;
 
   {
     ACE_GUARD(ACE_Thread_Mutex, g, send_queues_lock_);
 
     ThreadSendQueueMap::iterator it = thread_send_queues_.find(ACE_Thread::self());
     if (it != thread_send_queues_.end()) {
-      it->second->insert(it->second->end(), in.begin(), in.end());
+      it->second->push_back(MetaSubmessageVec());
+      it->second->back().swap(in);
     } else {
-      send = &in;
+      temp.push_back(MetaSubmessageVec());
+      temp.back().swap(in);
+      send = &temp;
     }
   }
 
@@ -2397,11 +2403,16 @@ RtpsUdpDataLink::queue_or_send_submessages(MetaSubmessageVec& in)
 }
 
 void
-RtpsUdpDataLink::bundle_and_send_submessages(MetaSubmessageVec& meta_submessages)
+RtpsUdpDataLink::bundle_and_send_submessages(MetaSubmessageVecVec& meta_submessages)
 {
   using namespace RTPS;
 
-  if (meta_submessages.empty()) {
+  bool has_data = false;
+  for (MetaSubmessageVecVec::const_iterator it = meta_submessages.begin(); !has_data && it != meta_submessages.end(); ++it) {
+    has_data |= !it->empty();
+  }
+
+  if (!has_data) {
     return;
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -285,6 +285,7 @@ private:
     }
   };
   typedef OPENDDS_VECTOR(MetaSubmessage) MetaSubmessageVec;
+  typedef OPENDDS_VECTOR(MetaSubmessageVec) MetaSubmessageVecVec;
 
   // RTPS reliability support for local writers:
 
@@ -596,7 +597,7 @@ private:
     IdCountSet nackfrag_counts_;
   };
 
-  void build_meta_submessage_map(MetaSubmessageVec& meta_submessages, AddrDestMetaSubmessageMap& adr_map);
+  void build_meta_submessage_map(MetaSubmessageVecVec& meta_submessages, AddrDestMetaSubmessageMap& adr_map);
   void bundle_mapped_meta_submessages(
     const Encoding& encoding,
     AddrDestMetaSubmessageMap& adr_map,
@@ -606,9 +607,9 @@ private:
                                CountKeeper& counts);
 
   void queue_or_send_submessages(MetaSubmessageVec& meta_submessages);
-  void bundle_and_send_submessages(MetaSubmessageVec& meta_submessages);
+  void bundle_and_send_submessages(MetaSubmessageVecVec& meta_submessages);
 
-  struct SubmessageQueue: RcObject, MetaSubmessageVec {
+  struct SubmessageQueue: RcObject, MetaSubmessageVecVec {
   };
   typedef RcHandle<SubmessageQueue> SubmessageQueue_rch;
 


### PR DESCRIPTION
The current implementation of thread queuing for sending bundled RTPS submessages uses copy-based insertion and doesn't leverage the fact that the calling context no longer needs access to the created RTPS submessages. Without full support for C++11, one potential avenue for improvement come from using std::vector's swap method to avoid the unnecessary copy.

In addition, make use of a scoped object for controlling begin / end of thread queuing for ease of use and maintainability.

And lastly, a bit of logging cleanup to avoid shadowing certain variables and to make log message formats consistent.