### PR TITLE
Github Actions Update + Migration from Azure/Jenkins

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,7 +29,7 @@ env:
   TRIGGERING_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
-  ACE_TAO_ubuntu-18_04_i0_java12_nojson:
+  ACE_TAO_u18_i0_xer0_js0_j12:
 
     runs-on: ubuntu-18.04
 
@@ -93,11 +93,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_i0_java12_nojson:
+  build_u18_i0_xer0_js0_j12:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_i0_java12_nojson
+    needs: ACE_TAO_u18_i0_xer0_js0_j12
 
     steps:
     - name: checkout MPC
@@ -114,13 +114,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_i0_java12_nojson_artifact
+        name: ACE_TAO_u18_i0_xer0_js0_j12_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_i0_java12_nojson.tar.xz
+        tar xvfJ ACE_TAO_u18_i0_xer0_js0_j12.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -165,104 +165,104 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_i0_java12_nojson:
+  # test_u18_i0_xer0_js0_j12:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_i0_java12_nojson
+  #   needs: build_u18_i0_xer0_js0_j12
 
-    steps:
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_i0_java12_nojson_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_i0_java12_nojson.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_i0_java12_nojson_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_i0_java12_nojson.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config CXX11 -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_i0_xer0_js0_j12_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_i0_xer0_js0_j12.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_i0_xer0_js0_j12_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_i0_xer0_js0_j12.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config CXX11 -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_o1d0n1_java12:
+  ACE_TAO_u18_o1d0v1_xer0_j12:
 
     runs-on: ubuntu-18.04
 
@@ -326,11 +326,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_o1d0n1_java12:
+  build_u18_o1d0v1_xer0_j12:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_o1d0n1_java12
+    needs: ACE_TAO_u18_o1d0v1_xer0_j12
 
     steps:
     - name: checkout MPC
@@ -347,13 +347,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_o1d0n1_java12_artifact
+        name: ACE_TAO_u18_o1d0v1_xer0_j12_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_o1d0n1_java12.tar.xz
+        tar xvfJ ACE_TAO_u18_o1d0v1_xer0_j12.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -398,11 +398,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_o1d0n1_java12:
+  test_u18_o1d0v1_xer0_j12:
 
     runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_o1d0n1_java12
+    needs: build_u18_o1d0v1_xer0_j12
 
     steps:
     - name: checkout MPC
@@ -424,13 +424,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_o1d0n1_java12_artifact
+        name: ACE_TAO_u18_o1d0v1_xer0_j12_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_o1d0n1_java12.tar.xz
+        tar xvfJ ACE_TAO_u18_o1d0v1_xer0_j12.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -439,13 +439,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-18_04_o1d0n1_java12_artifact
+        name: build_u18_o1d0v1_xer0_j12_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_o1d0n1_java12.tar.xz
+        tar xvfJ build_u18_o1d0v1_xer0_j12.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -495,7 +495,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_ubuntu-18_04_esafety_nojson:
+  # ACE_TAO_u18_esafe_js0:
 
   #   runs-on: ubuntu-18.04
 
@@ -562,11 +562,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_ubuntu-18_04_esafety_nojson:
+  # build_u18_esafe_js0:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: ACE_TAO_ubuntu-18_04_esafety_nojson
+  #   needs: ACE_TAO_u18_esafe_js0
 
   #   steps:
   #   - name: install xerces
@@ -585,13 +585,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
+  #       name: ACE_TAO_u18_esafe_js0_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
+  #       tar xvfJ ACE_TAO_u18_esafe_js0.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -629,11 +629,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_ubuntu-18_04_esafety_nojson:
+  # test_u18_esafe_js0:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: build_ubuntu-18_04_esafety_nojson
+  #   needs: build_u18_esafe_js0
 
   #   steps:
   #   - name: install xerces
@@ -657,13 +657,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
+  #       name: ACE_TAO_u18_esafe_js0_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
+  #       tar xvfJ ACE_TAO_u18_esafe_js0.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -672,13 +672,13 @@ jobs:
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_ubuntu-18_04_esafety_nojson_artifact
+  #       name: build_u18_esafe_js0_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_ubuntu-18_04_esafety_nojson.tar.xz
+  #       tar xvfJ build_u18_esafe_js0.tar.xz
   #   - name: check build configuration
   #     shell: bash
   #     run: |
@@ -728,7 +728,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   # #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit:
+  # ACE_TAO_u18_bsafe_js0_FM-1f:
 
   #   runs-on: ubuntu-18.04
 
@@ -795,11 +795,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_ubuntu-18_04_bsafety_nojson_nobit:
+  # build_u18_bsafe_js0_FM-1f:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit
+  #   needs: ACE_TAO_u18_bsafe_js0_FM-1f
 
   #   steps:
   #   - name: install xerces
@@ -818,13 +818,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
+  #       name: ACE_TAO_u18_bsafe_js0_FM-1f_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+  #       tar xvfJ ACE_TAO_u18_bsafe_js0_FM-1f.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -862,11 +862,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_ubuntu-18_04_bsafety_nojson_nobit:
+  # test_u18_bsafe_js0_FM-1f:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: build_ubuntu-18_04_bsafety_nojson_nobit
+  #   needs: build_u18_bsafe_js0_FM-1f
 
   #   steps:
   #   - name: install xerces
@@ -890,13 +890,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
+  #       name: ACE_TAO_u18_bsafe_js0_FM-1f_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+  #       tar xvfJ ACE_TAO_u18_bsafe_js0_FM-1f.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -905,13 +905,13 @@ jobs:
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_ubuntu-18_04_bsafety_nojson_nobit_artifact
+  #       name: build_u18_bsafe_js0_FM-1f_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+  #       tar xvfJ build_u18_bsafe_js0_FM-1f.tar.xz
   #   - name: check build configuration
   #     shell: bash
   #     run: |
@@ -961,7 +961,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_security_wofeatures:
+  ACE_TAO_u18_d0i0v1_sec_js0_FM-06:
 
     runs-on: ubuntu-18.04
 
@@ -1028,11 +1028,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_security_wofeatures:
+  build_u18_d0i0v1_sec_js0_FM-06:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_security_wofeatures
+    needs: ACE_TAO_u18_d0i0v1_sec_js0_FM-06
 
     steps:
     - name: install xerces
@@ -1051,13 +1051,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_security_wofeatures_artifact
+        name: ACE_TAO_u18_d0i0v1_sec_js0_FM-06_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_security_wofeatures.tar.xz
+        tar xvfJ ACE_TAO_u18_d0i0v1_sec_js0_FM-06.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1095,11 +1095,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_security_wofeatures:
+  test_u18_d0i0v1_sec_js0_FM-06:
 
     runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_security_wofeatures
+    needs: build_u18_d0i0v1_sec_js0_FM-06
 
     steps:
     - name: install xerces
@@ -1123,13 +1123,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_security_wofeatures_artifact
+        name: ACE_TAO_u18_d0i0v1_sec_js0_FM-06_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_security_wofeatures.tar.xz
+        tar xvfJ ACE_TAO_u18_d0i0v1_sec_js0_FM-06.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1138,13 +1138,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-18_04_security_wofeatures_artifact
+        name: build_u18_d0i0v1_sec_js0_FM-06_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_security_wofeatures.tar.xz
+        tar xvfJ build_u18_d0i0v1_sec_js0_FM-06.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -1194,7 +1194,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson:
+  ACE_TAO_u18_clang5_i0w1_sec:
 
     runs-on: ubuntu-18.04
 
@@ -1266,11 +1266,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_clang5_i0_wchar_security_nojson:
+  build_u18_clang5_i0w1_sec:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson
+    needs: ACE_TAO_u18_clang5_i0w1_sec
 
     steps:
     - name: install xerces
@@ -1294,13 +1294,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson_artifact
+        name: ACE_TAO_u18_clang5_i0w1_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson.tar.xz
+        tar xvfJ ACE_TAO_u18_clang5_i0w1_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1338,111 +1338,111 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_clang5_i0_wchar_security_nojson:
+  # test_u18_clang5_i0w1_sec:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_clang5_i0_wchar_security_nojson
+  #   needs: build_u18_clang5_i0w1_sec
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: install clang++
-      run: |
-        sudo apt-get install -y clang-5.0
-        sudo update-alternatives \
-          --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_clang5_i0_wchar_security_nojson_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_clang5_i0_wchar_security_nojson.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="clang++"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS  -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: install clang++
+  #     run: |
+  #       sudo apt-get install -y clang-5.0
+  #       sudo update-alternatives \
+  #         --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_clang5_i0w1_sec_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_clang5_i0w1_sec.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_clang5_i0w1_sec_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_clang5_i0w1_sec.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="clang++"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS  -a -l tests/security/security_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_clang10_nojson:
+  ACE_TAO_u18_clang10_sec_js0:
 
     runs-on: ubuntu-18.04
 
@@ -1514,11 +1514,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_clang10_nojson:
+  build_u18_clang10_sec_js0:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_clang10_nojson
+    needs: ACE_TAO_u18_clang10_sec_js0
 
     steps:
     - name: install clang++
@@ -1542,13 +1542,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_clang10_nojson_artifact
+        name: ACE_TAO_u18_clang10_sec_js0_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_clang10_nojson.tar.xz
+        tar xvfJ ACE_TAO_u18_clang10_sec_js0.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1586,111 +1586,111 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_clang10_nojson:
+  # test_u18_clang10_sec_js0:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_clang10_nojson
+  #   needs: build_u18_clang10_sec_js0
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: install clang++
-      run: |
-        sudo apt-get install -y clang-10
-        sudo update-alternatives \
-          --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_clang10_nojson_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_clang10_nojson.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_clang10_nojson_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_clang10_nojson.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="clang++"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SECURITY -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: install clang++
+  #     run: |
+  #       sudo apt-get install -y clang-10
+  #       sudo update-alternatives \
+  #         --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_clang10_sec_js0_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_clang10_sec_js0.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_clang10_sec_js0_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_clang10_sec_js0.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="clang++"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SECURITY -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar:
+  ACE_TAO_u18_gcc6_d0w1_cpp03:
 
     runs-on: ubuntu-18.04
 
@@ -1765,11 +1765,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_gcc6_cpp03_d0_wchar:
+  build_u18_gcc6_d0w1_cpp03:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar
+    needs: ACE_TAO_u18_gcc6_d0w1_cpp03
 
     steps:
     - name: install gcc
@@ -1796,13 +1796,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar_artifact
+        name: ACE_TAO_u18_gcc6_d0w1_cpp03_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar.tar.xz
+        tar xvfJ ACE_TAO_u18_gcc6_d0w1_cpp03.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1840,114 +1840,114 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_gcc6_cpp03_d0_wchar:
+  # test_u18_gcc6_d0w1_cpp03:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_gcc6_cpp03_d0_wchar
+  #   needs: build_u18_gcc6_d0w1_cpp03
 
-    steps:
-    - name: install gcc
-      run: |
-        sudo apt-get install -y gcc-6
-        sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-6 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-6 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-6
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_gcc6_cpp03_d0_wchar_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_gcc6_cpp03_d0_wchar.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config RAPIDJSON -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install gcc
+  #     run: |
+  #       sudo apt-get install -y gcc-6
+  #       sudo update-alternatives \
+  #         --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
+  #         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-6 \
+  #         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-6 \
+  #         --slave /usr/bin/gcov gcov /usr/bin/gcov-6
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_gcc6_d0w1_cpp03_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_gcc6_d0w1_cpp03.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_gcc6_d0w1_cpp03_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_gcc6_d0w1_cpp03.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config RAPIDJSON -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson:
+  ACE_TAO_u18_gcc8_i0_js0_j:
 
     runs-on: ubuntu-18.04
 
@@ -2022,11 +2022,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_gcc8_i0_java_nojson:
+  build_u18_gcc8_i0_js0_j:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson
+    needs: ACE_TAO_u18_gcc8_i0_js0_j
 
     steps:
     - name: install gcc
@@ -2053,13 +2053,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson_artifact
+        name: ACE_TAO_u18_gcc8_i0_js0_j_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson.tar.xz
+        tar xvfJ ACE_TAO_u18_gcc8_i0_js0_j.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2097,114 +2097,114 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_gcc8_i0_java_nojson:
+  # test_u18_gcc8_i0_js0_j:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_gcc8_i0_java_nojson
+  #   needs: build_u18_gcc8_i0_js0_j
 
-    steps:
-    - name: install gcc
-      run: |
-        sudo apt-get install -y gcc-8
-        sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-8 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-8 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-8
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_gcc8_i0_java_nojson_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_gcc8_i0_java_nojson.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install gcc
+  #     run: |
+  #       sudo apt-get install -y gcc-8
+  #       sudo update-alternatives \
+  #         --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+  #         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-8 \
+  #         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-8 \
+  #         --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_gcc8_i0_js0_j_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_gcc8_i0_js0_j.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_gcc8_i0_js0_j_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_gcc8_i0_js0_j.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_gcc10_i0_wchar:
+  ACE_TAO_u18_gcc10_i0w1_xer0:
 
     runs-on: ubuntu-18.04
 
@@ -2276,11 +2276,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_gcc10_i0_wchar:
+  build_u18_gcc10_i0w1_xer0:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_gcc10_i0_wchar
+    needs: ACE_TAO_u18_gcc10_i0w1_xer0
 
     steps:
     - name: install gcc
@@ -2305,13 +2305,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_gcc10_i0_wchar_artifact
+        name: ACE_TAO_u18_gcc10_i0w1_xer0_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_gcc10_i0_wchar.tar.xz
+        tar xvfJ ACE_TAO_u18_gcc10_i0w1_xer0.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2349,112 +2349,112 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_gcc10_i0_wchar:
+  # test_u18_gcc10_i0w1_xer0:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_gcc10_i0_wchar
+  #   needs: build_u18_gcc10_i0w1_xer0
 
-    steps:
-    - name: install gcc
-      run: |
-        sudo apt-get install -y gcc-10
-        sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_gcc10_i0_wchar_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_gcc10_i0_wchar.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_gcc10_i0_wchar_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_gcc10_i0_wchar.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config WCHAR -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install gcc
+  #     run: |
+  #       sudo apt-get install -y gcc-10
+  #       sudo update-alternatives \
+  #         --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+  #         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+  #         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+  #         --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_gcc10_i0w1_xer0_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_gcc10_i0w1_xer0.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_gcc10_i0w1_xer0_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_gcc10_i0w1_xer0.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config WCHAR -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures:
+  # ACE_TAO_u20_gcc10_bsafe_js0_FM-2c:
 
   #   runs-on: ubuntu-20.04
 
@@ -2529,11 +2529,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_ubuntu-20_04_gcc10_bsafety_wofeatures:
+  # build_u20_gcc10_bsafe_js0_FM-2c:
 
   #   runs-on: ubuntu-20.04
 
-  #   needs: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures
+  #   needs: ACE_TAO_u20_gcc10_bsafe_js0_FM-2c
 
   #   steps:
   #   - name: install gcc
@@ -2560,13 +2560,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+  #       name: ACE_TAO_u20_gcc10_bsafe_js0_FM-2c_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+  #       tar xvfJ ACE_TAO_u20_gcc10_bsafe_js0_FM-2c.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -2604,11 +2604,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_ubuntu-20_04_gcc10_bsafety_wofeatures:
+  # test_u20_gcc10_bsafe_js0_FM-2c:
 
   #   runs-on: ubuntu-20.04
 
-  #   needs: build_ubuntu-20_04_gcc10_bsafety_wofeatures
+  #   needs: build_u20_gcc10_bsafe_js0_FM-2c
 
   #   steps:
   #   - name: install gcc
@@ -2640,13 +2640,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+  #       name: ACE_TAO_u20_gcc10_bsafe_js0_FM-2c_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+  #       tar xvfJ ACE_TAO_u20_gcc10_bsafe_js0_FM-2c.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -2655,13 +2655,13 @@ jobs:
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+  #       name: build_u20_gcc10_bsafe_js0_FM-2c_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+  #       tar xvfJ build_u20_gcc10_bsafe_js0_FM-2c.tar.xz
   #   - name: check build configuration
   #     shell: bash
   #     run: |
@@ -2711,7 +2711,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-20_04_java_qt_ws_security:
+  ACE_TAO_u20_j_qt_ws_sec:
 
     runs-on: ubuntu-20.04
 
@@ -2779,11 +2779,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-20_04_java_qt_ws_security:
+  build_u20_j_qt_ws_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_ubuntu-20_04_java_qt_ws_security
+    needs: ACE_TAO_u20_j_qt_ws_sec
 
     steps:
     - name: install xerces
@@ -2806,13 +2806,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_java_qt_ws_security_artifact
+        name: ACE_TAO_u20_j_qt_ws_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_java_qt_ws_security.tar.xz
+        tar xvfJ ACE_TAO_u20_j_qt_ws_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2877,11 +2877,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-20_04_java_qt_ws_security:
+  test_u20_j_qt_ws_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: build_ubuntu-20_04_java_qt_ws_security
+    needs: build_u20_j_qt_ws_sec
 
     steps:
     - name: install xerces
@@ -2905,13 +2905,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_java_qt_ws_security_artifact
+        name: ACE_TAO_u20_j_qt_ws_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_java_qt_ws_security.tar.xz
+        tar xvfJ ACE_TAO_u20_j_qt_ws_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2920,13 +2920,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-20_04_java_qt_ws_security_artifact
+        name: build_u20_j_qt_ws_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-20_04_java_qt_ws_security.tar.xz
+        tar xvfJ build_u20_j_qt_ws_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -2976,7 +2976,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-20_04_ipv6:
+  ACE_TAO_u20_p1:
 
     runs-on: ubuntu-20.04
 
@@ -3043,11 +3043,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-20_04_ipv6_security:
+  build_u20_p1_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_ubuntu-20_04_ipv6
+    needs: ACE_TAO_u20_p1
 
     steps:
     - name: install xerces
@@ -3066,13 +3066,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
+        name: ACE_TAO_u20_p1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
+        tar xvfJ ACE_TAO_u20_p1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3110,11 +3110,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-20_04_ipv6_security:
+  test_u20_p1_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: build_ubuntu-20_04_ipv6_security
+    needs: build_u20_p1_sec
 
     steps:
     - name: install xerces
@@ -3138,13 +3138,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
+        name: ACE_TAO_u20_p1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
+        tar xvfJ ACE_TAO_u20_p1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3153,13 +3153,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-20_04_ipv6_security_artifact
+        name: build_u20_p1_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-20_04_ipv6_security.tar.xz
+        tar xvfJ build_u20_p1_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -3209,11 +3209,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  build_ubuntu-20_04_ipv6_java8_nobit:
+  build_u20_p1_j8_FM-1f:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_ubuntu-20_04_ipv6
+    needs: ACE_TAO_u20_p1
 
     steps:
     - name: install xerces
@@ -3232,13 +3232,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
+        name: ACE_TAO_u20_p1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
+        tar xvfJ ACE_TAO_u20_p1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3303,108 +3303,108 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-20_04_ipv6_java8_nobit:
+  # test_u20_p1_j8_FM-1f:
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    needs: build_ubuntu-20_04_ipv6_java8_nobit
+  #   needs: build_u20_p1_j8_FM-1f
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-20_04_ipv6_java8_nobit_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-20_04_ipv6_java8_nobit.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u20_p1_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u20_p1.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u20_p1_j8_FM-1f_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u20_p1_j8_FM-1f.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # Ubuntu 18.04 - WChar
 
-  ACE_TAO_ubuntu-18_04_wchar:
+  ACE_TAO_u18_w1:
 
     runs-on: ubuntu-18.04
 
@@ -3471,11 +3471,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_wchar_security:
+  build_u18_w1_sec:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_wchar
+    needs: ACE_TAO_u18_w1
 
     steps:
     - name: install xerces
@@ -3494,13 +3494,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_wchar_artifact
+        name: ACE_TAO_u18_w1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
+        tar xvfJ ACE_TAO_u18_w1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3538,11 +3538,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_wchar_security:
+  test_u18_w1_sec:
 
     runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_wchar_security
+    needs: build_u18_w1_sec
 
     steps:
     - name: install xerces
@@ -3566,13 +3566,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_wchar_artifact
+        name: ACE_TAO_u18_w1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
+        tar xvfJ ACE_TAO_u18_w1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3581,13 +3581,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-18_04_wchar_security_artifact
+        name: build_u18_w1_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_wchar_security.tar.xz
+        tar xvfJ build_u18_w1_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -3637,11 +3637,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  build_ubuntu-18_04_wchar_java_nocsp:
+  build_u18_w1_j_FM-2f:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_wchar
+    needs: ACE_TAO_u18_w1
 
     steps:
     - name: install xerces
@@ -3660,13 +3660,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_wchar_artifact
+        name: ACE_TAO_u18_w1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
+        tar xvfJ ACE_TAO_u18_w1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3731,11 +3731,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_wchar_java_nocsp:
+  test_u18_w1_j_FM-2f:
 
     runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_wchar_java_nocsp
+    needs: build_u18_w1_j_FM-2f
 
     steps:
     - name: install xerces
@@ -3759,13 +3759,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_wchar_artifact
+        name: ACE_TAO_u18_w1_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
+        tar xvfJ ACE_TAO_u18_w1.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -3774,13 +3774,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-18_04_wchar_java_nocsp_artifact
+        name: build_u18_w1_j_FM-2f_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_wchar_java_nocsp.tar.xz
+        tar xvfJ build_u18_w1_j_FM-2f.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -3830,7 +3830,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_ubuntu-18_04_static_qt_ws_security:
+  # ACE_TAO_u18_stat_qt_ws_sec:
 
   #   runs-on: ubuntu-18.04
 
@@ -3897,11 +3897,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_ubuntu-18_04_static_qt_ws_security:
+  # build_u18_stat_qt_ws_sec:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: ACE_TAO_ubuntu-18_04_static_qt_ws_security
+  #   needs: ACE_TAO_u18_stat_qt_ws_sec
 
   #   steps:
   #   - name: install xerces
@@ -3924,13 +3924,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-18_04_static_qt_ws_security_artifact
+  #       name: ACE_TAO_u18_stat_qt_ws_sec_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-18_04_static_qt_ws_security.tar.xz
+  #       tar xvfJ ACE_TAO_u18_stat_qt_ws_sec.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -3968,11 +3968,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_ubuntu-18_04_static_qt_ws_security:
+  # test_u18_stat_qt_ws_sec:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: build_ubuntu-18_04_static_qt_ws_security
+  #   needs: build_u18_stat_qt_ws_sec
 
   #   steps:
   #   - name: install xerces
@@ -3996,13 +3996,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_ubuntu-18_04_static_qt_ws_security_artifact
+  #       name: ACE_TAO_u18_stat_qt_ws_sec_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_ubuntu-18_04_static_qt_ws_security.tar.xz
+  #       tar xvfJ ACE_TAO_u18_stat_qt_ws_sec.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -4011,13 +4011,13 @@ jobs:
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_ubuntu-18_04_static_qt_ws_security_artifact
+  #       name: build_u18_stat_qt_ws_sec_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_ubuntu-18_04_static_qt_ws_security.tar.xz
+  #       tar xvfJ build_u18_stat_qt_ws_sec.tar.xz
   #   - name: check build configuration
   #     shell: bash
   #     run: |
@@ -4067,7 +4067,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_defaults_java_nocft:
+  ACE_TAO_u18_j_cft0_FM-37:
 
     runs-on: ubuntu-18.04
 
@@ -4134,11 +4134,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_defaults_java_nocft:
+  build_u18_j_cft0_FM-37:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_defaults_java_nocft
+    needs: ACE_TAO_u18_j_cft0_FM-37
 
     steps:
     - name: install xerces
@@ -4157,13 +4157,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-18_04_defaults_java_nocft_artifact
+        name: ACE_TAO_u18_j_cft0_FM-37_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_defaults_java_nocft.tar.xz
+        tar xvfJ ACE_TAO_u18_j_cft0_FM-37.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -4228,106 +4228,106 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_defaults_java_nocft:
+  # test_u18_j_cft0_FM-37:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_defaults_java_nocft
+  #   needs: build_u18_j_cft0_FM-37
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_defaults_java_nocft_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_defaults_java_nocft.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_defaults_java_nocft_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_defaults_java_nocft.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_u18_j_cft0_FM-37_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_u18_j_cft0_FM-37.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_u18_j_cft0_FM-37_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_u18_j_cft0_FM-37.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_windows-2019_ipv6_static_nojson:
+  # ACE_TAO_w19_p1_stat_js0:
 
   #   runs-on: windows-2019
 
@@ -4403,11 +4403,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_windows-2019_ipv6_static_nojson:
+  # build_w19_p1_stat_js0:
 
   #   runs-on: windows-2019
 
-  #   needs: ACE_TAO_windows-2019_ipv6_static_nojson
+  #   needs: ACE_TAO_w19_p1_stat_js0
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4435,14 +4435,14 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
+  #       name: ACE_TAO_w19_p1_stat_js0_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
-  #       rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+  #       tar xvfJ ACE_TAO_w19_p1_stat_js0.tar.xz
+  #       rm -f ACE_TAO_w19_p1_stat_js0.tar.xz
   #   - uses: ammaraskar/msvc-problem-matcher@0.1
   #   - name: set up msvc env
   #     uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4478,11 +4478,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_windows-2019_ipv6_static_nojson:
+  # test_w19_p1_stat_js0:
 
   #   runs-on: windows-2019
 
-  #   needs: build_windows-2019_ipv6_static_nojson
+  #   needs: build_w19_p1_stat_js0
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4515,25 +4515,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
+  #       name: ACE_TAO_w19_p1_stat_js0_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
-  #       rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+  #       tar xvfJ ACE_TAO_w19_p1_stat_js0.tar.xz
+  #       rm -f ACE_TAO_w19_p1_stat_js0.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_windows-2019_ipv6_static_nojson_artifact
+  #       name: build_w19_p1_stat_js0_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_windows-2019_ipv6_static_nojson.tar.xz
-  #       rm -f build_windows-2019_ipv6_static_nojson.tar.xz
+  #       tar xvfJ build_w19_p1_stat_js0.tar.xz
+  #       rm -f build_w19_p1_stat_js0.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |
@@ -4590,7 +4590,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures:
+  # ACE_TAO_w19_p1_cpp03_stat_FM-08:
 
   #   runs-on: windows-2019
 
@@ -4666,11 +4666,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_windows-2019_ipv6_cpp03_static_wofeatures:
+  # build_w19_p1_cpp03_stat_FM-08:
 
   #   runs-on: windows-2019
 
-  #   needs: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures
+  #   needs: ACE_TAO_w19_p1_cpp03_stat_FM-08
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4698,14 +4698,14 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+  #       name: ACE_TAO_w19_p1_cpp03_stat_FM-08_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-  #       rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #       tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
   #   - uses: ammaraskar/msvc-problem-matcher@0.1
   #   - name: set up msvc env
   #     uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4741,11 +4741,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_windows-2019_ipv6_cpp03_static_wofeatures:
+  # test_w19_p1_cpp03_stat_FM-08:
 
   #   runs-on: windows-2019
 
-  #   needs: build_windows-2019_ipv6_cpp03_static_wofeatures
+  #   needs: build_w19_p1_cpp03_stat_FM-08
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4778,25 +4778,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+  #       name: ACE_TAO_w19_p1_cpp03_stat_FM-08_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-  #       rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #       tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+  #       name: build_w19_p1_cpp03_stat_FM-08_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-  #       rm -f build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #       tar xvfJ build_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       rm -f build_w19_p1_cpp03_stat_FM-08.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |
@@ -4853,7 +4853,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_windows-2019_release_o1_ipv6_security:
+  # ACE_TAO_w19-release_o1p1_sec:
 
   #   runs-on: windows-2019
 
@@ -4929,11 +4929,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # build_windows-2019_release_o1_ipv6_security:
+  # build_w19-release_o1p1_sec:
 
   #   runs-on: windows-2019
 
-  #   needs: ACE_TAO_windows-2019_release_o1_ipv6_security
+  #   needs: ACE_TAO_w19-release_o1p1_sec
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4961,14 +4961,14 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
+  #       name: ACE_TAO_w19-release_o1p1_sec_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
-  #       rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+  #       tar xvfJ ACE_TAO_w19-release_o1p1_sec.tar.xz
+  #       rm -f ACE_TAO_w19-release_o1p1_sec.tar.xz
   #   - uses: ammaraskar/msvc-problem-matcher@0.1
   #   - name: set up msvc env
   #     uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -5011,11 +5011,11 @@ jobs:
   #       name: ${{ github.job }}_artifact
   #       path: ${{ github.job }}.tar.xz
 
-  # test_windows-2019_release_o1_ipv6_security:
+  # test_w19-release_o1p1_sec:
 
   #   runs-on: windows-2019
 
-  #   needs: build_windows-2019_release_o1_ipv6_security
+  #   needs: build_w19-release_o1p1_sec
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -5048,25 +5048,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
+  #       name: ACE_TAO_w19-release_o1p1_sec_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
-  #       rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+  #       tar xvfJ ACE_TAO_w19-release_o1p1_sec.tar.xz
+  #       rm -f ACE_TAO_w19-release_o1p1_sec.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_windows-2019_release_o1_ipv6_security_artifact
+  #       name: build_w19-release_o1p1_sec_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_windows-2019_release_o1_ipv6_security.tar.xz
-  #       rm -f build_windows-2019_release_o1_ipv6_security.tar.xz
+  #       tar xvfJ build_w19-release_o1p1_sec.tar.xz
+  #       rm -f build_w19-release_o1p1_sec.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |
@@ -5123,7 +5123,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_windows-2019_release_java_nobit:
+  ACE_TAO_w19-release_j_FM-1f:
 
     runs-on: windows-2019
 
@@ -5199,11 +5199,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_windows-2019_release_java_nobit:
+  build_w19-release_j_FM-1f:
 
     runs-on: windows-2019
 
-    needs: ACE_TAO_windows-2019_release_java_nobit
+    needs: ACE_TAO_w19-release_j_FM-1f
 
     steps:
     - name: install xerces-c
@@ -5231,14 +5231,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_windows-2019_release_java_nobit_artifact
+        name: ACE_TAO_w19-release_j_FM-1f_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_release_java_nobit.tar.xz
-        rm -f ACE_TAO_windows-2019_release_java_nobit.tar.xz
+        tar xvfJ ACE_TAO_w19-release_j_FM-1f.tar.xz
+        rm -f ACE_TAO_w19-release_j_FM-1f.tar.xz
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -5274,11 +5274,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_windows-2019_release_java_nobit:
+  test_w19-release_j_FM-1f:
 
     runs-on: windows-2019
 
-    needs: build_windows-2019_release_java_nobit
+    needs: build_w19-release_j_FM-1f
 
     steps:
     - name: install xerces-c
@@ -5311,25 +5311,25 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_windows-2019_release_java_nobit_artifact
+        name: ACE_TAO_w19-release_j_FM-1f_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_release_java_nobit.tar.xz
-        rm -f ACE_TAO_windows-2019_release_java_nobit.tar.xz
+        tar xvfJ ACE_TAO_w19-release_j_FM-1f.tar.xz
+        rm -f ACE_TAO_w19-release_j_FM-1f.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_windows-2019_release_java_nobit_artifact
+        name: build_w19-release_j_FM-1f_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_windows-2019_release_java_nobit.tar.xz
-        rm -f build_windows-2019_release_java_nobit.tar.xz
+        tar xvfJ build_w19-release_j_FM-1f.tar.xz
+        rm -f build_w19-release_j_FM-1f.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -5386,7 +5386,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_windows-2016_x86_d0i0:
+  ACE_TAO_w16_x86_d0i0:
 
     runs-on: windows-2016
     steps:
@@ -5463,11 +5463,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_windows-2016_x86_d0i0_security:
+  build_w16_x86_doi0_sec:
 
     runs-on: windows-2016
 
-    needs: ACE_TAO_windows-2016_x86_d0i0
+    needs: ACE_TAO_w16_x86_d0i0
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -5500,14 +5500,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_windows-2016_x86_d0i0_artifact
+        name: ACE_TAO_w16_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
-        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        tar xvfJ ACE_TAO_w16_x86_d0i0.tar.xz
+        rm -f ACE_TAO_w16_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -5551,11 +5551,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_windows-2016_x86_d0i0_security:
+  test_w16_x86_doi0_sec:
 
     runs-on: windows-2016
 
-    needs: build_windows-2016_x86_d0i0_security
+    needs: build_w16_x86_doi0_sec
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -5588,14 +5588,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_windows-2016_x86_d0i0_artifact
+        name: ACE_TAO_w16_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
-        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        tar xvfJ ACE_TAO_w16_x86_d0i0.tar.xz
+        rm -f ACE_TAO_w16_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -5605,14 +5605,14 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_windows-2016_x86_d0i0_security_artifact
+        name: build_w16_x86_doi0_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_windows-2016_x86_d0i0_security.tar.xz
-        rm -f build_windows-2016_x86_d0i0_security.tar.xz
+        tar xvfJ build_w16_x86_doi0_sec.tar.xz
+        rm -f build_w16_x86_doi0_sec.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -5669,11 +5669,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  build_windows-2016_x86_d0i0_java_nobit:
+  build_w16_x86_d0i0_j_FM-1f:
 
     runs-on: windows-2016
 
-    needs: ACE_TAO_windows-2016_x86_d0i0
+    needs: ACE_TAO_w16_x86_d0i0
 
     steps:
     - name: install xerces-c
@@ -5701,14 +5701,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_windows-2016_x86_d0i0_artifact
+        name: ACE_TAO_w16_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
-        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        tar xvfJ ACE_TAO_w16_x86_d0i0.tar.xz
+        rm -f ACE_TAO_w16_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -5752,123 +5752,123 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_windows-2016_x86_d0i0_java_nobit:
+  # test_w16_x86_d0i0_j_FM-1f:
 
-    runs-on: windows-2016
+  #   runs-on: windows-2016
 
-    needs: build_windows-2016_x86_d0i0_java_nobit
+  #   needs: build_w16_x86_d0i0_j_FM-1f
 
-    steps:
-    - name: install xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse xerces-c
-        vcpkgTriplet: x86-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2016_x86_d0i0_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
-        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
-        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-    - name: Move ACE and MPC to C Drive
-      shell: bash
-      run: |
-        mv OpenDDS/ACE_TAO /c/
-        mv MPC /c/
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_windows-2016_x86_d0i0_java_nobit_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_windows-2016_x86_d0i0_java_nobit.tar.xz
-        rm -f build_windows-2016_x86_d0i0_java_nobit.tar.xz
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: create autobuild config
-      shell: bash
-      run: |
-        cd OpenDDS
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        cat config.xml
-    - name: run OpenDDS tests
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ${{ github.job }}_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS\${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse xerces-c
+  #       vcpkgTriplet: x86-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_w16_x86_d0i0_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_w16_x86_d0i0.tar.xz
+  #       rm -f ACE_TAO_w16_x86_d0i0.tar.xz
+  #       find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+  #   - name: Move ACE and MPC to C Drive
+  #     shell: bash
+  #     run: |
+  #       mv OpenDDS/ACE_TAO /c/
+  #       mv MPC /c/
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_w16_x86_d0i0_j_FM-1f_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_w16_x86_d0i0_j_FM-1f.tar.xz
+  #       rm -f build_w16_x86_d0i0_j_FM-1f.tar.xz
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: create autobuild config
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+  #       <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       cat config.xml
+  #   - name: run OpenDDS tests
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS\${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   # macOS 11.0
 
@@ -6305,7 +6305,7 @@ jobs:
 
   # macOS 10.15
 
-  ACE_TAO_macos-10_15_o1d0_security:
+  ACE_TAO_m10_o1d0_sec:
 
     runs-on: macos-10.15
 
@@ -6373,11 +6373,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_macos-10_15_o1d0_security:
+  build_m10_o1d0_sec:
 
     runs-on: macos-10.15
 
-    needs: ACE_TAO_macos-10_15_o1d0_security
+    needs: ACE_TAO_m10_o1d0_sec
 
     steps:
     - name: install xerces-c
@@ -6397,13 +6397,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_macos-10_15_o1d0_security_artifact
+        name: ACE_TAO_m10_o1d0_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_macos-10_15_o1d0_security.tar.xz
+        tar xvfJ ACE_TAO_m10_o1d0_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -6441,11 +6441,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_macos-10_15_o1d0_security:
+  test_m10_o1d0_sec:
 
     runs-on: macos-10.15
 
-    needs: build_macos-10_15_o1d0_security
+    needs: build_m10_o1d0_sec
 
     steps:
     - name: install xerces-c
@@ -6470,13 +6470,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_macos-10_15_o1d0_security_artifact
+        name: ACE_TAO_m10_o1d0_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_macos-10_15_o1d0_security.tar.xz
+        tar xvfJ ACE_TAO_m10_o1d0_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -6485,13 +6485,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_macos-10_15_o1d0_security_artifact
+        name: build_m10_o1d0_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_macos-10_15_o1d0_security.tar.xz
+        tar xvfJ build_m10_o1d0_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -6541,7 +6541,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_macos-10_15_i0_java_no-bit:
+  ACE_TAO_m10_oi0_j_FM-1f:
 
     runs-on: macos-10.15
 
@@ -6610,11 +6610,11 @@ jobs:
         path: ${{ github.job }}.tar.xz
 
 
-  build_macos-10_15_i0_java_no-bit:
+  build_m10_oi0_j_FM-1f:
 
     runs-on: macos-10.15
 
-    needs: ACE_TAO_macos-10_15_i0_java_no-bit
+    needs: ACE_TAO_m10_oi0_j_FM-1f
 
     steps:
     - name: install xerces-c
@@ -6634,13 +6634,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_macos-10_15_i0_java_no-bit_artifact
+        name: ACE_TAO_m10_oi0_j_FM-1f_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_macos-10_15_i0_java_no-bit.tar.xz
+        tar xvfJ ACE_TAO_m10_oi0_j_FM-1f.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -6705,11 +6705,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_macos-10_15_i0_java_no-bit:
+  test_m10_oi0_j_FM-1f:
 
     runs-on: macos-10.15
 
-    needs: build_macos-10_15_i0_java_no-bit
+    needs: build_m10_oi0_j_FM-1f
 
     steps:
     - name: install xerces-c
@@ -6734,13 +6734,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_macos-10_15_i0_java_no-bit_artifact
+        name: ACE_TAO_m10_oi0_j_FM-1f_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_macos-10_15_i0_java_no-bit.tar.xz
+        tar xvfJ ACE_TAO_m10_oi0_j_FM-1f.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -6749,13 +6749,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_macos-10_15_i0_java_no-bit_artifact
+        name: build_m10_oi0_j_FM-1f_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_macos-10_15_i0_java_no-bit.tar.xz
+        tar xvfJ build_m10_oi0_j_FM-1f.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1276,7 +1276,7 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install clang++
-      run: | 
+      run: |
         sudo apt-get install -y clang-5.0
         sudo update-alternatives \
           --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
@@ -1348,7 +1348,7 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install clang++
-      run: | 
+      run: |
         sudo apt-get install -y clang-5.0
         sudo update-alternatives \
           --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
@@ -1696,7 +1696,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-6
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
@@ -1773,7 +1773,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-6
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
@@ -1848,7 +1848,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-6
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
@@ -1953,7 +1953,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-8
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
@@ -2030,7 +2030,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-8
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
@@ -2105,7 +2105,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-8
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
@@ -2210,7 +2210,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-10
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
@@ -2284,7 +2284,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-10
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
@@ -2357,7 +2357,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-10
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
@@ -2460,7 +2460,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-10
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
@@ -2537,7 +2537,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-10
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
@@ -2612,7 +2612,7 @@ jobs:
 
     steps:
     - name: install gcc
-      run: | 
+      run: |
         sudo apt-get install -y gcc-10
         sudo update-alternatives \
           --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
@@ -5481,7 +5481,7 @@ jobs:
       shell: bash
       run: |
         cd vcpkg
-        rm -rf buildtrees downloads 
+        rm -rf buildtrees downloads
         ls -l
 
     - name: checkout MPC

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -495,471 +495,471 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_esafety_nojson:
+  # ACE_TAO_ubuntu-18_04_esafety_nojson:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    steps:
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install xerces
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: build ACE and TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd ACE_TAO/ACE
-        make -j4
-        cd ../TAO
-        make -j4
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  #   steps:
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install xerces
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: build ACE and TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       cd ACE_TAO/ACE
+  #       make -j4
+  #       cd ../TAO
+  #       make -j4
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_esafety_nojson:
+  # build_ubuntu-18_04_esafety_nojson:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_esafety_nojson
+  #   needs: ACE_TAO_ubuntu-18_04_esafety_nojson
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --tests --safety-profile --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        . setenv.sh
-        make -j4
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        rm -rf ACE_TAO
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: configure OpenDDS
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --tests --safety-profile --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - uses: ammaraskar/gcc-problem-matcher@0.1
+  #   - name: build OpenDDS
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       . setenv.sh
+  #       make -j4
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.sh
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_esafety_nojson:
+  # test_ubuntu-18_04_esafety_nojson:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_esafety_nojson
+  #   needs: build_ubuntu-18_04_esafety_nojson
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_esafety_nojson_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_esafety_nojson.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_ubuntu-18_04_esafety_nojson_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_ubuntu-18_04_esafety_nojson.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  # #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  # ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit:
+
+  #   runs-on: ubuntu-18.04
+
+  #   steps:
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install xerces
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: build ACE and TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       cd ACE_TAO/ACE
+  #       make -j4
+  #       cd ../TAO
+  #       make -j4
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
+
+  # build_ubuntu-18_04_bsafety_nojson_nobit:
+
+  #   runs-on: ubuntu-18.04
+
+  #   needs: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit
+
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: configure OpenDDS
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --tests --safety-profile=base --no-rapidjson --no-built-in-topics --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - uses: ammaraskar/gcc-problem-matcher@0.1
+  #   - name: build OpenDDS
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       . setenv.sh
+  #       make -j4
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.sh
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
+
+  # test_ubuntu-18_04_bsafety_nojson_nobit:
+
+  #   runs-on: ubuntu-18.04
+
+  #   needs: build_ubuntu-18_04_bsafety_nojson_nobit
+
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_ubuntu-18_04_bsafety_nojson_nobit_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
-  ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit:
-
-    runs-on: ubuntu-18.04
-
-    steps:
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install xerces
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: build ACE and TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd ACE_TAO/ACE
-        make -j4
-        cd ../TAO
-        make -j4
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
-
-  build_ubuntu-18_04_bsafety_nojson_nobit:
-
-    runs-on: ubuntu-18.04
-
-    needs: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit
-
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --tests --safety-profile=base --no-rapidjson --no-built-in-topics --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        . setenv.sh
-        make -j4
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        rm -rf ACE_TAO
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
-
-  test_ubuntu-18_04_bsafety_nojson_nobit:
-
-    runs-on: ubuntu-18.04
-
-    needs: build_ubuntu-18_04_bsafety_nojson_nobit
-
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_bsafety_nojson_nobit_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   ACE_TAO_ubuntu-18_04_security_wofeatures:
 
@@ -2454,264 +2454,264 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures:
+  # ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures:
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    steps:
-    - name: install gcc
-      run: |
-        sudo apt-get install -y gcc-10
-        sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install xerces
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        ./configure --compiler=g++ --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: build ACE and TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd ACE_TAO/ACE
-        make -j4
-        cd ../TAO
-        make -j4
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  #   steps:
+  #   - name: install gcc
+  #     run: |
+  #       sudo apt-get install -y gcc-10
+  #       sudo update-alternatives \
+  #         --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+  #         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+  #         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+  #         --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install xerces
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --compiler=g++ --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: build ACE and TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       cd ACE_TAO/ACE
+  #       make -j4
+  #       cd ../TAO
+  #       make -j4
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-20_04_gcc10_bsafety_wofeatures:
+  # build_ubuntu-20_04_gcc10_bsafety_wofeatures:
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures
+  #   needs: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures
 
-    steps:
-    - name: install gcc
-      run: |
-        sudo apt-get install -y gcc-10
-        sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --compiler=g++ --safety-profile=base --tests --no-rapidjson --no-content-subscription --no-object-model-profile --no-persistence-profile --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        . setenv.sh
-        make -j4
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS/build/target
-        rm -rf ACE_TAO
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  #   steps:
+  #   - name: install gcc
+  #     run: |
+  #       sudo apt-get install -y gcc-10
+  #       sudo update-alternatives \
+  #         --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+  #         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+  #         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+  #         --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: configure OpenDDS
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --compiler=g++ --safety-profile=base --tests --no-rapidjson --no-content-subscription --no-object-model-profile --no-persistence-profile --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - uses: ammaraskar/gcc-problem-matcher@0.1
+  #   - name: build OpenDDS
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       . setenv.sh
+  #       make -j4
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/build/target
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.sh
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-20_04_gcc10_bsafety_wofeatures:
+  # test_ubuntu-20_04_gcc10_bsafety_wofeatures:
 
-    runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-20.04
 
-    needs: build_ubuntu-20_04_gcc10_bsafety_wofeatures
+  #   needs: build_ubuntu-20_04_gcc10_bsafety_wofeatures
 
-    steps:
-    - name: install gcc
-      run: |
-        sudo apt-get install -y gcc-10
-        sudo update-alternatives \
-          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
-          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
-          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
-          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config OPENDDS_SAFETY_PROFILE -Config RTPS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install gcc
+  #     run: |
+  #       sudo apt-get install -y gcc-10
+  #       sudo update-alternatives \
+  #         --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+  #         --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+  #         --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+  #         --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config OPENDDS_SAFETY_PROFILE -Config RTPS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-20_04_security_qt_ws_security:
+  ACE_TAO_ubuntu-20_04_java_qt_ws_security:
 
     runs-on: ubuntu-20.04
 
@@ -2779,11 +2779,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-20_04_security_qt_ws_security:
+  build_ubuntu-20_04_java_qt_ws_security:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_ubuntu-20_04_security_qt_ws_security
+    needs: ACE_TAO_ubuntu-20_04_java_qt_ws_security
 
     steps:
     - name: install xerces
@@ -2806,13 +2806,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_security_qt_ws_security_artifact
+        name: ACE_TAO_ubuntu-20_04_java_qt_ws_security_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_security_qt_ws_security.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-20_04_java_qt_ws_security.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2877,11 +2877,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-20_04_security_qt_ws_security:
+  test_ubuntu-20_04_java_qt_ws_security:
 
     runs-on: ubuntu-20.04
 
-    needs: build_ubuntu-20_04_security_qt_ws_security
+    needs: build_ubuntu-20_04_java_qt_ws_security
 
     steps:
     - name: install xerces
@@ -2905,13 +2905,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_ubuntu-20_04_security_qt_ws_security_artifact
+        name: ACE_TAO_ubuntu-20_04_java_qt_ws_security_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-20_04_security_qt_ws_security.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-20_04_java_qt_ws_security.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2920,13 +2920,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: build_ubuntu-20_04_security_qt_ws_security_artifact
+        name: build_ubuntu-20_04_java_qt_ws_security_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_ubuntu-20_04_security_qt_ws_security.tar.xz
+        tar xvfJ build_ubuntu-20_04_java_qt_ws_security.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -3830,242 +3830,242 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_ubuntu-18_04_security_qt_ws:
+  # ACE_TAO_ubuntu-18_04_static_qt_ws_security:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    steps:
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install xerces
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: build ACE and TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd ACE_TAO/ACE
-        make -j4
-        cd ../TAO
-        make -j4
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  #   steps:
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install xerces
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: build ACE and TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       cd ACE_TAO/ACE
+  #       make -j4
+  #       cd ../TAO
+  #       make -j4
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-  build_ubuntu-18_04_security_qt_ws:
+  # build_ubuntu-18_04_static_qt_ws_security:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_ubuntu-18_04_security_qt_ws
+  #   needs: ACE_TAO_ubuntu-18_04_static_qt_ws_security
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: install wireshark
-      run: sudo apt-get -y install wireshark-dev
-    - name: install qt
-      run: sudo apt-get -y install qtbase5-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_security_qt_ws_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_security_qt_ws.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --static --qt --wireshark --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j4
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        rm -rf ACE_TAO
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: install wireshark
+  #     run: sudo apt-get -y install wireshark-dev
+  #   - name: install qt
+  #     run: sudo apt-get -y install qtbase5-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-18_04_static_qt_ws_security_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-18_04_static_qt_ws_security.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: configure OpenDDS
+  #     run: |
+  #       cd OpenDDS
+  #       ./configure --static --qt --wireshark --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - uses: ammaraskar/gcc-problem-matcher@0.1
+  #   - name: build OpenDDS
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       make -j4
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.o" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.sh
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-  test_ubuntu-18_04_security_qt_ws:
+  # test_ubuntu-18_04_static_qt_ws_security:
 
-    runs-on: ubuntu-18.04
+  #   runs-on: ubuntu-18.04
 
-    needs: build_ubuntu-18_04_security_qt_ws
+  #   needs: build_ubuntu-18_04_static_qt_ws_security
 
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_ubuntu-18_04_security_qt_ws_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ACE_TAO_ubuntu-18_04_security_qt_ws.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_ubuntu-18_04_security_qt_ws_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_ubuntu-18_04_security_qt_ws.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install xerces
+  #     run: sudo apt-get -y install libxerces-c-dev
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_ubuntu-18_04_static_qt_ws_security_artifact
+  #       path: ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd ACE_TAO
+  #       tar xvfJ ACE_TAO_ubuntu-18_04_static_qt_ws_security.tar.xz
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_ubuntu-18_04_static_qt_ws_security_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_ubuntu-18_04_static_qt_ws_security.tar.xz
+  #   - name: check build configuration
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       tools/scripts/show_build_config.pl
+  #   - name: run OpenDDS tests
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       . setenv.sh
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$DDS_ROOT"/>
+  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   ACE_TAO_ubuntu-18_04_defaults_java_nocft:
 
@@ -4310,7 +4310,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config STATIC -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4327,802 +4327,801 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
+  # ACE_TAO_windows-2019_ipv6_static_nojson:
 
-  ACE_TAO_windows-2019_ipv6_static_nojson:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   steps:
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install openssl-windows & xerces-c
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: set up msvc env
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: ilammy/msvc-dev-cmd@v1.5.0
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       configure --ipv6 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+  #   - name: build ACE & TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ACE_TAO\ACE
+  #       msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+  #       cd ..\TAO
+  #       msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.obj" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-    steps:
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install openssl-windows & xerces-c
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: set up msvc env
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        cd OpenDDS
-        configure --ipv6 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-    - name: build ACE & TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ACE_TAO\ACE
-        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
-        cd ..\TAO
-        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.obj" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  # build_windows-2019_ipv6_static_nojson:
 
-  build_windows-2019_ipv6_static_nojson:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   needs: ACE_TAO_windows-2019_ipv6_static_nojson
 
-    needs: ACE_TAO_windows-2019_ipv6_static_nojson
+  #   steps:
+  #   - name: install openssl-windows & xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+  #       rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+  #   - uses: ammaraskar/msvc-problem-matcher@0.1
+  #   - name: set up msvc env
+  #     uses: ilammy/msvc-dev-cmd@v1.5.0
+  #   - name: configure OpenDDS
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       configure --ipv6 --static --tests --no-rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: build OpenDDS
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.cmd
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-    steps:
-    - name: install openssl-windows & xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
-        rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
-    - uses: ammaraskar/msvc-problem-matcher@0.1
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        configure --ipv6 --static --tests --no-rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        rm -rf ACE_TAO
-        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.cmd
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  # test_windows-2019_ipv6_static_nojson:
 
-  test_windows-2019_ipv6_static_nojson:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   needs: build_windows-2019_ipv6_static_nojson
 
-    needs: build_windows-2019_ipv6_static_nojson
+  #   steps:
+  #   - name: install openssl-windows & xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+  #       rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_windows-2019_ipv6_static_nojson_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_windows-2019_ipv6_static_nojson.tar.xz
+  #       rm -f build_windows-2019_ipv6_static_nojson.tar.xz
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: create autobuild config
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+  #       <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -ExeSubDir Static_Debug -Config STATIC -Config IPV6 -Config RTPS -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       cat config.xml
+  #   - name: run OpenDDS tests
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS\${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-    steps:
-    - name: install openssl-windows & xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
-        rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_windows-2019_ipv6_static_nojson_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_windows-2019_ipv6_static_nojson.tar.xz
-        rm -f build_windows-2019_ipv6_static_nojson.tar.xz
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: create autobuild config
-      shell: bash
-      run: |
-        cd OpenDDS
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -ExeSubDir Static_Debug -Config STATIC -Config IPV6 -Config RTPS -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        cat config.xml
-    - name: run OpenDDS tests
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ${{ github.job }}_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS\${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  # ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures:
 
-  ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   steps:
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install openssl-windows & xerces-c
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: set up msvc env
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: ilammy/msvc-dev-cmd@v1.5.0
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       configure --ipv6 --std=c++03 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+  #   - name: build ACE & TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ACE_TAO\ACE
+  #       msbuild -p:Configuration=Release,Platform=x64 -m ace.sln
+  #       cd ..\TAO
+  #       msbuild -p:Configuration=Release,Platform=x64 -m tao.sln
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.obj" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-    steps:
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install openssl-windows & xerces-c
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: set up msvc env
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        cd OpenDDS
-        configure --ipv6 --std=c++03 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-    - name: build ACE & TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ACE_TAO\ACE
-        msbuild -p:Configuration=Release,Platform=x64 -m ace.sln
-        cd ..\TAO
-        msbuild -p:Configuration=Release,Platform=x64 -m tao.sln
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.obj" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  # build_windows-2019_ipv6_cpp03_static_wofeatures:
 
-  build_windows-2019_ipv6_cpp03_static_wofeatures:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   needs: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures
 
-    needs: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures
+  #   steps:
+  #   - name: install openssl-windows & xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #       rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #   - uses: ammaraskar/msvc-problem-matcher@0.1
+  #   - name: set up msvc env
+  #     uses: ilammy/msvc-dev-cmd@v1.5.0
+  #   - name: configure OpenDDS
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       configure --ipv6 --std=c++03 --static --tests --rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: build OpenDDS
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       msbuild -p:Configuration=Release,Platform=x64 -m DDS.sln
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.cmd
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-    steps:
-    - name: install openssl-windows & xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-        rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-    - uses: ammaraskar/msvc-problem-matcher@0.1
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        configure --ipv6 --std=c++03 --static --tests --rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Release,Platform=x64 -m DDS.sln
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        rm -rf ACE_TAO
-        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.cmd
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  # test_windows-2019_ipv6_cpp03_static_wofeatures:
 
-  test_windows-2019_ipv6_cpp03_static_wofeatures:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   needs: build_windows-2019_ipv6_cpp03_static_wofeatures
 
-    needs: build_windows-2019_ipv6_cpp03_static_wofeatures
+  #   steps:
+  #   - name: install openssl-windows & xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #       rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #       rm -f build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: create autobuild config
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+  #       <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -ExeSubDir Static_Release -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       cat config.xml
+  #   - name: run OpenDDS tests
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS\${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-    steps:
-    - name: install openssl-windows & xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-        rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_windows-2019_ipv6_cpp03_static_wofeatures_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-        rm -f build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: create autobuild config
-      shell: bash
-      run: |
-        cd OpenDDS
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -ExeSubDir Static_Release -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        cat config.xml
-    - name: run OpenDDS tests
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ${{ github.job }}_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS\${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  # ACE_TAO_windows-2019_release_o1_ipv6_security:
 
-  ACE_TAO_windows-2019_release_o1_ipv6_security:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   steps:
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: get ACE_TAO commit
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       export ACE_COMMIT=$(git rev-parse HEAD)
+  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+  #   - name: Cache Artifact
+  #     id: cache-artifact
+  #     uses: actions/cache@v2.1.4
+  #     with:
+  #       path: ${{ github.job }}.tar.xz
+  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+  #   - name: install openssl-windows & xerces-c
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: set up msvc env
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     uses: ilammy/msvc-dev-cmd@v1.5.0
+  #   - name: configure OpenDDS
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       configure --optimize --ipv6 --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+  #   - name: build ACE & TAO
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ACE_TAO\ACE
+  #       msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+  #       cd ..\TAO
+  #       msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+  #   - name: create ACE_TAO tar.xz artifact
+  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+  #       find . -iname "*\.obj" | xargs rm
+  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+  #       xz -3 ../../${{ github.job }}.tar
+  #   - name: upload ACE_TAO artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-    steps:
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: Cache Artifact
-      id: cache-artifact
-      uses: actions/cache@v2.1.4
-      with:
-        path: ${{ github.job }}.tar.xz
-        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: install openssl-windows & xerces-c
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: set up msvc env
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        cd OpenDDS
-        configure --optimize --ipv6 --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-    - name: build ACE & TAO
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ACE_TAO\ACE
-        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
-        cd ..\TAO
-        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
-    - name: create ACE_TAO tar.xz artifact
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-        find . -iname "*\.obj" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-        xz -3 ../../${{ github.job }}.tar
-    - name: upload ACE_TAO artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  # build_windows-2019_release_o1_ipv6_security:
 
-  build_windows-2019_release_o1_ipv6_security:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   needs: ACE_TAO_windows-2019_release_o1_ipv6_security
 
-    needs: ACE_TAO_windows-2019_release_o1_ipv6_security
+  #   steps:
+  #   - name: install openssl-windows & xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+  #       rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+  #   - uses: ammaraskar/msvc-problem-matcher@0.1
+  #   - name: set up msvc env
+  #     uses: ilammy/msvc-dev-cmd@v1.5.0
+  #   - name: configure OpenDDS
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       configure --optimize --ipv6 --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: build OpenDDS
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+  #   - name: gitclean
+  #     shell: bash
+  #     run: |
+  #       touch output.txt
+  #       cd OpenDDS
+  #       git clean -nd -e ext | tee ../output.txt
+  #       if [ -s ../output.txt ]; then exit 1; fi
+  #   - name: create OpenDDS tar.xz artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       rm -rf ACE_TAO
+  #       find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+  #       tar cvf ../${{ github.job }}.tar setenv.cmd
+  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+  #       xz -3 ../${{ github.job }}.tar
+  #   - name: upload OpenDDS artifact
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_artifact
+  #       path: ${{ github.job }}.tar.xz
 
-    steps:
-    - name: install openssl-windows & xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
-        rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
-    - uses: ammaraskar/msvc-problem-matcher@0.1
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1.5.0
-    - name: configure OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        configure --optimize --ipv6 --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: build OpenDDS
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-    - name: gitclean
-      shell: bash
-      run: |
-        touch output.txt
-        cd OpenDDS
-        git clean -nd -e ext | tee ../output.txt
-        if [ -s ../output.txt ]; then exit 1; fi
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        rm -rf ACE_TAO
-        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.cmd
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
+  # test_windows-2019_release_o1_ipv6_security:
 
-  test_windows-2019_release_o1_ipv6_security:
+  #   runs-on: windows-2019
 
-    runs-on: windows-2019
+  #   needs: build_windows-2019_release_o1_ipv6_security
 
-    needs: build_windows-2019_release_o1_ipv6_security
-
-    steps:
-    - name: install openssl-windows & xerces-c
-      uses: lukka/run-vcpkg@v6
-      with:
-        vcpkgGitCommitId: ec6fe06
-        vcpkgArguments: --recurse openssl-windows xerces-c
-        vcpkgTriplet: x64-windows
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: OpenDDS/ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
-        path: OpenDDS/ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
-        rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: build_windows-2019_release_o1_ipv6_security_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ build_windows-2019_release_o1_ipv6_security.tar.xz
-        rm -f build_windows-2019_release_o1_ipv6_security.tar.xz
-    - name: check build configuration
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        perl tools\scripts\show_build_config.pl
-    - name: create autobuild config
-      shell: bash
-      run: |
-        cd OpenDDS
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        cat config.xml
-    - name: run OpenDDS tests
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd ${{ github.job }}_autobuild_workspace
-        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS\${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+  #   steps:
+  #   - name: install openssl-windows & xerces-c
+  #     uses: lukka/run-vcpkg@v6
+  #     with:
+  #       vcpkgGitCommitId: ec6fe06
+  #       vcpkgArguments: --recurse openssl-windows xerces-c
+  #       vcpkgTriplet: x64-windows
+  #   - name: checkout MPC
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/MPC
+  #       path: MPC
+  #   - name: checkout autobuild
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/autobuild
+  #       path: autobuild
+  #   - name: checkout OpenDDS
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       path: OpenDDS
+  #       submodules: true
+  #   - name: checkout ACE_TAO
+  #     uses: actions/checkout@v2.3.4
+  #     with:
+  #       repository: DOCGroup/ACE_TAO
+  #       ref: ace6tao2
+  #       path: OpenDDS/ACE_TAO
+  #   - name: download ACE_TAO artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
+  #       path: OpenDDS/ACE_TAO
+  #   - name: extract ACE_TAO artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS/ACE_TAO
+  #       tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+  #       rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+  #   - name: download OpenDDS artifact
+  #     uses: actions/download-artifact@v2
+  #     with:
+  #       name: build_windows-2019_release_o1_ipv6_security_artifact
+  #       path: OpenDDS
+  #   - name: extract OpenDDS artifact
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       tar xvfJ build_windows-2019_release_o1_ipv6_security.tar.xz
+  #       rm -f build_windows-2019_release_o1_ipv6_security.tar.xz
+  #   - name: check build configuration
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       perl tools\scripts\show_build_config.pl
+  #   - name: create autobuild config
+  #     shell: bash
+  #     run: |
+  #       cd OpenDDS
+  #       mkdir ${{ github.job }}_autobuild_workspace
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+  #       echo using commit $TRIGGERING_COMMIT for SHA
+  #       echo $TRIGGERING_COMMIT >> ./SHA
+  #       cat > config.xml <<EOF
+  #       <autobuild>
+  #       <configuration>
+  #       <variable name="log_file" value="output.log"/>
+  #       <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+  #       <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+  #       <variable name="junit_xml_output" value="Tests"/>
+  #       </configuration>
+  #       <command name="log" options="on"/>
+  #       <command name="print_os_version"/>
+  #       <command name="print_env_vars"/>
+  #       <command name="print_ace_config"/>
+  #       <command name="print_make_version"/>
+  #       <command name="check_compiler" options="gcc"/>
+  #       <command name="print_perl_version"/>
+  #       <command name="print_autobuild_config"/>
+  #       <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+  #       <command name="log" options="off"/>
+  #       <command name="process_logs" options="prettify"/>
+  #       </autobuild>
+  #       EOF
+  #       cat config.xml
+  #   - name: run OpenDDS tests
+  #     shell: cmd
+  #     run: |
+  #       cd OpenDDS
+  #       call setenv.cmd
+  #       cd ${{ github.job }}_autobuild_workspace
+  #       perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+  #   - name: upload autobuild output
+  #     uses: actions/upload-artifact@v2
+  #     with:
+  #       name: ${{ github.job }}_autobuild_output
+  #       path: OpenDDS\${{ github.job }}_autobuild_workspace
+  #   - name: check results
+  #     shell: bash
+  #     run: |
+  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
   ACE_TAO_windows-2019_release_java_nobit:
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5482,8 +5482,6 @@ jobs:
       run: |
         cd vcpkg
         rm -rf buildtrees downloads
-        ls -l
-
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,438 +29,2954 @@ env:
   TRIGGERING_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+  ACE_TAO_ubuntu-18_04_i0_java12_nojson:
 
-  # Ubuntu 20.04 - Defaults
+    runs-on: ubuntu-18.04
 
-#  ubuntu-20_04_defaults_ACE_TAO:
-#
-#    runs-on: ubuntu-20.04
-#
-#    steps:
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: get ACE_TAO commit
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        export ACE_COMMIT=$(git rev-parse HEAD)
-#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-#    - name: Cache Artifact
-#      id: cache-artifact
-#      uses: actions/cache@v2.1.4
-#      with:
-#        path: ${{ github.job }}.tar.xz
-#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-#    - name: install xerces
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: configure OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: |
-#        cd OpenDDS
-#        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: build ACE and TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        cd ACE_TAO/ACE
-#        make -j4
-#        cd ../TAO
-#        make -j4
-#    - name: create ACE_TAO tar.xz artifact
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-#        xz -3 ../../${{ github.job }}.tar
-#    - name: upload ACE_TAO artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-20_04_defaults_security_build:
-#
-#    runs-on: ubuntu-20.04
-#
-#    needs: ubuntu-20_04_defaults_ACE_TAO
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: configure OpenDDS
-#      run: |
-#        cd OpenDDS
-#        ./configure --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - uses: ammaraskar/gcc-problem-matcher@0.1
-#    - name: build OpenDDS
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.sh
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-20_04_defaults_security_test:
-#
-#    runs-on: ubuntu-20.04
-#
-#    needs: ubuntu-20_04_defaults_security_build
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-20_04_defaults_security_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ ubuntu-20_04_defaults_security_build.tar.xz
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - name: run OpenDDS tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS/${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-#
-#  ubuntu-20_04_defaults_java_no-bit_build:
-#
-#    runs-on: ubuntu-20.04
-#
-#    needs: ubuntu-20_04_defaults_ACE_TAO
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: configure OpenDDS
-#      run: |
-#        cd OpenDDS
-#        ./configure --tests --java=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64 --no-built-in-topics --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - uses: ammaraskar/gcc-problem-matcher@0.1
-#    - name: build OpenDDS
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4
-#    - name: set up TAO Hello test
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
-#    - name: build TAO Hello test
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4 dir=$TAO_ROOT/tests/Hello
-#    - name: set up Modeling tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        cd tools/modeling/tests
-#        ./setup.pl
-#        cd -
-#        mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
-#    - name: build Modeling tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4 -C tools/modeling/tests
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.sh
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-20_04_defaults_java_no-bit_test:
-#
-#    runs-on: ubuntu-20.04
-#
-#    needs: ubuntu-20_04_defaults_java_no-bit_build
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-20_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-20_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-20_04_defaults_java_no-bit_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ ubuntu-20_04_defaults_java_no-bit_build.tar.xz
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - name: run OpenDDS tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS/${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --no-inline --tests --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  # Ubuntu 20.04 - IPv6
+  build_ubuntu-18_04_i0_java12_nojson:
 
-  ubuntu-20_04_ipv6_ACE_TAO:
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_i0_java12_nojson
+
+    steps:
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_i0_java12_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_i0_java12_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --no-inline --tests --java=/usr/lib/jvm/adoptopenjdk-12-hotspot-amd64 --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: gitclean
+      shell: bash
+      run: |
+        touch output.txt
+        cd OpenDDS
+        git clean -nd -e ext | tee ../output.txt
+        if [ -s ../output.txt ]; then exit 1; fi
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_i0_java12_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_i0_java12_nojson
+
+    steps:
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_i0_java12_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_i0_java12_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_i0_java12_nojson_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_i0_java12_nojson.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config CXX11 -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_o1d0n1_java12:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --tests --optimize --no-debug --features=versioned_namspace=1 --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_o1d0n1_java12:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_o1d0n1_java12
+
+    steps:
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_o1d0n1_java12_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_o1d0n1_java12.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --optimize --no-debug --features=versioned_namespace=1 --tests --java=/usr/lib/jvm/adoptopenjdk-12-hotspot-amd64 --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: gitclean
+      shell: bash
+      run: |
+        touch output.txt
+        cd OpenDDS
+        git clean -nd -e ext | tee ../output.txt
+        if [ -s ../output.txt ]; then exit 1; fi
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_o1d0n1_java12:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_o1d0n1_java12
+
+    steps:
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_o1d0n1_java12_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_o1d0n1_java12.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_o1d0n1_java12_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_o1d0n1_java12.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_esafety_nojson:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_esafety_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_esafety_nojson
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --tests --safety-profile --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_esafety_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_esafety_nojson
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_esafety_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_esafety_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_esafety_nojson_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_esafety_nojson.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_bsafety_nojson_nobit:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --tests --safety-profile=base --no-rapidjson --no-built-in-topics --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_bsafety_nojson_nobit:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_bsafety_nojson_nobit
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_bsafety_nojson_nobit_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_bsafety_nojson_nobit.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_security_wofeatures:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --no-debug --no-inline --features=versioned_namespace=1 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_security_wofeatures:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_security_wofeatures
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_security_wofeatures_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_security_wofeatures.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --no-debug --no-inline --features=versioned_namespace=1 --tests --security --no-rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_security_wofeatures:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_security_wofeatures
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_security_wofeatures_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_security_wofeatures.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_security_wofeatures_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_security_wofeatures.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS  -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: install clang++
+      run: |
+        sudo apt-get install -y clang-5.0
+        sudo update-alternatives \
+          --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --compiler=clang++ --no-inline --features=uses_wchar=1 --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_clang5_i0_wchar_security_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: install clang++
+      run: | 
+        sudo apt-get install -y clang-5.0
+        sudo update-alternatives \
+          --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --compiler=clang++ --no-inline --features=uses_wchar=1 --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --rapidjson --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_clang5_i0_wchar_security_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_clang5_i0_wchar_security_nojson
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: install clang++
+      run: | 
+        sudo apt-get install -y clang-5.0
+        sudo update-alternatives \
+          --install /usr/bin/clang++ clang++ /usr/bin/clang++-5.0 100
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_clang5_i0_wchar_security_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_clang5_i0_wchar_security_nojson_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_clang5_i0_wchar_security_nojson.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="clang++"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS  -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_clang10_nojson:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: install clang++
+      run: |
+        sudo apt-get install -y clang-10
+        sudo update-alternatives \
+          --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --compiler=clang++ --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_clang10_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_clang10_nojson
+
+    steps:
+    - name: install clang++
+      run: |
+        sudo apt-get install -y clang-10
+        sudo update-alternatives \
+          --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_clang10_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_clang10_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --compiler=clang++ --std=c++11 --tests --security --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_clang10_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_clang10_nojson
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: install clang++
+      run: |
+        sudo apt-get install -y clang-10
+        sudo update-alternatives \
+          --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_clang10_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_clang10_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_clang10_nojson_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_clang10_nojson.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="clang++"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config OPENDDS_SECURITY -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-6
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-6 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-6 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-6
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --no-debug --features=uses_wchar=1 --std=c++03 --tests --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_gcc6_cpp03_d0_wchar:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-6
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-6 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-6 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-6
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --no-debug --features=uses_wchar=1 --std=c++03 --tests --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_gcc6_cpp03_d0_wchar:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_gcc6_cpp03_d0_wchar
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-6
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-6 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-6 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-6
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_gcc6_cpp03_d0_wchar.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_gcc6_cpp03_d0_wchar_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_gcc6_cpp03_d0_wchar.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config RAPIDJSON -Config GH_ACTIONS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-8
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-8 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-8 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --no-inline --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_gcc8_i0_java_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-8
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-8 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-8 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --no-inline --no-rapidjson --tests --java --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_gcc8_i0_java_nojson:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_gcc8_i0_java_nojson
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-8
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-8 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-8 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-8
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_gcc8_i0_java_nojson.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_gcc8_i0_java_nojson_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_gcc8_i0_java_nojson.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_gcc10_i0_wchar:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-10
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --no-inline --features=uses_wchar=1 --tests --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_gcc10_i0_wchar:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_gcc10_i0_wchar
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-10
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_gcc10_i0_wchar_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_gcc10_i0_wchar.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --no-inline --features=uses_wchar=1 --tests --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_gcc10_i0_wchar:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_gcc10_i0_wchar
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-10
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_gcc10_i0_wchar_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_gcc10_i0_wchar.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_gcc10_i0_wchar_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_gcc10_i0_wchar.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config WCHAR -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-10
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-20_04_gcc10_bsafety_wofeatures:
+
+    runs-on: ubuntu-20.04
+
+    needs: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-10
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --compiler=g++ --safety-profile=base --tests --no-rapidjson --no-content-subscription --no-object-model-profile --no-persistence-profile --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS/build/target
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-20_04_gcc10_bsafety_wofeatures:
+
+    runs-on: ubuntu-20.04
+
+    needs: build_ubuntu-20_04_gcc10_bsafety_wofeatures
+
+    steps:
+    - name: install gcc
+      run: | 
+        sudo apt-get install -y gcc-10
+        sudo update-alternatives \
+          --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+          --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-10 \
+          --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-10 \
+          --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-20_04_gcc10_bsafety_wofeatures_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-20_04_gcc10_bsafety_wofeatures.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config OPENDDS_SAFETY_PROFILE -Config RTPS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-20_04_security_qt_ws_security:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-20_04_security_qt_ws_security:
+
+    runs-on: ubuntu-20.04
+
+    needs: ACE_TAO_ubuntu-20_04_security_qt_ws_security
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: install wireshark
+      run: sudo apt-get -y install wireshark-dev
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-20_04_security_qt_ws_security_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-20_04_security_qt_ws_security.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --qt --wireshark --tests --security --java --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: set up TAO Hello test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
+    - name: build TAO Hello test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 dir=$TAO_ROOT/tests/Hello
+    - name: set up Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tools/modeling/tests
+        ./setup.pl
+        cd -
+        mwc.pl -type gnuace -workers 4 tools/modeling/tests/modeling_tests.mwc
+    - name: build Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 -C tools/modeling/tests
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-20_04_security_qt_ws_security:
+
+    runs-on: ubuntu-20.04
+
+    needs: build_ubuntu-20_04_security_qt_ws_security
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-20_04_security_qt_ws_security_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-20_04_security_qt_ws_security.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-20_04_security_qt_ws_security_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-20_04_security_qt_ws_security.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-20_04_ipv6:
 
     runs-on: ubuntu-20.04
 
@@ -527,11 +3043,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-20_04_ipv6_security_build:
+  build_ubuntu-20_04_ipv6_security:
 
     runs-on: ubuntu-20.04
 
-    needs: ubuntu-20_04_ipv6_ACE_TAO
+    needs: ACE_TAO_ubuntu-20_04_ipv6
 
     steps:
     - name: install xerces
@@ -550,13 +3066,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -594,11 +3110,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-20_04_ipv6_security_test:
+  test_ubuntu-20_04_ipv6_security:
 
     runs-on: ubuntu-20.04
 
-    needs: ubuntu-20_04_ipv6_security_build
+    needs: build_ubuntu-20_04_ipv6_security
 
     steps:
     - name: install xerces
@@ -622,13 +3138,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -637,13 +3153,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_ipv6_security_build_artifact
+        name: build_ubuntu-20_04_ipv6_security_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ ubuntu-20_04_ipv6_security_build.tar.xz
+        tar xvfJ build_ubuntu-20_04_ipv6_security.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -693,11 +3209,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ubuntu-20_04_ipv6_java_no-bit_build:
+  build_ubuntu-20_04_ipv6_java8_nobit:
 
     runs-on: ubuntu-20.04
 
-    needs: ubuntu-20_04_ipv6_ACE_TAO
+    needs: ACE_TAO_ubuntu-20_04_ipv6
 
     steps:
     - name: install xerces
@@ -716,13 +3232,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -787,11 +3303,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-20_04_ipv6_java_no-bit_test:
+  test_ubuntu-20_04_ipv6_java8_nobit:
 
     runs-on: ubuntu-20.04
 
-    needs: ubuntu-20_04_ipv6_java_no-bit_build
+    needs: build_ubuntu-20_04_ipv6_java8_nobit
 
     steps:
     - name: install xerces
@@ -815,13 +3331,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_ipv6_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-20_04_ipv6_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-20_04_ipv6_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-20_04_ipv6.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -830,13 +3346,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-20_04_ipv6_java_no-bit_build_artifact
+        name: build_ubuntu-20_04_ipv6_java8_nobit_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ ubuntu-20_04_ipv6_java_no-bit_build.tar.xz
+        tar xvfJ build_ubuntu-20_04_ipv6_java8_nobit.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -886,437 +3402,9 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # Ubuntu 18.04 - Defaults
-
-#  ubuntu-18_04_defaults_ACE_TAO:
-#
-#    runs-on: ubuntu-18.04
-#
-#    steps:
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: get ACE_TAO commit
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        export ACE_COMMIT=$(git rev-parse HEAD)
-#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-#    - name: Cache Artifact
-#      id: cache-artifact
-#      uses: actions/cache@v2.1.4
-#      with:
-#        path: ${{ github.job }}.tar.xz
-#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-#    - name: install xerces
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: configure OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: |
-#        cd OpenDDS
-#        ./configure --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: build ACE and TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        cd ACE_TAO/ACE
-#        make -j4
-#        cd ../TAO
-#        make -j4
-#    - name: create ACE_TAO tar.xz artifact
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-#        xz -3 ../../${{ github.job }}.tar
-#    - name: upload ACE_TAO artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-18_04_defaults_security_build:
-#
-#    runs-on: ubuntu-18.04
-#
-#    needs: ubuntu-18_04_defaults_ACE_TAO
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: configure OpenDDS
-#      run: |
-#        cd OpenDDS
-#        ./configure --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - uses: ammaraskar/gcc-problem-matcher@0.1
-#    - name: build OpenDDS
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.sh
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-18_04_defaults_security_test:
-#
-#    runs-on: ubuntu-18.04
-#
-#    needs: ubuntu-18_04_defaults_security_build
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-18_04_defaults_security_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ ubuntu-18_04_defaults_security_build.tar.xz
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - name: run OpenDDS tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS/${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-#
-#  ubuntu-18_04_defaults_java_no-csp_build:
-#
-#    runs-on: ubuntu-18.04
-#
-#    needs: ubuntu-18_04_defaults_ACE_TAO
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: configure OpenDDS
-#      run: |
-#        cd OpenDDS
-#        ./configure --tests --java --no-content-subscription --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - uses: ammaraskar/gcc-problem-matcher@0.1
-#    - name: build OpenDDS
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4
-#    - name: set up TAO Hello test
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mwc.pl -type gnuace -workers 4 $TAO_ROOT/tests/Hello
-#    - name: build TAO Hello test
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4 dir=$TAO_ROOT/tests/Hello
-#    - name: set up Modeling tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        cd tools/modeling/tests
-#        ./setup.pl
-#        cd -
-#        mwc.pl -type gnuace -workers 4 -features content_subscription=0 tools/modeling/tests/modeling_tests.mwc
-#    - name: build Modeling tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4 -C tools/modeling/tests
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.sh
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-18_04_defaults_java_no-csp_test:
-#
-#    runs-on: ubuntu-18.04
-#
-#    needs: ubuntu-18_04_defaults_java_no-csp_build
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-18_04_defaults_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-18_04_defaults_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-18_04_defaults_java_no-csp_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ ubuntu-18_04_defaults_java_no-csp_build.tar.xz
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - name: run OpenDDS tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS/${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
   # Ubuntu 18.04 - WChar
 
-  ubuntu-18_04_wchar_ACE_TAO:
+  ACE_TAO_ubuntu-18_04_wchar:
 
     runs-on: ubuntu-18.04
 
@@ -1383,11 +3471,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-18_04_wchar_security_build:
+  build_ubuntu-18_04_wchar_security:
 
     runs-on: ubuntu-18.04
 
-    needs: ubuntu-18_04_wchar_ACE_TAO
+    needs: ACE_TAO_ubuntu-18_04_wchar
 
     steps:
     - name: install xerces
@@ -1406,13 +3494,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-18_04_wchar_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1450,11 +3538,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-18_04_wchar_security_test:
+  test_ubuntu-18_04_wchar_security:
 
     runs-on: ubuntu-18.04
 
-    needs: ubuntu-18_04_wchar_security_build
+    needs: build_ubuntu-18_04_wchar_security
 
     steps:
     - name: install xerces
@@ -1478,13 +3566,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-18_04_wchar_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1493,13 +3581,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-18_04_wchar_security_build_artifact
+        name: build_ubuntu-18_04_wchar_security_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ ubuntu-18_04_wchar_security_build.tar.xz
+        tar xvfJ build_ubuntu-18_04_wchar_security.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -1549,11 +3637,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ubuntu-18_04_wchar_java_no-csp_build:
+  build_ubuntu-18_04_wchar_java_nocsp:
 
     runs-on: ubuntu-18.04
 
-    needs: ubuntu-18_04_wchar_ACE_TAO
+    needs: ACE_TAO_ubuntu-18_04_wchar
 
     steps:
     - name: install xerces
@@ -1572,13 +3660,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-18_04_wchar_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1643,11 +3731,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-18_04_wchar_java_no-csp_test:
+  test_ubuntu-18_04_wchar_java_nocsp:
 
     runs-on: ubuntu-18.04
 
-    needs: ubuntu-18_04_wchar_java_no-csp_build
+    needs: build_ubuntu-18_04_wchar_java_nocsp
 
     steps:
     - name: install xerces
@@ -1671,13 +3759,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-18_04_wchar_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-18_04_wchar_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-18_04_wchar_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-18_04_wchar.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -1686,13 +3774,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-18_04_wchar_java_no-csp_build_artifact
+        name: build_ubuntu-18_04_wchar_java_nocsp_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ ubuntu-18_04_wchar_java_no-csp_build.tar.xz
+        tar xvfJ build_ubuntu-18_04_wchar_java_nocsp.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -1742,11 +3830,246 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # Ubuntu 16.04 - Defaults
+  ACE_TAO_ubuntu-18_04_security_qt_ws:
 
-  ubuntu-16_04_defaults_ACE_TAO:
+    runs-on: ubuntu-18.04
 
-    runs-on: ubuntu-16.04
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_ubuntu-18_04_security_qt_ws:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_ubuntu-18_04_security_qt_ws
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: install wireshark
+      run: sudo apt-get -y install wireshark-dev
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_security_qt_ws_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_security_qt_ws.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --static --qt --wireshark --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_ubuntu-18_04_security_qt_ws:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_ubuntu-18_04_security_qt_ws
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_ubuntu-18_04_security_qt_ws_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_ubuntu-18_04_security_qt_ws.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_ubuntu-18_04_security_qt_ws_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_ubuntu-18_04_security_qt_ws.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_ubuntu-18_04_defaults_java_nocft:
+
+    runs-on: ubuntu-18.04
 
     steps:
     - name: checkout OpenDDS
@@ -1811,177 +4134,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-16_04_defaults_security_build:
+  build_ubuntu-18_04_defaults_java_nocft:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
-    needs: ubuntu-16_04_defaults_ACE_TAO
-
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ubuntu-16_04_defaults_ACE_TAO_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: configure OpenDDS
-      run: |
-        cd OpenDDS
-        ./configure --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
-    - name: build OpenDDS
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        make -j4
-    - name: create OpenDDS tar.xz artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        rm -rf ACE_TAO
-        find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-        xz -3 ../${{ github.job }}.tar
-    - name: upload OpenDDS artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_artifact
-        path: ${{ github.job }}.tar.xz
-
-  ubuntu-16_04_defaults_security_test:
-
-    runs-on: ubuntu-16.04
-
-    needs: ubuntu-16_04_defaults_security_build
-
-    steps:
-    - name: install xerces
-      run: sudo apt-get -y install libxerces-c-dev
-    - name: checkout MPC
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/MPC
-        path: MPC
-    - name: checkout autobuild
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/autobuild
-        path: autobuild
-    - name: checkout ACE_TAO
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: DOCGroup/ACE_TAO
-        ref: ace6tao2
-        path: ACE_TAO
-    - name: download ACE_TAO artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ubuntu-16_04_defaults_ACE_TAO_artifact
-        path: ACE_TAO
-    - name: extract ACE_TAO artifact
-      shell: bash
-      run: |
-        cd ACE_TAO
-        tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
-    - name: checkout OpenDDS
-      uses: actions/checkout@v2.3.4
-      with:
-        path: OpenDDS
-        submodules: true
-    - name: download OpenDDS artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ubuntu-16_04_defaults_security_build_artifact
-        path: OpenDDS
-    - name: extract OpenDDS artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvfJ ubuntu-16_04_defaults_security_build.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
-    - name: run OpenDDS tests
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        mkdir ${{ github.job }}_autobuild_workspace
-        cd ${{ github.job }}_autobuild_workspace
-        echo using commit $TRIGGERING_COMMIT for SHA
-        echo $TRIGGERING_COMMIT >> ./SHA
-        cat > config.xml <<EOF
-        <autobuild>
-        <configuration>
-        <variable name="log_file" value="output.log"/>
-        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="project_root" value="$DDS_ROOT"/>
-        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-        <variable name="junit_xml_output" value="Tests"/>
-        </configuration>
-        <command name="log" options="on"/>
-        <command name="print_os_version"/>
-        <command name="print_env_vars"/>
-        <command name="print_ace_config"/>
-        <command name="print_make_version"/>
-        <command name="check_compiler" options="gcc"/>
-        <command name="print_perl_version"/>
-        <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-        <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
-        </autobuild>
-        EOF
-        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-    - name: upload autobuild output
-      uses: actions/upload-artifact@v2
-      with:
-        name: ${{ github.job }}_autobuild_output
-        path: OpenDDS/${{ github.job }}_autobuild_workspace
-    - name: check results
-      shell: bash
-      run: |
-        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
-  ubuntu-16_04_defaults_java_no-cft_build:
-
-    runs-on: ubuntu-16.04
-
-    needs: ubuntu-16_04_defaults_ACE_TAO
+    needs: ACE_TAO_ubuntu-18_04_defaults_java_nocft
 
     steps:
     - name: install xerces
@@ -2000,13 +4157,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-18_04_defaults_java_nocft_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-18_04_defaults_java_nocft.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2071,11 +4228,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ubuntu-16_04_defaults_java_no-cft_test:
+  test_ubuntu-18_04_defaults_java_nocft:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
-    needs: ubuntu-16_04_defaults_java_no-cft_build
+    needs: build_ubuntu-18_04_defaults_java_nocft
 
     steps:
     - name: install xerces
@@ -2099,13 +4256,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_ACE_TAO_artifact
+        name: ACE_TAO_ubuntu-18_04_defaults_java_nocft_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ubuntu-16_04_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_ubuntu-18_04_defaults_java_nocft.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -2114,13 +4271,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: ubuntu-16_04_defaults_java_no-cft_build_artifact
+        name: build_ubuntu-18_04_defaults_java_nocft_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ ubuntu-16_04_defaults_java_no-cft_build.tar.xz
+        tar xvfJ build_ubuntu-18_04_defaults_java_nocft.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -2153,7 +4310,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config STATIC -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS -a -l java/tests/dcps_java_tests.lst -l tools/modeling/tests/modeling_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2170,244 +4327,8 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # Ubuntu 16.04 - Static
 
-#  ubuntu-16_04_static_ACE_TAO:
-#
-#    runs-on: ubuntu-16.04
-#
-#    steps:
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: get ACE_TAO commit
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        export ACE_COMMIT=$(git rev-parse HEAD)
-#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-#    - name: Cache Artifact
-#      id: cache-artifact
-#      uses: actions/cache@v2.1.4
-#      with:
-#        path: ${{ github.job }}.tar.xz
-#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-#    - name: install xerces
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: configure OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: |
-#        cd OpenDDS
-#        ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: build ACE and TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        cd ACE_TAO/ACE
-#        make -j4
-#        cd ../TAO
-#        make -j4
-#    - name: create ACE_TAO tar.xz artifact
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-#        xz -3 ../../${{ github.job }}.tar
-#    - name: upload ACE_TAO artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-16_04_static_security_build:
-#
-#    runs-on: ubuntu-16.04
-#
-#    needs: ubuntu-16_04_static_ACE_TAO
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-16_04_static_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-16_04_static_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: configure OpenDDS
-#      run: |
-#        cd OpenDDS
-#        ./configure --static --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - uses: ammaraskar/gcc-problem-matcher@0.1
-#    - name: build OpenDDS
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        make -j4
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.o" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.sh
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  ubuntu-16_04_static_security_test:
-#
-#    runs-on: ubuntu-16.04
-#
-#    needs: ubuntu-16_04_static_security_build
-#
-#    steps:
-#    - name: install xerces
-#      run: sudo apt-get -y install libxerces-c-dev
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-16_04_static_ACE_TAO_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ubuntu-16_04_static_ACE_TAO.tar.xz
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: ubuntu-16_04_static_security_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ ubuntu-16_04_static_security_build.tar.xz
-#    - name: check build configuration
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        tools/scripts/show_build_config.pl
-#    - name: run OpenDDS tests
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        . setenv.sh
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DDS_ROOT"/>
-#        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS/${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
-  # Windows 2019 - Defaults
-
-  windows-2019_defaults_ACE_TAO:
+  ACE_TAO_windows-2019_ipv6_static_nojson:
 
     runs-on: windows-2019
 
@@ -2456,7 +4377,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+        configure --ipv6 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
     - name: build ACE & TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       shell: cmd
@@ -2483,11 +4404,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2019_defaults_security_build:
+  build_windows-2019_ipv6_static_nojson:
 
     runs-on: windows-2019
 
-    needs: windows-2019_defaults_ACE_TAO
+    needs: ACE_TAO_windows-2019_ipv6_static_nojson
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -2515,14 +4436,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_ACE_TAO_artifact
+        name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
-        rm -f windows-2019_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+        rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -2530,7 +4451,7 @@ jobs:
       shell: cmd
       run: |
         cd OpenDDS
-        configure --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+        configure --ipv6 --static --tests --no-rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
     - name: check build configuration
       shell: cmd
       run: |
@@ -2558,11 +4479,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2019_defaults_security_test:
+  test_windows-2019_ipv6_static_nojson:
 
     runs-on: windows-2019
 
-    needs: windows-2019_defaults_security_build
+    needs: build_windows-2019_ipv6_static_nojson
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -2595,25 +4516,25 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_ACE_TAO_artifact
+        name: ACE_TAO_windows-2019_ipv6_static_nojson_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
-        rm -f windows-2019_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
+        rm -f ACE_TAO_windows-2019_ipv6_static_nojson.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_security_build_artifact
+        name: build_windows-2019_ipv6_static_nojson_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ windows-2019_defaults_security_build.tar.xz
-        rm -f windows-2019_defaults_security_build.tar.xz
+        tar xvfJ build_windows-2019_ipv6_static_nojson.tar.xz
+        rm -f build_windows-2019_ipv6_static_nojson.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -2646,7 +4567,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -ExeSubDir Static_Debug -Config STATIC -Config IPV6 -Config RTPS -Config GH_ACTIONS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2670,11 +4591,620 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  windows-2019_defaults_java_no-bit_build:
+  ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures:
 
     runs-on: windows-2019
 
-    needs: windows-2019_defaults_ACE_TAO
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --ipv6 --std=c++03 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+    - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ACE_TAO\ACE
+        msbuild -p:Configuration=Release,Platform=x64 -m ace.sln
+        cd ..\TAO
+        msbuild -p:Configuration=Release,Platform=x64 -m tao.sln
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_windows-2019_ipv6_cpp03_static_wofeatures:
+
+    runs-on: windows-2019
+
+    needs: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+        rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --ipv6 --std=c++03 --static --tests --rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Release,Platform=x64 -m DDS.sln
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_windows-2019_ipv6_cpp03_static_wofeatures:
+
+    runs-on: windows-2019
+
+    needs: build_windows-2019_ipv6_cpp03_static_wofeatures
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+        rm -f ACE_TAO_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_windows-2019_ipv6_cpp03_static_wofeatures_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+        rm -f build_windows-2019_ipv6_cpp03_static_wofeatures.tar.xz
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -ExeSubDir Static_Release -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_windows-2019_release_o1_ipv6_security:
+
+    runs-on: windows-2019
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --optimize --ipv6 --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+    - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ACE_TAO\ACE
+        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+        cd ..\TAO
+        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_windows-2019_release_o1_ipv6_security:
+
+    runs-on: windows-2019
+
+    needs: ACE_TAO_windows-2019_release_o1_ipv6_security
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+        rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --optimize --ipv6 --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+    - name: gitclean
+      shell: bash
+      run: |
+        touch output.txt
+        cd OpenDDS
+        git clean -nd -e ext | tee ../output.txt
+        if [ -s ../output.txt ]; then exit 1; fi
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_windows-2019_release_o1_ipv6_security:
+
+    runs-on: windows-2019
+
+    needs: build_windows-2019_release_o1_ipv6_security
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_windows-2019_release_o1_ipv6_security_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+        rm -f ACE_TAO_windows-2019_release_o1_ipv6_security.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_windows-2019_release_o1_ipv6_security_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_windows-2019_release_o1_ipv6_security.tar.xz
+        rm -f build_windows-2019_release_o1_ipv6_security.tar.xz
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests/security/security_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+
+  ACE_TAO_windows-2019_release_java_nobit:
+
+    runs-on: windows-2019
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --tests --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+    - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ACE_TAO\ACE
+        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+        cd ..\TAO
+        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_windows-2019_release_java_nobit:
+
+    runs-on: windows-2019
+
+    needs: ACE_TAO_windows-2019_release_java_nobit
 
     steps:
     - name: install xerces-c
@@ -2702,14 +5232,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_ACE_TAO_artifact
+        name: ACE_TAO_windows-2019_release_java_nobit_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
-        rm -f windows-2019_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2019_release_java_nobit.tar.xz
+        rm -f ACE_TAO_windows-2019_release_java_nobit.tar.xz
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -2745,11 +5275,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2019_defaults_java_no-bit_test:
+  test_windows-2019_release_java_nobit:
 
     runs-on: windows-2019
 
-    needs: windows-2019_defaults_java_no-bit_build
+    needs: build_windows-2019_release_java_nobit
 
     steps:
     - name: install xerces-c
@@ -2782,25 +5312,25 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_ACE_TAO_artifact
+        name: ACE_TAO_windows-2019_release_java_nobit_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2019_defaults_ACE_TAO.tar.xz
-        rm -f windows-2019_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2019_release_java_nobit.tar.xz
+        rm -f ACE_TAO_windows-2019_release_java_nobit.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2019_defaults_java_no-bit_build_artifact
+        name: build_windows-2019_release_java_nobit_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ windows-2019_defaults_java_no-bit_build.tar.xz
-        rm -f windows-2019_defaults_java_no-bit_build.tar.xz
+        tar xvfJ build_windows-2019_release_java_nobit.tar.xz
+        rm -f build_windows-2019_release_java_nobit.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -2857,929 +5387,9 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # Windows 2019 - WChar
-
-#  windows-2019_wchar_ACE_TAO:
-#
-#    runs-on: windows-2019
-#
-#    steps:
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: get ACE_TAO commit
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        export ACE_COMMIT=$(git rev-parse HEAD)
-#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-#    - name: Cache Artifact
-#      id: cache-artifact
-#      uses: actions/cache@v2.1.4
-#      with:
-#        path: ${{ github.job }}.tar.xz
-#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-#    - name: install openssl-windows & xerces-c
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: set up msvc env
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --features=uses_wchar=1 --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-#    - name: build ACE & TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ACE_TAO\ACE
-#        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
-#        cd ..\TAO
-#        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
-#    - name: create ACE_TAO tar.xz artifact
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        find . -iname "*\.obj" | xargs rm
-#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-#        xz -3 ../../${{ github.job }}.tar
-#    - name: upload ACE_TAO artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2019_wchar_security_build:
-#
-#    runs-on: windows-2019
-#
-#    needs: windows-2019_wchar_ACE_TAO
-#
-#    steps:
-#    - name: install openssl-windows & xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2019_wchar_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
-#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --features=uses_wchar=1 --tests --rapidjson --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: build OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.cmd
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2019_wchar_security_test:
-#
-#    runs-on: windows-2019
-#
-#    needs: windows-2019_wchar_security_build
-#
-#    steps:
-#    - name: install openssl-windows & xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2019_wchar_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
-#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2019_wchar_security_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ windows-2019_wchar_security_build.tar.xz
-#        rm -f windows-2019_wchar_security_build.tar.xz
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$DBS_GHW\\OpenDDS -Config WCHAR -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-#
-#  windows-2019_wchar_java_no-bit_build:
-#
-#    runs-on: windows-2019
-#
-#    needs: windows-2019_wchar_ACE_TAO
-#
-#    steps:
-#    - name: install xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2019_wchar_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
-#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --features=uses_wchar=1e --tests --java --no-built-in-topics --rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: build OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.cmd
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2019_wchar_java_no-bit_test:
-#
-#    runs-on: windows-2019
-#
-#    needs: windows-2019_wchar_java_no-bit_build
-#
-#    steps:
-#    - name: install xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2019_wchar_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2019_wchar_ACE_TAO.tar.xz
-#        rm -f windows-2019_wchar_ACE_TAO.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2019_wchar_java_no-bit_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ windows-2019_wchar_java_no-bit_build.tar.xz
-#        rm -f windows-2019_wchar_java_no-bit_build.tar.xz
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$DBS_GHW\\OpenDDS -Config WCHAR -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
-  # Windows 2016 - No Debug, No Inline
-
-#  windows-2016_no-debug_no-inline_ACE_TAO:
-#
-#    runs-on: windows-2016
-#
-#    steps:
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: get ACE_TAO commit
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        export ACE_COMMIT=$(git rev-parse HEAD)
-#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-#    - name: Cache Artifact
-#      id: cache-artifact
-#      uses: actions/cache@v2.1.4
-#      with:
-#        path: ${{ github.job }}.tar.xz
-#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-#    - name: install openssl-windows & xerces-c
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: set up msvc env
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-#    - name: build ACE & TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ACE_TAO\ACE
-#        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
-#        cd ..\TAO
-#        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
-#    - name: create ACE_TAO tar.xz artifact
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        find . -iname "*\.obj" | xargs rm
-#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-#        xz -3 ../../${{ github.job }}.tar
-#    - name: upload ACE_TAO artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2016_no-debug_no-inline_security_build:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_no-debug_no-inline_ACE_TAO
-#
-#    steps:
-#    - name: install openssl-windows & xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: Move ACE and MPC to C Drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS/ACE_TAO /c/
-#        mv MPC /c/
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="%VCPKG_ROOT%\installed\x64-windows" --openssl="%VCPKG_ROOT%\installed\x64-windows"
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: build OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.cmd
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2016_no-debug_no-inline_security_test:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_no-debug_no-inline_security_build
-#
-#    steps:
-#    - name: install openssl-windows & xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_no-debug_no-inline_security_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ windows-2016_no-debug_no-inline_security_build.tar.xz
-#        rm -f windows-2016_no-debug_no-inline_security_build.tar.xz
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-#
-#  windows-2016_no-debug_no-inline_java_no-bit_build:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_no-debug_no-inline_ACE_TAO
-#
-#    steps:
-#    - name: install xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: Move ACE and MPC to C Drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS/ACE_TAO /c/
-#        mv MPC /c/
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3="%VCPKG_ROOT%\installed\x64-windows"
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: build OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.cmd
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2016_no-debug_no-inline_java_no-bit_test:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_no-debug_no-inline_java_no-bit_build
-#
-#    steps:
-#    - name: install xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_no-debug_no-inline_java_no-bit_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
-#        rm -f windows-2016_no-debug_no-inline_java_no-bit_build.tar.xz
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$DBS_GHW\\OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
-  # Windows 2016 - x86, No Debug, No Inline
-
-  windows-2016_x86_no-debug_no-inline_ACE_TAO:
+  ACE_TAO_windows-2016_x86_d0i0:
 
     runs-on: windows-2016
-
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
@@ -3854,11 +5464,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2016_x86_no-debug_no-inline_security_build:
+  build_windows-2016_x86_d0i0_security:
 
     runs-on: windows-2016
 
-    needs: windows-2016_x86_no-debug_no-inline_ACE_TAO
+    needs: ACE_TAO_windows-2016_x86_d0i0
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -3867,6 +5477,13 @@ jobs:
         vcpkgGitCommitId: ec6fe06
         vcpkgArguments: --recurse openssl-windows xerces-c
         vcpkgTriplet: x86-windows
+    - name: ls
+      shell: bash
+      run: |
+        cd vcpkg
+        rm -rf buildtrees downloads 
+        ls -l
+
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:
@@ -3886,14 +5503,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
+        name: ACE_TAO_windows-2016_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -3937,11 +5554,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2016_x86_no-debug_no-inline_security_test:
+  test_windows-2016_x86_d0i0_security:
 
     runs-on: windows-2016
 
-    needs: windows-2016_x86_no-debug_no-inline_security_build
+    needs: build_windows-2016_x86_d0i0_security
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -3974,14 +5591,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
+        name: ACE_TAO_windows-2016_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -3991,14 +5608,14 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_x86_no-debug_no-inline_security_build_artifact
+        name: build_windows-2016_x86_d0i0_security_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ windows-2016_x86_no-debug_no-inline_security_build.tar.xz
-        rm -f windows-2016_x86_no-debug_no-inline_security_build.tar.xz
+        tar xvfJ build_windows-2016_x86_d0i0_security.tar.xz
+        rm -f build_windows-2016_x86_d0i0_security.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -4053,13 +5670,13 @@ jobs:
       shell: bash
       run: |
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
+        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  windows-2016_x86_no-debug_no-inline_java_no-bit_build:
+  build_windows-2016_x86_d0i0_java_nobit:
 
     runs-on: windows-2016
 
-    needs: windows-2016_x86_no-debug_no-inline_ACE_TAO
+    needs: ACE_TAO_windows-2016_x86_d0i0
 
     steps:
     - name: install xerces-c
@@ -4087,14 +5704,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
+        name: ACE_TAO_windows-2016_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -4138,11 +5755,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  windows-2016_x86_no-debug_no-inline_java_no-bit_test:
+  test_windows-2016_x86_d0i0_java_nobit:
 
     runs-on: windows-2016
 
-    needs: windows-2016_x86_no-debug_no-inline_java_no-bit_build
+    needs: build_windows-2016_x86_d0i0_java_nobit
 
     steps:
     - name: install xerces-c
@@ -4175,14 +5792,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_x86_no-debug_no-inline_ACE_TAO_artifact
+        name: ACE_TAO_windows-2016_x86_d0i0_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
-        rm -f windows-2016_x86_no-debug_no-inline_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_windows-2016_x86_d0i0.tar.xz
+        rm -f ACE_TAO_windows-2016_x86_d0i0.tar.xz
         find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
     - name: Move ACE and MPC to C Drive
       shell: bash
@@ -4192,14 +5809,14 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: windows-2016_x86_no-debug_no-inline_java_no-bit_build_artifact
+        name: build_windows-2016_x86_d0i0_java_nobit_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ windows-2016_x86_no-debug_no-inline_java_no-bit_build.tar.xz
-        rm -f windows-2016_x86_no-debug_no-inline_java_no-bit_build.tar.xz
+        tar xvfJ build_windows-2016_x86_d0i0_java_nobit.tar.xz
+        rm -f build_windows-2016_x86_d0i0_java_nobit.tar.xz
     - name: check build configuration
       shell: cmd
       run: |
@@ -4256,478 +5873,12 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # Windows 2016 - IPv6, No Debug, No Inline
-
-#  windows-2016_ipv6_no-debug_no-inline_ACE_TAO:
-#
-#    runs-on: windows-2016
-#
-#    steps:
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: get ACE_TAO commit
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        export ACE_COMMIT=$(git rev-parse HEAD)
-#        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-#    - name: Cache Artifact
-#      id: cache-artifact
-#      uses: actions/cache@v2.1.4
-#      with:
-#        path: ${{ github.job }}.tar.xz
-#        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-#    - name: install openssl-windows & xerces-c
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: set up msvc env
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --ipv6 --no-debug --no-inline --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-#    - name: build ACE & TAO
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ACE_TAO\ACE
-#        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
-#        cd ..\TAO
-#        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
-#    - name: create ACE_TAO tar.xz artifact
-#      if: steps.cache-artifact.outputs.cache-hit != 'true'
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-#        find . -iname "*\.obj" | xargs rm
-#        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-#        xz -3 ../../${{ github.job }}.tar
-#    - name: upload ACE_TAO artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2016_ipv6_no-debug_no-inline_security_build:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_ipv6_no-debug_no-inline_ACE_TAO
-#
-#    steps:
-#    - name: install openssl-windows & xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: Move ACE and MPC to C Drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS/ACE_TAO /c/
-#        mv MPC /c/
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --tests --rapidjson --security --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: build OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.cmd
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2016_ipv6_no-debug_no-inline_security_test:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_ipv6_no-debug_no-inline_security_build
-#
-#    steps:
-#    - name: install openssl-windows & xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse openssl-windows xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_ipv6_no-debug_no-inline_security_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_security_build.tar.xz
-#        rm -f windows-2016_ipv6_no-debug_no-inline_security_build.tar.xz
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$DBS_GHW\\OpenDDS -Config IPV6 -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -a -l tests\\security\\security_tests.lst"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-#
-#  windows-2016_ipv6_no-debug_no-inline_java_no-bit_build:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_ipv6_no-debug_no-inline_ACE_TAO
-#
-#    steps:
-#    - name: install xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: Move ACE and MPC to C Drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS/ACE_TAO /c/
-#        mv MPC /c/
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.5.0
-#    - name: configure OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        configure --tests --java --no-built-in-topics --rapidjson --ace="C:\ACE_TAO\ACE" --tao="C:\ACE_TAO\TAO" --mpc="C:\MPC" --xerces3=%VCPKG_ROOT%/installed/x64-windows
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: build OpenDDS
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-#    - name: create OpenDDS tar.xz artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        rm -rf ACE_TAO
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#        tar cvf ../${{ github.job }}.tar setenv.cmd
-#        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-#        xz -3 ../${{ github.job }}.tar
-#    - name: upload OpenDDS artifact
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_artifact
-#        path: ${{ github.job }}.tar.xz
-#
-#  windows-2016_ipv6_no-debug_no-inline_java_no-bit_test:
-#
-#    runs-on: windows-2016
-#
-#    needs: windows-2016_ipv6_no-debug_no-inline_java_no-bit_build
-#
-#    steps:
-#    - name: install xerces-c
-#      uses: lukka/run-vcpkg@v6
-#      with:
-#        vcpkgGitCommitId: ec6fe06
-#        vcpkgArguments: --recurse xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v2.3.4
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_ipv6_no-debug_no-inline_ACE_TAO_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        rm -f windows-2016_ipv6_no-debug_no-inline_ACE_TAO.tar.xz
-#        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v2
-#      with:
-#        name: windows-2016_ipv6_no-debug_no-inline_java_no-bit_build_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ windows-2016_ipv6_no-debug_no-inline_java_no-bit_build.tar.xz
-#        rm -f windows-2016_ipv6_no-debug_no-inline_java_no-bit_build.tar.xz
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export DBS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\\\\/g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$DBS_GHW\\OpenDDS"/>
-#        <variable name="root" value="$DBS_GHW\\OpenDDS\\${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="gcc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$DBS_GHW\\OpenDDS -Config IPV6 -Config RTPS -Config WIN32 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-
   # macOS 11.0
 
 #  macos-11_0_defaults_ACE_TAO:
-#
+
 #    runs-on: macos-11.0
-#
+
 #    steps:
 #    - name: checkout OpenDDS
 #      uses: actions/checkout@v2.3.4
@@ -4791,13 +5942,13 @@ jobs:
 #      with:
 #        name: ${{ github.job }}_artifact
 #        path: ${{ github.job }}.tar.xz
-#
+
 #  macos-11_0_defaults_security_build:
-#
+
 #    runs-on: macos-11.0
-#
+
 #    needs: macos-11_0_defaults_ACE_TAO
-#
+
 #    steps:
 #    - name: install xerces-c
 #      run: |
@@ -4859,13 +6010,13 @@ jobs:
 #      with:
 #        name: ${{ github.job }}_artifact
 #        path: ${{ github.job }}.tar.xz
-#
+
 #  macos-11_0_defaults_security_test:
-#
+
 #    runs-on: macos-11.0
-#
+
 #    needs: macos-11_0_defaults_security_build
-#
+
 #    steps:
 #    - name: install xerces-c
 #      run: |
@@ -4959,13 +6110,13 @@ jobs:
 #      run: |
 #        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 #        if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
-#
+
 #  macos-11_0_defaults_java_no-bit_build:
-#
+
 #    runs-on: macos-11.0
-#
+
 #    needs: macos-11_0_defaults_ACE_TAO
-#
+
 #    steps:
 #    - name: install xerces-c
 #      run: |
@@ -5054,7 +6205,7 @@ jobs:
 #      with:
 #        name: ${{ github.job }}_artifact
 #        path: ${{ github.job }}.tar.xz
-#
+
 #  macos-11_0_defaults_java_no-bit_test:
 #
 #    runs-on: macos-11.0
@@ -5157,7 +6308,7 @@ jobs:
 
   # macOS 10.15
 
-  macos-10_15_defaults_ACE_TAO:
+  ACE_TAO_macos-10_15_o1d0_security:
 
     runs-on: macos-10.15
 
@@ -5199,7 +6350,7 @@ jobs:
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
-        ./configure --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
+        ./configure --optimize --no-debug --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
     - name: build ACE and TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -5225,11 +6376,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  macos-10_15_defaults_security_build:
+  build_macos-10_15_o1d0_security:
 
     runs-on: macos-10.15
 
-    needs: macos-10_15_defaults_ACE_TAO
+    needs: ACE_TAO_macos-10_15_o1d0_security
 
     steps:
     - name: install xerces-c
@@ -5249,13 +6400,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_ACE_TAO_artifact
+        name: ACE_TAO_macos-10_15_o1d0_security_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_macos-10_15_o1d0_security.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -5264,7 +6415,7 @@ jobs:
     - name: configure OpenDDS
       run: |
         cd OpenDDS
-        ./configure --std=c++11 --tests --rapidjson --security --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
+        ./configure --optimize --no-debug --std=c++11 --tests --rapidjson --security --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
     - name: check build configuration
       shell: bash
       run: |
@@ -5293,11 +6444,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  macos-10_15_defaults_security_test:
+  test_macos-10_15_o1d0_security:
 
     runs-on: macos-10.15
 
-    needs: macos-10_15_defaults_security_build
+    needs: build_macos-10_15_o1d0_security
 
     steps:
     - name: install xerces-c
@@ -5322,13 +6473,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_ACE_TAO_artifact
+        name: ACE_TAO_macos-10_15_o1d0_security_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_macos-10_15_o1d0_security.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -5337,13 +6488,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_security_build_artifact
+        name: build_macos-10_15_o1d0_security_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ macos-10_15_defaults_security_build.tar.xz
+        tar xvfJ build_macos-10_15_o1d0_security.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -5393,11 +6544,80 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  macos-10_15_defaults_java_no-bit_build:
+  ACE_TAO_macos-10_15_i0_java_no-bit:
 
     runs-on: macos-10.15
 
-    needs: macos-10_15_defaults_ACE_TAO
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure  --no-inline --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl/
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+
+  build_macos-10_15_i0_java_no-bit:
+
+    runs-on: macos-10.15
+
+    needs: ACE_TAO_macos-10_15_i0_java_no-bit
 
     steps:
     - name: install xerces-c
@@ -5417,13 +6637,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_ACE_TAO_artifact
+        name: ACE_TAO_macos-10_15_i0_java_no-bit_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_macos-10_15_i0_java_no-bit.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -5432,7 +6652,7 @@ jobs:
     - name: configure OpenDDS
       run: |
         cd OpenDDS
-        ./configure --std=c++11 --tests --rapidjson --java --no-built-in-topics --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+        ./configure --no-inline --std=c++11 --tests --rapidjson --java --no-built-in-topics --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: check build configuration
       shell: bash
       run: |
@@ -5488,11 +6708,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  macos-10_15_defaults_java_no-bit_test:
+  test_macos-10_15_i0_java_no-bit:
 
     runs-on: macos-10.15
 
-    needs: macos-10_15_defaults_java_no-bit_build
+    needs: build_macos-10_15_i0_java_no-bit
 
     steps:
     - name: install xerces-c
@@ -5517,13 +6737,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_ACE_TAO_artifact
+        name: ACE_TAO_macos-10_15_i0_java_no-bit_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ macos-10_15_defaults_ACE_TAO.tar.xz
+        tar xvfJ ACE_TAO_macos-10_15_i0_java_no-bit.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -5532,13 +6752,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v2
       with:
-        name: macos-10_15_defaults_java_no-bit_build_artifact
+        name: build_macos-10_15_i0_java_no-bit_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ macos-10_15_defaults_java_no-bit_build.tar.xz
+        tar xvfJ build_macos-10_15_i0_java_no-bit.tar.xz
     - name: check build configuration
       shell: bash
       run: |


### PR DESCRIPTION
As part of our modernization of our CI/Scoreboard we wanted to migrate all of our CI to github actions.  This PR represents the first step of that.  It has migrated all of our CI builds from Azure and Jenkins to GHA.  Some extraneous builds were removed and others were changed.  

There are documents in confluence and the google drive describing the plan and the problems remaining.

The Safety and Static builds are expected to fail for this PR.