### PR TITLE
RTPS messages are not logged

### DIFF
--- a/dds/DCPS/JsonValueWriter.h
+++ b/dds/DCPS/JsonValueWriter.h
@@ -11,7 +11,7 @@
 #ifdef OPENDDS_RAPIDJSON
 #ifndef OPENDDS_SAFETY_PROFILE
 
-#define OPENDDS_HAVE_JSON_VALUE_WRITER 1
+#define OPENDDS_HAS_JSON_VALUE_WRITER 1
 
 #include "dcps_export.h"
 

--- a/dds/DCPS/JsonValueWriter.h
+++ b/dds/DCPS/JsonValueWriter.h
@@ -11,6 +11,8 @@
 #ifdef OPENDDS_RAPIDJSON
 #ifndef OPENDDS_SAFETY_PROFILE
 
+#define OPENDDS_HAVE_JSON_VALUE_WRITER 1
+
 #include "dcps_export.h"
 
 #include "ValueWriter.h"

--- a/dds/DCPS/RTPS/BaseMessageUtils.h
+++ b/dds/DCPS/RTPS/BaseMessageUtils.h
@@ -13,6 +13,7 @@
 #include "BaseMessageTypes.h"
 
 #include <dds/DCPS/Hash.h>
+#include <dds/DCPS/Util.h>
 #include <dds/DCPS/Message_Block_Ptr.h>
 #include <dds/DCPS/Serializer.h>
 #include <dds/DCPS/TypeSupportImpl.h>
@@ -222,34 +223,32 @@ inline RTPS::SequenceNumber_t to_rtps_seqnum(const DCPS::SequenceNumber& opendds
   return rtps_seqnum;
 }
 
-inline void append_submessage(RTPS::Message& message, const RTPS::Submessage& submessage) {
-  ACE_CDR::ULong idx = message.submessages.length();
-  message.submessages.length(idx + 1);
-  message.submessages[idx] = submessage;
+inline void append_submessage(RTPS::Message& message, const RTPS::InfoDestinationSubmessage& submessage)
+{
+  RTPS::Submessage sm;
+  sm.info_dst_sm(submessage);
+  DCPS::push_back(message.submessages, sm);
 }
 
-inline void append_submessage(RTPS::Message& message, const RTPS::InfoDestinationSubmessage& submessage) {
-  ACE_CDR::ULong idx = message.submessages.length();
-  message.submessages.length(idx + 1);
-  message.submessages[idx].info_dst_sm(submessage);
+inline void append_submessage(RTPS::Message& message, const RTPS::InfoTimestampSubmessage& submessage)
+{
+  RTPS::Submessage sm;
+  sm.info_ts_sm(submessage);
+  DCPS::push_back(message.submessages, sm);
 }
 
-inline void append_submessage(RTPS::Message& message, const RTPS::InfoTimestampSubmessage& submessage) {
-  ACE_CDR::ULong idx = message.submessages.length();
-  message.submessages.length(idx + 1);
-  message.submessages[idx].info_ts_sm(submessage);
+inline void append_submessage(RTPS::Message& message, const RTPS::DataSubmessage& submessage)
+{
+  RTPS::Submessage sm;
+  sm.data_sm(submessage);
+  DCPS::push_back(message.submessages, sm);
 }
 
-inline void append_submessage(RTPS::Message& message, const RTPS::DataSubmessage& submessage) {
-  ACE_CDR::ULong idx = message.submessages.length();
-  message.submessages.length(idx + 1);
-  message.submessages[idx].data_sm(submessage);
-}
-
-inline void append_submessage(RTPS::Message& message, const RTPS::DataFragSubmessage& submessage) {
-  ACE_CDR::ULong idx = message.submessages.length();
-  message.submessages.length(idx + 1);
-  message.submessages[idx].data_frag_sm(submessage);
+inline void append_submessage(RTPS::Message& message, const RTPS::DataFragSubmessage& submessage)
+{
+  RTPS::Submessage sm;
+  sm.data_frag_sm(submessage);
+  DCPS::push_back(message.submessages, sm);
 }
 
 } // namespace RTPS

--- a/dds/DCPS/RTPS/BaseMessageUtils.h
+++ b/dds/DCPS/RTPS/BaseMessageUtils.h
@@ -222,6 +222,36 @@ inline RTPS::SequenceNumber_t to_rtps_seqnum(const DCPS::SequenceNumber& opendds
   return rtps_seqnum;
 }
 
+inline void append_submessage(RTPS::Message& message, const RTPS::Submessage& submessage) {
+  ACE_CDR::ULong idx = message.submessages.length();
+  message.submessages.length(idx + 1);
+  message.submessages[idx] = submessage;
+}
+
+inline void append_submessage(RTPS::Message& message, const RTPS::InfoDestinationSubmessage& submessage) {
+  ACE_CDR::ULong idx = message.submessages.length();
+  message.submessages.length(idx + 1);
+  message.submessages[idx].info_dst_sm(submessage);
+}
+
+inline void append_submessage(RTPS::Message& message, const RTPS::InfoTimestampSubmessage& submessage) {
+  ACE_CDR::ULong idx = message.submessages.length();
+  message.submessages.length(idx + 1);
+  message.submessages[idx].info_ts_sm(submessage);
+}
+
+inline void append_submessage(RTPS::Message& message, const RTPS::DataSubmessage& submessage) {
+  ACE_CDR::ULong idx = message.submessages.length();
+  message.submessages.length(idx + 1);
+  message.submessages[idx].data_sm(submessage);
+}
+
+inline void append_submessage(RTPS::Message& message, const RTPS::DataFragSubmessage& submessage) {
+  ACE_CDR::ULong idx = message.submessages.length();
+  message.submessages.length(idx + 1);
+  message.submessages[idx].data_frag_sm(submessage);
+}
+
 } // namespace RTPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/RTPS/Logging.cpp
+++ b/dds/DCPS/RTPS/Logging.cpp
@@ -7,6 +7,9 @@
 
 #include "Logging.h"
 
+#include "BaseMessageUtils.h"
+#include "MessageTypes.h"
+
 #include <dds/DCPS/JsonValueWriter.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -33,7 +36,7 @@ void log_message(const char* format,
                  bool send,
                  const Message& message)
 {
-#ifdef OPENDDS_HAVE_JSON_VALUE_WRITER
+#ifdef OPENDDS_HAS_JSON_VALUE_WRITER
   DCPS::JsonValueWriter<> jvw;
   jvw.begin_struct();
   jvw.begin_struct_member("guidPrefix");
@@ -48,8 +51,79 @@ void log_message(const char* format,
   jvw.end_struct();
   ACE_DEBUG((LM_DEBUG, format, jvw.buffer().GetString()));
 #else
-  ACE_DEBUG((LM_DEBUG, format, "ERROR: OpenDDS lacks JSON serialization support"));
+  ACE_UNUSED_ARG(format);
+  ACE_UNUSED_ARG(prefix);
+  ACE_UNUSED_ARG(send);
+  ACE_UNUSED_ARG(message);
+  ACE_DEBUG((LM_DEBUG, "ERROR: OpenDDS lacks JSON serialization support, can't log RTPS messages\n"));
 #endif
+}
+
+void parse_submessages(Message& message,
+                       ACE_Message_Block* mb)
+{
+  DCPS::Message_Block_Ptr buff(mb);
+  const DCPS::Encoding encoding_plain_native(DCPS::Encoding::KIND_XCDR1);
+  DCPS::Serializer ser(buff.get(), encoding_plain_native);
+  while (buff->length() > 3) {
+    const char subm = buff->rd_ptr()[0], flags = buff->rd_ptr()[1];
+    ser.swap_bytes((flags & RTPS::FLAG_E) != ACE_CDR_BYTE_ORDER);
+    const size_t start = buff->length();
+    CORBA::UShort submessageLength = 0;
+    switch (subm) {
+    case RTPS::INFO_DST: {
+      RTPS::InfoDestinationSubmessage sm;
+      ser >> sm;
+      submessageLength = sm.smHeader.submessageLength;
+      append_submessage(message, sm);
+      break;
+    }
+    case RTPS::INFO_TS: {
+      RTPS::InfoTimestampSubmessage sm;
+      ser >> sm;
+      submessageLength = sm.smHeader.submessageLength;
+      append_submessage(message, sm);
+      break;
+    }
+    case RTPS::DATA: {
+      RTPS::DataSubmessage sm;
+      ser >> sm;
+      submessageLength = sm.smHeader.submessageLength;
+      append_submessage(message, sm);
+      break;
+    }
+    case RTPS::DATA_FRAG: {
+      RTPS::DataFragSubmessage sm;
+      ser >> sm;
+      submessageLength = sm.smHeader.submessageLength;
+      append_submessage(message, sm);
+      break;
+    }
+    default:
+      RTPS::SubmessageHeader smHeader;
+      if (!(ser >> smHeader)) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("(%P|%t) ERROR: RtpsUdpDataLink::durability_resend() - ")
+                   ACE_TEXT("failed to deserialize SubmessageHeader\n")));
+      }
+      submessageLength = smHeader.submessageLength;
+      break;
+    }
+    if (submessageLength && buff->length()) {
+      const size_t read = start - buff->length();
+      if (read < static_cast<size_t>(submessageLength + RTPS::SMHDR_SZ)) {
+        if (!ser.skip(static_cast<CORBA::UShort>(submessageLength + RTPS::SMHDR_SZ
+                                                 - read))) {
+          ACE_ERROR((LM_ERROR,
+                     ACE_TEXT("(%P|%t) ERROR: RtpsUdpDataLink::durability_resend() - ")
+                     ACE_TEXT("failed to skip sub message length\n")));
+        }
+      }
+    } else if (!submessageLength) {
+      break; // submessageLength of 0 indicates the last submessage
+    }
+
+  }
 }
 
 } // namespace RTPS

--- a/dds/DCPS/RTPS/Logging.cpp
+++ b/dds/DCPS/RTPS/Logging.cpp
@@ -1,0 +1,58 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "Logging.h"
+
+#include <dds/DCPS/JsonValueWriter.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+
+namespace DCPS {
+
+void vwrite(ValueWriter& vw, const GuidPrefix_t& prefix)
+{
+  vw.begin_array();
+  for (size_t idx = 0; idx != sizeof(prefix); ++idx) {
+    vw.write_byte(prefix[idx]);
+  }
+  vw.end_array();
+}
+
+}
+
+namespace RTPS {
+
+void log_message(const char* format,
+                 const DCPS::GuidPrefix_t& prefix,
+                 bool send,
+                 const Message& message)
+{
+#ifdef OPENDDS_HAVE_JSON_VALUE_WRITER
+  DCPS::JsonValueWriter<> jvw;
+  jvw.begin_struct();
+  jvw.begin_struct_member("guidPrefix");
+  vwrite(jvw, prefix);
+  jvw.end_struct_member();
+  jvw.begin_struct_member("send");
+  jvw.write_boolean(send);
+  jvw.end_struct_member();
+  jvw.begin_struct_member("message");
+  vwrite(jvw, message);
+  jvw.end_struct_member();
+  jvw.end_struct();
+  ACE_DEBUG((LM_DEBUG, format, jvw.buffer().GetString()));
+#else
+  ACE_DEBUG((LM_DEBUG, format, "ERROR: OpenDDS lacks JSON serialization support"));
+#endif
+}
+
+} // namespace RTPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RTPS/Logging.h
+++ b/dds/DCPS/RTPS/Logging.h
@@ -32,6 +32,10 @@ void log_message(const char* format,
                  bool send,
                  const Message& message);
 
+OpenDDS_Rtps_Export
+void parse_submessages(Message& message,
+                       ACE_Message_Block* mb);
+
 } // namespace RTPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/RTPS/Logging.h
+++ b/dds/DCPS/RTPS/Logging.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_RTPS_LOGGING_H
+#define OPENDDS_DCPS_RTPS_LOGGING_H
+
+#include "rtps_export.h"
+
+#include "RtpsCoreTypeSupportImpl.h"
+
+#include <dds/Versioned_Namespace.h>
+
+#include <dds/DCPS/GuidUtils.h>
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace RTPS {
+
+/// Log a serialized RTPS message.
+OpenDDS_Rtps_Export
+void log_message(const char* format,
+                 const DCPS::GuidPrefix_t& prefix,
+                 bool send,
+                 const Message& message);
+
+} // namespace RTPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_RTPS_LOGGING_H */

--- a/dds/DCPS/RTPS/Logging.h
+++ b/dds/DCPS/RTPS/Logging.h
@@ -34,7 +34,7 @@ void log_message(const char* format,
 
 OpenDDS_Rtps_Export
 void parse_submessages(Message& message,
-                       ACE_Message_Block* mb);
+                       const ACE_Message_Block& mb);
 
 } // namespace RTPS
 } // namespace OpenDDS

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -885,6 +885,11 @@ module OpenDDS {
     struct DiscoveredTopicData {
       DDS::TopicBuiltinTopicData ddsTopicData;
     };
+
+    struct Message {
+      Header hdr;
+      SubmessageSeq submessages;
+    };
   };
 };
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2410,7 +2410,7 @@ Spdp::SpdpTransport::dispose_unregister()
     RTPS::Message message;
     message.hdr = hdr_;
     append_submessage(message, data_);
-    RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), hdr_.guidPrefix, true, message);
+    RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", hdr_.guidPrefix, true, message);
   }
 
   send(SEND_TO_LOCAL | SEND_TO_RELAY);
@@ -2551,7 +2551,7 @@ Spdp::SpdpTransport::write_i(WriteFlags flags)
     RTPS::Message message;
     message.hdr = hdr_;
     append_submessage(message, data_);
-    RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), hdr_.guidPrefix, true, message);
+    RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", hdr_.guidPrefix, true, message);
   }
 
   send(flags);
@@ -2623,7 +2623,7 @@ Spdp::SpdpTransport::write_i(const DCPS::RepoId& guid, WriteFlags flags)
     message.hdr = hdr_;
     append_submessage(message, info_dst);
     append_submessage(message, data_);
-    RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), hdr_.guidPrefix, true, message);
+    RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", hdr_.guidPrefix, true, message);
   }
 
   send(flags);
@@ -2833,6 +2833,7 @@ Spdp::SpdpTransport::handle_input(ACE_HANDLE h)
           break;
         }
       }
+      // fallthrough
       default:
         SubmessageHeader smHeader;
         if (!(ser >> smHeader)) {
@@ -2860,8 +2861,8 @@ Spdp::SpdpTransport::handle_input(ACE_HANDLE h)
       }
     }
 
-    if (!DCPS::GuidPrefixEqual()(hdr_.guidPrefix, header.guidPrefix) && DCPS::transport_debug.log_messages) {
-      RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), hdr_.guidPrefix, false, message);
+    if (DCPS::transport_debug.log_messages && !DCPS::GuidPrefixEqual()(hdr_.guidPrefix, header.guidPrefix)) {
+      RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", hdr_.guidPrefix, false, message);
     }
 
   } else if ((buff_.size() >= 4) && (ACE_OS::memcmp(buff_.rd_ptr(), "RTPX", 4) == 0)) {

--- a/dds/DCPS/transport/framework/TransportDebug.cpp
+++ b/dds/DCPS/transport/framework/TransportDebug.cpp
@@ -18,7 +18,7 @@ TransportDebug::TransportDebug()
   : log_messages(false)
 {}
 
-TransportDebug transport_debug;
+OpenDDS_Dcps_Export TransportDebug transport_debug;
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/transport/framework/TransportDebug.cpp
+++ b/dds/DCPS/transport/framework/TransportDebug.cpp
@@ -9,6 +9,8 @@
 
 #include "TransportDebug.h"
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
 namespace OpenDDS {
 namespace DCPS {
 
@@ -22,3 +24,5 @@ OpenDDS_Dcps_Export TransportDebug transport_debug;
 
 } // namespace DCPS
 } // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportDebug.cpp
+++ b/dds/DCPS/transport/framework/TransportDebug.cpp
@@ -9,4 +9,16 @@
 
 #include "TransportDebug.h"
 
-OpenDDS_Dcps_Export unsigned int OpenDDS::DCPS::Transport_debug_level = 0;
+namespace OpenDDS {
+namespace DCPS {
+
+OpenDDS_Dcps_Export unsigned int Transport_debug_level = 0;
+
+TransportDebug::TransportDebug()
+  : log_messages(false)
+{}
+
+TransportDebug transport_debug;
+
+} // namespace DCPS
+} // namespace OpenDDS

--- a/dds/DCPS/transport/framework/TransportDebug.h
+++ b/dds/DCPS/transport/framework/TransportDebug.h
@@ -45,6 +45,14 @@ namespace DCPS {
 // This needs to be initialized somewhere.
 extern OpenDDS_Dcps_Export unsigned int Transport_debug_level;
 
+class OpenDDS_Dcps_Export TransportDebug {
+public:
+  TransportDebug();
+
+  bool log_messages;
+};
+extern OpenDDS_Dcps_Export TransportDebug transport_debug;
+
 } // namespace OpenDDS
 } // namespace DCPS
 

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -224,6 +224,8 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
     }
   }
 
+  finish_message();
+
   if (cur_rb->data_block()->reference_count() > 1) {
     ACE_DES_FREE(
       cur_rb,

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -95,6 +95,8 @@ protected:
   virtual void deliver_sample(ReceivedDataSample&  sample,
                               const ACE_INET_Addr& remote_address) = 0;
 
+  virtual void finish_message() {}
+
   /// Let the subclass start.
   virtual int start_i() = 0;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3476,7 +3476,7 @@ void RtpsUdpDataLink::durability_resend(TransportQueueElement* element,
       RTPS::Message message;
       send_strategy()->send_rtps_control(message, *const_cast<ACE_Message_Block*>((*i)->msg()), addrs);
       if (transport_debug.log_messages) {
-        parse_submessages(message, const_cast<ACE_Message_Block*>((*i)->msg())->duplicate());
+        parse_submessages(message, *const_cast<ACE_Message_Block*>((*i)->msg()));
         RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", message.hdr.guidPrefix, true, message);
       }
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -335,7 +335,7 @@ RtpsUdpReceiveStrategy::deliver_sample(ReceivedDataSample& sample,
   const RtpsSampleHeader& rsh = received_sample_header();
 
   if (transport_debug.log_messages) {
-    append_submessage(message_, rsh.submessage_);
+    DCPS::push_back(message_.submessages, rsh.submessage_);
   }
 
 #ifdef OPENDDS_SECURITY
@@ -360,7 +360,7 @@ void
 RtpsUdpReceiveStrategy::finish_message()
 {
   if (transport_debug.log_messages) {
-    RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), receiver_.local_, false, message_);
+    RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", receiver_.local_, false, message_);
   }
 }
 
@@ -641,9 +641,9 @@ RtpsUdpReceiveStrategy::deliver_from_secure(const RTPS::Submessage& submessage)
           VDBG((LM_DEBUG, "(%P|%t) DBG:   Reassembled complete message from decoded\n"));
           encoded_submsg_ = true;
           if (transport_debug.log_messages) {
-            // Pop the secure envelop.
+            // Pop the secure envelope.
             message_.submessages.length(message_.submessages.length() - 3);
-            append_submessage(message_, rsh.submessage_);
+            DCPS::push_back(message_.submessages, rsh.submessage_);
           }
           deliver_sample_i(plain_sample, rsh.submessage_);
           return;
@@ -651,9 +651,9 @@ RtpsUdpReceiveStrategy::deliver_from_secure(const RTPS::Submessage& submessage)
       }
       encoded_submsg_ = true;
       if (transport_debug.log_messages) {
-        // Pop the secure envelop.
+        // Pop the secure envelope.
         message_.submessages.length(message_.submessages.length() - 3);
-        append_submessage(message_, rsh.submessage_);
+        DCPS::push_back(message_.submessages, rsh.submessage_);
       }
       deliver_sample_i(plain_sample, rsh.submessage_);
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -95,6 +95,8 @@ private:
   virtual void deliver_sample(ReceivedDataSample& sample,
                               const ACE_INET_Addr& remote_address);
 
+  virtual void finish_message();
+
   void deliver_sample_i(ReceivedDataSample& sample,
                         const RTPS::Submessage& submessage);
 
@@ -159,6 +161,7 @@ private:
 
   MessageReceiver receiver_;
   ACE_INET_Addr remote_address_;
+  RTPS::Message message_;
 
 #ifdef OPENDDS_SECURITY
   RTPS::SecuritySubmessage secure_prefix_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -16,6 +16,7 @@
 #include "dds/DCPS/RTPS/BaseMessageTypes.h"
 #include "dds/DCPS/RTPS/BaseMessageUtils.h"
 #include "dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h"
+#include "dds/DCPS/RTPS/Logging.h"
 
 #include "dds/DCPS/Serializer.h"
 
@@ -52,14 +53,14 @@ RtpsUdpSendStrategy::RtpsUdpSendStrategy(RtpsUdpDataLink* link,
     rtps_header_mb_(&rtps_header_db_, ACE_Message_Block::DONT_DELETE),
     network_is_unreachable_(false)
 {
-  std::memcpy(rtps_header_.prefix, RTPS::PROTOCOL_RTPS, sizeof RTPS::PROTOCOL_RTPS);
-  rtps_header_.version = OpenDDS::RTPS::PROTOCOLVERSION;
-  rtps_header_.vendorId = OpenDDS::RTPS::VENDORID_OPENDDS;
-  std::memcpy(rtps_header_.guidPrefix, local_prefix,
+  std::memcpy(rtps_message_.hdr.prefix, RTPS::PROTOCOL_RTPS, sizeof RTPS::PROTOCOL_RTPS);
+  rtps_message_.hdr.version = OpenDDS::RTPS::PROTOCOLVERSION;
+  rtps_message_.hdr.vendorId = OpenDDS::RTPS::VENDORID_OPENDDS;
+  std::memcpy(rtps_message_.hdr.guidPrefix, local_prefix,
               sizeof(GuidPrefix_t));
   Serializer writer(&rtps_header_mb_, encoding_unaligned_native);
   // byte order doesn't matter for the RTPS Header
-  writer << rtps_header_;
+  writer << rtps_message_.hdr;
 }
 
 namespace {
@@ -144,6 +145,12 @@ RtpsUdpSendStrategy::OverrideToken::~OverrideToken()
 bool
 RtpsUdpSendStrategy::marshal_transport_header(ACE_Message_Block* mb)
 {
+  if (transport_debug.log_messages) {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_message_mutex_, false);
+    RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), rtps_message_.hdr.guidPrefix, true, rtps_message_);
+    rtps_message_.submessages.length(0);
+  }
+
   Serializer writer(mb, encoding_unaligned_native); // byte order doesn't matter for the RTPS Header
   return writer.write_octet_array(reinterpret_cast<ACE_CDR::Octet*>(rtps_header_data_),
     RTPS::RTPSHDR_SZ);
@@ -160,9 +167,15 @@ namespace {
 }
 
 void
-RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
+RtpsUdpSendStrategy::send_rtps_control(RTPS::Message& message,
+                                       ACE_Message_Block& submessages,
                                        const ACE_INET_Addr& addr)
 {
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, rtps_message_mutex_);
+    message.hdr = rtps_message_.hdr;
+  }
+
   const AMB_Continuation cont(rtps_header_mb_lock_, rtps_header_mb_, submessages);
 
 #ifdef OPENDDS_SECURITY
@@ -188,9 +201,15 @@ RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
 }
 
 void
-RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
+RtpsUdpSendStrategy::send_rtps_control(RTPS::Message& message,
+                                       ACE_Message_Block& submessages,
                                        const OPENDDS_SET(ACE_INET_Addr)& addrs)
 {
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, rtps_message_mutex_);
+    message.hdr = rtps_message_.hdr;
+  }
+
   const AMB_Continuation cont(rtps_header_mb_lock_, rtps_header_mb_, submessages);
 
 #ifdef OPENDDS_SECURITY
@@ -212,6 +231,15 @@ RtpsUdpSendStrategy::send_rtps_control(ACE_Message_Block& submessages,
     const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
     ACE_ERROR((prio, "(%P|%t) RtpsUdpSendStrategy::send_rtps_control() - "
       "failed to send RTPS control message\n"));
+  }
+}
+
+void
+RtpsUdpSendStrategy::append_submessages(const RTPS::SubmessageSeq& submessages)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, rtps_message_mutex_);
+  for (ACE_CDR::ULong idx = 0; idx != submessages.length(); ++idx) {
+    RTPS::append_submessage(rtps_message_, submessages[idx]);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -147,7 +147,7 @@ RtpsUdpSendStrategy::marshal_transport_header(ACE_Message_Block* mb)
 {
   if (transport_debug.log_messages) {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, rtps_message_mutex_, false);
-    RTPS::log_message(ACE_TEXT("(%P|%t) {transport_debug.log_messages} %C\n"), rtps_message_.hdr.guidPrefix, true, rtps_message_);
+    RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", rtps_message_.hdr.guidPrefix, true, rtps_message_);
     rtps_message_.submessages.length(0);
   }
 
@@ -239,7 +239,7 @@ RtpsUdpSendStrategy::append_submessages(const RTPS::SubmessageSeq& submessages)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, rtps_message_mutex_);
   for (ACE_CDR::ULong idx = 0; idx != submessages.length(); ++idx) {
-    RTPS::append_submessage(rtps_message_, submessages[idx]);
+    DCPS::push_back(rtps_message_.submessages, submessages[idx]);
   }
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
@@ -49,10 +49,13 @@ public:
   OverrideToken override_destinations(
     const OPENDDS_SET(ACE_INET_Addr)& destinations);
 
-  void send_rtps_control(ACE_Message_Block& submessages,
+  void send_rtps_control(RTPS::Message& message,
+                         ACE_Message_Block& submessages,
                          const ACE_INET_Addr& destination);
-  void send_rtps_control(ACE_Message_Block& submessages,
+  void send_rtps_control(RTPS::Message& message,
+                         ACE_Message_Block& submessages,
                          const OPENDDS_SET(ACE_INET_Addr)& destinations);
+  void append_submessages(const RTPS::SubmessageSeq& submessages);
 
 #if defined(OPENDDS_SECURITY)
   void encode_payload(const RepoId& pub_id, Message_Block_Ptr& payload,
@@ -131,7 +134,8 @@ private:
   const ACE_INET_Addr* override_single_dest_;
 
   const size_t max_message_size_;
-  RTPS::Header rtps_header_;
+  RTPS::Message rtps_message_;
+  ACE_Thread_Mutex rtps_message_mutex_;
   char rtps_header_data_[RTPS::RTPSHDR_SZ];
   ACE_Data_Block rtps_header_db_;
   ACE_Message_Block rtps_header_mb_;


### PR DESCRIPTION
Problem
-------

In some situations, it is impossible to collect a packet capture for
debugging RTPS issues.  In this case, it is desirable to have a log of
the RTPS messages.

Solution
--------

Add support for logging RTPS messages.  Payloads for DATA and
DATA_FRAG submessages are not logged.  Messages are logged before any
encryption is applied and after all decryptions are applied.