### PR TITLE
SPDP may be delayed by one period when changing relay address

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2541,6 +2541,12 @@ Spdp::SpdpTransport::write_i(WriteFlags flags)
   send(flags);
 }
 
+void
+Spdp::send_to_relay()
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  tport_->write_i(SpdpTransport::SEND_TO_RELAY);
+}
 
 void
 Spdp::SpdpTransport::write_i(const DCPS::RepoId& guid, WriteFlags flags)

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -201,6 +201,7 @@ public:
   );
 
   DCPS::RcHandle<RtpsDiscoveryConfig> config() const { return config_; }
+  void send_to_relay();
 
 protected:
   Sedp& endpoint_manager() { return *sedp_; }


### PR DESCRIPTION
Problem
-------

A change in SPDP relay address will not be picked up until the timer
expires.  This may cause a delay when recovering from connectivity
problems.

Solution
--------

Send an SPDP message to the relay when the address changes.