### PR TITLE
Type lookup leaks memory for remote-remote

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1216,6 +1216,10 @@ namespace OpenDDS {
           return; // Possible and ok, since lock is released
         }
 
+        if (!writer_local && !reader_local) {
+          return;
+        }
+
         MatchingData md;
 
         // if the type object is not in cache, send RPC request
@@ -1254,13 +1258,6 @@ namespace OpenDDS {
                 reader_type_info, md, MatchingPair(writer, reader), reader, is_discovery_protected);
               return;
             }
-          }
-
-          MatchingDataIter md_it = matching_data_buffer_.find(MatchingPair(writer, reader));
-          if (md_it != matching_data_buffer_.end()) {
-            md_it->second = md;
-          } else {
-            matching_data_buffer_.insert(std::make_pair(MatchingPair(writer, reader), md));
           }
         }
 


### PR DESCRIPTION
Problem
-------

The type lookup support does not filter out remote-remote matches.
Furthermore, a match that does not require a type lookup inserts into
a datastructure which is never cleaned.

Solution
--------

Detect remote-remote matches and don't insert when not necessary.