### PR TITLE
Clean up jni local references.

### DIFF
--- a/java/idl2jni/codegen/im_jni.cpp
+++ b/java/idl2jni/codegen/im_jni.cpp
@@ -1889,7 +1889,6 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   "  jclass clazz = jni->GetObjectClass (source);\n" <<
   "  jmethodID mid_disc = jni->GetMethodID (clazz, \"discriminator\", \"()"
   << disc_sig << "\");\n"
-  "  jni->DeleteLocalRef(clazz);\n"
   "  " << disc_ty << " disc = jni->Call" << disc_meth << "Method (source, "
   "mid_disc);\n" <<
   extra_enum1 <<
@@ -1897,6 +1896,7 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   "    {\n" <<
   branchesToCxx <<
   "    }\n"
+  "  jni->DeleteLocalRef(clazz);\n"
   "  target._d (" << extra_enum2 << ");\n" //in case the Java side had one of
   "}\n\n" <<                               //the "alternate" labels for 1 br.
   c.sigToJava << "\n"

--- a/java/idl2jni/codegen/im_jni.cpp
+++ b/java/idl2jni/codegen/im_jni.cpp
@@ -472,6 +472,7 @@ bool idl_mapping_jni::gen_enum(UTL_ScopedName *name,
   "  jfieldID fid = jni->GetFieldID (clazz, \"_value\", \"I\");\n"
   "  target = static_cast<" << c.cxx
   << "> (jni->GetIntField (source, fid));\n"
+  "  jni->DeleteLocalRef(clazz);\n"
   "}\n\n" <<
   c.sigToJava << "\n"
   "{\n"
@@ -480,6 +481,7 @@ bool idl_mapping_jni::gen_enum(UTL_ScopedName *name,
   "  jmethodID factory = jni->GetStaticMethodID (clazz, \"from_int\", "
   "\"(I)L" << enumJVMsig << ";\");\n"
   "  target = jni->CallStaticObjectMethod (clazz, factory, source);\n"
+  "  jni->DeleteLocalRef(clazz);\n"
   "}\n\n";
   return true;
 }
@@ -580,6 +582,10 @@ bool idl_mapping_jni::gen_struct(UTL_ScopedName *name,
   "      clazz = jni->GetObjectClass (target);\n"
   "    }\n" <<
   fieldsToJava <<
+  "  if (createNewObject)\n"
+  "    {\n"
+  "      jni->DeleteLocalRef(clazz);\n"
+  "    }\n"
   "}\n\n";
   return true;
 }
@@ -974,6 +980,7 @@ string arg_conversion(const char *name, AST_Type *type,
       + ", \"<init>\", \"()V\");\n"
       "  jobject _j_" + name + " = _jni->NewObject (_hc_" + name
       + ", _hm_" + name + ");\n"
+      "  _jni->DeleteLocalRef(_hc_" + string(name) + ");\n"
       "  holderize (_jni, _j_" + name + ", _n_" + name + ", \"" + jvmSig
       + "\");\n";
 
@@ -991,7 +998,8 @@ string arg_conversion(const char *name, AST_Type *type,
       "  jmethodID _hm_" + name + " = _jni->GetMethodID (_hc_" + name
       + ", \"<init>\", \"()V\");\n"
       "  jobject _j_" + name + " = _jni->NewObject (_hc_" + name
-      + ", _hm_" + name + ");\n";
+      + ", _hm_" + name + ");\n"
+      "  _jni->DeleteLocalRef(_hc_" + string(name) + ");\n";
     tao_argconv_out +=
       "  " + jni + " _o_" + name + " = deholderize<" + jni + "> (_jni, _j_"
       + name + ", \"" + jvmSig + "\");\n"
@@ -1119,6 +1127,7 @@ void write_native_attribute_r(UTL_ScopedName *name, const char *javaStub,
     "  " << tao_retval << array_cast << "_jni->Call" << jniFn
     << "Method (globalCallback_, _mid" << java_args
     << ((array_cast == "") ? "" : ")") << ");\n"
+    "  _jni->DeleteLocalRef(_clazz);\n"
     "  jthrowable _excep = _jni->ExceptionOccurred ();\n"
     "  if (_excep) throw_cxx_exception (_jni, _excep);\n"
     << tao_argconv_out
@@ -1212,6 +1221,7 @@ void write_native_attribute_w(UTL_ScopedName *name, const char *javaStub,
     "  " << tao_retval << array_cast << "_jni->Call" << jniFn
     << "Method (globalCallback_, _mid" << java_args
     << ((array_cast == "") ? "" : ")") << ");\n"
+    "  _jni->DeleteLocalRef(_clazz);\n"
     "  jthrowable _excep = _jni->ExceptionOccurred ();\n"
     "  if (_excep) throw_cxx_exception (_jni, _excep);\n"
     << tao_argconv_out
@@ -1366,6 +1376,7 @@ void write_native_operation(UTL_ScopedName *name, const char *javaStub,
     "  " << tao_retval << array_cast << "_jni->Call" << jniFn
     << "Method (globalCallback_, _mid" << java_args
     << ((array_cast == "") ? "" : ")") << ");\n"
+    "  _jni->DeleteLocalRef(_clazz);\n"
     "  jthrowable _excep = _jni->ExceptionOccurred ();\n"
     "  if (_excep) throw_cxx_exception (_jni, _excep);\n"
     << tao_argconv_out
@@ -1442,6 +1453,7 @@ bool idl_mapping_jni::gen_interf(UTL_ScopedName *name, bool local,
     "    {\n"
     "      target = new " << name_underscores << "JavaPeer (jni, source);\n"
     "    }\n"
+    "  jni->DeleteLocalRef(taoObjClazz);\n"
     "}\n\n";
 
   else /*!local*/ c.cppfile <<
@@ -1465,6 +1477,7 @@ bool idl_mapping_jni::gen_interf(UTL_ScopedName *name, bool local,
   "  jmethodID ctor = jni->GetMethodID (stubClazz, \"<init>\", \"(J)V\");\n"
   "  target = jni->NewObject (stubClazz, ctor, reinterpret_cast<jlong> (\n"
   "    CORBA::Object::_duplicate (source.in ())));\n"
+  "  jni->DeleteLocalRef(stubClazz);\n"
   "}\n\n";
 
   // implement native_unarrow native method for the Helper class
@@ -1836,7 +1849,8 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
       "  jmethodID from_int = jni->GetStaticMethodID (dclazz, \"from_int\", "
       "\"(I)" + disc_sig + "\");\n"
       "  jobject jdisc = jni->CallStaticObjectMethod (dclazz, from_int, "
-      "static_cast<jint> (source._d ()));\n";
+      "static_cast<jint> (source._d ()));\n"
+      "  jni->DeleteLocalRef(dclazz);\n";
     explicitDiscCleanup =
       "  jni->DeleteLocalRef (jdisc);\n";
 
@@ -1875,6 +1889,7 @@ bool idl_mapping_jni::gen_union(UTL_ScopedName *name,
   "  jclass clazz = jni->GetObjectClass (source);\n" <<
   "  jmethodID mid_disc = jni->GetMethodID (clazz, \"discriminator\", \"()"
   << disc_sig << "\");\n"
+  "  jni->DeleteLocalRef(clazz);\n"
   "  " << disc_ty << " disc = jni->Call" << disc_meth << "Method (source, "
   "mid_disc);\n" <<
   extra_enum1 <<


### PR DESCRIPTION
This fixes local reference table overflow crashes in Android 7.