### PR TITLE
Slow and no longer existing readers slow association

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -946,6 +946,7 @@ create_association_data_proto(DCPS::AssociationData& proto,
   proto.remote_reliable_ = true;
   proto.remote_durable_ = true;
   DCPS::assign(proto.remote_id_.guidPrefix, pdata.participantProxy.guidPrefix);
+  proto.remote_transport_context_ = pdata.participantProxy.opendds_participant_flags.bits;
   populate_locators(proto.remote_data_, pdata);
 }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3953,6 +3953,7 @@ RtpsUdpDataLink::RtpsWriter::~RtpsWriter()
   }
 
   heartbeat_.cancel_and_wait();
+  nack_response_.cancel_and_wait();
 }
 
 CORBA::Long RtpsUdpDataLink::RtpsWriter::inc_heartbeat_count()

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2807,10 +2807,9 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   const SequenceNumber ack = to_opendds_seqnum(acknack.readerSNState.bitmapBase);
   const bool reset = acknack.count.value == 0 && ack <= reader->cur_cumulative_ack_;
 
-  // TODO: Add filtering logic.
-
   if (!reset) {
-    if (!compare_and_update_counts(acknack.count.value, reader->acknack_recvd_count_)) {
+    if (!compare_and_update_counts(acknack.count.value, reader->acknack_recvd_count_) &&
+        (!reader->reflects_heartbeat_count() || acknack.count.value != 0 || reader->acknack_recvd_count_ != 0)) {
       VDBG((LM_WARNING, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
             "WARNING Count indicates duplicate, dropping\n"));
       return;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3746,7 +3746,7 @@ void
 RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(OPENDDS_VECTOR(TransportQueueElement*)& pendingCallbacks,
                                                  MetaSubmessageVec& meta_submessages)
 {
-  if (preassociation_readers_.empty() && lagging_readers_.empty() && readers_expecting_heartbeat_.empty()) {
+  if (preassociation_readers_.empty() && lagging_readers_.empty()) {
     return;
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1340,7 +1340,7 @@ bool RtpsUdpDataLink::requires_inline_qos(const GUIDSeq_var& peers)
 bool RtpsUdpDataLink::force_inline_qos_ = false;
 
 void
-RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& now)
+RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& /*now*/)
 {
   OPENDDS_VECTOR(TransportQueueElement*) pendingCallbacks;
 
@@ -1349,31 +1349,15 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& now
     return;
   }
 
-  RtpsUdpInst& cfg = link->config();
-
   MetaSubmessageVec meta_submessages;
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
-    if (expected_acks_) {
-      // One more readers did not ack since the last heartbeat.
-      heartbeat_period_ *= cfg.heartbeat_backoff_factor_;
-    } else if (last_ack_ != MonotonicTimePoint::zero_value && last_heartbeat_ != MonotonicTimePoint::zero_value) {
-      heartbeat_period_ = (last_ack_ - last_heartbeat_) * cfg.heartbeat_safety_factor_;
-    }
-    heartbeat_period_ = std::min(heartbeat_period_, std::max(cfg.heartbeat_period_maximum_, cfg.heartbeat_period_minimum_));
-    heartbeat_period_ = std::max(heartbeat_period_, std::min(cfg.heartbeat_period_maximum_, cfg.heartbeat_period_minimum_));
-    expected_acks_ = 0;
 
-    send_and_gather_nack_replies_i(meta_submessages);
     gather_heartbeats_i(pendingCallbacks, meta_submessages);
 
     if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
-      heartbeat_.schedule(heartbeat_period_);
-      last_heartbeat_ = now;
-    } else {
-      last_heartbeat_ = MonotonicTimePoint::zero_value;
+      heartbeat_.schedule(link->config().heartbeat_period_);
     }
-    last_ack_ = MonotonicTimePoint::zero_value;
   }
 
   link->queue_or_send_submessages(meta_submessages);
@@ -1381,6 +1365,24 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& now
   for (size_t i = 0; i < pendingCallbacks.size(); ++i) {
     pendingCallbacks[i]->data_dropped();
   }
+}
+
+void
+RtpsUdpDataLink::RtpsWriter::send_nack_responses(const DCPS::MonotonicTimePoint& /*now*/)
+{
+  RtpsUdpDataLink_rch link = link_.lock();
+  if (!link) {
+    return;
+  }
+
+  MetaSubmessageVec meta_submessages;
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+    gather_nack_replies_i(meta_submessages);
+  }
+
+  link->queue_or_send_submessages(meta_submessages);
 }
 
 void
@@ -1752,6 +1754,7 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_i(const RTPS::HeartBeatSubmessage
                                                  bool directed,
                                                  MetaSubmessageVec& meta_submessages)
 {
+  // TODO: Delay responses by heartbeat_response_delay_.
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
   RtpsUdpDataLink_rch link = link_.lock();
@@ -1863,7 +1866,7 @@ RtpsUdpDataLink::RtpsWriter::add_reader(const ReaderInfo_rch& reader)
     if (link) {
       link->queue_or_send_submessages(meta_submessages);
     }
-    heartbeat_.schedule(heartbeat_period_);
+    heartbeat_.schedule(link->config().heartbeat_period_);
 
     return true;
   }
@@ -2772,7 +2775,7 @@ RtpsUdpDataLink::RtpsWriter::gather_gaps_i(const ReaderInfo_rch& reader,
 void
 RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& acknack,
                                              const RepoId& src_prefix,
-                                             MetaSubmessageVec& /*meta_submessages*/)
+                                             MetaSubmessageVec& meta_submessages)
 {
   const RepoId remote = make_id(src_prefix, acknack.readerId);
 
@@ -2804,6 +2807,8 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   const SequenceNumber ack = to_opendds_seqnum(acknack.readerSNState.bitmapBase);
   const bool reset = acknack.count.value == 0 && ack <= reader->cur_cumulative_ack_;
 
+  // TODO: Add filtering logic.
+
   if (!reset) {
     if (!compare_and_update_counts(acknack.count.value, reader->acknack_recvd_count_)) {
       VDBG((LM_WARNING, "(%P|%t) RtpsUdpDataLink::received(ACKNACK) "
@@ -2811,17 +2816,11 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       return;
     }
 
-    if (reader->reflects_heartbeat_count() && acknack.count.value != heartbeat_count_) {
-      return;
-    }
-
-    if (reader->expecting_ack_) {
-      reader->expecting_ack_ = false;
-      --expected_acks_;
-      last_ack_ = MonotonicTimePoint::now();
-      if (expected_acks_ == 0) {
-        heartbeat_.cancel();
-        heartbeat_.schedule(TimeDuration::zero_value);
+    if (reader->reflects_heartbeat_count()) {
+      if (acknack.count.value < reader->required_acknack_count_) {
+        return;
+      } else {
+        reader->required_acknack_count_ = heartbeat_count_;
       }
     }
   }
@@ -2842,6 +2841,11 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       check_leader_lagger();
       // Heartbeat is already scheduled.
     }
+    // Send a heartbeat immediately so the reader can request data.
+    const SingleSendBuffer::Proxy proxy(*send_buff_);
+    MetaSubmessage meta_submessage(id_, GUID_UNKNOWN);
+    initialize_heartbeat(proxy, meta_submessage);
+    gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
   }
 
   OPENDDS_MAP(SequenceNumber, TransportQueueElement*) pendingCallbacks;
@@ -2865,7 +2869,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       snris_insert(lagging_readers_, reader);
       previous_acked_sn = reader->acked_sn();
       check_leader_lagger();
-      heartbeat_.schedule(heartbeat_period_);
+      heartbeat_.schedule(link->config().heartbeat_period_);
 
       if (reader->durable_ && !reader->expecting_durable_data()) {
         // TODO: Consider how this works if the durable data has not been acked.
@@ -2911,7 +2915,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
   // Process the nack.
   reader->requests_.reset();
-  bool schedule_nack_reply = false;
+  bool schedule_nack_response = false;
   {
     const SingleSendBuffer::Proxy proxy(*send_buff_);
     if ((acknack.readerSNState.numBits == 0 ||
@@ -2929,7 +2933,8 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
     if (!reader->requests_.empty()) {
       readers_expecting_data_.insert(reader);
-      schedule_nack_reply = true;
+      readers_expecting_heartbeat_.insert(reader);
+      schedule_nack_response = true;
     } else {
       readers_expecting_data_.erase(reader);
     }
@@ -2937,7 +2942,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
   if (!is_final) {
     readers_expecting_heartbeat_.insert(reader);
-    schedule_nack_reply = true;
+    schedule_nack_response = true;
   }
 
   if (preassociation_readers_.count(reader) == 0) {
@@ -2969,8 +2974,8 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
   }
 #endif
 
-  if (schedule_nack_reply) {
-    heartbeat_.schedule(heartbeat_period_);
+  if (schedule_nack_response) {
+    nack_response_.schedule(link->config().nak_response_delay_);
   }
 
   g.release();
@@ -3032,11 +3037,12 @@ void RtpsUdpDataLink::RtpsWriter::process_nackfrag(const RTPS::NackFragSubmessag
   const SequenceNumber seq = to_opendds_seqnum(nackfrag.writerSN);
   reader->requested_frags_[seq] = nackfrag.fragmentNumberState;
   readers_expecting_data_.insert(reader);
-  heartbeat_.schedule(heartbeat_period_);
+  readers_expecting_heartbeat_.insert(reader);
+  nack_response_.schedule(link->config().nak_response_delay_);
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::send_and_gather_nack_replies_i(MetaSubmessageVec& meta_submessages)
+RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_submessages)
 {
   RtpsUdpDataLink_rch link = link_.lock();
 
@@ -3249,6 +3255,18 @@ RtpsUdpDataLink::RtpsWriter::send_and_gather_nack_replies_i(MetaSubmessageVec& m
   }
 
   readers_expecting_data_.clear();
+
+  MetaSubmessage meta_submessage(id_, GUID_UNKNOWN);
+  initialize_heartbeat(proxy, meta_submessage);
+
+  // Directed, final.
+  meta_submessage.sm_.heartbeat_sm().smHeader.flags |= RTPS::FLAG_F;
+  for (ReaderInfoSet::const_iterator pos = readers_expecting_heartbeat_.begin(), limit = readers_expecting_heartbeat_.end();
+       pos != limit; ++pos) {
+    const ReaderInfo_rch& reader = *pos;
+    gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
+  }
+  readers_expecting_heartbeat_.clear();
 }
 
 SequenceNumber
@@ -3298,6 +3316,11 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
 {
   ACE_UNUSED_ARG(reader_id);
 
+  RtpsUdpDataLink_rch link = link_.lock();
+  if (!link) {
+    return;
+  }
+
 #ifdef OPENDDS_SECURITY
     if (!is_pvs_writer_) {
 #endif
@@ -3313,7 +3336,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
             lagging_readers_[previous_max_sn] = leading_pos->second;
           }
           leading_readers_.erase(leading_pos);
-          heartbeat_.schedule(heartbeat_period_);
+          heartbeat_.schedule(link->config().heartbeat_period_);
         }
       }
 #ifdef OPENDDS_SECURITY
@@ -3331,7 +3354,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
       if (acked_sn == previous_max_sn && previous_max_sn != max_sn_) {
         snris_erase(leading_readers_, acked_sn, reader);
         snris_insert(lagging_readers_, reader);
-        heartbeat_.schedule(heartbeat_period_);
+        heartbeat_.schedule(link->config().heartbeat_period_);
       }
     }
 #endif
@@ -3341,6 +3364,11 @@ void
 RtpsUdpDataLink::RtpsWriter::make_lagger_leader(const ReaderInfo_rch& reader,
                                                 const SequenceNumber previous_acked_sn)
 {
+  RtpsUdpDataLink_rch link = link_.lock();
+  if (!link) {
+    return;
+  }
+
   const SequenceNumber acked_sn = reader->acked_sn();
   if (previous_acked_sn == acked_sn) { return; }
   const SequenceNumber previous_max_sn = expected_max_sn(reader);
@@ -3354,7 +3382,7 @@ RtpsUdpDataLink::RtpsWriter::make_lagger_leader(const ReaderInfo_rch& reader,
   snris_erase(previous_acked_sn == previous_max_sn ? leading_readers_ : lagging_readers_, previous_acked_sn, reader);
   snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
   if (acked_sn != max_sn) {
-    heartbeat_.schedule(heartbeat_period_);
+    heartbeat_.schedule(link->config().heartbeat_period_);
   }
 }
 
@@ -3716,8 +3744,6 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(OPENDDS_VECTOR(TransportQueueEl
          pos != limit; ++pos) {
       const ReaderInfo_rch& reader = *pos;
       gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
-      reader->expecting_ack_ = true;
-      ++expected_acks_;
     }
   }
 
@@ -3737,8 +3763,6 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(OPENDDS_VECTOR(TransportQueueEl
         // TODO: This should be factored out in a sporadic task.
         expire_durable_data(pos->second, cfg, now, pendingCallbacks);
         meta_submessage.to_guids_.insert(pos->first);
-        pos->second->expecting_ack_ = true;
-        ++expected_acks_;
       }
       meta_submessages.push_back(meta_submessage);
       meta_submessage.reset_destination();
@@ -3752,25 +3776,9 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(OPENDDS_VECTOR(TransportQueueEl
           // TODO: This should be factored out in a sporadic task.
           expire_durable_data(reader, cfg, now, pendingCallbacks);
           gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
-          reader->expecting_ack_ = true;
-          ++expected_acks_;
         }
       }
     }
-  }
-
-  // Directed, final.
-  if (!readers_expecting_heartbeat_.empty()) {
-    meta_submessage.sm_.heartbeat_sm().smHeader.flags |= RTPS::FLAG_F;
-    for (ReaderInfoSet::const_iterator pos = readers_expecting_heartbeat_.begin(), limit = readers_expecting_heartbeat_.end();
-         pos != limit; ++pos) {
-      const ReaderInfo_rch& reader = *pos;
-      if (preassociation_readers_.count(reader) == 0 &&
-          !is_lagging(reader)) {
-        gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
-      }
-    }
-    readers_expecting_heartbeat_.clear();
   }
 }
 
@@ -3930,9 +3938,8 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
  , is_ps_writer_(id_.entityId == RTPS::ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER)
 #endif
- , expected_acks_(0)
- , heartbeat_period_(link->config().heartbeat_period_)
  , heartbeat_(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats)
+ , nack_response_(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses)
 {
   send_buff_->bind(link->send_strategy());
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -156,7 +156,7 @@ public:
   void register_for_reader(const RepoId& writerid,
                            const RepoId& readerid,
                            const ACE_INET_Addr& address,
-                           OpenDDS::DCPS::DiscoveryListener* listener);
+                           DiscoveryListener* listener);
 
   void unregister_for_reader(const RepoId& writerid,
                              const RepoId& readerid);
@@ -164,7 +164,7 @@ public:
   void register_for_writer(const RepoId& readerid,
                            const RepoId& writerid,
                            const ACE_INET_Addr& address,
-                           OpenDDS::DCPS::DiscoveryListener* listener);
+                           DiscoveryListener* listener);
 
   void unregister_for_writer(const RepoId& readerid,
                              const RepoId& writerid);
@@ -194,12 +194,12 @@ public:
   void disable_response_queue();
 
 private:
-  void join_multicast_group(const DCPS::NetworkInterface& nic,
+  void join_multicast_group(const NetworkInterface& nic,
                             bool all_interfaces = false);
-  void leave_multicast_group(const DCPS::NetworkInterface& nic);
-  void add_address(const DCPS::NetworkInterface& interface,
+  void leave_multicast_group(const NetworkInterface& nic);
+  void add_address(const NetworkInterface& interface,
                    const ACE_INET_Addr& address);
-  void remove_address(const DCPS::NetworkInterface& interface,
+  void remove_address(const NetworkInterface& interface,
                       const ACE_INET_Addr& address);
 
   // Internal non-locking versions of the above
@@ -223,7 +223,7 @@ private:
   typedef OPENDDS_MAP_CMP(RepoId, OPENDDS_VECTOR(RepoId),GUID_tKeyLessThan) DestToEntityMap;
 
   ReactorTask_rch reactor_task_;
-  RcHandle<DCPS::JobQueue> job_queue_;
+  RcHandle<JobQueue> job_queue_;
 
   RtpsUdpSendStrategy* send_strategy();
   RtpsUdpReceiveStrategy* receive_strategy();
@@ -393,8 +393,8 @@ private:
     Sporadic heartbeat_;
     Sporadic nack_response_;
 
-    void send_heartbeats(const DCPS::MonotonicTimePoint& now);
-    void send_nack_responses(const DCPS::MonotonicTimePoint& now);
+    void send_heartbeats(const MonotonicTimePoint& now);
+    void send_nack_responses(const MonotonicTimePoint& now);
     void add_gap_submsg_i(RTPS::SubmessageSeq& msg,
                           SequenceNumber gap_start);
     void end_historic_samples_i(const DataSampleHeader& header,
@@ -555,7 +555,7 @@ private:
     const RepoId& id() const { return id_; }
 
   private:
-    void send_preassociation_acknacks(const DCPS::MonotonicTimePoint& now);
+    void send_preassociation_acknacks(const MonotonicTimePoint& now);
     void gather_preassociation_acknack_i(MetaSubmessageVec& meta_submessages,
                                          const WriterInfo_rch& writer);
 
@@ -715,8 +715,8 @@ private:
     queue_or_send_submessages(meta_submessages);
   }
 
-  void send_heartbeats(const DCPS::MonotonicTimePoint& now);
-  void check_heartbeats(const DCPS::MonotonicTimePoint& now);
+  void send_heartbeats(const MonotonicTimePoint& now);
+  void check_heartbeats(const MonotonicTimePoint& now);
 
   CORBA::Long best_effort_heartbeat_count_;
 
@@ -748,7 +748,7 @@ private:
       , status(DOES_NOT_EXIST)
     { }
   };
-  typedef OPENDDS_MULTIMAP_CMP(RepoId, InterestingRemote, DCPS::GUID_tKeyLessThan) InterestingRemoteMapType;
+  typedef OPENDDS_MULTIMAP_CMP(RepoId, InterestingRemote, GUID_tKeyLessThan) InterestingRemoteMapType;
   InterestingRemoteMapType interesting_readers_;
   InterestingRemoteMapType interesting_writers_;
 
@@ -763,7 +763,7 @@ private:
   void send_heartbeats_manual_i(const TransportSendControlElement* tsce,
                                 MetaSubmessageVec& meta_submessages);
 
-  typedef OPENDDS_MAP_CMP(EntityId_t, CORBA::Long, DCPS::EntityId_tKeyLessThan) CountMapType;
+  typedef OPENDDS_MAP_CMP(EntityId_t, CORBA::Long, EntityId_tKeyLessThan) CountMapType;
   CountMapType heartbeat_counts_;
 
   const size_t max_bundle_size_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -39,7 +39,7 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , heartbeat_backoff_factor_(2.0)
   , heartbeat_safety_factor_(2.0)
   , nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
-  , heartbeat_period_(0, 100000) // no default in RTPS spec
+  , heartbeat_period_(1) // no default in RTPS spec
   , heartbeat_period_minimum_(0, 10000)
   , heartbeat_period_maximum_(1, 0)
   , heartbeat_response_delay_(0, 500*1000 /*microseconds*/) // default from RTPS

--- a/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
@@ -137,9 +137,16 @@ void DataReaderListenerImpl::on_liveliness_changed(
 
 void DataReaderListenerImpl::on_subscription_matched(
   DDS::DataReader_ptr,
-  const DDS::SubscriptionMatchedStatus &)
+  const DDS::SubscriptionMatchedStatus& status)
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched()\n")));
+  // For the reverse lease test, the DataReader will rediscover the DataWriter.
+  // The DataWriter may have some unacknowledged samples that it will send again.
+  // Reset the count to avoid interpretting these as duplicates.
+  if (status.current_count == 0) {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched() - resetting counts\n")));
+    counts_.clear();
+  }
 }
 
 void DataReaderListenerImpl::on_sample_rejected(

--- a/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
@@ -143,7 +143,7 @@ void DataReaderListenerImpl::on_subscription_matched(
   // For the reverse lease test, the DataReader will rediscover the DataWriter.
   // The DataWriter may have some unacknowledged samples that it will send again.
   // Reset the count to avoid interpretting these as duplicates.
-  if (status.current_count == 0) {
+  if (status.current_count_change > 0) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_subscription_matched() - resetting counts\n")));
     counts_.clear();
   }

--- a/tests/DCPS/SetQosPartition/Writer.cpp
+++ b/tests/DCPS/SetQosPartition/Writer.cpp
@@ -84,9 +84,9 @@ Writer::svc ()
       {
         ACE_ERROR ((LM_ERROR,
                     ACE_TEXT("(%P|%t) ERROR: Writer::svc, ")
-                    ACE_TEXT ("%dth write() returned %d.\n"),
+                    ACE_TEXT("%dth write() returned %d.\n"),
                     i,
-                    -1));
+                    ret));
       }
 
       // Sleep for half a second between writes to allow some deadline
@@ -102,7 +102,7 @@ Writer::svc ()
       {
         ACE_ERROR ((LM_ERROR,
                     ACE_TEXT("(%P|%t) ERROR: Writer::svc, ")
-                    ACE_TEXT ("wait_for_acknowledgments returned %d.\n"),
+                    ACE_TEXT("wait_for_acknowledgments returned %d.\n"),
                     ret));
       }
   }

--- a/tests/DCPS/SetQosPartition/Writer.cpp
+++ b/tests/DCPS/SetQosPartition/Writer.cpp
@@ -95,6 +95,16 @@ Writer::svc ()
       // deadline period.
       ACE_OS::sleep (ACE_Time_Value (0, 500000));
     }
+
+    DDS::Duration_t d = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+    ::DDS::ReturnCode_t const ret = writer_->wait_for_acknowledgments(d);
+    if (ret != DDS::RETCODE_OK)
+      {
+        ACE_ERROR ((LM_ERROR,
+                    ACE_TEXT("(%P|%t) ERROR: Writer::svc, ")
+                    ACE_TEXT ("wait_for_acknowledgments returned %d.\n"),
+                    ret));
+      }
   }
   catch (CORBA::Exception& e)
   {

--- a/tests/DCPS/SetQosPartition/subscriber.cpp
+++ b/tests/DCPS/SetQosPartition/subscriber.cpp
@@ -176,6 +176,9 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         ACE_OS::sleep (1);
       }
 
+      // Let reader acknowledge the data.
+      ACE_OS::sleep (3);
+
       // ----------------------------------------------
       // Now switch first reader/subscriber from A to B
       // and it should be connected with DataWriter.


### PR DESCRIPTION
Problem
-------

A slow or no longer existing reader will cause the heartbeat period to
grow to the maximum.  This will persist until the defunct reader is
purged from the sytem.

Solution
--------

1. Remove the logic for computing an adaptive heartbeat period.

2. Use a separate timer for nack responses.

3. Add filtering based on reflecting heartbeat counts that discards
   acknacks that are too old.  This is to handle cases where the
   round-trip latency is greater than the heartbeat period.