### PR TITLE
Static Build Fix for GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4684,23 +4684,22 @@ jobs:
         cd DevGuideExamples\DCPS\Messenger
         perl run_test.pl -ExeSubDir Static_Debug
     - name: build CMake
-      shell: bash
+      shell: cmd
       run: |
         cd OpenDDS
-        . setenv.sh
+        call setenv.cmd
         cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
         mkdir build
         cd build
         cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
         cmake --build .
     - name: run CMake test
-      shell: bash
+      shell: cmd
       run: |
         cd OpenDDS
-        . setenv.sh
+        call setenv.cmd
         cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        perl ../../../../DCPS/Messenger/run_test.pl -ExeSubDir Debug rtps
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -4963,7 +4962,7 @@ jobs:
       run: |
         cd OpenDDS
         call setenv.cmd
-        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS_no_tests.sln
     - name: run Dev Guide tests
       shell: cmd
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1905,7 +1905,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         cd tests/cmake_integration
-        perl run_ci_tests.pl
+        perl run_ci_tests.pl --skip-cxx11
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -4590,7 +4590,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd tests/cmake_integration/
-        perl run_ci_tests.pl --no-shared
+        perl run_ci_tests.pl --no-shared --build-config=Debug
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -175,24 +175,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: gitclean
       shell: bash
       run: |
@@ -426,24 +415,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: gitclean
       shell: bash
       run: |
@@ -682,24 +660,13 @@ jobs:
   #       cd OpenDDS/build/target
   #       . setenv.sh
   #       make -j4
-  #   - name: build CMake
+  #   - name: build and run CMake tests
   #     shell: bash
   #     run: |
   #       cd OpenDDS
   #       . setenv.sh
-  #       cd tests/cmake_integration/Messenger/Messenger_1
-  #       rm -fr build
-  #       mkdir build
-  #       cd build
-  #       cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-  #       cmake --build .
-  #   - name: run CMake test
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd tests/cmake_integration/Messenger/Messenger_1/build
-  #       perl run_test.pl rtps
+  #       cd tests/cmake_integration
+  #       perl run_ci_tests.pl
   #   - name: create OpenDDS tar.xz artifact
   #     shell: bash
   #     run: |
@@ -933,24 +900,13 @@ jobs:
   #       cd OpenDDS/build/target
   #       . setenv.sh
   #       make -j4
-  #   - name: build CMake
+  #   - name: build and run CMake tests
   #     shell: bash
   #     run: |
   #       cd OpenDDS
   #       . setenv.sh
-  #       cd tests/cmake_integration/Messenger/Messenger_1
-  #       rm -fr build
-  #       mkdir build
-  #       cd build
-  #       cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-  #       cmake --build .
-  #   - name: run CMake test
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd tests/cmake_integration/Messenger/Messenger_1/build
-  #       perl run_test.pl rtps
+  #       cd tests/cmake_integration
+  #       perl run_ci_tests.pl
   #   - name: create OpenDDS tar.xz artifact
   #     shell: bash
   #     run: |
@@ -1427,24 +1383,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -1693,24 +1638,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -1965,24 +1899,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -2240,24 +2163,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -2510,24 +2422,13 @@ jobs:
         cd OpenDDS
         . setenv.sh
         make -j4
-    - name: build CMake
+    - name: build and run CMake tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1
-        rm -fr build
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl run_test.pl rtps
+        cd tests/cmake_integration
+        perl run_ci_tests.pl
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4024,7 +4024,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_c_u18_stat_qt_ws_sec:
+  ACE_TAO_u18_stat_qt_ws_sec_2:
 
     runs-on: ubuntu-18.04
 
@@ -4091,11 +4091,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_c_u18_stat_qt_ws_sec:
+  build_u18_stat_qt_ws_sec_2:
 
     runs-on: ubuntu-18.04
 
-    needs: ACE_TAO_c_u18_stat_qt_ws_sec
+    needs: ACE_TAO_u18_stat_qt_ws_sec_2
 
     steps:
     - name: install xerces
@@ -4118,13 +4118,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_c_u18_stat_qt_ws_sec_artifact
+        name: ACE_TAO_u18_stat_qt_ws_sec_2_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_c_u18_stat_qt_ws_sec.tar.xz
+        tar xvfJ ACE_TAO_u18_stat_qt_ws_sec_2.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
       with:
@@ -4181,11 +4181,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  # test_c_u18_stat_qt_ws_sec:
+  # test_u18_stat_qt_ws_sec_2:
 
   #   runs-on: ubuntu-18.04
 
-  #   needs: build_c_u18_stat_qt_ws_sec
+  #   needs: build_u18_stat_qt_ws_sec_2
 
   #   steps:
   #   - name: install xerces
@@ -4209,13 +4209,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_c_u18_stat_qt_ws_sec_artifact
+  #       name: ACE_TAO_u18_stat_qt_ws_sec_2_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_c_u18_stat_qt_ws_sec.tar.xz
+  #       tar xvfJ ACE_TAO_u18_stat_qt_ws_sec_2.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -4224,13 +4224,13 @@ jobs:
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_c_u18_stat_qt_ws_sec_artifact
+  #       name: build_u18_stat_qt_ws_sec_2_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_c_u18_stat_qt_ws_sec.tar.xz
+  #       tar xvfJ build_u18_stat_qt_ws_sec_2.tar.xz
   #   - name: check build configuration
   #     shell: bash
   #     run: |
@@ -4540,7 +4540,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_c_w19_p1_stat_js0:
+  ACE_TAO_w19_p1_stat_js0_2:
 
     runs-on: windows-2019
 
@@ -4616,11 +4616,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_c_w19_p1_stat_js0:
+  build_w19_p1_stat_js0_2:
 
     runs-on: windows-2019
 
-    needs: ACE_TAO_c_w19_p1_stat_js0
+    needs: ACE_TAO_w19_p1_stat_js0_2
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -4648,14 +4648,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_c_w19_p1_stat_js0_artifact
+        name: ACE_TAO_w19_p1_stat_js0_2_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_c_w19_p1_stat_js0.tar.xz
-        rm -f ACE_TAO_c_w19_p1_stat_js0.tar.xz
+        tar xvfJ ACE_TAO_w19_p1_stat_js0_2.tar.xz
+        rm -f ACE_TAO_w19_p1_stat_js0_2.tar.xz
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4716,11 +4716,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  # test_c_w19_p1_stat_js0:
+  # test_w19_p1_stat_js0_2:
 
   #   runs-on: windows-2019
 
-  #   needs: build_c_w19_p1_stat_js0
+  #   needs: build_w19_p1_stat_js0_2
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4753,25 +4753,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_c_w19_p1_stat_js0_artifact
+  #       name: ACE_TAO_w19_p1_stat_js0_2_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_c_w19_p1_stat_js0.tar.xz
-  #       rm -f ACE_TAO_c_w19_p1_stat_js0.tar.xz
+  #       tar xvfJ ACE_TAO_w19_p1_stat_js0_2.tar.xz
+  #       rm -f ACE_TAO_w19_p1_stat_js0_2.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_c_w19_p1_stat_js0_artifact
+  #       name: build_w19_p1_stat_js0_2_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_c_w19_p1_stat_js0.tar.xz
-  #       rm -f build_c_w19_p1_stat_js0.tar.xz
+  #       tar xvfJ build_w19_p1_stat_js0_2.tar.xz
+  #       rm -f build_w19_p1_stat_js0_2.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |
@@ -4828,7 +4828,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_c_w19_p1_cpp03_stat_FM-08:
+  ACE_TAO_w19_p1_cpp03_stat_FM-08_2:
 
     runs-on: windows-2019
 
@@ -4904,11 +4904,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_c_w19_p1_cpp03_stat_FM-08:
+  build_w19_p1_cpp03_stat_FM-08_2:
 
     runs-on: windows-2019
 
-    needs: ACE_TAO_c_w19_p1_cpp03_stat_FM-08
+    needs: ACE_TAO_w19_p1_cpp03_stat_FM-08_2
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -4936,14 +4936,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_c_w19_p1_cpp03_stat_FM-08_artifact
+        name: ACE_TAO_w19_p1_cpp03_stat_FM-08_2_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
-        rm -f ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
+        tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08_2.tar.xz
+        rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08_2.tar.xz
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4986,11 +4986,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  # test_c_w19_p1_cpp03_stat_FM-08:
+  # test_w19_p1_cpp03_stat_FM-08_2:
 
   #   runs-on: windows-2019
 
-  #   needs: build_c_w19_p1_cpp03_stat_FM-08
+  #   needs: build_w19_p1_cpp03_stat_FM-08_2
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -5023,25 +5023,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_c_w19_p1_cpp03_stat_FM-08_artifact
+  #       name: ACE_TAO_w19_p1_cpp03_stat_FM-08_2_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
-  #       rm -f ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08_2.tar.xz
+  #       rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08_2.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_c_w19_p1_cpp03_stat_FM-08_artifact
+  #       name: build_w19_p1_cpp03_stat_FM-08_2_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_c_w19_p1_cpp03_stat_FM-08.tar.xz
-  #       rm -f build_c_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       tar xvfJ build_w19_p1_cpp03_stat_FM-08_2.tar.xz
+  #       rm -f build_w19_p1_cpp03_stat_FM-08_2.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4683,23 +4683,13 @@ jobs:
         call setenv.cmd
         cd DevGuideExamples\DCPS\Messenger
         perl run_test.pl -ExeSubDir Static_Debug
-    - name: build CMake
+    - name: build and run CMake tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
-        cd tests/cmake_integration/Messenger/Messenger_1
-        mkdir build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-        cmake --build .
-    - name: run CMake test
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        cd tests/cmake_integration/Messenger/Messenger_1/build
-        perl ../../../../DCPS/Messenger/run_test.pl -ExeSubDir Debug rtps
+        cd tests/cmake_integration/
+        perl run_ci_tests.pl --no-shared
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4828,7 +4828,7 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  ACE_TAO_w19_p1_cpp03_stat_FM-08:
+  ACE_TAO_c_w19_p1_cpp03_stat_FM-08:
 
     runs-on: windows-2019
 
@@ -4904,11 +4904,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_w19_p1_cpp03_stat_FM-08:
+  build_c_w19_p1_cpp03_stat_FM-08:
 
     runs-on: windows-2019
 
-    needs: ACE_TAO_w19_p1_cpp03_stat_FM-08
+    needs: ACE_TAO_c_w19_p1_cpp03_stat_FM-08
 
     steps:
     - name: install openssl-windows & xerces-c
@@ -4936,14 +4936,14 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v2
       with:
-        name: ACE_TAO_w19_p1_cpp03_stat_FM-08_artifact
+        name: ACE_TAO_c_w19_p1_cpp03_stat_FM-08_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
-        rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
+        tar xvfJ ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
+        rm -f ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
     - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.5.0
@@ -4986,11 +4986,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  # test_w19_p1_cpp03_stat_FM-08:
+  # test_c_w19_p1_cpp03_stat_FM-08:
 
   #   runs-on: windows-2019
 
-  #   needs: build_w19_p1_cpp03_stat_FM-08
+  #   needs: build_c_w19_p1_cpp03_stat_FM-08
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -5023,25 +5023,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_w19_p1_cpp03_stat_FM-08_artifact
+  #       name: ACE_TAO_c_w19_p1_cpp03_stat_FM-08_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
-  #       rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       tar xvfJ ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       rm -f ACE_TAO_c_w19_p1_cpp03_stat_FM-08.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_w19_p1_cpp03_stat_FM-08_artifact
+  #       name: build_c_w19_p1_cpp03_stat_FM-08_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_w19_p1_cpp03_stat_FM-08.tar.xz
-  #       rm -f build_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       tar xvfJ build_c_w19_p1_cpp03_stat_FM-08.tar.xz
+  #       rm -f build_c_w19_p1_cpp03_stat_FM-08.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4024,149 +4024,168 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_u18_stat_qt_ws_sec:
+  ACE_TAO_c_u18_stat_qt_ws_sec:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_c_u18_stat_qt_ws_sec:
+
+    runs-on: ubuntu-18.04
+
+    needs: ACE_TAO_c_u18_stat_qt_ws_sec
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: install wireshark
+      run: sudo apt-get -y install wireshark-dev
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_c_u18_stat_qt_ws_sec_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_c_u18_stat_qt_ws_sec.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure --static --qt --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: set up Dev Guide tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mwc.pl -type gnuace -workers 4 $DDS_ROOT/DevGuideExamples/DCPS/Messenger
+    - name: build Dev Guide tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 dir=$DDS_ROOT/DevGuideExamples/DCPS/Messenger
+    - name: run Dev Guide tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd DevGuideExamples/DCPS/Messenger
+        perl run_test.pl
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  # test_c_u18_stat_qt_ws_sec:
 
   #   runs-on: ubuntu-18.04
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: get ACE_TAO commit
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       export ACE_COMMIT=$(git rev-parse HEAD)
-  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-  #   - name: Cache Artifact
-  #     id: cache-artifact
-  #     uses: actions/cache@v2.1.4
-  #     with:
-  #       path: ${{ github.job }}.tar.xz
-  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-  #   - name: install xerces
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: sudo apt-get -y install libxerces-c-dev
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v2.3.4
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: configure OpenDDS
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       cd OpenDDS
-  #       ./configure --static --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-  #   - name: build ACE and TAO
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd ACE_TAO/ACE
-  #       make -j4
-  #       cd ../TAO
-  #       make -j4
-  #   - name: create ACE_TAO tar.xz artifact
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-  #       find . -iname "*\.o" | xargs rm
-  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-  #       xz -3 ../../${{ github.job }}.tar
-  #   - name: upload ACE_TAO artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
-
-  # build_u18_stat_qt_ws_sec:
-
-  #   runs-on: ubuntu-18.04
-
-  #   needs: ACE_TAO_u18_stat_qt_ws_sec
-
-  #   steps:
-  #   - name: install xerces
-  #     run: sudo apt-get -y install libxerces-c-dev
-  #   - name: install wireshark
-  #     run: sudo apt-get -y install wireshark-dev
-  #   - name: install qt
-  #     run: sudo apt-get -y install qtbase5-dev
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #       name: ACE_TAO_u18_stat_qt_ws_sec_artifact
-  #       path: ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_u18_stat_qt_ws_sec.tar.xz
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: configure OpenDDS
-  #     run: |
-  #       cd OpenDDS
-  #       ./configure --static --qt --wireshark --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - uses: ammaraskar/gcc-problem-matcher@0.1
-  #   - name: build OpenDDS
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       make -j4
-  #   - name: create OpenDDS tar.xz artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       rm -rf ACE_TAO
-  #       find . -iname "*\.o" | xargs rm
-  #       tar cvf ../${{ github.job }}.tar setenv.sh
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-  #       xz -3 ../${{ github.job }}.tar
-  #   - name: upload OpenDDS artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
-
-  # test_u18_stat_qt_ws_sec:
-
-  #   runs-on: ubuntu-18.04
-
-  #   needs: build_u18_stat_qt_ws_sec
+  #   needs: build_c_u18_stat_qt_ws_sec
 
   #   steps:
   #   - name: install xerces
@@ -4190,13 +4209,13 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_u18_stat_qt_ws_sec_artifact
+  #       name: ACE_TAO_c_u18_stat_qt_ws_sec_artifact
   #       path: ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_u18_stat_qt_ws_sec.tar.xz
+  #       tar xvfJ ACE_TAO_c_u18_stat_qt_ws_sec.tar.xz
   #   - name: checkout OpenDDS
   #     uses: actions/checkout@v2.3.4
   #     with:
@@ -4205,13 +4224,13 @@ jobs:
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_u18_stat_qt_ws_sec_artifact
+  #       name: build_c_u18_stat_qt_ws_sec_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_u18_stat_qt_ws_sec.tar.xz
+  #       tar xvfJ build_c_u18_stat_qt_ws_sec.tar.xz
   #   - name: check build configuration
   #     shell: bash
   #     run: |
@@ -4521,180 +4540,187 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_w19_p1_stat_js0:
+  ACE_TAO_c_w19_p1_stat_js0:
+
+    runs-on: windows-2019
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --ipv6 --static --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+    - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ACE_TAO\ACE
+        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+        cd ..\TAO
+        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_c_w19_p1_stat_js0:
+
+    runs-on: windows-2019
+
+    needs: ACE_TAO_c_w19_p1_stat_js0
+
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_c_w19_p1_stat_js0_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_c_w19_p1_stat_js0.tar.xz
+        rm -f ACE_TAO_c_w19_p1_stat_js0.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --ipv6 --static --no-rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS_no_tests.sln
+    - name: run Dev Guide tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd DevGuideExamples\DCPS\Messenger
+        perl run_test.pl -ExeSubDir Static_Debug
+    - name: build CMake
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tests/cmake_integration/Messenger/Messenger_1
+        rm -fr build
+        mkdir build
+        cd build
+        cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
+        cmake --build .
+    - name: run CMake test
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tests/cmake_integration/Messenger/Messenger_1/build
+        perl run_test.pl rtps
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  # test_c_w19_p1_stat_js0:
 
   #   runs-on: windows-2019
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: get ACE_TAO commit
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       export ACE_COMMIT=$(git rev-parse HEAD)
-  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-  #   - name: Cache Artifact
-  #     id: cache-artifact
-  #     uses: actions/cache@v2.1.4
-  #     with:
-  #       path: ${{ github.job }}.tar.xz
-  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-  #   - name: install openssl-windows & xerces-c
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: lukka/run-vcpkg@v6
-  #     with:
-  #       vcpkgGitCommitId: ec6fe06
-  #       vcpkgArguments: --recurse openssl-windows xerces-c
-  #       vcpkgTriplet: x64-windows
-  #   - name: checkout MPC
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: set up msvc env
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: ilammy/msvc-dev-cmd@v1.5.0
-  #   - name: configure OpenDDS
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       configure --ipv6 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-  #   - name: build ACE & TAO
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       call setenv.cmd
-  #       cd ACE_TAO\ACE
-  #       msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
-  #       cd ..\TAO
-  #       msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
-  #   - name: create ACE_TAO tar.xz artifact
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-  #       find . -iname "*\.obj" | xargs rm
-  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-  #       xz -3 ../../${{ github.job }}.tar
-  #   - name: upload ACE_TAO artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
-
-  # build_w19_p1_stat_js0:
-
-  #   runs-on: windows-2019
-
-  #   needs: ACE_TAO_w19_p1_stat_js0
-
-  #   steps:
-  #   - name: install openssl-windows & xerces-c
-  #     uses: lukka/run-vcpkg@v6
-  #     with:
-  #       vcpkgGitCommitId: ec6fe06
-  #       vcpkgArguments: --recurse openssl-windows xerces-c
-  #       vcpkgTriplet: x64-windows
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #       name: ACE_TAO_w19_p1_stat_js0_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_w19_p1_stat_js0.tar.xz
-  #       rm -f ACE_TAO_w19_p1_stat_js0.tar.xz
-  #   - uses: ammaraskar/msvc-problem-matcher@0.1
-  #   - name: set up msvc env
-  #     uses: ilammy/msvc-dev-cmd@v1.5.0
-  #   - name: configure OpenDDS
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       configure --ipv6 --static --tests --no-rapidjson --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-  #   - name: check build configuration
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       call setenv.cmd
-  #       perl tools\scripts\show_build_config.pl
-  #   - name: build OpenDDS
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       call setenv.cmd
-  #       msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
-  #   - name: build CMake
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd tests/cmake_integration/Messenger/Messenger_1
-  #       rm -fr build
-  #       mkdir build
-  #       cd build
-  #       cmake -DCMAKE_PREFIX_PATH=$OPENDDS_INSTALL_PREFIX ..
-  #       cmake --build .
-  #   - name: run CMake test
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd tests/cmake_integration/Messenger/Messenger_1/build
-  #       perl run_test.pl rtps
-  #   - name: create OpenDDS tar.xz artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       rm -rf ACE_TAO
-  #       find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-  #       tar cvf ../${{ github.job }}.tar setenv.cmd
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-  #       xz -3 ../${{ github.job }}.tar
-  #   - name: upload OpenDDS artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
-
-  # test_w19_p1_stat_js0:
-
-  #   runs-on: windows-2019
-
-  #   needs: build_w19_p1_stat_js0
+  #   needs: build_c_w19_p1_stat_js0
 
   #   steps:
   #   - name: install openssl-windows & xerces-c
@@ -4727,25 +4753,25 @@ jobs:
   #   - name: download ACE_TAO artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: ACE_TAO_w19_p1_stat_js0_artifact
+  #       name: ACE_TAO_c_w19_p1_stat_js0_artifact
   #       path: OpenDDS/ACE_TAO
   #   - name: extract ACE_TAO artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_w19_p1_stat_js0.tar.xz
-  #       rm -f ACE_TAO_w19_p1_stat_js0.tar.xz
+  #       tar xvfJ ACE_TAO_c_w19_p1_stat_js0.tar.xz
+  #       rm -f ACE_TAO_c_w19_p1_stat_js0.tar.xz
   #   - name: download OpenDDS artifact
   #     uses: actions/download-artifact@v2
   #     with:
-  #       name: build_w19_p1_stat_js0_artifact
+  #       name: build_c_w19_p1_stat_js0_artifact
   #       path: OpenDDS
   #   - name: extract OpenDDS artifact
   #     shell: bash
   #     run: |
   #       cd OpenDDS
-  #       tar xvfJ build_w19_p1_stat_js0.tar.xz
-  #       rm -f build_w19_p1_stat_js0.tar.xz
+  #       tar xvfJ build_c_w19_p1_stat_js0.tar.xz
+  #       rm -f build_c_w19_p1_stat_js0.tar.xz
   #   - name: check build configuration
   #     shell: cmd
   #     run: |
@@ -4802,156 +4828,163 @@ jobs:
   #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
   #       if ! grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"; then echo "::error file=latest.txt,line=0,col=0::Test Failures: see 'Test Results: ${{ github.job }}'"; fi
 
-  # ACE_TAO_w19_p1_cpp03_stat_FM-08:
+  ACE_TAO_w19_p1_cpp03_stat_FM-08:
 
-  #   runs-on: windows-2019
+    runs-on: windows-2019
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: get ACE_TAO commit
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       export ACE_COMMIT=$(git rev-parse HEAD)
-  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-  #   - name: Cache Artifact
-  #     id: cache-artifact
-  #     uses: actions/cache@v2.1.4
-  #     with:
-  #       path: ${{ github.job }}.tar.xz
-  #       key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-  #   - name: install openssl-windows & xerces-c
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: lukka/run-vcpkg@v6
-  #     with:
-  #       vcpkgGitCommitId: ec6fe06
-  #       vcpkgArguments: --recurse openssl-windows xerces-c
-  #       vcpkgTriplet: x64-windows
-  #   - name: checkout MPC
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: set up msvc env
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: ilammy/msvc-dev-cmd@v1.5.0
-  #   - name: configure OpenDDS
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       configure --ipv6 --std=c++03 --static --tests --security --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
-  #   - name: build ACE & TAO
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       call setenv.cmd
-  #       cd ACE_TAO\ACE
-  #       msbuild -p:Configuration=Release,Platform=x64 -m ace.sln
-  #       cd ..\TAO
-  #       msbuild -p:Configuration=Release,Platform=x64 -m tao.sln
-  #   - name: create ACE_TAO tar.xz artifact
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-  #       find . -iname "*\.obj" | xargs rm
-  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-  #       xz -3 ../../${{ github.job }}.tar
-  #   - name: upload ACE_TAO artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v2.1.4
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: ${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: install openssl-windows & xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: set up msvc env
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --ipv6 --std=c++03 --static --rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows --mpcopts=-hierarchy
+    - name: build ACE & TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ACE_TAO\ACE
+        msbuild -p:Configuration=Debug,Platform=x64 -m ace.sln
+        cd ..\TAO
+        msbuild -p:Configuration=Debug,Platform=x64 -m tao.sln
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.obj" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  # build_w19_p1_cpp03_stat_FM-08:
+  build_w19_p1_cpp03_stat_FM-08:
 
-  #   runs-on: windows-2019
+    runs-on: windows-2019
 
-  #   needs: ACE_TAO_w19_p1_cpp03_stat_FM-08
+    needs: ACE_TAO_w19_p1_cpp03_stat_FM-08
 
-  #   steps:
-  #   - name: install openssl-windows & xerces-c
-  #     uses: lukka/run-vcpkg@v6
-  #     with:
-  #       vcpkgGitCommitId: ec6fe06
-  #       vcpkgArguments: --recurse openssl-windows xerces-c
-  #       vcpkgTriplet: x64-windows
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v2.3.4
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v2
-  #     with:
-  #       name: ACE_TAO_w19_p1_cpp03_stat_FM-08_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
-  #       rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
-  #   - uses: ammaraskar/msvc-problem-matcher@0.1
-  #   - name: set up msvc env
-  #     uses: ilammy/msvc-dev-cmd@v1.5.0
-  #   - name: configure OpenDDS
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       configure --ipv6 --std=c++03 --static --tests --rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
-  #   - name: check build configuration
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       call setenv.cmd
-  #       perl tools\scripts\show_build_config.pl
-  #   - name: build OpenDDS
-  #     shell: cmd
-  #     run: |
-  #       cd OpenDDS
-  #       call setenv.cmd
-  #       msbuild -p:Configuration=Release,Platform=x64 -m DDS.sln
-  #   - name: create OpenDDS tar.xz artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       rm -rf ACE_TAO
-  #       find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-  #       tar cvf ../${{ github.job }}.tar setenv.cmd
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-  #       xz -3 ../${{ github.job }}.tar
-  #   - name: upload OpenDDS artifact
-  #     uses: actions/upload-artifact@v2
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
+    steps:
+    - name: install openssl-windows & xerces-c
+      uses: lukka/run-vcpkg@v6
+      with:
+        vcpkgGitCommitId: ec6fe06
+        vcpkgArguments: --recurse openssl-windows xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2.3.4
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_w19_p1_cpp03_stat_FM-08_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
+        rm -f ACE_TAO_w19_p1_cpp03_stat_FM-08.tar.xz
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.5.0
+    - name: configure OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        configure --ipv6 --std=c++03 --static --rapidjson --no-built-in-topics --no-content-subscription --no-ownership-profile --no-object-model-profile --no-persistence-profile --ace=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/ACE --tao=%GITHUB_WORKSPACE%/OpenDDS/ACE_TAO/TAO --mpc=%GITHUB_WORKSPACE%/MPC --xerces3=%VCPKG_ROOT%/installed/x64-windows --openssl=%VCPKG_ROOT%/installed/x64-windows
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: build OpenDDS
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        msbuild -p:Configuration=Debug,Platform=x64 -m DDS.sln
+    - name: run Dev Guide tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd DevGuideExamples\DCPS\Messenger
+        perl run_test.pl -ExeSubDir Static_Debug
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.cmd
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
   # test_w19_p1_cpp03_stat_FM-08:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,17 +17,6 @@ jobs:
       Debug64:
         BuildPlatform: x64
         BuildConfiguration: Debug
-      Release64:
-        BuildPlatform: x64
-        BuildConfiguration: Release
-        MessengerTests: true
-      Debug32:
-        BuildPlatform: Win32
-        BuildConfiguration: Debug
-      Release32:
-        BuildPlatform: Win32
-        BuildConfiguration: Release
-        MessengerTests: true
   variables:
     VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
   steps:
@@ -120,111 +109,6 @@ jobs:
       perl integration_run_test.pl -ExeSubDir %SUBDIR_FOR_MESSENGER%
     displayName: Run Examples DCPS Messenger
 
-- job: VisualStudio2017
-  timeoutInMinutes: 120
-  pool:
-    vmImage: vs2017-win2016
-  strategy:
-    matrix:
-      Release64:
-        BuildPlatform: x64
-        BuildConfiguration: Release
-  variables:
-    VCPKG_ROOT: $(Build.SourcesDirectory)\vcpkg
-  steps:
-  - script: |
-      if %BuildPlatform%==x64 (set VCVARS_ARCH=x64) else set VCVARS_ARCH=x86
-      echo ##vso[task.setvariable variable=VcVarsArch]%VCVARS_ARCH%
-    displayName: Set VcVarsArch
-  - script: |
-      git clone -q --depth 1 git://github.com/Microsoft/vcpkg %VCPKG_ROOT%
-      call %VCPKG_ROOT%\bootstrap-vcpkg.bat
-      set VCPKG_ARCH=$(VcVarsArch)-windows
-      %VCPKG_ROOT%\vcpkg install --triplet %VCPKG_ARCH% openssl xerces-c
-      rmdir /s/q %VCPKG_ROOT%\packages %VCPKG_ROOT%\buildtrees %VCPKG_ROOT%\downloads
-      echo ##vso[task.setvariable variable=VcPkgInst]%VCPKG_ROOT%\installed\%VCPKG_ARCH%
-    displayName: Vcpkg
-    condition: not(and(eq(variables['BuildConfiguration'], 'Debug'), eq(variables['BuildPlatform'], 'x64')))
-  - task: BatchScript@1
-    displayName: VcVars
-    inputs:
-      filename: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"'
-      arguments: $(VcVarsArch)
-      modifyEnvironment: true
-  - task: BatchScript@1
-    displayName: Put perl on PATH
-    inputs:
-      filename: tools\scripts\prepend_path
-      arguments: 'C:\Strawberry\perl\bin'
-      modifyEnvironment: true
-  - script: |
-      if %BuildConfiguration%==Release set OPT=--no-tests --no-debug --optimize
-      if %BuildConfiguration%==Debug set OPT=--features=uses_wchar=1
-      set SEC=--security --xerces3=$(VcPkgInst) --openssl=$(VcPkgInst)
-      if %BuildConfiguration%==Debug if %BuildPlatform%==x64 set SEC=
-      call configure -v --ace-github-latest --tests %SEC% %OPT%
-      perl tools\scripts\show_build_config.pl
-      if %BuildConfiguration%==Release (set SLN=DDS_TAOv2.sln) else set SLN=DDS_TAOv2_all.sln
-      echo ##vso[task.setvariable variable=BuildSolution]%SLN%
-    failOnStderr: #
-    displayName: Run configure script
-  - script: |
-      for /d %%x in (tests\googletest\build\*) do @if not %%x==tests\googletest\build\install del /s/q %%x
-      del /s/q ACE_TAO\ACE\protocols ACE_TAO\ACE\contrib ACE_TAO\ACE\examples
-      del /s/q ACE_TAO\ACE\tests ACE_TAO\ACE\netsvcs ACE_TAO\ACE\websvcs
-      del /s/q ACE_TAO\ACE\ASNMP ACE_TAO\ACE\performance-tests
-      del /s/q ACE_TAO\ACE\tests ACE_TAO\ACE\Kokyu ACE_TAO\TAO\interop-tests
-      del /s/q ACE_TAO\TAO\DevGuideExamples ACE_TAO\TAO\examples
-      del /s/q ACE_TAO\TAO\orbsvcs\tests ACE_TAO\TAO\orbsvcs\performance-tests
-      del /s/q ACE_TAO\TAO\orbsvcs\examples
-    displayName: Remove unused files from external repos
-  - task: BatchScript@1
-    displayName: Setenv from configure script
-    inputs:
-      filename: setenv.cmd
-      modifyEnvironment: true
-  - task: VSBuild@1
-    displayName: Build solution
-    inputs:
-      solution: $(BuildSolution)
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-      maximumCpuCount: true
-  - script: |
-      perl "%ACE_ROOT%/bin/mwc.pl" -type vs2017 tests\DCPS\Messenger DevGuideExamples\DCPS\Messenger
-    condition: ne(variables['BuildConfiguration'], 'Debug')
-    displayName: Generate Messenger sln files
-  - task: VSBuild@1
-    displayName: Build Messenger Test
-    inputs:
-      solution: $(DDS_ROOT)\tests\DCPS\Messenger\Messenger.sln
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-    condition: ne(variables['BuildConfiguration'], 'Debug')
-  - task: VSBuild@1
-    displayName: Build Messenger Example
-    inputs:
-      solution: $(DDS_ROOT)\DevGuideExamples\DCPS\Messenger\Messenger.sln
-      platform: $(BuildPlatform)
-      configuration: $(BuildConfiguration)
-    condition: ne(variables['BuildConfiguration'], 'Debug')
-  - script: |
-      del /s/q *.obj *.idb
-    displayName: Remove unused build outputs
-  - script: |
-      if %BuildConfiguration%==Release (set SUBDIR_FOR_MESSENGER=Release) else set SUBDIR_FOR_MESSENGER=.
-      cd tests\DCPS\Messenger
-      perl run_test.pl rtps -ExeSubDir %SUBDIR_FOR_MESSENGER%
-    displayName: Run DCPS Messenger Test
-  - script: |
-      if %BuildConfiguration%==Release (set SUBDIR_FOR_MESSENGER=Release) else set SUBDIR_FOR_MESSENGER=.
-      cd DevGuideExamples\DCPS\Messenger
-      perl integration_run_test.pl -ExeSubDir %SUBDIR_FOR_MESSENGER%
-    displayName: Run Examples DCPS Messenger
-  - script: |
-      perl tests\cmake_integration\run_ci_tests.pl --build-config=$(BuildConfiguration) --generator="Visual Studio 15 2017" --arch $(BuildPlatform)
-    displayName: Compile and run CMake tests
-
 - job: Linux
   timeoutInMinutes: 120
   pool:
@@ -236,58 +120,12 @@ jobs:
     TEST_GITIGNORE: false
   strategy:
     matrix:
-      Debug:
-        ConfigOpts: --no-inline --java=$(JAVA_HOME_12_X64)
-        TEST_JAVA_MESSENGER: true
-        TEST_GITIGNORE: true
-      Release:
-        ConfigOpts: --no-debug --optimize --java=$(JAVA_HOME_12_X64)
-        TEST_JAVA_MESSENGER: true
-        DoMakeInstall: true
       Safety:
         ConfigOpts: --safety-profile
         TEST_MESSENGER: false
       SafetyBaseNoBuiltinTopics:
         ConfigOpts: --safety-profile=base --no-built-in-topics
         TEST_MESSENGER: false
-      Security:
-        ConfigOpts: --security --features=versioned_namespace=1
-        PackageDeps: libxerces-c-dev libssl-dev cmake
-        TEST_GITIGNORE: true
-      SecurityWithoutFeatures:
-        ConfigOpts: >
-          --security --no-inline --no-debug --features=versioned_namespace=1
-          --no-built-in-topics --no-content-subscription --no-ownership-profile
-          --no-object-model-profile --no-persistence-profile --no-rapidjson
-        TEST_MESSENGER: false
-        PackageDeps: libxerces-c-dev libssl-dev cmake
-      WChar:
-        ConfigOpts: --features=uses_wchar=1 --no-inline
-      CLANG5:
-        ConfigOpts: --compiler=clang++-5.0 --security --std=c++11 --features=uses_wchar=1 --no-inline
-        PackageDeps: libxerces-c-dev libssl-dev cmake clang-5.0
-      CLANG6:
-        ConfigOpts: --compiler=clang++-6.0 --security --std=c++11
-        PackageDeps: libxerces-c-dev libssl-dev cmake clang-6.0
-      CLANG10:
-        ConfigOpts: --compiler=clang++-10 --security --std=c++11
-        PackageDeps: libxerces-c-dev libssl-dev cmake clang-10
-        Repo: llvm-toolchain-$(lsb_release -cs)-10
-      GCC6_CPP03:
-        ConfigOpts: --compiler=g++-6 --std=c++03
-        PackageDeps: g++-6
-        CMakeTestOpts: --skip-cxx11
-      GCC6:
-        ConfigOpts: --compiler=g++-6 --xerces --features=uses_wchar=1 --no-debug
-        PackageDeps: libxerces-c-dev g++-6
-      GCC8:
-        ConfigOpts: --compiler=g++-8 --xerces --no-inline --no-rapidjson --java=$(JAVA_HOME_12_X64)
-        TEST_JAVA_MESSENGER: true
-        PackageDeps: libxerces-c-dev g++-8
-      GCC10:
-        ConfigOpts: --compiler=g++-10 --xerces --no-inline
-        TEST_FACE_MESSENGER: true
-        PackageDeps: libxerces-c-dev g++-10
   steps:
   - script: |
       set -e
@@ -433,40 +271,3 @@ jobs:
       exit $STATUS
     condition: eq(variables['TEST_GITIGNORE'], 'true')
     displayName: Check validity of .gitignore
-
-- job: macOS
-  timeoutInMinutes: 120
-  pool:
-    vmImage: macOS-latest
-  variables:
-    TEST_MESSENGER: true
-  strategy:
-    maxParallel: 2
-    matrix:
-      Debug:
-        ConfigOpts: --no-inline
-      Release:
-        ConfigOpts: --no-debug --optimize
-  steps:
-  - script: |
-      ./configure -v --std=c++11 --ace-github-latest --tests $(ConfigOpts)
-      tools/scripts/show_build_config.pl
-    displayName: Run configure script
-  - script: make -sj6
-    displayName: Compile
-  - script: >
-      source setenv.sh &&
-      tests/cmake_integration/run_ci_tests.pl
-    displayName: Compile and run CMake tests
-  - script: |
-      source setenv.sh
-      cd DevGuideExamples/DCPS/Messenger
-      perl integration_run_test.pl
-    condition: eq(variables['TEST_MESSENGER'], 'true')
-    displayName: Run Examples DCPS Messenger
-  - script: |
-      source setenv.sh
-      cd tests/DCPS/Messenger
-      perl run_test.pl all
-    condition: eq(variables['TEST_MESSENGER'], 'true')
-    displayName: Run DCPS Messenger Test

--- a/tests/cmake_integration/Nested_IDL/CMakeLists.txt
+++ b/tests/cmake_integration/Nested_IDL/CMakeLists.txt
@@ -30,7 +30,7 @@ set(the_ecu "ecu")
 
 add_executable(${the_ecu} "ecu.cpp")
 
-add_library(ecu_lib SHARED)
+add_library(ecu_lib)
 
 OPENDDS_TARGET_SOURCES(ecu_lib ecu.idl
   ./engine/engine_specs.idl


### PR DESCRIPTION
The initial PR for GHA did not have working static builds. This PR fixes them by removing the test build option so that the builds do not run out of disk space.  Additionally dev guide messenger test is built/run so that we have at least a little test coverage in the CI for static builds.

Similar to other GHA PRs, there will need to be a name reversion 8 days after the PR is merged due to cacheing of build artifacts.

To reviewers: The only non uncommenting changes are the ./configure options, and adding DevGuideExamples sections to each.