### PR TITLE
Avoid Matching on RTPS Relay

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -755,7 +755,7 @@ DataReaderImpl::signal_liveliness(const RepoId& remote_participant)
     ACE_READ_GUARD(ACE_RW_Thread_Mutex, read_guard, this->writers_lock_);
     for (WriterMapType::iterator pos = writers_.lower_bound(prefix),
            limit = writers_.end();
-         pos != limit && GuidPrefixEqual() (pos->first.guidPrefix, prefix.guidPrefix);
+         pos != limit && equal_guid_prefixes(pos->first, prefix);
          ++pos) {
       writers.push_back(std::make_pair(pos->first, pos->second));
     }

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1009,6 +1009,10 @@ namespace OpenDDS {
           discovered_endpoints = td.discovered_subscriptions();
         }
 
+        if (local_endpoints.empty()) {
+          return;
+        }
+
         for (RepoIdSet::const_iterator iter = local_endpoints.begin();
              iter != local_endpoints.end(); ++iter) {
           // check to make sure it's a Reader/Writer or Writer/Reader match
@@ -1019,11 +1023,6 @@ namespace OpenDDS {
               match(reader ? *iter : repoId, reader ? repoId : *iter);
             }
           }
-        }
-
-        // Remote/remote matches are a waste of time
-        if (!guid_prefixes_equal(repoId, participant_id_)) {
-          return;
         }
 
         for (RepoIdSet::const_iterator iter = discovered_endpoints.begin();

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1009,7 +1009,9 @@ namespace OpenDDS {
           discovered_endpoints = td.discovered_subscriptions();
         }
 
-        if (local_endpoints.empty()) {
+        const bool is_remote = !equal_guid_prefixes(repoId, participant_id_);
+        if (is_remote && local_endpoints.empty()) {
+          // Nothing to match.
           return;
         }
 
@@ -1026,7 +1028,7 @@ namespace OpenDDS {
         }
 
         // Remote/remote matches are a waste of time
-        if (!equal_guid_prefixes(repoId, participant_id_)) {
+        if (is_remote) {
           return;
         }
 

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1025,6 +1025,11 @@ namespace OpenDDS {
           }
         }
 
+        // Remote/remote matches are a waste of time
+        if (!equal_guid_prefixes(repoId, participant_id_)) {
+          return;
+        }
+
         for (RepoIdSet::const_iterator iter = discovered_endpoints.begin();
              iter != discovered_endpoints.end(); ++iter) {
           // check to make sure it's a Reader/Writer or Writer/Reader match

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1021,6 +1021,11 @@ namespace OpenDDS {
           }
         }
 
+        // Remote/remote matches are a waste of time
+        if (!guid_prefixes_equal(repoId, participant_id_)) {
+          return;
+        }
+
         for (RepoIdSet::const_iterator iter = discovered_endpoints.begin();
              iter != discovered_endpoints.end(); ++iter) {
           // check to make sure it's a Reader/Writer or Writer/Reader match
@@ -1214,10 +1219,6 @@ namespace OpenDDS {
             ACE_DEBUG((LM_DEBUG, "(%P|%t) EndpointManager::match: Undiscovered Reader\n"));
           }
           return; // Possible and ok, since lock is released
-        }
-
-        if (!writer_local && !reader_local) {
-          return;
         }
 
         MatchingData md;

--- a/dds/DCPS/GuidUtils.h
+++ b/dds/DCPS/GuidUtils.h
@@ -149,22 +149,6 @@ bool equal_guid_prefixes(const GUID_t& lhs, const GUID_t& rhs)
   return equal_guid_prefixes(lhs.guidPrefix, rhs.guidPrefix);
 }
 
-struct GuidPrefixEqual {
-
-  bool
-  operator() (const GuidPrefix_t& lhs, const GuidPrefix_t& rhs) const
-  {
-    return equal_guid_prefixes(lhs, rhs);
-  }
-
-  bool
-  operator() (const GUID_t& lhs, const GUID_t& rhs) const
-  {
-    return equal_guid_prefixes(lhs, rhs);
-  }
-
-};
-
 #ifndef OPENDDS_SAFETY_PROFILE
 inline bool
 operator==(const EntityId_t& lhs, const EntityId_t& rhs)

--- a/dds/DCPS/GuidUtils.h
+++ b/dds/DCPS/GuidUtils.h
@@ -137,18 +137,30 @@ operator<(const GUID_t& lhs, const GUID_t& rhs)
   return GUID_tKeyLessThan()(lhs, rhs);
 }
 
+OpenDDS_Dcps_Export inline
+bool equal_guid_prefixes(const GuidPrefix_t& lhs, const GuidPrefix_t& rhs)
+{
+  return std::memcmp(&lhs, &rhs, sizeof(GuidPrefix_t)) == 0;
+}
+
+OpenDDS_Dcps_Export inline
+bool equal_guid_prefixes(const GUID_t& lhs, const GUID_t& rhs)
+{
+  return equal_guid_prefixes(lhs.guidPrefix, rhs.guidPrefix);
+}
+
 struct GuidPrefixEqual {
 
   bool
   operator() (const GuidPrefix_t& lhs, const GuidPrefix_t& rhs) const
   {
-    return std::memcmp(&lhs, &rhs, sizeof(GuidPrefix_t)) == 0;
+    return equal_guid_prefixes(lhs, rhs);
   }
 
   bool
   operator() (const GUID_t& lhs, const GUID_t& rhs) const
   {
-    return std::memcmp(&lhs.guidPrefix, &rhs.guidPrefix, sizeof(GuidPrefix_t)) == 0;
+    return equal_guid_prefixes(lhs, rhs);
   }
 
 };

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3087,7 +3087,7 @@ Sedp::data_received(DCPS::MessageId /*message_id*/,
     const DCPS::RepoIdSet::const_iterator pos =
       sub_pos->second.matched_endpoints_.lower_bound(prefix);
     if (pos != sub_pos->second.matched_endpoints_.end() &&
-        DCPS::GuidPrefixEqual()(pos->guidPrefix, prefix.guidPrefix)) {
+        DCPS::equal_guid_prefixes(*pos, prefix)) {
       DCPS::DataReaderCallbacks_rch sl = sub_pos->second.subscription_.lock();
       if (sl) {
         sl->signal_liveliness(guid_participant);
@@ -3125,7 +3125,7 @@ Sedp::received_participant_message_data_secure(DCPS::MessageId /*message_id*/,
   for (i = local_subscriptions_.begin(), n = local_subscriptions_.end(); i != n; ++i) {
     const DCPS::RepoIdSet::const_iterator pos = i->second.matched_endpoints_.lower_bound(prefix);
 
-    if (pos != i->second.matched_endpoints_.end() && DCPS::GuidPrefixEqual()(pos->guidPrefix, prefix.guidPrefix)) {
+    if (pos != i->second.matched_endpoints_.end() && DCPS::equal_guid_prefixes(*pos, prefix)) {
       DCPS::DataReaderCallbacks_rch sl = i->second.subscription_.lock();
       if (sl) {
         sl->signal_liveliness(guid_participant);
@@ -5737,7 +5737,7 @@ void Sedp::resend_user_crypto_tokens(const RepoId& id)
     for (DCPS::RepoIdSet::const_iterator writer_pos = reader_pos->second.matched_endpoints_.begin(),
            writer_limit = reader_pos->second.matched_endpoints_.end();
          writer_pos != writer_limit; ++writer_pos) {
-      if (!DCPS::GuidPrefixEqual()(writer_pos->guidPrefix, remote_participant.guidPrefix)) {
+      if (!DCPS::equal_guid_prefixes(*writer_pos, remote_participant)) {
         continue;
       }
       const DDS::Security::DatawriterCryptoHandle dwch =
@@ -5767,7 +5767,7 @@ void Sedp::resend_user_crypto_tokens(const RepoId& id)
     for (DCPS::RepoIdSet::const_iterator reader_pos = writer_pos->second.matched_endpoints_.begin(),
            reader_limit = writer_pos->second.matched_endpoints_.end();
          reader_pos != reader_limit; ++reader_pos) {
-      if (!DCPS::GuidPrefixEqual()(reader_pos->guidPrefix, remote_participant.guidPrefix)) {
+      if (!DCPS::equal_guid_prefixes(*reader_pos, remote_participant)) {
         continue;
       }
       const DDS::Security::DatareaderCryptoHandle drch =

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2867,7 +2867,7 @@ Spdp::SpdpTransport::handle_input(ACE_HANDLE h)
       }
     }
 
-    if (DCPS::transport_debug.log_messages && !DCPS::GuidPrefixEqual()(hdr_.guidPrefix, header.guidPrefix)) {
+    if (DCPS::transport_debug.log_messages && !DCPS::equal_guid_prefixes(hdr_.guidPrefix, header.guidPrefix)) {
       RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", hdr_.guidPrefix, false, message);
     }
 

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -805,7 +805,7 @@ RecorderImpl::signal_liveliness(const RepoId& remote_participant)
     ACE_READ_GUARD(ACE_RW_Thread_Mutex, read_guard, this->writers_lock_);
     for (WriterMapType::iterator pos = writers_.lower_bound(prefix),
            limit = writers_.end();
-         pos != limit && GuidPrefixEqual() (pos->first.guidPrefix, prefix.guidPrefix);
+         pos != limit && equal_guid_prefixes(pos->first, prefix);
          ++pos) {
       writers.push_back(std::make_pair(pos->first, pos->second));
     }

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -98,7 +98,7 @@ void StaticEndpointManager::init_bit()
     const RepoId& remoteid = pos->first;
     const EndpointRegistry::Writer& writer = pos->second;
 
-    if (!GuidPrefixEqual()(participant_id_.guidPrefix, remoteid.guidPrefix)) {
+    if (!equal_guid_prefixes(participant_id_, remoteid)) {
       const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(remoteid);
 
       // pos represents a remote.
@@ -144,7 +144,7 @@ void StaticEndpointManager::init_bit()
     const RepoId& remoteid = pos->first;
     const EndpointRegistry::Reader& reader = pos->second;
 
-    if (!GuidPrefixEqual()(participant_id_.guidPrefix, remoteid.guidPrefix)) {
+    if (!equal_guid_prefixes(participant_id_, remoteid)) {
       const DDS::BuiltinTopicKey_t key = repo_id_to_bit_key(remoteid);
 
       // pos represents a remote.

--- a/dds/DCPS/security/framework/HandleRegistry.cpp
+++ b/dds/DCPS/security/framework/HandleRegistry.cpp
@@ -239,13 +239,12 @@ HandleRegistry::get_remote_datareader_security_attributes(const DCPS::RepoId& id
 HandleRegistry::DatareaderCryptoHandleList
 HandleRegistry::get_all_remote_datareaders(const DCPS::RepoId& prefix) const
 {
-  const DCPS::GuidPrefixEqual guid_prefix_equal = DCPS::GuidPrefixEqual();
   DatareaderCryptoHandleList retval;
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, retval);
   for (DatareaderCryptoHandleMap::const_iterator pos =
          remote_datareader_crypto_handles_.lower_bound(DCPS::make_id(prefix, DCPS::ENTITYID_UNKNOWN)),
          limit = remote_datareader_crypto_handles_.end();
-       pos != limit && guid_prefix_equal(pos->first, prefix); ++pos) {
+       pos != limit && DCPS::equal_guid_prefixes(pos->first, prefix); ++pos) {
     retval.push_back(std::make_pair(pos->first, pos->second.first));
   }
   return retval;
@@ -310,13 +309,12 @@ HandleRegistry::get_remote_datawriter_security_attributes(const DCPS::RepoId& id
 HandleRegistry::DatawriterCryptoHandleList
 HandleRegistry::get_all_remote_datawriters(const DCPS::RepoId& prefix) const
 {
-  const DCPS::GuidPrefixEqual guid_prefix_equal = DCPS::GuidPrefixEqual();
   DatawriterCryptoHandleList retval;
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, retval);
   for (DatawriterCryptoHandleMap::const_iterator pos =
          remote_datawriter_crypto_handles_.lower_bound(DCPS::make_id(prefix, DCPS::ENTITYID_UNKNOWN)),
          limit = remote_datawriter_crypto_handles_.end();
-       pos != limit && guid_prefix_equal(pos->first, prefix); ++pos) {
+       pos != limit && DCPS::equal_guid_prefixes(pos->first, prefix); ++pos) {
     retval.push_back(std::make_pair(pos->first, pos->second.first));
   }
   return retval;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -113,7 +113,7 @@ RtpsUdpTransport::use_ice_now(bool after)
 RtpsUdpDataLink_rch
 RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 {
-  OPENDDS_ASSERT(!GuidPrefixEqual()(local_prefix, GUIDPREFIX_UNKNOWN));
+  OPENDDS_ASSERT(!equal_guid_prefixes(local_prefix, GUIDPREFIX_UNKNOWN));
 
   assign(local_prefix_, local_prefix);
 #ifdef OPENDDS_SECURITY
@@ -833,7 +833,7 @@ RtpsUdpTransport::relay_stun_task(const DCPS::MonotonicTimePoint& /*now*/)
 
   process_relay_sra(relay_srsm_.send(stun_server_address, ICE::Configuration::instance()->server_reflexive_indication_count(), local_prefix_));
 
-  if (!GuidPrefixEqual()(local_prefix_, GUIDPREFIX_UNKNOWN) && stun_server_address != ACE_INET_Addr()) {
+  if (!equal_guid_prefixes(local_prefix_, GUIDPREFIX_UNKNOWN) && stun_server_address != ACE_INET_Addr()) {
     ice_endpoint_.send(stun_server_address, relay_srsm_.message());
   }
 }


### PR DESCRIPTION
Also remove `GuidPrefixEqual` since nothing was using it as a struct and replaced it with a normal function.