### PR TITLE
Fix Spdp Shutdown / Dispose Memory Access Issues

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -2022,7 +2022,7 @@ namespace OpenDDS {
         ACE_GUARD(ACE_Thread_Mutex, g, lock_);
         endpoint_manager().ignore(ignoreId);
 
-        const DiscoveredParticipantIter iter = participants_.find(ignoreId);
+        DiscoveredParticipantIter iter = participants_.find(ignoreId);
         if (iter != participants_.end()) {
           remove_discovered_participant(iter);
         }
@@ -2327,8 +2327,11 @@ namespace OpenDDS {
 
       virtual EndpointManagerType& endpoint_manager() = 0;
 
-      void remove_discovered_participant(DiscoveredParticipantIter iter)
+      void remove_discovered_participant(DiscoveredParticipantIter& iter)
       {
+        if (iter == participants_.end()) {
+          return;
+        }
         RepoId part_id = iter->first;
         bool removed = endpoint_manager().disassociate(iter->second.pdata_);
         iter = participants_.find(part_id); // refresh iter after disassociate, which can unlock
@@ -2375,7 +2378,7 @@ namespace OpenDDS {
         }
       }
 
-      virtual void remove_discovered_participant_i(DiscoveredParticipantIter) {}
+      virtual void remove_discovered_participant_i(DiscoveredParticipantIter&) {}
 
 #ifndef DDS_HAS_MINIMUM_BIT
     DCPS::ParticipantBuiltinTopicDataDataReaderImpl* part_bit()

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -2551,6 +2551,7 @@ namespace OpenDDS {
           participants_.erase(domain);
         }
 
+        participant->shutdown();
         return true;
       }
 

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2610,7 +2610,7 @@ DomainParticipantImpl::handle_exception(ACE_HANDLE /*fd*/)
   shutdown_mutex_.acquire();
   shutdown_result_ = ret;
   shutdown_complete_ = true;
-  shutdown_condition_.notify_one();
+  shutdown_condition_.notify_all();
   shutdown_mutex_.release();
 
   return 0;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1731,6 +1731,11 @@ Sedp::disassociate(ParticipantData_t& pdata)
     result = true;
   }
 
+  BuiltinEndpointSet_t associated_endpoints = pdata.associated_endpoints;
+#ifdef OPENDDS_SECURITY
+  DDS::Security::ExtendedBuiltinEndpointSet_t extended_associated_endpoints = pdata.extended_associated_endpoints;
+#endif
+
   for (OPENDDS_VECTOR(DiscoveredPublication)::iterator it = pubs_to_remove_from_bit.begin(); it != pubs_to_remove_from_bit.end(); ++it) {
     remove_from_bit_i(*it);
   }
@@ -1738,11 +1743,6 @@ Sedp::disassociate(ParticipantData_t& pdata)
   for (OPENDDS_VECTOR(DiscoveredSubscription)::iterator it = subs_to_remove_from_bit.begin(); it != subs_to_remove_from_bit.end(); ++it) {
     remove_from_bit_i(*it);
   }
-
-  BuiltinEndpointSet_t associated_endpoints = pdata.associated_endpoints;
-#ifdef OPENDDS_SECURITY
-  DDS::Security::ExtendedBuiltinEndpointSet_t extended_associated_endpoints = pdata.extended_associated_endpoints;
-#endif
 
   { // Release lock, so we can call into transport
     ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1739,57 +1739,62 @@ Sedp::disassociate(ParticipantData_t& pdata)
     remove_from_bit_i(*it);
   }
 
+  BuiltinEndpointSet_t associated_endpoints = pdata.associated_endpoints;
+#ifdef OPENDDS_SECURITY
+  DDS::Security::ExtendedBuiltinEndpointSet_t extended_associated_endpoints = pdata.extended_associated_endpoints;
+#endif
+
   { // Release lock, so we can call into transport
     ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(lock_);
     ACE_GUARD_RETURN(ACE_Reverse_Lock< ACE_Thread_Mutex>, rg, rev_lock, false);
 
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER,
                         part,
                         ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER,
                         *publications_writer_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR,
                         part,
                         ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER,
                         *publications_reader_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER,
                         part,
                         ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER,
                         *subscriptions_writer_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR,
                         part,
                         ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER,
                         *subscriptions_reader_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER,
                         part,
                         ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER,
                         *participant_message_writer_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER,
                         part,
                         ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER,
                         *participant_message_reader_);
 
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_WRITER,
                         part,
                         ENTITYID_TL_SVC_REQ_READER,
                         *type_lookup_request_writer_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_READER,
                         part,
                         ENTITYID_TL_SVC_REQ_WRITER,
                         *type_lookup_request_reader_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_WRITER,
                         part,
                         ENTITYID_TL_SVC_REPLY_READER,
                         *type_lookup_reply_writer_);
-    disassociate_helper(pdata.associated_endpoints,
+    disassociate_helper(associated_endpoints,
                         BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_READER,
                         part,
                         ENTITYID_TL_SVC_REPLY_WRITER,
@@ -1798,7 +1803,16 @@ Sedp::disassociate(ParticipantData_t& pdata)
     //FUTURE: if/when topic propagation is supported, add it here
 
 #ifdef OPENDDS_SECURITY
-    disassociate_security_builtins(pdata);
+    disassociate_security_builtins(part, associated_endpoints, extended_associated_endpoints);
+#endif
+  }
+
+  // Since we've reverse locked, we can't trust the old pdata anymore
+  if (spdp_.has_discovered_participant(part)) {
+    ParticipantData_t& safe_pdata = spdp_.get_participant_data(part);
+    safe_pdata.associated_endpoints = associated_endpoints;
+#ifdef OPENDDS_SECURITY
+    safe_pdata.extended_associated_endpoints = extended_associated_endpoints;
 #endif
   }
 
@@ -1806,89 +1820,88 @@ Sedp::disassociate(ParticipantData_t& pdata)
 }
 
 #ifdef OPENDDS_SECURITY
-void Sedp::disassociate_security_builtins(ParticipantData_t& pdata)
+void Sedp::disassociate_security_builtins(const DCPS::RepoId& part, BuiltinEndpointSet_t& associated_endpoints,
+  DDS::Security::ExtendedBuiltinEndpointSet_t& extended_associated_endpoints)
 {
   using namespace DDS::Security;
 
-  const RepoId part = make_id(pdata.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
-
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER,
                       part,
                       ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER,
                       *publications_secure_writer_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       SEDP_BUILTIN_PUBLICATIONS_SECURE_READER,
                       part,
                       ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER,
                       *publications_secure_reader_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER,
                       part,
                       ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER,
                       *subscriptions_secure_writer_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER,
                       part,
                       ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER,
                       *subscriptions_secure_reader_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER,
                       part,
                       ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER,
                       *participant_message_secure_writer_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER,
                       part,
                       ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER,
                       *participant_message_secure_reader_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER,
                       part,
                       ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER,
                       *participant_stateless_message_writer_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER,
                       part,
                       ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER,
                       *participant_stateless_message_reader_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER,
                       part,
                       ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER,
                       *participant_volatile_message_secure_writer_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER,
                       part,
                       ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER,
                       *participant_volatile_message_secure_reader_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER,
                       part,
                       ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER,
                       *dcps_participant_secure_writer_);
-  disassociate_helper(pdata.associated_endpoints,
+  disassociate_helper(associated_endpoints,
                       SPDP_BUILTIN_PARTICIPANT_SECURE_READER,
                       part,
                       ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER,
                       *dcps_participant_secure_reader_);
 
-  disassociate_helper(pdata.extended_associated_endpoints,
+  disassociate_helper(extended_associated_endpoints,
                       TYPE_LOOKUP_SERVICE_REQUEST_WRITER_SECURE,
                       part,
                       ENTITYID_TL_SVC_REQ_READER_SECURE,
                       *type_lookup_request_secure_writer_);
-  disassociate_helper(pdata.extended_associated_endpoints,
+  disassociate_helper(extended_associated_endpoints,
                       TYPE_LOOKUP_SERVICE_REQUEST_READER_SECURE,
                       part,
                       ENTITYID_TL_SVC_REQ_WRITER_SECURE,
                       *type_lookup_request_secure_reader_);
-  disassociate_helper(pdata.extended_associated_endpoints,
+  disassociate_helper(extended_associated_endpoints,
                       TYPE_LOOKUP_SERVICE_REPLY_WRITER_SECURE,
                       part,
                       ENTITYID_TL_SVC_REPLY_READER_SECURE,
                       *type_lookup_reply_secure_writer_);
-  disassociate_helper(pdata.extended_associated_endpoints,
+  disassociate_helper(extended_associated_endpoints,
                       TYPE_LOOKUP_SERVICE_REPLY_READER_SECURE,
                       part,
                       ENTITYID_TL_SVC_REPLY_WRITER_SECURE,

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -110,7 +110,8 @@ public:
   void generate_remote_crypto_handles(const Security::SPDPdiscoveredParticipantData& pdata);
   void associate_secure_reader_to_writer(const DCPS::RepoId& remote_writer);
   void associate_secure_writer_to_reader(const DCPS::RepoId& remote_reader);
-  void disassociate_security_builtins(ParticipantData_t& pdata);
+  void disassociate_security_builtins(const DCPS::RepoId& part, BuiltinEndpointSet_t& associated_endpoints,
+                                      DDS::Security::ExtendedBuiltinEndpointSet_t& extended_associated_endpoints);
   void remove_remote_crypto_handle(const DCPS::RepoId& participant, const EntityId_t& entity);
 
   void send_builtin_crypto_tokens(const DCPS::RepoId& remoteId);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2831,6 +2831,9 @@ Spdp::SpdpTransport::handle_input(ACE_HANDLE h)
           plist[0]._d(PID_PARTICIPANT_GUID);
         }
 
+        // Creating a WeakRcHandle from a dereferenced object pointer is only valid when we know the object is still valid
+        // The current design of Spdp doesn't permit the reactor thread (which calls this method) to run when the object is invalid
+        // While this assumption is true, creating the WeakRcHandle this way is safe
         DCPS::WeakRcHandle<Spdp> wh(*outer_);
         DCPS::RcHandle<Spdp> outer = wh.lock();
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4078,6 +4078,8 @@ void Spdp::process_participant_ice(const ParameterList& plist,
   }
 }
 
+#endif
+
 const ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid) const
 {
   DiscoveredParticipantConstIter iter = participants_.find(make_part_guid(guid));
@@ -4089,8 +4091,6 @@ ParticipantData_t& Spdp::get_participant_data(const DCPS::RepoId& guid)
   DiscoveredParticipantIter iter = participants_.find(make_part_guid(guid));
   return iter->second.pdata_;
 }
-
-#endif
 
 void
 Spdp::rtps_relay_only_now(bool f)

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -207,12 +207,12 @@ public:
 
 protected:
   Sedp& endpoint_manager() { return *sedp_; }
-  void remove_discovered_participant_i(DiscoveredParticipantIter iter);
+  void remove_discovered_participant_i(DiscoveredParticipantIter& iter);
 
 #ifndef DDS_HAS_MINIMUM_BIT
   void enqueue_location_update_i(DiscoveredParticipantIter iter, DCPS::ParticipantLocation mask, const ACE_INET_Addr& from);
-  void process_location_updates_i(DiscoveredParticipantIter iter, bool force_publish = false);
-  void publish_location_update_i(DiscoveredParticipantIter iter);
+  void process_location_updates_i(DiscoveredParticipantIter& iter, bool force_publish = false);
+  void publish_location_update_i(DiscoveredParticipantIter& iter);
 #endif
 
   bool announce_domain_participant_qos();

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -164,10 +164,10 @@ public:
                                const ParticipantData_t& pdata,
                                const DCPS::RepoId& guid);
 
+#endif
+
   const ParticipantData_t& get_participant_data(const DCPS::RepoId& guid) const;
   ParticipantData_t& get_participant_data(const DCPS::RepoId& guid);
-
-#endif
 
   u_short get_spdp_port() const { return tport_ ? tport_->uni_port_ : 0; }
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -98,6 +98,8 @@ public:
   // Managing reader/writer associations
   void signal_liveliness(DDS::LivelinessQosPolicyKind kind);
 
+  void shutdown();
+
   // Is Spdp shutting down?
   bool shutting_down()
   {

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -230,6 +230,8 @@ public:
     bit_subscriber_ = 0;
   }
 
+  void shutdown() {}
+
 private:
   virtual StaticEndpointManager& endpoint_manager() { return *endpoint_manager_; }
 


### PR DESCRIPTION
There are a couple race conditions causing heap-use-after-free ASAN issues in Spdp/Sedp.
- First, a race condition exists between SpdpTransport::handle_input() and Spdp's destructor. Simply moving to a weak object handle during the call to data_recieved potentially causes the reactor thread in charge of cleaning up its own reactor, so the actual shutdown work for Spdp needed to be moved to a separate method to allow trivial behaviors in ~Spdp().
- Second, the reverse locking was still causing issues with the iterators, but this time it was because the "updated" iterators weren't getting passed back up into calling methods when applicable, and also because we weren't checking to see if the pdata object in disassociate was being invalidated after our reverse lock to call disassociate_helper functions.

This PR should hopefully fix those issues.