### PR TITLE
Fix address sanitizer global-buffer-overflow issue in DiffieHellman.cpp

### DIFF
--- a/dds/DCPS/security/SSL/DiffieHellman.cpp
+++ b/dds/DCPS/security/SSL/DiffieHellman.cpp
@@ -18,6 +18,15 @@ namespace OpenDDS {
 namespace Security {
 namespace SSL {
 
+namespace {
+  int compare(const DDS::OctetSeq& s1, const char* s2) {
+    size_t s1_len = s1.length();
+    while (s1_len > 0 && s1.get_buffer()[s1_len - 1] == 0) { s1_len--; }
+    const size_t s2_len = std::strlen(s2);
+    return s1_len != s2_len ? -1 : std::memcmp(s1.get_buffer(), s2, s2_len);
+  }
+}
+
 struct DH_Handle {
   DH* dh_;
   explicit DH_Handle(EVP_PKEY* key)
@@ -432,12 +441,10 @@ int ECDH_PRIME_256_V1_CEUM::compute_shared_secret(const DDS::OctetSeq& pub_key)
 
 DiffieHellman* DiffieHellman::factory(const DDS::OctetSeq& kagree_algo)
 {
-  if (0 == std::memcmp(kagree_algo.get_buffer(), "DH+MODP-2048-256",
-                       kagree_algo.length())) {
+  if (0 == compare(kagree_algo, "DH+MODP-2048-256")) {
     return new DiffieHellman(new DH_2048_MODP_256_PRIME);
 
-  } else if (0 == std::memcmp(kagree_algo.get_buffer(), "ECDH+prime256v1-CEUM",
-                              kagree_algo.length())) {
+  } else if (0 == compare(kagree_algo, "ECDH+prime256v1-CEUM")) {
     return new DiffieHellman(new ECDH_PRIME_256_V1_CEUM);
 
   } else {

--- a/dds/DCPS/security/SSL/DiffieHellman.cpp
+++ b/dds/DCPS/security/SSL/DiffieHellman.cpp
@@ -19,11 +19,9 @@ namespace Security {
 namespace SSL {
 
 namespace {
-  int compare(const DDS::OctetSeq& s1, const char* s2) {
-    size_t s1_len = s1.length();
-    while (s1_len > 0 && s1.get_buffer()[s1_len - 1] == 0) { s1_len--; }
-    const size_t s2_len = std::strlen(s2);
-    return s1_len != s2_len ? -1 : std::memcmp(s1.get_buffer(), s2, s2_len);
+  // Assumes both buffers are null-terminated (and that s2_len includes final null, as with sizeof() for a const char[])
+  int compare(const DDS::OctetSeq& s1, const char* s2, const size_t s2_len) {
+    return s1.length() != s2_len ? -1 : std::memcmp(s1.get_buffer(), s2, s2_len);
   }
 }
 
@@ -441,10 +439,10 @@ int ECDH_PRIME_256_V1_CEUM::compute_shared_secret(const DDS::OctetSeq& pub_key)
 
 DiffieHellman* DiffieHellman::factory(const DDS::OctetSeq& kagree_algo)
 {
-  if (0 == compare(kagree_algo, "DH+MODP-2048-256")) {
+  if (0 == compare(kagree_algo, DH_2048_MODP_256_PRIME_STR, sizeof (DH_2048_MODP_256_PRIME_STR))) {
     return new DiffieHellman(new DH_2048_MODP_256_PRIME);
 
-  } else if (0 == compare(kagree_algo, "ECDH+prime256v1-CEUM")) {
+  } else if (0 == compare(kagree_algo, ECDH_PRIME_256_V1_CEUM_STR, sizeof (ECDH_PRIME_256_V1_CEUM_STR))) {
     return new DiffieHellman(new ECDH_PRIME_256_V1_CEUM);
 
   } else {

--- a/dds/DCPS/security/SSL/DiffieHellman.h
+++ b/dds/DCPS/security/SSL/DiffieHellman.h
@@ -19,6 +19,9 @@ namespace OpenDDS {
 namespace Security {
 namespace SSL {
 
+const char DH_2048_MODP_256_PRIME_STR[] = "DH+MODP-2048-256";
+const char ECDH_PRIME_256_V1_CEUM_STR[] = "ECDH+prime256v1-CEUM";
+
 class OpenDDS_Security_Export DHAlgorithm {
 public:
   typedef DCPS::unique_ptr<DHAlgorithm> unique_ptr;
@@ -71,7 +74,7 @@ public:
    */
   int compute_shared_secret(const DDS::OctetSeq& pub_key);
 
-  const char* kagree_algo() const { return "DH+MODP-2048-256"; }
+  const char* kagree_algo() const { return DH_2048_MODP_256_PRIME_STR; }
 };
 
 class OpenDDS_Security_Export ECDH_PRIME_256_V1_CEUM : public DHAlgorithm {
@@ -94,7 +97,7 @@ public:
    */
   int compute_shared_secret(const DDS::OctetSeq& pub_key);
 
-  const char* kagree_algo() const { return "ECDH+prime256v1-CEUM"; }
+  const char* kagree_algo() const { return ECDH_PRIME_256_V1_CEUM_STR; }
 };
 
 class OpenDDS_Security_Export DiffieHellman {


### PR DESCRIPTION
AddressSanitizer is pointing out a global-buffer-overflow issue in the DiffieHellman code where it's technically comparing the length of an octet sequence (of potentially arbitrary length) against fixed-length string constants and using the sequence length to do the comparison. In practice, the lengths will probably be from a small subset of known algorithm names, and since they seem to be null terminated the "overflow" will probably only ever be a single character, but we probably ought to clean it up.

Optionally, we could also investigate why the octet sequences are null terminated and clean that up to avoid the "trimming" math that needs to happen in compare, but the current changes at least resolve the address sanitizer complaints.