### PR TITLE
Fix RTPS Writer Shutdown Memory Access Issue

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -797,6 +797,18 @@ void RtpsUdpDataLink::client_stop(const RepoId& localId)
         writers_.erase(pos);
       }
     }
+    if (writer)
+    {
+      OPENDDS_VECTOR(TransportQueueElement*) to_drop;
+      writer->pre_stop_helper(to_drop, true);
+
+      typedef OPENDDS_VECTOR(TransportQueueElement*)::iterator tqe_iter;
+      tqe_iter drop_it = to_drop.begin();
+      while (drop_it != to_drop.end()) {
+        (*drop_it)->data_dropped(true);
+        ++drop_it;
+      }
+    }
   }
 }
 
@@ -824,6 +836,13 @@ RtpsUdpDataLink::RtpsWriter::pre_stop_helper(OPENDDS_VECTOR(TransportQueueElemen
       send_buff_->release_acked(*sns_it);
       ++sns_it;
     }
+  }
+
+  g2.release();
+  g.release();
+
+  if (stopping_) {
+    heartbeat_.cancel_and_wait();
   }
 }
 
@@ -1349,9 +1368,14 @@ bool RtpsUdpDataLink::force_inline_qos_ = false;
 void
 RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& now)
 {
-  OPENDDS_VECTOR(TransportQueueElement*) pendingCallbacks;
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  if (stopping_) {
+    return;
+  }
 
   RtpsUdpDataLink_rch link = link_.lock();
+
   if (!link) {
     return;
   }
@@ -1359,29 +1383,30 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& now
   RtpsUdpInst& cfg = link->config();
 
   MetaSubmessageVec meta_submessages;
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
-    if (expected_acks_) {
-      // One more readers did not ack since the last heartbeat.
-      heartbeat_period_ *= cfg.heartbeat_backoff_factor_;
-    } else if (last_ack_ != MonotonicTimePoint::zero_value && last_heartbeat_ != MonotonicTimePoint::zero_value) {
-      heartbeat_period_ = (last_ack_ - last_heartbeat_) * cfg.heartbeat_safety_factor_;
-    }
-    heartbeat_period_ = std::min(heartbeat_period_, std::max(cfg.heartbeat_period_maximum_, cfg.heartbeat_period_minimum_));
-    heartbeat_period_ = std::max(heartbeat_period_, std::min(cfg.heartbeat_period_maximum_, cfg.heartbeat_period_minimum_));
-    expected_acks_ = 0;
+  OPENDDS_VECTOR(TransportQueueElement*) pendingCallbacks;
 
-    send_and_gather_nack_replies_i(meta_submessages);
-    gather_heartbeats_i(pendingCallbacks, meta_submessages);
-
-    if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
-      heartbeat_.schedule(heartbeat_period_);
-      last_heartbeat_ = now;
-    } else {
-      last_heartbeat_ = MonotonicTimePoint::zero_value;
-    }
-    last_ack_ = MonotonicTimePoint::zero_value;
+  if (expected_acks_) {
+    // One more readers did not ack since the last heartbeat.
+    heartbeat_period_ *= cfg.heartbeat_backoff_factor_;
+  } else if (last_ack_ != MonotonicTimePoint::zero_value && last_heartbeat_ != MonotonicTimePoint::zero_value) {
+    heartbeat_period_ = (last_ack_ - last_heartbeat_) * cfg.heartbeat_safety_factor_;
   }
+  heartbeat_period_ = std::min(heartbeat_period_, std::max(cfg.heartbeat_period_maximum_, cfg.heartbeat_period_minimum_));
+  heartbeat_period_ = std::max(heartbeat_period_, std::min(cfg.heartbeat_period_maximum_, cfg.heartbeat_period_minimum_));
+  expected_acks_ = 0;
+
+  send_and_gather_nack_replies_i(meta_submessages);
+  gather_heartbeats_i(pendingCallbacks, meta_submessages);
+
+  if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
+    heartbeat_.schedule(heartbeat_period_);
+    last_heartbeat_ = now;
+  } else {
+    last_heartbeat_ = MonotonicTimePoint::zero_value;
+  }
+  last_ack_ = MonotonicTimePoint::zero_value;
+
+  g.release();
 
   link->queue_or_send_submessages(meta_submessages);
 
@@ -1862,6 +1887,11 @@ bool
 RtpsUdpDataLink::RtpsWriter::add_reader(const ReaderInfo_rch& reader)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
+
+  if (stopping_) {
+    return false;
+  }
+
   ReaderInfoMap::const_iterator iter = remote_readers_.find(reader->id_);
   if (iter == remote_readers_.end()) {
 #ifdef OPENDDS_SECURITY
@@ -2797,6 +2827,10 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
+  if (stopping_) {
+    return;
+  }
+
   RtpsUdpDataLink_rch link = link_.lock();
 
   if (!link) {
@@ -3029,6 +3063,10 @@ void RtpsUdpDataLink::RtpsWriter::process_nackfrag(const RTPS::NackFragSubmessag
                                                    MetaSubmessageVec& /*meta_submessages*/)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  if (stopping_) {
+    return;
+  }
 
   RtpsUdpDataLink_rch link = link_.lock();
 
@@ -3330,6 +3368,10 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
                                                 SequenceNumber previous_max_sn)
 {
   ACE_UNUSED_ARG(reader_id);
+
+  if (stopping_) {
+    return;
+  }
 
 #ifdef OPENDDS_SECURITY
     if (!is_pvs_writer_) {
@@ -3981,8 +4023,6 @@ RtpsUdpDataLink::RtpsWriter::~RtpsWriter()
       ACE_TEXT("deleting with %d elements left not fully acknowledged\n"),
       elems_not_acked_.size()));
   }
-
-  heartbeat_.cancel_and_wait();
 }
 
 CORBA::Long RtpsUdpDataLink::RtpsWriter::inc_heartbeat_count()

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -797,13 +797,12 @@ void RtpsUdpDataLink::client_stop(const RepoId& localId)
         writers_.erase(pos);
       }
     }
-    if (writer)
-    {
-      OPENDDS_VECTOR(TransportQueueElement*) to_drop;
+
+    if (writer) {
+      TqeVector to_drop;
       writer->pre_stop_helper(to_drop, true);
 
-      typedef OPENDDS_VECTOR(TransportQueueElement*)::iterator tqe_iter;
-      tqe_iter drop_it = to_drop.begin();
+      TqeVector::iterator drop_it = to_drop.begin();
       while (drop_it != to_drop.end()) {
         (*drop_it)->data_dropped(true);
         ++drop_it;
@@ -813,7 +812,7 @@ void RtpsUdpDataLink::client_stop(const RepoId& localId)
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop, bool true_stop)
+RtpsUdpDataLink::RtpsWriter::pre_stop_helper(TqeVector& to_drop, bool true_stop)
 {
   typedef SnToTqeMap::iterator iter_t;
 
@@ -851,7 +850,7 @@ RtpsUdpDataLink::pre_stop_i()
 {
   DBG_ENTRY_LVL("RtpsUdpDataLink","pre_stop_i",6);
   DataLink::pre_stop_i();
-  OPENDDS_VECTOR(TransportQueueElement*) to_drop;
+  TqeVector to_drop;
   {
     ACE_GUARD(ACE_Thread_Mutex, g, writers_lock_);
 
@@ -865,8 +864,7 @@ RtpsUdpDataLink::pre_stop_i()
       writers_.erase(last);
     }
   }
-  typedef OPENDDS_VECTOR(TransportQueueElement*)::iterator tqe_iter;
-  tqe_iter drop_it = to_drop.begin();
+  TqeVector::iterator drop_it = to_drop.begin();
   while (drop_it != to_drop.end()) {
     (*drop_it)->data_dropped(true);
     ++drop_it;
@@ -887,7 +885,7 @@ void
 RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
                                         const RepoId& local_id)
 {
-  OPENDDS_VECTOR(TransportQueueElement*) to_drop;
+  TqeVector to_drop;
   using std::pair;
   const GuidConverter conv(local_id);
   if (conv.isWriter()) {
@@ -938,8 +936,7 @@ RtpsUdpDataLink::release_reservations_i(const RepoId& remote_id,
     }
   }
 
-  typedef OPENDDS_VECTOR(TransportQueueElement*)::iterator tqe_iter;
-  for (tqe_iter drop_it = to_drop.begin(); drop_it != to_drop.end(); ++drop_it) {
+  for (TqeVector::iterator drop_it = to_drop.begin(); drop_it != to_drop.end(); ++drop_it) {
     (*drop_it)->data_dropped(true);
   }
 }
@@ -1383,7 +1380,7 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const DCPS::MonotonicTimePoint& now
   RtpsUdpInst& cfg = link->config();
 
   MetaSubmessageVec meta_submessages;
-  OPENDDS_VECTOR(TransportQueueElement*) pendingCallbacks;
+  TqeVector pendingCallbacks;
 
   if (expected_acks_) {
     // One more readers did not ack since the last heartbeat.
@@ -3695,7 +3692,7 @@ void
 RtpsUdpDataLink::RtpsWriter::expire_durable_data(const ReaderInfo_rch& reader,
                                                  const RtpsUdpInst& cfg,
                                                  const MonotonicTimePoint& now,
-                                                 OPENDDS_VECTOR(TransportQueueElement*)& pendingCallbacks)
+                                                 TqeVector& pendingCallbacks)
 {
   if (!reader->durable_data_.empty()) {
     const MonotonicTimePoint expiration = reader->durable_timestamp_ + cfg.durable_data_timeout_;
@@ -3758,7 +3755,7 @@ RtpsUdpDataLink::RtpsWriter::gather_directed_heartbeat_i(const SingleSendBuffer:
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(OPENDDS_VECTOR(TransportQueueElement*)& pendingCallbacks,
+RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(TqeVector& pendingCallbacks,
                                                  MetaSubmessageVec& meta_submessages)
 {
   if (preassociation_readers_.empty() && lagging_readers_.empty() && readers_expecting_heartbeat_.empty()) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -425,7 +425,7 @@ private:
     void expire_durable_data(const ReaderInfo_rch& reader,
                              const RtpsUdpInst& cfg,
                              const MonotonicTimePoint& now,
-                             OPENDDS_VECTOR(TransportQueueElement*)& pendingCallbacks);
+                             TqeVector& pendingCallbacks);
 
 #ifdef OPENDDS_SECURITY
     bool is_pvs_writer() const { return is_pvs_writer_; }
@@ -468,7 +468,7 @@ private:
     size_t reader_count() const;
     CORBA::Long inc_heartbeat_count();
 
-    void pre_stop_helper(OPENDDS_VECTOR(TransportQueueElement*)& to_drop, bool true_stop);
+    void pre_stop_helper(TqeVector& to_drop, bool true_stop);
     TransportQueueElement* customize_queue_element_helper(TransportQueueElement* element,
                                                           bool requires_inline_qos,
                                                           MetaSubmessageVec& meta_submessages,
@@ -482,7 +482,7 @@ private:
                           MetaSubmessageVec& meta_submessages);
     void process_acked_by_all();
     void send_and_gather_nack_replies_i(MetaSubmessageVec& meta_submessages);
-    void gather_heartbeats_i(OPENDDS_VECTOR(TransportQueueElement*)& pendingCallbacks,
+    void gather_heartbeats_i(TqeVector& pendingCallbacks,
                              MetaSubmessageVec& meta_submessages);
     void gather_heartbeats(const RepoIdSet& additional_guids,
                            MetaSubmessageVec& meta_submessages);


### PR DESCRIPTION
There's currently a race condition with the scheduled heartbeat timers and RtpsWriter destruction, especially when a "stopped" writer allows incoming packets to reschedule the heartbeat timer before being destroyed.