### PR TITLE
Adding wait_for_cancel Job To Github Actions 'Build & Test' Workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,9 +61,26 @@ env:
   TRIGGERING_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+
+  wait_cancel_previous:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: convictional/trigger-workflow-and-wait@v1.3.0
+      with:
+        owner: ${{ github.repository_owner }}
+        repo: OpenDDS
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow_file_name: cancel_previous_runs.yml
+        ref: ${{ env.TRIGGERING_COMMIT }}
+        trigger_workflow: false
+
   ACE_TAO_u18_i0_xer0_js0_j12:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: checkout OpenDDS
@@ -315,6 +332,8 @@ jobs:
   ACE_TAO_u18_o1d0v1_xer0_j12_2:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: checkout OpenDDS
@@ -1069,6 +1088,8 @@ jobs:
 
     runs-on: ubuntu-18.04
 
+    needs: wait_cancel_previous
+
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
@@ -1301,6 +1322,8 @@ jobs:
   ACE_TAO_u18_clang5_i0w1_sec:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: install clang++
@@ -1568,6 +1591,8 @@ jobs:
 
     runs-on: ubuntu-18.04
 
+    needs: wait_cancel_previous
+
     steps:
     - name: install clang++
       run: |
@@ -1833,6 +1858,8 @@ jobs:
   ACE_TAO_u18_gcc6_d0w1_cpp03:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: install gcc
@@ -2109,6 +2136,8 @@ jobs:
 
     runs-on: ubuntu-18.04
 
+    needs: wait_cancel_previous
+
     steps:
     - name: install gcc
       run: |
@@ -2383,6 +2412,8 @@ jobs:
   ACE_TAO_u18_gcc10_i0w1_xer0:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: install gcc
@@ -2909,6 +2940,8 @@ jobs:
 
     runs-on: ubuntu-20.04
 
+    needs: wait_cancel_previous
+
     steps:
 
     - name: checkout OpenDDS
@@ -3173,6 +3206,8 @@ jobs:
   ACE_TAO_u20_p1:
 
     runs-on: ubuntu-20.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: checkout OpenDDS
@@ -3601,6 +3636,8 @@ jobs:
   ACE_TAO_u18_w1:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: checkout OpenDDS
@@ -4264,6 +4301,8 @@ jobs:
   ACE_TAO_u18_j_cft0_FM-37:
 
     runs-on: ubuntu-18.04
+
+    needs: wait_cancel_previous
 
     steps:
     - name: checkout OpenDDS
@@ -5339,6 +5378,8 @@ jobs:
 
     runs-on: windows-2019
 
+    needs: wait_cancel_previous
+
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
@@ -5601,6 +5642,9 @@ jobs:
   ACE_TAO_w16_x86_d0i0:
 
     runs-on: windows-2016
+
+    needs: wait_cancel_previous
+
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
@@ -6521,6 +6565,8 @@ jobs:
 
     runs-on: macos-10.15
 
+    needs: wait_cancel_previous
+
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v2.3.4
@@ -6756,6 +6802,8 @@ jobs:
   ACE_TAO_m10_oi0_j_FM-1f:
 
     runs-on: macos-10.15
+
+    needs: wait_cancel_previous
 
     steps:
     - name: checkout OpenDDS


### PR DESCRIPTION
Problem:

The current "Build & Test" workflow has quite a few jobs in it, and approximately 1/3 of them (the ACE_TAO jobs) run immediately upon seeing a triggering event. Even though new pushes to qualifying branches will also trigger the "cancel duplicate builds" workflow, there's not much of a guarantee that these ACE_TAO jobs won't run first, clogging up the job queue even when they are destined to be canceled (imagine several rapid pushes on the same PR).

Solution:
Add an "initial" job that waits for the accompanying "cancel" workflow to finish running (and canceling previous build jobs) before starting any of the current workflow jobs. This should hopefully help smooth things out and allow the cancel workflow to run more quickly even when there are lots of PR commits going on across several PRs.