### PR TITLE
Add Missing Decrement to ZeroCopyDataSeq

### DIFF
--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -435,6 +435,9 @@ public:
   /// Release the instance with the handle.
   void release_instance(DDS::InstanceHandle_t handle);
 
+  /// Release all instances held by the reader.
+  virtual void release_all_instances() = 0;
+
   // Reset time interval for each instance.
   void reschedule_deadline();
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1048,6 +1048,19 @@ namespace OpenDDS {
     return marshal_skip_serialize_;
   }
 
+  void release_all_instances()
+  {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
+
+    const typename InstanceMap::iterator end = instance_map_.end();
+    typename InstanceMap::iterator it = instance_map_.begin();
+    while (it != end) {
+      const DDS::InstanceHandle_t handle = it->second;
+      ++it; // it will be invalid, so iterate now.
+      release_instance(handle);
+    }
+  }
+
 protected:
 
   virtual RcHandle<MessageHolder> dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample& sample,

--- a/dds/DCPS/ZeroCopySeq_T.cpp
+++ b/dds/DCPS/ZeroCopySeq_T.cpp
@@ -5,8 +5,8 @@
  * See: http://www.opendds.org/license.html
  */
 
-#ifndef ZEROCOPYSEQ_T_CPP
-#define ZEROCOPYSEQ_T_CPP
+#ifndef OPENDDS_DCPS_ZEROCOPYSEQ_T_CPP
+#define OPENDDS_DCPS_ZEROCOPYSEQ_T_CPP
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 # pragma once
@@ -156,8 +156,8 @@ ZeroCopyDataSeq<Sample_T, DEF_MAX>::get_buffer(
 #endif
 
 template <class Sample_T, size_t DEF_MAX>
-void
-ZeroCopyDataSeq<Sample_T, DEF_MAX>::increment_references(void){
+void ZeroCopyDataSeq<Sample_T, DEF_MAX>::increment_references()
+{
   if (is_zero_copy()) {
     for (size_t ii = 0; ii < ptrs_.size(); ++ii) {
       ptrs_[ii]->inc_ref();
@@ -170,4 +170,4 @@ ZeroCopyDataSeq<Sample_T, DEF_MAX>::increment_references(void){
 
 TAO_END_VERSIONED_NAMESPACE_DECL
 
-#endif /* ZEROCOPYSEQ_H  */
+#endif /* OPENDDS_DCPS_ZEROCOPYSEQ_CPP  */

--- a/dds/DCPS/ZeroCopySeq_T.h
+++ b/dds/DCPS/ZeroCopySeq_T.h
@@ -151,11 +151,11 @@ private:
 
   /**
    * In some versions of ACE, ACE_Vector doesn't have a working swap()
-    * function, so we have to provide our own.
-    *
-    * This version also provides public access to the allocator_ member,
-    * something the ACE_Vector doesn't do
-    */
+   * function, so we have to provide our own.
+   *
+   * This version also provides public access to the allocator_ member,
+   * something the ACE_Vector doesn't do
+   */
   class ZeroCopyVector
         : public ACE_Vector<OpenDDS::DCPS::ReceivedDataElement*, DEF_MAX> {
   public:

--- a/dds/DCPS/ZeroCopySeq_T.inl
+++ b/dds/DCPS/ZeroCopySeq_T.inl
@@ -6,7 +6,8 @@
  */
 
 #include "ReceivedDataElementList.h"
-#include "ace/Truncate.h"
+
+#include <ace/Truncate.h>
 
 #include <utility>
 #include <algorithm>
@@ -276,8 +277,10 @@ ZeroCopyDataSeq<Sample_T, DEF_MAX>::assign_ptr(
   OpenDDS::DCPS::ReceivedDataElement* item)
 {
   OPENDDS_ASSERT(is_zero_copy());
-  if (ptrs_[ii])
+  if (ptrs_[ii]) {
+    --ptrs_[ii]->zero_copy_cnt_;
     ptrs_[ii]->dec_ref();
+  }
 
   item->inc_ref();
   ++item->zero_copy_cnt_;

--- a/tests/DCPS/unit/MyTypeSupportImpl.h
+++ b/tests/DCPS/unit/MyTypeSupportImpl.h
@@ -12,10 +12,11 @@
 #ifndef MYTYPESUPPORTIMPL_H_
 #define MYTYPESUPPORTIMPL_H_
 
-#include "dds/DCPS/DataReaderImpl.h"
-#include "dds/DCPS/DataWriterImpl.h"
-#include "dds/DCPS/Definitions.h"
 #include "MyTypeSupportC.h"
+
+#include <dds/DCPS/DataReaderImpl.h>
+#include <dds/DCPS/DataWriterImpl.h>
+#include <dds/DCPS/Definitions.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -31,30 +32,23 @@ class MyTypeSupportImpl : public virtual OpenDDS::DCPS::LocalObject<MyTypeSuppor
 {
 
 public:
-  MyTypeSupportImpl (void);
+  MyTypeSupportImpl();
 
-  virtual ~MyTypeSupportImpl (void);
+  virtual ~MyTypeSupportImpl();
 
-
-  virtual ::DDS::ReturnCode_t register_type (
-      ::DDS::DomainParticipant_ptr participant,
-      const char * type_name
-    );
+  virtual ::DDS::ReturnCode_t register_type(
+    ::DDS::DomainParticipant_ptr participant,
+    const char* type_name);
 
   virtual ::DDS::ReturnCode_t unregister_type(
-      ::DDS::DomainParticipant_ptr participant,
-      const char * type_name
-    );
+    ::DDS::DomainParticipant_ptr participant,
+    const char* type_name);
 
-  virtual
-  char * get_type_name (
-    );
+  virtual char* get_type_name();
 
-  virtual ::DDS::DataWriter_ptr create_datawriter (
-    );
+  virtual ::DDS::DataWriter_ptr create_datawriter();
 
-  virtual ::DDS::DataReader_ptr create_datareader (
-    );
+  virtual ::DDS::DataReader_ptr create_datareader();
 
 #ifndef OPENDDS_NO_MULTI_TOPIC
   virtual ::DDS::DataReader_ptr create_multitopic_datareader();
@@ -72,8 +66,10 @@ public:
 class MyDataReaderImpl :  public virtual OpenDDS::DCPS::DataReaderImpl
 {
 public:
-  virtual ::DDS::ReturnCode_t enable_specific (
-      ) { return ::DDS::RETCODE_OK;};
+  virtual ::DDS::ReturnCode_t enable_specific ()
+  {
+    return ::DDS::RETCODE_OK;
+  }
 
   virtual ::DDS::ReturnCode_t auto_return_loan (void *)
   {
@@ -87,6 +83,7 @@ public:
 
   virtual void purge_data(OpenDDS::DCPS::SubscriptionInstance_rch) {}
   virtual void release_instance_i(DDS::InstanceHandle_t) {}
+  void release_all_instances() {}
   virtual OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::MessageHolder>
   dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample&,
                 OpenDDS::DCPS::SubscriptionInstance_rch &,
@@ -96,8 +93,6 @@ public:
   {
     return OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::MessageHolder>();
   }
-  virtual void dec_ref_data_element(OpenDDS::DCPS::ReceivedDataElement *) {}
-  virtual void delete_instance_map (void *) {}
   bool contains_sample_filtered(DDS::SampleStateMask, DDS::ViewStateMask,
     DDS::InstanceStateMask, const OpenDDS::DCPS::FilterEvaluator&,
     const DDS::StringSeq&) { return true; }


### PR DESCRIPTION
If a data sequence object was reused in a scenario involving a previous read of a different instance, the zero-copy count of a sample wasn't being decremented when it should've been. This resulted in an incorrect outstanding zero-copy loan error when trying to delete the data reader.

This fixes that and adds a case to the ZeroCopyRead test to try to simulate that sequence of events.