### PR TITLE
patch for generated_global cmake test

### DIFF
--- a/tests/cmake_integration/generated_global/idl/CMakeLists.txt
+++ b/tests/cmake_integration/generated_global/idl/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(file
 endforeach()
 
 # Messenger library
-add_library(${messenger} SHARED)
+add_library(${messenger})
 set_target_properties(${messenger}
   PROPERTIES OUTPUT_NAME messenger
 )


### PR DESCRIPTION
The generated_global test was failing on static builds.  This removal was a remnant from when I was first trying to replicate the issue and is no longer needed.