### PR TITLE
Generated Global blocked from running by --no-shared

### DIFF
--- a/tests/cmake_integration/CMakeLists.txt
+++ b/tests/cmake_integration/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.3)
 
 project(opendds_cmake_tests_root_project)
 
+find_package(OpenDDS REQUIRED)
+
 add_subdirectory(Messenger)
 add_subdirectory(Nested_IDL)
-add_subdirectory(generated_global)
+if(NOT OPENDDS_STATIC)
+  add_subdirectory(generated_global)
+endif()

--- a/tests/cmake_integration/Messenger/C++11_Messenger/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/C++11_Messenger/CMakeLists.txt
@@ -1,7 +1,9 @@
 project(OpenDDS_C++11_Messenger CXX)
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(OpenDDS REQUIRED)
+if(NOT OpenDDS_FOUND)
+  find_package(OpenDDS REQUIRED)
+endif()
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
 set(target_prefix "opendds_cmake_cpp11_messenger_")

--- a/tests/cmake_integration/Messenger/Messenger_1/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/Messenger_1/CMakeLists.txt
@@ -7,7 +7,9 @@
 project(OpenDDS_Messenger1_cmake CXX)
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(OpenDDS REQUIRED)
+if(NOT OpenDDS_FOUND)
+  find_package(OpenDDS REQUIRED)
+endif()
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
 

--- a/tests/cmake_integration/Messenger/Messenger_2/CMakeLists.txt
+++ b/tests/cmake_integration/Messenger/Messenger_2/CMakeLists.txt
@@ -7,7 +7,9 @@
 project(OpenDDS_Messenger2_cmake CXX)
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(OpenDDS REQUIRED)
+if(NOT OpenDDS_FOUND)
+  find_package(OpenDDS REQUIRED)
+endif()
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
 

--- a/tests/cmake_integration/Nested_IDL/CMakeLists.txt
+++ b/tests/cmake_integration/Nested_IDL/CMakeLists.txt
@@ -4,7 +4,9 @@
 project(OpenDDS_car_cmake CXX)
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(OpenDDS REQUIRED)
+if(NOT OpenDDS_FOUND)
+  find_package(OpenDDS REQUIRED)
+endif()
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
 

--- a/tests/cmake_integration/generated_global/cpp/CMakeLists.txt
+++ b/tests/cmake_integration/generated_global/cpp/CMakeLists.txt
@@ -7,9 +7,15 @@
 project(opendds_generated_property CXX)
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(OpenDDS REQUIRED)
+if(NOT OpenDDS_FOUND)
+  find_package(OpenDDS REQUIRED)
+endif()
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
+
+if (OPENDDS_STATIC)
+  message(FATAL_ERROR "This test cannot be run on static builds.")
+endif()
 
 if (NOT OPENDDS_OWNERSHIP_PROFILE)
   message(FATAL_ERROR "These tests require OpenDDS to be built with Ownership Profile enabled")

--- a/tests/cmake_integration/generated_global/idl/CMakeLists.txt
+++ b/tests/cmake_integration/generated_global/idl/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(file
 endforeach()
 
 # Messenger library
-add_library(${messenger})
+add_library(${messenger} SHARED)
 set_target_properties(${messenger}
   PROPERTIES OUTPUT_NAME messenger
 )

--- a/tests/cmake_integration/generated_global/idl/CMakeLists.txt
+++ b/tests/cmake_integration/generated_global/idl/CMakeLists.txt
@@ -7,10 +7,15 @@
 project(opendds_generated_property CXX)
 cmake_minimum_required(VERSION 3.8.2)
 
-find_package(OpenDDS REQUIRED)
-
+if(NOT OpenDDS_FOUND)
+  find_package(OpenDDS REQUIRED)
+endif()
 
 set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
+
+if (OPENDDS_STATIC)
+  message(FATAL_ERROR "This test cannot be run on static builds.")
+endif()
 
 if (NOT OPENDDS_OWNERSHIP_PROFILE)
   message(FATAL_ERROR "These tests require OpenDDS to be built with Ownership Profile enabled")

--- a/tests/cmake_integration/run_ci_tests.pl
+++ b/tests/cmake_integration/run_ci_tests.pl
@@ -48,7 +48,8 @@ exit 1 if !GetOptions(
     "no-shared" => \$no_shared,
     );
 
-my @dirs = ('../Nested_IDL', 'Messenger_1', 'Messenger_2', '../generated_global');
+my @dirs = ('../Nested_IDL', 'Messenger_1', 'Messenger_2');
+push @dirs, '../generated_global' unless $no_shared;
 push @dirs, 'C++11_Messenger' unless $skip_cxx11;
 
 my %builds_lib = ('Messenger_2' => 1, 'C++11_Messenger' => 1);


### PR DESCRIPTION
The previous change made test unfailable.  This will actually allow the test to fail while blocking it from running when an undesired error would occur. 