### PR TITLE
Allow Security Attributes Tests to run without OWNERSHIP_PROFILE enabled

### DIFF
--- a/tests/security/attributes/DataReaderListener.cpp
+++ b/tests/security/attributes/DataReaderListener.cpp
@@ -144,10 +144,12 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
           std::cout << "ERROR: Invalid message.text" << std::endl;
           valid_ = false;
         }
-        if (message.subject_id != 99) {
+        static CORBA::Long previous_subject_id = 100;
+        if (message.subject_id != previous_subject_id - 1) {
           std::cout << "ERROR: Invalid message.subject_id" << std::endl;
           valid_ = false;
         }
+        previous_subject_id = message.subject_id;
       } else if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: instance is disposed\n")));
 

--- a/tests/security/attributes/Writer.cpp
+++ b/tests/security/attributes/Writer.cpp
@@ -125,6 +125,7 @@ Writer::svc()
       }
 
       message.count++;
+      message.subject_id--;
     }
 
   } catch (const CORBA::Exception& e) {

--- a/tests/security/attributes/publisher.cpp
+++ b/tests/security/attributes/publisher.cpp
@@ -162,7 +162,6 @@ int run_test(int argc, ACE_TCHAR *argv[], Args& my_args)
       pub->get_default_datawriter_qos(qos);
       if (dw_reliable()) {
         std::cerr << "Reliable DataWriter" << std::endl;
-        qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
         qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
       }
 


### PR DESCRIPTION
Problem:
The writer's KEEP_ALL was causing issues for NO_OWNERSHIP_PROFILE, causing the attributes tests to fail.

Solution:
KEEP_ALL isn't really necessary for this test, so rework instances to avoid need for KEEP_ALL so attributes testing can still be done when OWNERSHIP_PROFILE is disabled.
