### PR TITLE
configure: Allow Java with linux-cross, Fixes #2518

### DIFF
--- a/configure
+++ b/configure
@@ -76,6 +76,7 @@ my %platforminfo =
                      'aceplatform' => 'linux',
                      'aceconfig' => 'linux',
                      'no_host' => 1,
+                     'java_platform' => 'linux',
                      'usage' => ['Use --target-compiler to specify the ' .
                                  'cross-compiler binary',
                                 ],
@@ -108,7 +109,6 @@ my %platforminfo =
                   'usage' => [
                       "Use --macros=ANDROID_ABI=<ARCH> to specify the",
                       "target architecture.",
-                      "Defaults to armeabi-v7a which is 32-bit ARMv7.",
                       "Use --macros=android_sdk=<SDK_PATH> and",
                       "--macros=android_target_api=<API_NUMBER> to specify",
                       "where to find android.jar.",


### PR DESCRIPTION
Fixes #2518. Linux cross compiles should be able to safely use the normal Linux JNI headers.

Also remove line about `ANDROID_ABI` default macro that isn't true anymore in ACE7. Users will have to see the details in `android.md`.