### PR TITLE
add copyright statement to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -85,6 +85,7 @@
   <div class="wrapper">
     <p>{{ site.description }}</p>
     <a href="{{ site.github.repository_url }}/blob/gh-pages/{{ page.path }}">Edit this page on GitHub</a>
+    <p>&copy; 2021 Object Computing, Inc. All rights reserved.</p>
   </div>
 </footer>
 


### PR DESCRIPTION
Legal asked us to add a copyright statement to the footer of all our websites. I added "&copy; 2021 Object Computing, Inc. All rights reserved." to the bottom of the page.