### PR TITLE
RtpsRelay clients use relay's local address

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -315,6 +315,16 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                              -1);
           }
           config->sedp_local_address(addr);
+        } else if (name == "SedpAdvertisedLocalAddress") {
+          ACE_INET_Addr addr;
+          if (addr.set(it->second.c_str())) {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) ERROR: RtpsDiscovery::Config::discovery_config(): ")
+                              ACE_TEXT("failed to parse SedpAdvertisedLocalAddress %C\n"),
+                              it->second.c_str()),
+                             -1);
+          }
+          config->sedp_advertised_address(addr);
         } else if (name == "SpdpLocalAddress") {
           ACE_INET_Addr addr;
           if (addr.set(u_short(0), it->second.c_str())) {

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -197,6 +197,21 @@ public:
     }
   }
 
+  ACE_INET_Addr sedp_advertised_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+    return sedp_advertised_address_;
+  }
+  void sedp_advertised_address(const ACE_INET_Addr& mi)
+  {
+    if (mi.get_type() == AF_INET) {
+      ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+      sedp_advertised_address_ = mi;
+    } else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsDiscoveryConfig::sedp_local_address set failed because address family is not AF_INET\n")));
+    }
+  }
+
   ACE_INET_Addr spdp_local_address() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
@@ -277,6 +292,21 @@ public:
       ipv6_sedp_local_address_ = mi;
     } else {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsDiscoveryConfig::ipv6_sedp_local_address set failed because address family is not AF_INET6\n")));
+    }
+  }
+
+  ACE_INET_Addr ipv6_sedp_advertised_address() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
+    return ipv6_sedp_advertised_address_;
+  }
+  void ipv6_sedp_advertised_address(const ACE_INET_Addr& mi)
+  {
+    if (mi.get_type() == AF_INET6) {
+      ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+      ipv6_sedp_advertised_address_ = mi;
+    } else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsDiscoveryConfig::ipv6_sedp_advertised_address set failed because address family is not AF_INET6\n")));
     }
   }
 
@@ -594,10 +624,10 @@ private:
   unsigned char ttl_;
   bool sedp_multicast_;
   OPENDDS_STRING multicast_interface_;
-  ACE_INET_Addr sedp_local_address_, spdp_local_address_;
+  ACE_INET_Addr sedp_local_address_, sedp_advertised_address_, spdp_local_address_;
   ACE_INET_Addr default_multicast_group_;  /// FUTURE: handle > 1 group.
 #ifdef ACE_HAS_IPV6
-  ACE_INET_Addr ipv6_sedp_local_address_, ipv6_spdp_local_address_;
+  ACE_INET_Addr ipv6_sedp_local_address_, ipv6_sedp_advertised_address_, ipv6_spdp_local_address_;
   ACE_INET_Addr ipv6_default_multicast_group_;
 #endif
   OPENDDS_STRING guid_interface_;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -387,8 +387,10 @@ Sedp::init(const RepoId& guid,
   }
 
   rtps_inst->local_address_ = disco.config()->sedp_local_address();
+  rtps_inst->advertised_address_ = disco.config()->sedp_advertised_address();
 #ifdef ACE_HAS_IPV6
   rtps_inst->ipv6_local_address_ = disco.config()->ipv6_sedp_local_address();
+  rtps_inst->ipv6_advertised_address_ = disco.config()->sedp_ipv6_advertised_address();
 #endif
 
   rtps_relay_address(disco.config()->sedp_rtps_relay_address());

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -82,6 +82,16 @@ public:
     }
   }
 
+  ACE_INET_Addr advertised_address() const { return advertised_address_; }
+  void advertised_address(const ACE_INET_Addr& addr)
+  {
+    if (addr.get_type() == AF_INET) {
+      advertised_address_ = addr;
+    } else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsUdpInst::advertised_address set failed because address family is not AF_INET\n")));
+    }
+  }
+
 #ifdef ACE_HAS_IPV6
   ACE_INET_Addr ipv6_multicast_group_address() const { return ipv6_multicast_group_address_; }
   void ipv6_multicast_group_address(const ACE_INET_Addr& addr)
@@ -100,6 +110,16 @@ public:
       ipv6_local_address_ = addr;
     } else {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsUdpInst::ipv6_local_address set failed because address family is not AF_INET6\n")));
+    }
+  }
+
+  ACE_INET_Addr ipv6_advertised_address() const { return ipv6_advertised_address_; }
+  void ipv6_advertised_address(const ACE_INET_Addr& addr)
+  {
+    if (addr.get_type() == AF_INET6) {
+      ipv6_advertised_address_ = addr;
+    } else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsUdpInst::ipv6_advertised_address set failed because address family is not AF_INET6\n")));
     }
   }
 #endif
@@ -136,9 +156,11 @@ private:
 
   ACE_INET_Addr multicast_group_address_;
   ACE_INET_Addr local_address_;
+  ACE_INET_Addr advertised_address_;
 #ifdef ACE_HAS_IPV6
   ACE_INET_Addr ipv6_multicast_group_address_;
   ACE_INET_Addr ipv6_local_address_;
+  ACE_INET_Addr ipv6_advertised_address_;
 #endif
 
   mutable ACE_SYNCH_MUTEX config_lock_;


### PR DESCRIPTION
Problem
-------

The relay advertises it's local address for SEDP.  Clients of the
relay will attempt to send messages to this address.  If the relay is
behind a firewall, then this local address will most likely not be
routable and the packets sent to it are wasted.

Solution
--------

Provide a configuration option to specify the advertised address for
the SEDP endpoints.