### PR TITLE
Internal tracking of InstanceHandles

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -372,15 +372,15 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
   }
   // We no longer hold the publication_handle_lock_.
 
+
+  RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
+
+  if (!participant)
+    return;
+
+  const DDS::InstanceHandle_t handle = participant->assign_handle(remote_id);
+
   if (!is_bit_) {
-
-    RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
-
-    if (!participant)
-      return;
-
-    const DDS::InstanceHandle_t handle = participant->assign_handle(remote_id);
-
     // We acquire the publication_handle_lock_ for the remainder of our
     // processing.
     {

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -213,7 +213,7 @@ DataReaderImpl::get_instance_handle()
   using namespace OpenDDS::DCPS;
   RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
   if (participant)
-    return participant->id_to_handle(subscription_id_);
+    return participant->lookup_handle(subscription_id_);
   return DDS::HANDLE_NIL;
 }
 
@@ -382,7 +382,7 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
     if (!participant)
       return;
 
-    const DDS::InstanceHandle_t handle = participant->id_to_handle(remote_id);
+    const DDS::InstanceHandle_t handle = participant->assign_handle(remote_id);
 
     // We acquire the publication_handle_lock_ for the remainder of our
     // processing.
@@ -2485,10 +2485,18 @@ DataReaderImpl::get_next_handle(const DDS::BuiltinTopicKey_t& key)
 
   if (is_bit()) {
     const RepoId id = bit_key_to_repo_id(key);
-    return participant->id_to_handle(id);
+    return participant->assign_handle(id);
 
   } else {
-    return participant->id_to_handle(GUID_UNKNOWN);
+    return participant->assign_handle();
+  }
+}
+
+void DataReaderImpl::return_handle(DDS::InstanceHandle_t handle)
+{
+  const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
+  if (participant) {
+    participant->return_handle(handle);
   }
 }
 
@@ -2608,7 +2616,7 @@ DataReaderImpl::lookup_instance_handles(const WriterIdSeq& ids,
   RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
   if (participant) {
     for (CORBA::ULong i = 0; i < num_wrts; ++i) {
-      hdls[i] = participant->id_to_handle(ids[i]);
+      hdls[i] = participant->lookup_handle(ids[i]);
     }
   }
 }

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -210,11 +210,8 @@ void DataReaderImpl::init(
 DDS::InstanceHandle_t
 DataReaderImpl::get_instance_handle()
 {
-  using namespace OpenDDS::DCPS;
-  RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
-  if (participant)
-    return participant->lookup_handle(subscription_id_);
-  return DDS::HANDLE_NIL;
+  const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
+  return get_entity_instance_handle(subscription_id_, participant.get());
 }
 
 void

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -373,7 +373,7 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
   // We no longer hold the publication_handle_lock_.
 
 
-  RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
+  const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
 
   if (!participant)
     return;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -581,6 +581,8 @@ public:
 
   const RepoId& get_repo_id() const { return this->subscription_id_; }
 
+  void return_handle(DDS::InstanceHandle_t handle);
+
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1735,7 +1735,7 @@ void store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_data,
     DDS::BuiltinTopicKey_t key = OpenDDS::DCPS::keyFromSample(static_cast<MessageType*>(instance_data.get()));
     bool owns_handle = false;
     if (handle == DDS::HANDLE_NIL) {
-      handle = this->get_next_handle(key);
+      handle = get_next_handle(key);
       owns_handle = true;
     }
     OpenDDS::DCPS::SubscriptionInstance_rch instance =

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1733,16 +1733,17 @@ void store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_data,
 
     just_registered = true;
     DDS::BuiltinTopicKey_t key = OpenDDS::DCPS::keyFromSample(static_cast<MessageType*>(instance_data.get()));
-    handle = handle == DDS::HANDLE_NIL ? this->get_next_handle( key) : handle;
+    bool owns_handle = false;
+    if (handle == DDS::HANDLE_NIL) {
+      handle = this->get_next_handle(key);
+      owns_handle = true;
+    }
     OpenDDS::DCPS::SubscriptionInstance_rch instance =
       OpenDDS::DCPS::make_rch<OpenDDS::DCPS::SubscriptionInstance>(
         this,
         this->qos_,
         ref(this->instances_lock_),
-        handle);
-
-    instance->instance_handle_ = handle;
-
+        handle, owns_handle);
     {
       ACE_GUARD(ACE_Recursive_Thread_Mutex, instance_guard, instances_lock_);
       int ret = OpenDDS::DCPS::bind(instances_, handle, instance);

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -165,21 +165,29 @@ DataWriterImpl::init(
 DDS::InstanceHandle_t
 DataWriterImpl::get_instance_handle()
 {
-  using namespace OpenDDS::DCPS;
   RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
-  if (participant)
-    return participant->id_to_handle(publication_id_);
+  if (participant) {
+    return participant->lookup_handle(publication_id_);
+  }
   return DDS::HANDLE_NIL;
 }
 
 DDS::InstanceHandle_t
 DataWriterImpl::get_next_handle()
 {
-  using namespace OpenDDS::DCPS;
   RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
-  if (participant)
-    return participant->id_to_handle(GUID_UNKNOWN);
+  if (participant) {
+    return participant->assign_handle();
+  }
   return DDS::HANDLE_NIL;
+}
+
+void DataWriterImpl::return_handle(DDS::InstanceHandle_t handle)
+{
+  const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
+  if (participant) {
+    participant->return_handle(handle);
+  }
 }
 
 DDS::Subscriber_var
@@ -416,8 +424,7 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
     if (!participant)
       return;
 
-    DDS::InstanceHandle_t handle =
-      participant->id_to_handle(remote_id);
+    const DDS::InstanceHandle_t handle = participant->assign_handle(remote_id);
 
     {
       // protect publication_match_status_ and status changed flags.
@@ -665,6 +672,11 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
   // subscription lost.
   if (notify_lost && handles.length() > 0) {
     this->notify_publication_lost(handles);
+  }
+
+  const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
+  for (unsigned int i = 0; i < handles.length(); ++i) {
+    participant->return_handle(handles[i]);
   }
 }
 
@@ -2669,7 +2681,7 @@ DataWriterImpl::lookup_instance_handles(const ReaderIdSeq& ids,
   hdls.length(num_rds);
 
   for (CORBA::ULong i = 0; i < num_rds; ++i) {
-    hdls[i] = participant->id_to_handle(ids[i]);
+    hdls[i] = participant->lookup_handle(ids[i]);
   }
 }
 

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -165,11 +165,8 @@ DataWriterImpl::init(
 DDS::InstanceHandle_t
 DataWriterImpl::get_instance_handle()
 {
-  RcHandle<DomainParticipantImpl> participant = this->participant_servant_.lock();
-  if (participant) {
-    return participant->lookup_handle(publication_id_);
-  }
-  return DDS::HANDLE_NIL;
+  const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
+  return get_entity_instance_handle(publication_id_, participant.get());
 }
 
 DDS::InstanceHandle_t

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -573,6 +573,8 @@ private:
 
   void association_complete_i(const RepoId& remote_id);
 
+  void return_handle(DDS::InstanceHandle_t handle);
+
   friend class ::DDS_TEST; // allows tests to get at privates
 
 

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1518,10 +1518,7 @@ DDS::ReturnCode_t
 DomainParticipantImpl::get_discovered_participants(
   DDS::InstanceHandleSeq & participant_handles)
 {
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                   guard,
-                   this->handle_protector_,
-                   DDS::RETCODE_ERROR);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
   HandleMap::const_iterator itEnd = this->handles_.end();
 
@@ -1551,10 +1548,7 @@ DomainParticipantImpl::get_discovered_participant_data(
   DDS::InstanceHandle_t participant_handle)
 {
   {
-    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                     guard,
-                     this->handle_protector_,
-                     DDS::RETCODE_ERROR);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
     bool found = false;
     HandleMap::const_iterator itEnd = this->handles_.end();
@@ -1603,10 +1597,7 @@ DDS::ReturnCode_t
 DomainParticipantImpl::get_discovered_topics(
   DDS::InstanceHandleSeq & topic_handles)
 {
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                   guard,
-                   this->handle_protector_,
-                   DDS::RETCODE_ERROR);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
   HandleMap::const_iterator itEnd = this->handles_.end();
 
@@ -1635,10 +1626,7 @@ DomainParticipantImpl::get_discovered_topic_data(
   DDS::InstanceHandle_t topic_handle)
 {
   {
-    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                     guard,
-                     this->handle_protector_,
-                     DDS::RETCODE_ERROR);
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
     bool found = false;
     HandleMap::const_iterator itEnd = this->handles_.end();
@@ -1920,10 +1908,7 @@ DomainParticipantImpl::id_to_handle(const RepoId& id)
     return this->participant_handles_.next();
   }
 
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                   guard,
-                   this->handle_protector_,
-                   HANDLE_UNKNOWN);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::HANDLE_NIL);
 
   HandleMap::const_iterator location = this->handles_.find(id);
   DDS::InstanceHandle_t result;
@@ -1944,10 +1929,7 @@ RepoId
 DomainParticipantImpl::get_repoid(const DDS::InstanceHandle_t& handle)
 {
   RepoId result = GUID_UNKNOWN;
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
-                   guard,
-                   this->handle_protector_,
-                   GUID_UNKNOWN);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, result);
   RepoIdMap::const_iterator location = this->repoIds_.find(handle);
   if (location != this->repoIds_.end()) {
     result = location->second;

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -150,9 +150,14 @@ DomainParticipantImpl::create_publisher(
   if (! this->validate_publisher_qos(pub_qos))
     return DDS::Publisher::_nil();
 
+  // Although Publisher entities have GUIDs assigned (see pub_id_gen_),
+  // these are not GUIDs from the RTPS spec and
+  // so the handle doesn't need to correlate to the GUID.
+  const DDS::InstanceHandle_t handle = assign_handle();
+
   PublisherImpl* pub = 0;
   ACE_NEW_RETURN(pub,
-                 PublisherImpl(participant_handles_.next(),
+                 PublisherImpl(handle,
                                pub_id_gen_.next(),
                                pub_qos,
                                a_listener,
@@ -249,9 +254,11 @@ DomainParticipantImpl::create_subscriber(
     return DDS::Subscriber::_nil();
   }
 
+  const DDS::InstanceHandle_t handle = assign_handle();
+
   SubscriberImpl* sub = 0;
   ACE_NEW_RETURN(sub,
-                 SubscriberImpl(participant_handles_.next(),
+                 SubscriberImpl(handle,
                                 sub_qos,
                                 a_listener,
                                 mask,
@@ -1515,27 +1522,21 @@ DomainParticipantImpl::get_current_time(DDS::Time_t& current_time)
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
 DDS::ReturnCode_t
-DomainParticipantImpl::get_discovered_participants(
-  DDS::InstanceHandleSeq & participant_handles)
+DomainParticipantImpl::get_discovered_participants(DDS::InstanceHandleSeq& participant_handles)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
-  HandleMap::const_iterator itEnd = this->handles_.end();
-
-  for (HandleMap::const_iterator iter = this->handles_.begin();
-       iter != itEnd; ++iter) {
+  const CountedHandleMap::const_iterator itEnd = handles_.end();
+  for (CountedHandleMap::const_iterator iter = handles_.begin(); iter != itEnd; ++iter) {
     GuidConverter converter(iter->first);
 
-    if (converter.entityKind() == KIND_PARTICIPANT)
-    {
+    if (converter.entityKind() == KIND_PARTICIPANT) {
       // skip itself and the ignored participant
-      if (iter->first == this->dp_id_
-      || (this->ignored_participants_.find(iter->first)
-        != this->ignored_participants_.end ())) {
+      if (iter->first == dp_id_ || ignored_participants_.count(iter->first)) {
         continue;
       }
 
-      push_back(participant_handles, iter->second);
+      push_back(participant_handles, iter->second.first);
     }
   }
 
@@ -1551,13 +1552,11 @@ DomainParticipantImpl::get_discovered_participant_data(
     ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
     bool found = false;
-    HandleMap::const_iterator itEnd = this->handles_.end();
-
-    for (HandleMap::const_iterator iter = this->handles_.begin();
-         iter != itEnd; ++iter) {
+    const CountedHandleMap::const_iterator itEnd = handles_.end();
+    for (CountedHandleMap::const_iterator iter = handles_.begin(); iter != itEnd; ++iter) {
       GuidConverter converter(iter->first);
 
-      if (participant_handle == iter->second
+      if (participant_handle == iter->second.first
           && converter.entityKind() == KIND_PARTICIPANT) {
         found = true;
         break;
@@ -1594,26 +1593,19 @@ DomainParticipantImpl::get_discovered_participant_data(
 }
 
 DDS::ReturnCode_t
-DomainParticipantImpl::get_discovered_topics(
-  DDS::InstanceHandleSeq & topic_handles)
+DomainParticipantImpl::get_discovered_topics(DDS::InstanceHandleSeq& topic_handles)
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
-  HandleMap::const_iterator itEnd = this->handles_.end();
-
-  for (HandleMap::const_iterator iter = this->handles_.begin();
-       iter != itEnd; ++iter) {
+  const CountedHandleMap::const_iterator itEnd = handles_.end();
+  for (CountedHandleMap::const_iterator iter = handles_.begin(); iter != itEnd; ++iter) {
     GuidConverter converter(iter->first);
-
     if (converter.isTopic()) {
-
-      // skip the ignored topic
-      if (this->ignored_topics_.find(iter->first)
-          != this->ignored_topics_.end ()) {
+      if (ignored_topics_.count(iter->first)) {
         continue;
       }
 
-      push_back(topic_handles, iter->second);
+      push_back(topic_handles, iter->second.first);
     }
   }
 
@@ -1629,13 +1621,10 @@ DomainParticipantImpl::get_discovered_topic_data(
     ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::RETCODE_ERROR);
 
     bool found = false;
-    HandleMap::const_iterator itEnd = this->handles_.end();
-
-    for (HandleMap::const_iterator iter = this->handles_.begin();
-         iter != itEnd; ++iter) {
+    const CountedHandleMap::const_iterator itEnd = handles_.end();
+    for (CountedHandleMap::const_iterator iter = handles_.begin(); iter != itEnd; ++iter) {
       GuidConverter converter(iter->first);
-
-      if (topic_handle == iter->second && converter.isTopic()) {
+      if (topic_handle == iter->second.first && converter.isTopic()) {
         found = true;
         break;
       }
@@ -1898,43 +1887,70 @@ DomainParticipantImpl::get_unique_id()
 DDS::InstanceHandle_t
 DomainParticipantImpl::get_instance_handle()
 {
-  return this->id_to_handle(this->dp_id_);
+  return lookup_handle(dp_id_);
 }
 
-DDS::InstanceHandle_t
-DomainParticipantImpl::id_to_handle(const RepoId& id)
+DDS::InstanceHandle_t DomainParticipantImpl::assign_handle(const GUID_t& id)
 {
   if (id == GUID_UNKNOWN) {
-    return this->participant_handles_.next();
+    const DDS::InstanceHandle_t ih = participant_handles_.next();
+    ACE_DEBUG((LM_DEBUG, "New unmapped IH %d\n", ih));
+    return ih;
   }
 
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::HANDLE_NIL);
 
-  HandleMap::const_iterator location = this->handles_.find(id);
-  DDS::InstanceHandle_t result;
-
-  if (location == this->handles_.end()) {
-    // Map new handle in both directions
-    result = this->participant_handles_.next();
-    this->handles_[id] = result;
-    this->repoIds_[result] = id;
-  } else {
-    result = location->second;
+  const CountedHandleMap::iterator location = handles_.find(id);
+  if (location == handles_.end()) {
+    const DDS::InstanceHandle_t handle = participant_handles_.next();
+    ACE_DEBUG((LM_DEBUG, "New mapped IH %d for %C\n", handle, LogGuid(id).c_str()));
+    handles_[id] = std::make_pair(handle, 1);
+    repoIds_[handle] = id;
+    return handle;
   }
 
-  return result;
+  HandleWithCounter& mapped = location->second;
+  ++mapped.second;
+  ACE_DEBUG((LM_DEBUG, "Incremented mapped IH %d to %d\n", mapped.first, mapped.second));
+  return mapped.first;
 }
 
-RepoId
-DomainParticipantImpl::get_repoid(const DDS::InstanceHandle_t& handle)
+DDS::InstanceHandle_t DomainParticipantImpl::lookup_handle(const GUID_t& id) const
 {
-  RepoId result = GUID_UNKNOWN;
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, result);
-  RepoIdMap::const_iterator location = this->repoIds_.find(handle);
-  if (location != this->repoIds_.end()) {
-    result = location->second;
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::HANDLE_NIL);
+  const CountedHandleMap::const_iterator iter = handles_.find(id);
+  OPENDDS_ASSERT(id == GUID_UNKNOWN || iter != handles_.end());
+  return iter == handles_.end() ? DDS::HANDLE_NIL : iter->second.first;
+}
+
+void DomainParticipantImpl::return_handle(DDS::InstanceHandle_t handle)
+{
+  ACE_GUARD(ACE_Thread_Mutex, guard, handle_protector_);
+  const RepoIdMap::iterator r_iter = repoIds_.find(handle);
+  if (r_iter == repoIds_.end()) {
+    ACE_DEBUG((LM_DEBUG, "Returned unmapped IH %d\n", handle));
+    return;
   }
-  return result;
+
+  const CountedHandleMap::iterator h_iter = handles_.find(r_iter->second);
+  if (h_iter == handles_.end()) {
+    return;
+  }
+
+  ACE_DEBUG((LM_DEBUG, "Returned mapped IH %d RC %d\n", handle, h_iter->second.second));
+
+  HandleWithCounter& mapped = h_iter->second;
+  if (--mapped.second == 0) {
+    handles_.erase(h_iter);
+    repoIds_.erase(r_iter);
+  }
+}
+
+GUID_t DomainParticipantImpl::get_repoid(DDS::InstanceHandle_t handle) const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, GUID_UNKNOWN);
+  const RepoIdMap::const_iterator location = repoIds_.find(handle);
+  return location == repoIds_.end() ? GUID_UNKNOWN : location->second;
 }
 
 DDS::Topic_ptr

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1887,7 +1887,7 @@ DomainParticipantImpl::get_unique_id()
 DDS::InstanceHandle_t
 DomainParticipantImpl::get_instance_handle()
 {
-  return lookup_handle(dp_id_);
+  return get_entity_instance_handle(dp_id_, this);
 }
 
 DDS::InstanceHandle_t DomainParticipantImpl::assign_handle(const GUID_t& id)

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -480,7 +480,6 @@ private:
   TopicDescriptionMap topic_descrs_;
 #endif
 
-
   typedef std::pair<DDS::InstanceHandle_t, unsigned int> HandleWithCounter;
   typedef OPENDDS_MAP_CMP(GUID_t, HandleWithCounter, GUID_tKeyLessThan) CountedHandleMap;
 

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -476,7 +476,7 @@ private:
   /// Protect the topic collection.
   ACE_Recursive_Thread_Mutex topics_protector_;
   /// Protect the handle collection.
-  ACE_Recursive_Thread_Mutex handle_protector_;
+  ACE_Thread_Mutex handle_protector_;
   /// Protect the shutdown.
   ACE_Thread_Mutex shutdown_mutex_;
   ConditionVariable<ACE_Thread_Mutex> shutdown_condition_;

--- a/dds/DCPS/EntityImpl.cpp
+++ b/dds/DCPS/EntityImpl.cpp
@@ -5,7 +5,10 @@
  */
 
 #include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+
 #include "EntityImpl.h"
+
+#include "DomainParticipantImpl.h"
 #include "StatusConditionImpl.h"
 #include "transport/framework/TransportConfig.h"
 
@@ -21,11 +24,16 @@ EntityImpl::EntityImpl()
   , status_condition_(new StatusConditionImpl(this))
   , observer_()
   , events_(Observer::e_NONE)
+  , instance_handle_(DDS::HANDLE_NIL)
 {
 }
 
 EntityImpl::~EntityImpl()
 {
+  const RcHandle<DomainParticipantImpl> participant = participant_for_instance_handle_.lock();
+  if (participant) {
+    participant->return_handle(instance_handle_);
+  }
 }
 
 DDS::ReturnCode_t
@@ -128,6 +136,23 @@ void EntityImpl::set_observer(Observer_rch observer, Observer::Event e)
 {
   observer_ = observer;
   events_ = e;
+}
+
+DDS::InstanceHandle_t EntityImpl::get_entity_instance_handle(const GUID_t& id,
+                                                             DomainParticipantImpl* participant)
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DDS::HANDLE_NIL);
+
+  if (instance_handle_ != DDS::HANDLE_NIL) {
+    return instance_handle_;
+  }
+
+  if (!participant) {
+    return DDS::HANDLE_NIL;
+  }
+
+  participant_for_instance_handle_ = *participant;
+  return instance_handle_ = participant->assign_handle(id);
 }
 
 } // namespace DCPS

--- a/dds/DCPS/EntityImpl.h
+++ b/dds/DCPS/EntityImpl.h
@@ -28,6 +28,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+class DomainParticipantImpl;
+
 /**
 * @class EntityImpl
 *
@@ -79,6 +81,8 @@ protected:
 
   bool get_deleted();
 
+  DDS::InstanceHandle_t get_entity_instance_handle(const GUID_t& id, DomainParticipantImpl* participant);
+
 #ifdef ACE_HAS_CPP11
   /// The flag indicates the entity is enabled.
   std::atomic<bool>       enabled_;
@@ -108,6 +112,9 @@ private:
   Observer::Event events_;
 
   mutable ACE_Thread_Mutex lock_;
+
+  DDS::InstanceHandle_t instance_handle_;
+  WeakRcHandle<DomainParticipantImpl> participant_for_instance_handle_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -74,7 +74,7 @@ void InstanceState::sample_info(DDS::SampleInfo& si, const ReceivedDataElement* 
   RcHandle<DataReaderImpl> reader = reader_.lock();
   if (reader) {
     RcHandle<DomainParticipantImpl> participant = reader->participant_servant_.lock();
-    si.publication_handle = participant ? participant->id_to_handle(de->pub_) : DDS::HANDLE_NIL;
+    si.publication_handle = participant ? participant->lookup_handle(de->pub_) : DDS::HANDLE_NIL;
   } else {
     si.publication_handle = DDS::HANDLE_NIL;
   }

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -53,6 +53,11 @@ PublisherImpl::PublisherImpl(DDS::InstanceHandle_t      handle,
 
 PublisherImpl::~PublisherImpl()
 {
+  const RcHandle<DomainParticipantImpl> participant = participant_.lock();
+  if (participant) {
+    participant->return_handle(handle_);
+  }
+
   //The datawriters should be deleted already before calling delete
   //publisher.
   if (!is_clean()) {
@@ -1000,7 +1005,6 @@ PublisherImpl::validate_datawriter_qos(const DDS::DataWriterQos& qos,
   return true;
 }
 
-OPENDDS_END_VERSIONED_NAMESPACE_DECL
-
 } // namespace DCPS
 } // namespace OpenDDS
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -1017,7 +1017,7 @@ RecorderImpl::enable()
 DDS::InstanceHandle_t
 RecorderImpl::get_instance_handle()
 {
-  return this->participant_servant_->lookup_handle(subscription_id_);
+  return get_entity_instance_handle(subscription_id_, participant_servant_);
 }
 
 void

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -446,7 +446,7 @@ RecorderImpl::add_association(const RepoId&            yourId,
   if (!is_bit_) {
 
     DDS::InstanceHandle_t handle =
-      this->participant_servant_->id_to_handle(writer.writerId);
+      this->participant_servant_->assign_handle(writer.writerId);
 
     //
     // We acquire the publication_handle_lock_ for the remainder of our
@@ -707,6 +707,10 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
   // if (this->monitor_) {
   //   this->monitor_->report();
   // }
+
+  for (unsigned int i = 0; i < handles.length(); ++i) {
+    participant_servant_->return_handle(handles[i]);
+  }
 }
 
 void
@@ -928,7 +932,7 @@ RecorderImpl::lookup_instance_handles(const WriterIdSeq&       ids,
   hdls.length(num_wrts);
 
   for (CORBA::ULong i = 0; i < num_wrts; ++i) {
-    hdls[i] = this->participant_servant_->id_to_handle(ids[i]);
+    hdls[i] = participant_servant_->lookup_handle(ids[i]);
   }
 }
 
@@ -1013,7 +1017,7 @@ RecorderImpl::enable()
 DDS::InstanceHandle_t
 RecorderImpl::get_instance_handle()
 {
-  return this->participant_servant_->id_to_handle(subscription_id_);
+  return this->participant_servant_->lookup_handle(subscription_id_);
 }
 
 void
@@ -1036,10 +1040,10 @@ RecorderImpl::unregister_for_writer(const RepoId& participant,
 
 #if !defined (DDS_HAS_MINIMUM_BIT)
 DDS::ReturnCode_t
-RecorderImpl::repoid_to_bit_key(const DCPS::RepoId&     id,
+RecorderImpl::repoid_to_bit_key(const GUID_t& id,
                                 DDS::BuiltinTopicKey_t& key)
 {
-  DDS::InstanceHandle_t const publication_handle = this->participant_servant_->id_to_handle(id);
+  const DDS::InstanceHandle_t publication_handle = participant_servant_->lookup_handle(id);
 
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                    guard,

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -445,8 +445,7 @@ RecorderImpl::add_association(const RepoId&            yourId,
   //
   if (!is_bit_) {
 
-    DDS::InstanceHandle_t handle =
-      this->participant_servant_->assign_handle(writer.writerId);
+    const DDS::InstanceHandle_t handle = participant_servant_->assign_handle(writer.writerId);
 
     //
     // We acquire the publication_handle_lock_ for the remainder of our

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -503,8 +503,7 @@ ReplayerImpl::association_complete_i(const RepoId& remote_id)
 
   if (!is_bit_) {
 
-    DDS::InstanceHandle_t handle =
-      this->participant_servant_->id_to_handle(remote_id);
+    const DDS::InstanceHandle_t handle = participant_servant_->assign_handle(remote_id);
 
     {
       // protect publication_match_status_ and status changed flags.
@@ -678,6 +677,10 @@ ReplayerImpl::remove_associations(const ReaderIdSeq & readers,
   // subscription lost.
   if (notify_lost && handles.length() > 0) {
     this->notify_publication_lost(handles);
+  }
+
+  for (unsigned int i = 0; i < handles.length(); ++i) {
+    participant_servant_->return_handle(handles[i]);
   }
 }
 
@@ -1024,7 +1027,7 @@ ReplayerImpl::lookup_instance_handles(const ReaderIdSeq&       ids,
   hdls.length(num_rds);
 
   for (CORBA::ULong i = 0; i < num_rds; ++i) {
-    hdls[i] = this->participant_servant_->id_to_handle(ids[i]);
+    hdls[i] = participant_servant_->lookup_handle(ids[i]);
   }
 }
 
@@ -1043,7 +1046,7 @@ ReplayerImpl::need_sequence_repair() const
 DDS::InstanceHandle_t
 ReplayerImpl::get_instance_handle()
 {
-  return this->participant_servant_->id_to_handle(publication_id_);
+  return this->participant_servant_->lookup_handle(publication_id_);
 }
 
 DDS::ReturnCode_t

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -1046,7 +1046,7 @@ ReplayerImpl::need_sequence_repair() const
 DDS::InstanceHandle_t
 ReplayerImpl::get_instance_handle()
 {
-  return this->participant_servant_->lookup_handle(publication_id_);
+  return get_entity_instance_handle(publication_id_, participant_servant_);
 }
 
 DDS::ReturnCode_t

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -63,6 +63,11 @@ SubscriberImpl::SubscriberImpl(DDS::InstanceHandle_t       handle,
 
 SubscriberImpl::~SubscriberImpl()
 {
+  const RcHandle<DomainParticipantImpl> participant = participant_.lock();
+  if (participant) {
+    participant->return_handle(handle_);
+  }
+
   // The datareaders should be deleted already before calling delete
   // subscriber.
   if (!is_clean()) {

--- a/dds/DCPS/SubscriptionInstance.cpp
+++ b/dds/DCPS/SubscriptionInstance.cpp
@@ -1,0 +1,57 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+
+#include "SubscriptionInstance.h"
+
+#include "DataReaderImpl.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+SubscriptionInstance::SubscriptionInstance(DataReaderImpl* reader,
+                                           const DDS::DataReaderQos& qos,
+                                           ACE_Recursive_Thread_Mutex& lock,
+                                           DDS::InstanceHandle_t handle,
+                                           bool owns_handle)
+  : instance_state_(make_rch<InstanceState>(reader, ref(lock), handle))
+  , rcvd_samples_(instance_state_)
+  , instance_handle_(handle)
+  , owns_handle_(owns_handle)
+  , deadline_timer_id_(-1)
+{
+  switch (qos.destination_order.kind) {
+  case DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS:
+    rcvd_strategy_.reset(new ReceptionDataStrategy(rcvd_samples_));
+    break;
+
+  case DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS:
+    rcvd_strategy_.reset(new SourceDataStrategy(rcvd_samples_));
+    break;
+  }
+
+  if (!rcvd_strategy_) {
+    ACE_ERROR((LM_ERROR,
+                ACE_TEXT("(%P|%t) ERROR: SubscriptionInstance: ")
+                ACE_TEXT("unable to allocate ReceiveDataStrategy!\n")));
+  }
+}
+
+SubscriptionInstance::~SubscriptionInstance()
+{
+  if (owns_handle_) {
+    const RcHandle<DataReaderImpl> reader = instance_state_->data_reader().lock();
+    if (reader) {
+      reader->return_handle(instance_handle_);
+    }
+  }
+}
+
+}
+}
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/SubscriptionInstance.h
+++ b/dds/DCPS/SubscriptionInstance.h
@@ -44,21 +44,21 @@ public:
   ~SubscriptionInstance();
 
   /// Instance state for this instance
-  InstanceState_rch instance_state_;
+  const InstanceState_rch instance_state_;
 
   /// Sequence number of the move recent data sample received
-  SequenceNumber last_sequence_ ;
+  SequenceNumber last_sequence_;
 
   /// Data sample(s) in this instance
-  ReceivedDataElementList rcvd_samples_ ;
+  ReceivedDataElementList rcvd_samples_;
 
   /// ReceivedDataElementList strategy
   unique_ptr<ReceivedDataStrategy> rcvd_strategy_;
 
   /// The instance handle for the registered object
-  DDS::InstanceHandle_t instance_handle_;
+  const DDS::InstanceHandle_t instance_handle_;
 
-  bool owns_handle_;
+  const bool owns_handle_;
 
   MonotonicTimePoint last_sample_tv_;
 

--- a/dds/DCPS/SubscriptionInstance.h
+++ b/dds/DCPS/SubscriptionInstance.h
@@ -8,17 +8,13 @@
 #ifndef OPENDDS_DCPS_SUBSCRIPTION_INSTANCE_H
 #define OPENDDS_DCPS_SUBSCRIPTION_INSTANCE_H
 
-#include "ace/OS_Memory.h"
-
-#include "dds/DdsDcpsInfrastructureC.h"
-
 #include "dcps_export.h"
 #include "ReceivedDataElementList.h"
 #include "ReceivedDataStrategy.h"
 #include "InstanceState.h"
-#include "PoolAllocationBase.h"
 #include "RcObject.h"
-#include "ace/Synch_Traits.h"
+
+#include "dds/DdsDcpsInfrastructureC.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -37,34 +33,15 @@ class DataReaderImpl;
   * @brief Struct that has information about an instance and the instance
   *        sample list.
   */
-class SubscriptionInstance : public RcObject {
+class OpenDDS_Dcps_Export SubscriptionInstance : public RcObject {
 public:
-  SubscriptionInstance(DataReaderImpl *reader,
+  SubscriptionInstance(DataReaderImpl* reader,
                        const DDS::DataReaderQos& qos,
                        ACE_Recursive_Thread_Mutex& lock,
-                       DDS::InstanceHandle_t handle)
-    : instance_state_(make_rch<InstanceState>(reader, ref(lock), handle)),
-      last_sequence_(),
-      rcvd_samples_(instance_state_),
-      instance_handle_(handle),
-      deadline_timer_id_(-1)
-  {
-    switch (qos.destination_order.kind) {
-    case DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS:
-      this->rcvd_strategy_.reset(new ReceptionDataStrategy(this->rcvd_samples_));
-      break;
+                       DDS::InstanceHandle_t handle,
+                       bool owns_handle);
 
-    case DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS:
-      this->rcvd_strategy_.reset(new SourceDataStrategy(this->rcvd_samples_));
-      break;
-    }
-
-    if (!this->rcvd_strategy_) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: SubscriptionInstance: ")
-                 ACE_TEXT(" unable to allocate ReceiveDataStrategy!\n")));
-    }
-  }
+  ~SubscriptionInstance();
 
   /// Instance state for this instance
   InstanceState_rch instance_state_;
@@ -80,6 +57,8 @@ public:
 
   /// The instance handle for the registered object
   DDS::InstanceHandle_t instance_handle_;
+
+  bool owns_handle_;
 
   MonotonicTimePoint last_sample_tv_;
 

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -174,7 +174,7 @@ TopicImpl::get_id() const
 DDS::InstanceHandle_t
 TopicImpl::get_instance_handle()
 {
-  return this->participant_->id_to_handle(this->id_);
+  return participant_->lookup_handle(id_);
 }
 
 const char*

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -174,7 +174,7 @@ TopicImpl::get_id() const
 DDS::InstanceHandle_t
 TopicImpl::get_instance_handle()
 {
-  return participant_->lookup_handle(id_);
+  return get_entity_instance_handle(id_, participant_);
 }
 
 const char*

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1234,6 +1234,7 @@ WriteDataContainer::unregister_all()
     // Get the next iterator before erase the instance handle.
     PublicationInstanceMapType::iterator it_next = it;
     ++it_next;
+    writer_->return_handle(it->first);
     // Remove the instance from the instance list.
     unbind(instances_, it->first);
     it = it_next;

--- a/docs/design/INSTANCE_HANDLES
+++ b/docs/design/INSTANCE_HANDLES
@@ -88,11 +88,6 @@ Entity::get_instance_handle() and DomainParticipant::contains_entity()
 methods, the InstanceHandle_t value represents a local Entity within
 the scope of the DomainParticipant.
 
-NOTE: Even though there is no inheritance from Entity shown for DataReader
-      and DataWriter in the specification, the IDL included there for
-      the PSM clearly shows this relationship, so these are considered
-      Entities.
-
 For the SampleInfo and various Status variable fields, the
 InstanceHandle_t values represent either a DataReader key value
 (instance_handle, last_instance_handle) or an Entity within the entire
@@ -147,7 +142,7 @@ opaque handle values be a CORBA::Long.  OpenDDS follows this suggestion.
 A consequence of maintaining the handle values as unique within a
 participant is that the total number of Entities plus data instances in
 all readers and writers may not exceed the maximum allowed value of the
-handle type.  For OpenDDS this is a 32 bit value.  Note that this
+handle type.  For OpenDDS this is a 32-bit value.  Note that this
 includes all values generated, even if they are no longer actively
 participating in the operation of the middleware (disposed instances,
 destroyed Entities).  OpenDDS does not currently implement a value reuse
@@ -161,22 +156,30 @@ implementation of OpenDDS:
       unique handle values.
 
   DomainParticipantImpl::participant_handles_
-    - Object of InstanceHandleGenerator used as the generating Sequence
+    - Reference to a InstanceHandleGenerator used as the generating Sequence
       for handles.
 
-  DomainParticipantImpl::handles_,handles_protector_
+  InstanceHandle_t = DomainParticipantImpl::assign_handle(GUID_t = GUID_UNKNOWN)
+    - Create a new instance handle either "mapped" from a GUID (if not UNKNOWN)
+      or "unampped" (just a unique integer value).  This instance handle needs
+      to be returned to the Participant using return_handle (see below).
+
+  DomainParticipantImpl::handles_, handles_protector_
     - Mapping of GUID_t values to instance handles and lock for guarding
       access to the container.
 
-  InstanceHandle_t = DomainParticipant::get_handle(GUID_t)
-    - If the GUID_t value represents and Entity, an index is searched for
-      that Entity and any existing handle value returned.  Otherwise a
-      unique new handle value is generated.  The new value is stored in
-      the index if it represents an Entity.
+  InstanceHandle_t = DomainParticipantImpl::lookup_handle(GUID_t)
+    - If the GUID_t value represents an Entity, an index is searched for
+      that Entity and any existing handle value returned.
 
-  InstanceHandle_t = DataWriterImpl::get_next_instance()
-    - Obtains a handle value for unique data key value instances as they
-      are created.
+  DomainParticipantImpl::return_handle(InstanceHandle_t)
+    - The handle that was previously assigned in assign_handle is returned
+      to the pool for potential reuse.  Each successful call to assign_handle
+      should have a corresponding call to return_handle.
+
+  InstanceHandle_t = DataWriterImpl::get_next_handle()
+    - Obtains a handle value for each unique data key value instance as it is
+      created.
 
   InstanceHandle_t = DataReaderImpl::get_next_handle(BuiltinTopicKey_t)
     - If the reader is for a BuiltinTopic Topic, then a handle is
@@ -192,7 +195,7 @@ Instance handles, BIT Keys, and GUIDs (aka RepoIds) are all related:
   - Convert to a GUID using DomainParticipantImpl::get_repoid()
   - Convert to a BIT Key using BIT_Helper_1 or the BIT Data Reader
 - Starting from a GUID (aka RepoId):
-  - Convert to an Instance Handle using DomainParticipantImpl::get_handle()
+  - Convert to an Instance Handle using DomainParticipantImpl::lookup_handle()
   - Direct conversion to a BIT Key is not supported (first get the handle)
 - Starting from a BIT Key:
   - Convert to a GUID using Discovery::bit_key_to_repo_id()

--- a/examples/DCPS/DistributedContent/AbstractionLayer.cpp
+++ b/examples/DCPS/DistributedContent/AbstractionLayer.cpp
@@ -119,7 +119,7 @@ AbstractionLayer::init_DDS(int& argc, ACE_TCHAR *argv[])
   // Get the repo id for the subscription
   ::OpenDDS::DCPS::RepoId ignore_id = dr_servant->get_repo_id ();
   // Get the instance handle for the subscription
-  ::DDS::InstanceHandle_t handle = dp_servant->id_to_handle(ignore_id);
+  ::DDS::InstanceHandle_t handle = dp_servant->lookup_handle(ignore_id);
 
   // tell the domain participant to ignore the subscription
   DDS::ReturnCode_t ret = dp_->ignore_subscription (handle);

--- a/tests/DCPS/BuiltInTopic/common.cpp
+++ b/tests/DCPS/BuiltInTopic/common.cpp
@@ -64,7 +64,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_PARTICIPANT,  participant %C ignore participant %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->id_to_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
 
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_PARTICIPANT, ignored participant %C has handle 0x%x.\n"),
@@ -100,7 +100,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_TOPIC, participant %C ignore topic %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->id_to_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_TOPIC,  ignored topic %C has handle 0x%x.\n"),
         ignoreBuffer.str().c_str(),
@@ -134,7 +134,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_PUBLICATION, participant %C ignore publication %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->id_to_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_PUBLICATION,  ignored topic %C has handle 0x%x.\n"),
         ignoreBuffer.str().c_str(),
@@ -168,7 +168,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_SUBSCRIPTION, participant %C ignore subscription %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->id_to_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_SUBSCRIPTION,  ignored topic %C has handle 0x%x.\n"),
         ignoreBuffer.str().c_str(),

--- a/tests/DCPS/BuiltInTopicTest/monitor.cpp
+++ b/tests/DCPS/BuiltInTopicTest/monitor.cpp
@@ -254,7 +254,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
           OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
-          if (part_svt->id_to_handle (id) != handles[i])
+          if (part_svt->lookup_handle(id) != handles[i])
           {
             ACE_ERROR((LM_ERROR, "(%P|%t) monitor: get_discovered_participant_data test failed.\n"));
             return 1;
@@ -370,7 +370,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
             TheServiceParticipant->get_discovery(participant->get_domain_id());
           OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
-          if (part_svt->id_to_handle (id) != handles[i])
+          if (part_svt->lookup_handle(id) != handles[i])
           {
             ACE_ERROR((LM_ERROR, "(%P|%t) monitor: get_discovered_topic_data test failed.\n"));
             return 1;

--- a/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
+++ b/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
@@ -646,7 +646,7 @@ bool check_discovered_participants(DomainParticipant_var& dp,
       }
 
       OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
-      if (dp_impl->id_to_handle(repo_id) != part_handles[0]) {
+      if (dp_impl->lookup_handle(repo_id) != part_handles[0]) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("ERROR: %P discovered participant ")
                                     ACE_TEXT("BIT key could not be converted ")
                                     ACE_TEXT("to repo id, then handle\n")),

--- a/tools/monitor/MonitorTask.cpp
+++ b/tools/monitor/MonitorTask.cpp
@@ -868,7 +868,7 @@ Monitor::MonitorTask::readBuiltinTopicData(
   // Find the instance to read.
   OpenDDS::DCPS::DomainParticipantImpl* dpi =
     dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(this->participant_.in());
-  DDS::InstanceHandle_t instance = dpi->id_to_handle(id);
+  const DDS::InstanceHandle_t instance = dpi->lookup_handle(id);
 
   if (this->options_.verbose()) {
     OpenDDS::DCPS::GuidConverter converter(id);


### PR DESCRIPTION
- DomainParticipantImpl::get_handle previously could do two different things, these are now separated into assign_handle and lookup_handle
- Added DomainParticipantImpl::return_handle