### PR TITLE
RTPS sends too many little messages

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -45,8 +45,6 @@ using DCPS::TimeDuration;
 RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   : resend_period_(30 /*seconds*/) // see RTPS v2.1 9.6.1.4.2
   , quick_resend_ratio_(0.1)
-  , sedp_heartbeat_backoff_factor_(2.0)
-  , sedp_heartbeat_safety_factor_(1.1)
   , min_resend_delay_(TimeDuration::from_msec(100))
   , lease_duration_(300)
   , pb_(7400) // see RTPS v2.1 9.6.1.3 for PB, DG, PG, D0, D1 defaults
@@ -80,11 +78,10 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , max_type_lookup_service_reply_period_(5, 0)
   , use_xtypes_(true)
   , sedp_heartbeat_period_(1)
-  , sedp_heartbeat_period_minimum_(0, 10000)
-  , sedp_heartbeat_period_maximum_(1, 0)
   , sedp_nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
+  , sedp_send_delay_(0, 10 * 1000)
   , participant_flags_(PFLAGS_THIS_VERSION)
-  , responsive_mode_(false)
+  , sedp_responsive_mode_(false)
 {}
 
 RtpsDiscovery::RtpsDiscovery(const RepoKey& key)
@@ -171,28 +168,6 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
               value.c_str(), rtps_name.c_str()), -1);
           }
           config->quick_resend_ratio(ratio);
-        } else if (name == "SedpHeartbeatBackoffFactor") {
-          const OPENDDS_STRING& value = it->second;
-          double ratio;
-          if (!DCPS::convertToDouble(value, ratio)) {
-            ACE_ERROR_RETURN((LM_ERROR,
-              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
-              ACE_TEXT("Invalid entry (%C) for SedpHeartbeatBackoffFactor in ")
-              ACE_TEXT("[rtps_discovery/%C] section.\n"),
-              value.c_str(), rtps_name.c_str()), -1);
-          }
-          config->sedp_heartbeat_backoff_factor(ratio);
-        } else if (name == "SedpHeartbeatSafetyFactor") {
-          const OPENDDS_STRING& value = it->second;
-          double ratio;
-          if (!DCPS::convertToDouble(value, ratio)) {
-            ACE_ERROR_RETURN((LM_ERROR,
-              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
-              ACE_TEXT("Invalid entry (%C) for SedpHeartbeatSafetyFactor in ")
-              ACE_TEXT("[rtps_discovery/%C] section.\n"),
-              value.c_str(), rtps_name.c_str()), -1);
-          }
-          config->sedp_heartbeat_safety_factor(ratio);
         } else if (name == "MinResendDelay") {
           const OPENDDS_STRING& value = it->second;
           int delay;
@@ -636,27 +611,15 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                               ACE_TEXT("[rtps_discovery/%C] section.\n"),
                               string_value.c_str(), rtps_name.c_str()), -1);
           }
-        } else if (name == "SedpHeartbeatPeriodMinimum") {
+        } else if (name == "SedpSendDelay") {
           const OPENDDS_STRING& string_value = it->second;
           int value;
           if (DCPS::convertToInteger(string_value, value)) {
-            config->sedp_heartbeat_period_minimum(TimeDuration::from_msec(value));
+            config->sedp_send_delay(TimeDuration::from_msec(value));
           } else {
             ACE_ERROR_RETURN((LM_ERROR,
                               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
-                              ACE_TEXT("Invalid entry (%C) for SedpHeartbeatPeriodMinimum in ")
-                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
-                              string_value.c_str(), rtps_name.c_str()), -1);
-          }
-        } else if (name == "SedpHeartbeatPeriodMaximum") {
-          const OPENDDS_STRING& string_value = it->second;
-          int value;
-          if (DCPS::convertToInteger(string_value, value)) {
-            config->sedp_heartbeat_period_maximum(TimeDuration::from_msec(value));
-          } else {
-            ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
-                              ACE_TEXT("Invalid entry (%C) for SedpHeartbeatPeriodMaximum in ")
+                              ACE_TEXT("Invalid entry (%C) for SedpSendDelay in ")
                               ACE_TEXT("[rtps_discovery/%C] section.\n"),
                               string_value.c_str(), rtps_name.c_str()), -1);
           }
@@ -732,7 +695,7 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                               ACE_TEXT("[rtps_discovery/%C] section.\n"),
                               value.c_str(), rtps_name.c_str()), -1);
           }
-          config->responsive_mode(bool(smInt));
+          config->sedp_responsive_mode(bool(smInt));
         } else {
           ACE_ERROR_RETURN((LM_ERROR,
             ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -60,29 +60,6 @@ public:
     ACE_Guard<ACE_Thread_Mutex> g(lock_);
     quick_resend_ratio_ = ratio;
   }
-
-  double sedp_heartbeat_backoff_factor() const
-  {
-    ACE_Guard<ACE_Thread_Mutex> g(lock_);
-    return sedp_heartbeat_backoff_factor_;
-  }
-  void sedp_heartbeat_backoff_factor(double ratio)
-  {
-    ACE_Guard<ACE_Thread_Mutex> g(lock_);
-    sedp_heartbeat_backoff_factor_ = ratio;
-  }
-
-  double sedp_heartbeat_safety_factor() const
-  {
-    ACE_Guard<ACE_Thread_Mutex> g(lock_);
-    return sedp_heartbeat_safety_factor_;
-  }
-  void sedp_heartbeat_safety_factor(double ratio)
-  {
-    ACE_Guard<ACE_Thread_Mutex> g(lock_);
-    sedp_heartbeat_safety_factor_ = ratio;
-  }
-
   DCPS::TimeDuration min_resend_delay() const
   {
     ACE_Guard<ACE_Thread_Mutex> g(lock_);
@@ -527,28 +504,6 @@ public:
     sedp_heartbeat_period_ = period;
   }
 
-  DCPS::TimeDuration sedp_heartbeat_period_minimum() const
-  {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
-    return sedp_heartbeat_period_minimum_;
-  }
-  void sedp_heartbeat_period_minimum(const DCPS::TimeDuration& period_minimum)
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    sedp_heartbeat_period_minimum_ = period_minimum;
-  }
-
-  DCPS::TimeDuration sedp_heartbeat_period_maximum() const
-  {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
-    return sedp_heartbeat_period_maximum_;
-  }
-  void sedp_heartbeat_period_maximum(const DCPS::TimeDuration& period_maximum)
-  {
-    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    sedp_heartbeat_period_maximum_ = period_maximum;
-  }
-
   DCPS::TimeDuration sedp_nak_response_delay() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
@@ -558,6 +513,17 @@ public:
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
     sedp_nak_response_delay_ = period;
+  }
+
+  DCPS::TimeDuration sedp_send_delay() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return sedp_send_delay_;
+  }
+  void sedp_send_delay(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    sedp_send_delay_ = period;
   }
 
   CORBA::ULong participant_flags() const
@@ -571,23 +537,21 @@ public:
     participant_flags_ = participant_flags;
   }
 
-  bool responsive_mode() const
+  bool sedp_responsive_mode() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
-    return responsive_mode_;
+    return sedp_responsive_mode_;
   }
-  void responsive_mode(bool responsive_mode)
+  void sedp_responsive_mode(bool sedp_responsive_mode)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    responsive_mode_ = responsive_mode;
+    sedp_responsive_mode_ = sedp_responsive_mode;
   }
 
 private:
   mutable ACE_Thread_Mutex lock_;
   DCPS::TimeDuration resend_period_;
   double quick_resend_ratio_;
-  double sedp_heartbeat_backoff_factor_;
-  double sedp_heartbeat_safety_factor_;
   DCPS::TimeDuration min_resend_delay_;
   DCPS::TimeDuration lease_duration_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
@@ -622,11 +586,10 @@ private:
   DCPS::TimeDuration max_type_lookup_service_reply_period_;
   bool use_xtypes_;
   DCPS::TimeDuration sedp_heartbeat_period_;
-  DCPS::TimeDuration sedp_heartbeat_period_minimum_;
-  DCPS::TimeDuration sedp_heartbeat_period_maximum_;
   DCPS::TimeDuration sedp_nak_response_delay_;
+  DCPS::TimeDuration sedp_send_delay_;
   CORBA::ULong participant_flags_;
-  bool responsive_mode_;
+  bool sedp_responsive_mode_;
 };
 
 typedef OpenDDS::DCPS::RcHandle<RtpsDiscoveryConfig> RtpsDiscoveryConfig_rch;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -356,20 +356,11 @@ Sedp::init(const RepoId& guid,
   // Use a static cast to avoid dependency on the RtpsUdp library
   DCPS::RtpsUdpInst_rch rtps_inst =
       DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
-  // The SEDP endpoints may need to wait at least one resend period before
-  // the handshake completes (allows time for our SPDP multicast to be
-  // received by the other side).  Arbitrary constant of 5 to account for
-  // possible network lossiness.
-  static const double HANDSHAKE_MULTIPLIER = 5;
-  rtps_inst->handshake_timeout_ = disco.resend_period() * HANDSHAKE_MULTIPLIER;
   rtps_inst->max_message_size_ = disco.config()->sedp_max_message_size();
   rtps_inst->heartbeat_period_ = disco.config()->sedp_heartbeat_period();
-  rtps_inst->heartbeat_period_minimum_ = disco.config()->sedp_heartbeat_period_minimum();
-  rtps_inst->heartbeat_period_maximum_ = disco.config()->sedp_heartbeat_period_maximum();
-  rtps_inst->heartbeat_backoff_factor_ = disco.config()->sedp_heartbeat_backoff_factor();
-  rtps_inst->heartbeat_safety_factor_ = disco.config()->sedp_heartbeat_safety_factor();
   rtps_inst->nak_response_delay_ = disco.config()->sedp_nak_response_delay();
-  rtps_inst->responsive_mode_ = disco.config()->responsive_mode();
+  rtps_inst->responsive_mode_ = disco.config()->sedp_responsive_mode();
+  rtps_inst->send_delay_ = disco.config()->sedp_send_delay();
 
   if (disco.sedp_multicast()) {
     // Bind to a specific multicast group

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -606,7 +606,8 @@ private:
     IdCountSet nackfrag_counts_;
   };
 
-  void build_meta_submessage_map(MetaSubmessageVecVec& meta_submessages, AddrDestMetaSubmessageMap& adr_map);
+  typedef OPENDDS_VECTOR(MetaSubmessageVecVec) MetaSubmessageVecVecVec;
+  void build_meta_submessage_map(MetaSubmessageVecVecVec& meta_submessages, AddrDestMetaSubmessageMap& adr_map);
   void bundle_mapped_meta_submessages(
     const Encoding& encoding,
     AddrDestMetaSubmessageMap& adr_map,
@@ -615,15 +616,15 @@ private:
                                OPENDDS_VECTOR(size_t)& meta_submessage_bundle_sizes,
                                CountKeeper& counts);
 
-  void queue_or_send_submessages(MetaSubmessageVec& meta_submessages);
-  void bundle_and_send_submessages(MetaSubmessageVecVec& meta_submessages);
+  void queue_submessages(MetaSubmessageVec& meta_submessages);
+  void bundle_and_send_submessages(MetaSubmessageVecVecVec& meta_submessages);
 
-  struct SubmessageQueue: RcObject, MetaSubmessageVecVec {
-  };
-  typedef RcHandle<SubmessageQueue> SubmessageQueue_rch;
-
-  typedef OPENDDS_MAP(ACE_thread_t, SubmessageQueue_rch) ThreadSendQueueMap;
+  typedef OPENDDS_MAP(ACE_thread_t, MetaSubmessageVecVec) ThreadSendQueueMap;
   ThreadSendQueueMap thread_send_queues_;
+  MetaSubmessageVecVecVec send_queue_;
+  typedef PmfSporadicTask<RtpsUdpDataLink> Sporadic;
+  Sporadic flush_send_queue_task_;
+  void flush_send_queue(const MonotonicTimePoint& now);
 
   RepoIdSet pending_reliable_readers_;
 
@@ -688,7 +689,7 @@ private:
       RtpsWriter& writer = **it;
       (writer.*func)(submessage, src, meta_submessages);
     }
-    queue_or_send_submessages(meta_submessages);
+    queue_submessages(meta_submessages);
   }
 
   template<typename T, typename FN>
@@ -730,7 +731,7 @@ private:
       RtpsReader& reader = **it;
       (reader.*func)(submessage, src, directed, meta_submessages);
     }
-    queue_or_send_submessages(meta_submessages);
+    queue_submessages(meta_submessages);
   }
 
   void send_heartbeats(const MonotonicTimePoint& now);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -35,17 +35,12 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , ttl_(1)
   , max_message_size_(RtpsUdpSendStrategy::UDP_MAX_MESSAGE_SIZE)
   , nak_depth_(0)
-  , quick_reply_ratio_(0.1)
-  , heartbeat_backoff_factor_(2.0)
-  , heartbeat_safety_factor_(2.0)
   , nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
   , heartbeat_period_(1) // no default in RTPS spec
-  , heartbeat_period_minimum_(0, 10000)
-  , heartbeat_period_maximum_(1, 0)
   , heartbeat_response_delay_(0, 500*1000 /*microseconds*/) // default from RTPS
-  , handshake_timeout_(30) // default syn_timeout in OpenDDS_Multicast
   , durable_data_timeout_(60)
   , responsive_mode_(false)
+  , send_delay_(0, 10 * 1000)
   , opendds_discovery_guid_(GUID_UNKNOWN)
   , multicast_group_address_(7401, "239.255.0.2")
   , local_address_(u_short(0), "0.0.0.0")
@@ -103,24 +98,16 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("nak_depth"), nak_depth_, size_t);
 
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("quick_reply_ratio"), quick_reply_ratio_, double);
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("heartbeat_backoff_factor"), heartbeat_backoff_factor_, double);
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("heartbeat_safety_factor"), heartbeat_safety_factor_, double);
-
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("ttl"), ttl_, unsigned char);
 
   GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("nak_response_delay"),
                         nak_response_delay_);
   GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("heartbeat_period"),
                         heartbeat_period_);
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("heartbeat_period_minimum"),
-                        heartbeat_period_minimum_);
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("heartbeat_period_maximum"),
-                        heartbeat_period_maximum_);
   GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("heartbeat_response_delay"),
                         heartbeat_response_delay_);
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("handshake_timeout"),
-                        handshake_timeout_);
+  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("send_delay"),
+                        send_delay_);
 
   ACE_TString rtps_relay_address_s;
   GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DataRtpsRelayAddress"),
@@ -187,7 +174,6 @@ RtpsUdpInst::dump_to_str() const
   ret += formatNameForDump("nak_response_delay") + to_dds_string(nak_response_delay_.value().msec()) + '\n';
   ret += formatNameForDump("heartbeat_period") + to_dds_string(heartbeat_period_.value().msec()) + '\n';
   ret += formatNameForDump("heartbeat_response_delay") + to_dds_string(heartbeat_response_delay_.value().msec()) + '\n';
-  ret += formatNameForDump("handshake_timeout") + to_dds_string(handshake_timeout_.value().msec()) + '\n';
   ret += formatNameForDump("send_buffer_size") + to_dds_string(send_buffer_size_) + '\n';
   ret += formatNameForDump("rcv_buffer_size") + to_dds_string(rcv_buffer_size_) + '\n';
   ret += formatNameForDump("ttl") + to_dds_string(ttl_) + '\n';

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -38,17 +38,12 @@ public:
 
   size_t max_message_size_;
   size_t nak_depth_;
-  double quick_reply_ratio_;
-  double heartbeat_backoff_factor_;
-  double heartbeat_safety_factor_;
   TimeDuration nak_response_delay_;
   TimeDuration heartbeat_period_;
-  TimeDuration heartbeat_period_minimum_;
-  TimeDuration heartbeat_period_maximum_;
   TimeDuration heartbeat_response_delay_;
-  TimeDuration handshake_timeout_;
   TimeDuration durable_data_timeout_;
   bool responsive_mode_;
+  TimeDuration send_delay_;
 
   virtual int load(ACE_Configuration_Heap& cf,
                    ACE_Configuration_Section_Key& sect);

--- a/examples/DCPS/ishapes/main.cpp
+++ b/examples/DCPS/ishapes/main.cpp
@@ -66,7 +66,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[]) {
       TransportRegistry::instance()->create_inst("the_rtps_transport",
                                                  "rtps_udp");
     RtpsUdpInst_rch rui = static_rchandle_cast<RtpsUdpInst>(inst);
-    rui->handshake_timeout_ = 1;
 
     config->instances_.push_back(inst);
     TransportRegistry::instance()->global_config(config);

--- a/java/dds/OpenDDS/DCPS/transport/RtpsUdpInst.java
+++ b/java/dds/OpenDDS/DCPS/transport/RtpsUdpInst.java
@@ -35,7 +35,4 @@ public class RtpsUdpInst extends TransportInst {
 
     public native long getHeartbeatResponseDelay();
     public native void setHeartbeatResponseDelay(long hrd);
-
-    public native long getHandshakeTimeout();
-    public native void setHandshakeTimeout(long ht);
 }

--- a/java/dds/OpenDDS_DCPS_jni.cpp
+++ b/java/dds/OpenDDS_DCPS_jni.cpp
@@ -1219,22 +1219,6 @@ void JNICALL Java_OpenDDS_DCPS_transport_RtpsUdpInst_setHeartbeatResponseDelay
   inst->heartbeat_response_delay_ = OpenDDS::DCPS::TimeDuration::from_msec(val);
 }
 
-// RtpsUdpInst::getHandshakeTimeout
-jlong JNICALL Java_OpenDDS_DCPS_transport_RtpsUdpInst_getHandshakeTimeout
-(JNIEnv * jni, jobject jthis)
-{
-  OpenDDS::DCPS::RtpsUdpInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: RtpsUdpInst>(jni, jthis));
-  return inst->handshake_timeout_.value().msec();
-}
-
-// RtpsUdpInst::setHandshakeTimeout
-void JNICALL Java_OpenDDS_DCPS_transport_RtpsUdpInst_setHandshakeTimeout
-(JNIEnv * jni, jobject jthis, jlong val)
-{
-  OpenDDS::DCPS::RtpsUdpInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: RtpsUdpInst>(jni, jthis));
-  inst->handshake_timeout_ = OpenDDS::DCPS::TimeDuration::from_msec(val);
-}
-
 // WaitSet and GuardCondition
 
 jlong JNICALL Java_DDS_WaitSet__1jni_1init(JNIEnv *, jclass)


### PR DESCRIPTION
Problem
-------

For reliability, RTPS sends small messages like heartbeats, acknacks,
and gaps.  When the RtpsUdpDataLink was using consolidate timers,
these messages were bundled together which had the advantage of
reducing the overhead associated with sending a bunch of small
messages.

Solution
--------

Add a send queue to the RtpsUdpDataLink that is sent whenever it is
full (enough) or after a configurable delay.