### PR TITLE
Prevent Deadlock During RtpsReader Shutdown

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1513,6 +1513,10 @@ RtpsUdpDataLink::RtpsReader::pre_stop_helper()
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
+  if (stopping_) {
+    return;
+  }
+
   stopping_ = true;
 
   preassociation_writers_.clear();
@@ -1531,6 +1535,8 @@ RtpsUdpDataLink::RtpsReader::pre_stop_helper()
   for (WriterInfoMap::iterator it = remote_writers_.begin(); it != remote_writers_.end(); ++it) {
     it->second->held_.clear();
   }
+
+  g.release();
 
   preassociation_task_.cancel_and_wait();
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1515,6 +1515,8 @@ RtpsUdpDataLink::RtpsReader::pre_stop_helper()
 
   stopping_ = true;
 
+  preassociation_writers_.clear();
+
   RtpsUdpDataLink_rch link = link_.lock();
 
   if (!link) {
@@ -1529,6 +1531,12 @@ RtpsUdpDataLink::RtpsReader::pre_stop_helper()
   for (WriterInfoMap::iterator it = remote_writers_.begin(); it != remote_writers_.end(); ++it) {
     it->second->held_.clear();
   }
+
+  preassociation_task_.cancel_and_wait();
+}
+
+RtpsUdpDataLink::RtpsReader::~RtpsReader()
+{
 }
 
 bool
@@ -2076,7 +2084,7 @@ RtpsUdpDataLink::RtpsReader::send_preassociation_acknacks(const MonotonicTimePoi
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
-    if (preassociation_writers_.empty()) {
+    if (stopping_ || preassociation_writers_.empty()) {
       return;
     }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -533,9 +533,7 @@ private:
       , preassociation_task_(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks)
     {}
 
-    ~RtpsReader() {
-      preassociation_task_.cancel_and_wait();
-    }
+    ~RtpsReader();
 
     bool add_writer(const WriterInfo_rch& info);
     bool has_writer(const RepoId& id) const;


### PR DESCRIPTION
Minor adjustments to RtpsReader shutdown to prevent deadlock in SporadicTask's cancel_and_wait().