### PR TITLE
Remove SequenceBackInsertIterator for OctetSeq

### DIFF
--- a/dds/DCPS/security/Authentication/LocalAuthCredentialData.cpp
+++ b/dds/DCPS/security/Authentication/LocalAuthCredentialData.cpp
@@ -84,10 +84,11 @@ bool LocalAuthCredentialData::load_access_permissions(const DDS::Security::Permi
     return false;
   }
 
-  DCPS::SequenceBackInsertIterator<DDS::OctetSeq> back_inserter(access_permissions_);
-  std::copy(cperm, cperm + std::strlen(cperm), back_inserter);
+  size_t len = std::strlen(cperm);
+  access_permissions_.length(len + 1);
+  std::memcpy(&access_permissions_[0], cperm, len);
+  access_permissions_[len] = 0u;
 
-  *back_inserter = 0u;
   return true;
 }
 

--- a/dds/DCPS/security/Authentication/LocalAuthCredentialData.cpp
+++ b/dds/DCPS/security/Authentication/LocalAuthCredentialData.cpp
@@ -84,10 +84,9 @@ bool LocalAuthCredentialData::load_access_permissions(const DDS::Security::Permi
     return false;
   }
 
-  size_t len = std::strlen(cperm);
-  access_permissions_.length(len + 1);
-  std::memcpy(&access_permissions_[0], cperm, len);
-  access_permissions_[len] = 0u;
+  const size_t len = std::strlen(cperm);
+  access_permissions_.length(static_cast<CORBA::ULong>(len + 1));
+  std::memcpy(&access_permissions_[0], cperm, len + 1); // copies the NULL
 
   return true;
 }

--- a/dds/DCPS/security/SSL/SignedDocument.cpp
+++ b/dds/DCPS/security/SSL/SignedDocument.cpp
@@ -308,7 +308,7 @@ PKCS7* SignedDocument::PKCS7_from_SMIME_file(const std::string& path)
   const std::ifstream::pos_type end = in.tellg();
   in.seekg(0, std::ios::beg);
 
-  original_.length(end - begin + 1);
+  original_.length(static_cast<CORBA::ULong>(end - begin + 1));
   in.read(reinterpret_cast<char*>(original_.get_buffer()), end - begin);
 
   if (!in) {


### PR DESCRIPTION
Problem:
SequenceBackInsertIterator for OctetSeq is particularly inefficient due to repeated resize / memcpy calls for what can usually be done with a single resize & memcpy.

Solution:
Avoid using SequenceBackInsertIterator for OctetSeq.