### PR TITLE
Performance Improvements for Access Control's use of Xerces

### DIFF
--- a/dds/DCPS/security/AccessControl/Governance.cpp
+++ b/dds/DCPS/security/AccessControl/Governance.cpp
@@ -98,36 +98,48 @@ int Governance::load(const SSL::SignedDocument& doc)
   // Find the domain rules
   xercesc::DOMNodeList * domainRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("domain_rule")));
 
-  for (XMLSize_t r = 0; r < domainRules->getLength(); ++r) {
+  for (XMLSize_t r = 0, dr_len = domainRules->getLength(); r < dr_len; ++r) {
     Governance::DomainRule rule_holder_;
     rule_holder_.domain_attrs.plugin_participant_attributes = 0;
 
-    // Pull out domain ids used in the rule. We are NOT supporting ranges at this time
-    xercesc::DOMNodeList * ruleNodes = domainRules->item(r)->getChildNodes();
+    const xercesc::DOMNode* domainRule = domainRules->item(r);
 
-    for (XMLSize_t rn = 0; rn < ruleNodes->getLength(); rn++) {
-      const XStr dn_tag = ruleNodes->item(rn)->getNodeName();
+    // Pull out domain ids used in the rule. We are NOT supporting ranges at this time
+    xercesc::DOMNodeList * ruleNodes = domainRule->getChildNodes();
+
+    for (XMLSize_t rn = 0, rn_len = ruleNodes->getLength(); rn < rn_len; rn++) {
+
+      const xercesc::DOMNode* ruleNode = ruleNodes->item(rn);
+
+      const XStr dn_tag = ruleNode->getNodeName();
 
       if (ACE_TEXT("domains") == dn_tag) {
-        xercesc::DOMNodeList * domainIdNodes = ruleNodes->item(rn)->getChildNodes();
+        xercesc::DOMNodeList * domainIdNodes = ruleNode->getChildNodes();
 
-        for (XMLSize_t did = 0; did < domainIdNodes->getLength(); did++) {
-          if (ACE_TEXT("id") == XStr(domainIdNodes->item(did)->getNodeName())) {
-            const XMLCh* t = domainIdNodes->item(did)->getTextContent();
+        for (XMLSize_t did = 0, did_len = domainIdNodes->getLength(); did < did_len; did++) {
+
+          const xercesc::DOMNode* domainIdNode = domainIdNodes->item(did);
+
+          if (ACE_TEXT("id") == XStr(domainIdNode->getNodeName())) {
+            const XMLCh* t = domainIdNode->getTextContent();
             unsigned int i;
             if (xercesc::XMLString::textToBin(t, i)) {
               rule_holder_.domain_list.insert(i);
             }
-          } else if (ACE_TEXT("id_range") == XStr(domainIdNodes->item(did)->getNodeName())) {
+          } else if (ACE_TEXT("id_range") == XStr(domainIdNode->getNodeName())) {
             int min_value = 0;
             int max_value = 0;
-            xercesc::DOMNodeList * domRangeIdNodes = domainIdNodes->item(did)->getChildNodes();
 
-            for (XMLSize_t drid = 0; drid < domRangeIdNodes->getLength(); drid++) {
-              if (ACE_OS::strcmp("min", xercesc::XMLString::transcode(domRangeIdNodes->item(drid)->getNodeName())) == 0) {
-                min_value = atoi(xercesc::XMLString::transcode(domRangeIdNodes->item(drid)->getTextContent()));
-              } else if (strcmp("max", xercesc::XMLString::transcode(domRangeIdNodes->item(drid)->getNodeName())) == 0) {
-                max_value = atoi(xercesc::XMLString::transcode(domRangeIdNodes->item(drid)->getTextContent()));
+            const xercesc::DOMNodeList * domRangeIdNodes = domainIdNode->getChildNodes();
+
+            for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; drid++) {
+
+              const xercesc::DOMNode* domRangeIdNode = domRangeIdNodes->item(drid);
+
+              if (ACE_OS::strcmp("min", xercesc::XMLString::transcode(domRangeIdNode->getNodeName())) == 0) {
+                min_value = atoi(xercesc::XMLString::transcode(domRangeIdNode->getTextContent()));
+              } else if (strcmp("max", xercesc::XMLString::transcode(domRangeIdNode->getNodeName())) == 0) {
+                max_value = atoi(xercesc::XMLString::transcode(domRangeIdNode->getTextContent()));
 
                 if (min_value > max_value) {
                   ACE_DEBUG((LM_ERROR, ACE_TEXT(
@@ -230,13 +242,19 @@ int Governance::load(const SSL::SignedDocument& doc)
 
     xercesc::DOMNodeList * topic_rules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("topic_rule")));
 
-    for (XMLSize_t tr = 0; tr < topic_rules->getLength(); tr++) {
-      xercesc::DOMNodeList * topic_rule_nodes = topic_rules->item(tr)->getChildNodes();
+    for (XMLSize_t tr = 0, tr_len = topic_rules->getLength(); tr < tr_len; tr++) {
+
+      const xercesc::DOMNode* topic_rule = topic_rules->item(tr);
+
+      const xercesc::DOMNodeList * topic_rule_nodes = topic_rule->getChildNodes();
       Governance::TopicAccessRule t_rules;
 
-      for (XMLSize_t trn = 0; trn < topic_rule_nodes->getLength(); trn++) {
-        XStr tr_tag = topic_rule_nodes->item(trn)->getNodeName();
-        char * tr_val = xercesc::XMLString::transcode(topic_rule_nodes->item(trn)->getTextContent());
+      for (XMLSize_t trn = 0, trn_len = topic_rule_nodes->getLength(); trn < trn_len; trn++) {
+
+        const xercesc::DOMNode* topic_rule_node = topic_rule_nodes->item(trn);
+
+        XStr tr_tag = topic_rule_node->getNodeName();
+        char * tr_val = xercesc::XMLString::transcode(topic_rule_node->getTextContent());
 
         if (tr_tag == ACE_TEXT("topic_expression")) {
           t_rules.topic_expression = tr_val;

--- a/dds/DCPS/security/AccessControl/Governance.cpp
+++ b/dds/DCPS/security/AccessControl/Governance.cpp
@@ -88,15 +88,15 @@ int Governance::load(const SSL::SignedDocument& doc)
 
   // Successfully parsed the governance file
 
-  xercesc::DOMDocument* xmlDoc = parser->getDocument();
+  const xercesc::DOMDocument* xmlDoc = parser->getDocument();
 
-  xercesc::DOMElement* elementRoot = xmlDoc->getDocumentElement();
+  const xercesc::DOMElement* elementRoot = xmlDoc->getDocumentElement();
   if (!elementRoot) {
     throw std::runtime_error("empty XML document");
   }
 
   // Find the domain rules
-  xercesc::DOMNodeList * domainRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("domain_rule")));
+  const xercesc::DOMNodeList* domainRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("domain_rule")));
 
   for (XMLSize_t r = 0, dr_len = domainRules->getLength(); r < dr_len; ++r) {
     Governance::DomainRule rule_holder_;
@@ -105,7 +105,7 @@ int Governance::load(const SSL::SignedDocument& doc)
     const xercesc::DOMNode* domainRule = domainRules->item(r);
 
     // Pull out domain ids used in the rule. We are NOT supporting ranges at this time
-    xercesc::DOMNodeList * ruleNodes = domainRule->getChildNodes();
+    const xercesc::DOMNodeList* ruleNodes = domainRule->getChildNodes();
 
     for (XMLSize_t rn = 0, rn_len = ruleNodes->getLength(); rn < rn_len; rn++) {
 
@@ -114,7 +114,7 @@ int Governance::load(const SSL::SignedDocument& doc)
       const XStr dn_tag = ruleNode->getNodeName();
 
       if (ACE_TEXT("domains") == dn_tag) {
-        xercesc::DOMNodeList * domainIdNodes = ruleNode->getChildNodes();
+        const xercesc::DOMNodeList* domainIdNodes = ruleNode->getChildNodes();
 
         for (XMLSize_t did = 0, did_len = domainIdNodes->getLength(); did < did_len; did++) {
 
@@ -130,7 +130,7 @@ int Governance::load(const SSL::SignedDocument& doc)
             int min_value = 0;
             int max_value = 0;
 
-            const xercesc::DOMNodeList * domRangeIdNodes = domainIdNode->getChildNodes();
+            const xercesc::DOMNodeList* domRangeIdNodes = domainIdNode->getChildNodes();
 
             for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; drid++) {
 
@@ -159,23 +159,23 @@ int Governance::load(const SSL::SignedDocument& doc)
     }
 
     // Process allow_unauthenticated_participants
-    xercesc::DOMNodeList * allow_unauthenticated_participants_ =
+    const xercesc::DOMNodeList* allow_unauthenticated_participants_ =
               xmlDoc->getElementsByTagName(XStr(ACE_TEXT("allow_unauthenticated_participants")));
-    char * attr_aup = xercesc::XMLString::transcode(allow_unauthenticated_participants_->item(0)->getTextContent());
+    char* attr_aup = xercesc::XMLString::transcode(allow_unauthenticated_participants_->item(0)->getTextContent());
     rule_holder_.domain_attrs.allow_unauthenticated_participants = (ACE_OS::strcasecmp(attr_aup,"false") == 0 ? false : true);
     xercesc::XMLString::release(&attr_aup);
 
     // Process enable_join_access_control
-    xercesc::DOMNodeList * enable_join_access_control_ =
+    const xercesc::DOMNodeList* enable_join_access_control_ =
              xmlDoc->getElementsByTagName(XStr(ACE_TEXT("enable_join_access_control")));
-    char * attr_ejac = xercesc::XMLString::transcode(enable_join_access_control_->item(0)->getTextContent());
+    char* attr_ejac = xercesc::XMLString::transcode(enable_join_access_control_->item(0)->getTextContent());
     rule_holder_.domain_attrs.is_access_protected = ACE_OS::strcasecmp(attr_ejac, "false") == 0 ? false : true;
     xercesc::XMLString::release(&attr_ejac);
 
     // Process discovery_protection_kind
-    xercesc::DOMNodeList * discovery_protection_kind_ =
+    const xercesc::DOMNodeList* discovery_protection_kind_ =
              xmlDoc->getElementsByTagName(XStr(ACE_TEXT("discovery_protection_kind")));
-    char * attr_dpk = xercesc::XMLString::transcode(discovery_protection_kind_->item(0)->getTextContent());
+    char* attr_dpk = xercesc::XMLString::transcode(discovery_protection_kind_->item(0)->getTextContent());
     if (ACE_OS::strcasecmp(attr_dpk, "NONE") == 0) {
       rule_holder_.domain_attrs.is_discovery_protected = false;
     } else if (ACE_OS::strcasecmp(attr_dpk, "SIGN") == 0) {
@@ -194,9 +194,9 @@ int Governance::load(const SSL::SignedDocument& doc)
     xercesc::XMLString::release(&attr_dpk);
 
     // Process liveliness_protection_kind
-    xercesc::DOMNodeList * liveliness_protection_kind_ =
+    const xercesc::DOMNodeList* liveliness_protection_kind_ =
              xmlDoc->getElementsByTagName(XStr(ACE_TEXT("liveliness_protection_kind")));
-    char * attr_lpk = xercesc::XMLString::transcode(liveliness_protection_kind_->item(0)->getTextContent());
+    char* attr_lpk = xercesc::XMLString::transcode(liveliness_protection_kind_->item(0)->getTextContent());
     if (ACE_OS::strcasecmp(attr_lpk, "NONE") == 0) {
       rule_holder_.domain_attrs.is_liveliness_protected = false;
     } else if (ACE_OS::strcasecmp(attr_lpk, "SIGN") == 0) {
@@ -215,9 +215,9 @@ int Governance::load(const SSL::SignedDocument& doc)
     xercesc::XMLString::release(&attr_lpk);
 
     // Process rtps_protection_kind
-    xercesc::DOMNodeList * rtps_protection_kind_ =
+    const xercesc::DOMNodeList* rtps_protection_kind_ =
              xmlDoc->getElementsByTagName(XStr(ACE_TEXT("rtps_protection_kind")));
-    char * attr_rpk = xercesc::XMLString::transcode(rtps_protection_kind_->item(0)->getTextContent());
+    char* attr_rpk = xercesc::XMLString::transcode(rtps_protection_kind_->item(0)->getTextContent());
 
     if (ACE_OS::strcasecmp(attr_rpk, "NONE") == 0) {
       rule_holder_.domain_attrs.is_rtps_protected = false;
@@ -240,21 +240,21 @@ int Governance::load(const SSL::SignedDocument& doc)
 
     // Process topic rules
 
-    xercesc::DOMNodeList * topic_rules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("topic_rule")));
+    const xercesc::DOMNodeList* topic_rules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("topic_rule")));
 
     for (XMLSize_t tr = 0, tr_len = topic_rules->getLength(); tr < tr_len; tr++) {
 
       const xercesc::DOMNode* topic_rule = topic_rules->item(tr);
 
-      const xercesc::DOMNodeList * topic_rule_nodes = topic_rule->getChildNodes();
+      const xercesc::DOMNodeList* topic_rule_nodes = topic_rule->getChildNodes();
       Governance::TopicAccessRule t_rules;
 
       for (XMLSize_t trn = 0, trn_len = topic_rule_nodes->getLength(); trn < trn_len; trn++) {
 
         const xercesc::DOMNode* topic_rule_node = topic_rule_nodes->item(trn);
 
-        XStr tr_tag = topic_rule_node->getNodeName();
-        char * tr_val = xercesc::XMLString::transcode(topic_rule_node->getTextContent());
+        const XStr tr_tag = topic_rule_node->getNodeName();
+        char* tr_val = xercesc::XMLString::transcode(topic_rule_node->getTextContent());
 
         if (tr_tag == ACE_TEXT("topic_expression")) {
           t_rules.topic_expression = tr_val;

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -95,36 +95,44 @@ int Permissions::load(const SSL::SignedDocument& doc)
   // Find the validity rules
   xercesc::DOMNodeList* grantRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("grant")));
 
-  for (XMLSize_t r = 0; r < grantRules->getLength(); ++r) {
+  for (XMLSize_t r = 0, r_len = grantRules->getLength(); r < r_len; ++r) {
     Grant_rch grant = DCPS::make_rch<Grant>();
 
+    const xercesc::DOMNode* grantRule = grantRules->item(r);
+
     // Pull out the grant name for this grant
-    xercesc::DOMNamedNodeMap* rattrs = grantRules->item(r)->getAttributes();
+    xercesc::DOMNamedNodeMap* rattrs = grantRule->getAttributes();
     grant->name = toString(rattrs->item(0)->getTextContent());
 
     // Pull out subject name, validity, and default
-    xercesc::DOMNodeList* grantNodes = grantRules->item(r)->getChildNodes();
+    xercesc::DOMNodeList* grantNodes = grantRule->getChildNodes();
 
     bool valid_subject = false, valid_default = false;
-    for (XMLSize_t gn = 0; gn < grantNodes->getLength(); ++gn) {
-      const XStr g_tag = grantNodes->item(gn)->getNodeName();
+    for (XMLSize_t gn = 0, gn_len = grantNodes->getLength(); gn < gn_len; ++gn) {
+
+      const xercesc::DOMNode* grantNode = grantNodes->item(gn);
+
+      const XStr g_tag = grantNode->getNodeName();
 
       if (g_tag == ACE_TEXT("subject_name")) {
-        valid_subject = (grant->subject.parse(toString(grantNodes->item(gn)->getTextContent())) == 0);
+        valid_subject = (grant->subject.parse(toString(grantNode->getTextContent())) == 0);
       } else if (g_tag == ACE_TEXT("validity")) {
-        xercesc::DOMNodeList* validityNodes = grantNodes->item(gn)->getChildNodes();
+        xercesc::DOMNodeList* validityNodes = grantNode->getChildNodes();
 
-        for (XMLSize_t vn = 0; vn < validityNodes->getLength(); ++vn) {
-          const XStr v_tag = validityNodes->item(vn)->getNodeName();
+        for (XMLSize_t vn = 0, vn_len = validityNodes->getLength(); vn < vn_len; ++vn) {
+
+          const xercesc::DOMNode* validityNode = validityNodes->item(gn);
+
+          const XStr v_tag = validityNode->getNodeName();
 
           if (v_tag == ACE_TEXT("not_before")) {
-            grant->validity.not_before = toString((validityNodes->item(vn)->getTextContent()));
+            grant->validity.not_before = toString((validityNode->getTextContent()));
           } else if (v_tag == ACE_TEXT("not_after")) {
-            grant->validity.not_after = toString((validityNodes->item(vn)->getTextContent()));
+            grant->validity.not_after = toString((validityNode->getTextContent()));
           }
         }
       } else if (g_tag == ACE_TEXT("default")) {
-        const std::string def = toString(grantNodes->item(gn)->getTextContent());
+        const std::string def = toString(grantNode->getTextContent());
         valid_default = true;
         if (def == "ALLOW") {
           grant->default_permission = ALLOW;
@@ -145,37 +153,49 @@ int Permissions::load(const SSL::SignedDocument& doc)
     }
 
     // Pull out allow/deny rules
-    xercesc::DOMNodeList* adGrantNodes = grantRules->item(r)->getChildNodes();
+    xercesc::DOMNodeList* adGrantNodes = grantRule->getChildNodes();
 
-    for (XMLSize_t gn = 0; gn < adGrantNodes->getLength(); ++gn) {
-      const XStr g_tag = adGrantNodes->item(gn)->getNodeName();
+    for (XMLSize_t gn = 0, gn_len = adGrantNodes->getLength(); gn < gn_len; ++gn) {
+
+      const xercesc::DOMNode* adGrantNode = adGrantNodes->item(gn);
+
+      const XStr g_tag = adGrantNode->getNodeName();
 
       if (g_tag == ACE_TEXT("allow_rule") || g_tag == ACE_TEXT("deny_rule")) {
         Rule rule;
 
         rule.ad_type = (g_tag == ACE_TEXT("allow_rule")) ? ALLOW : DENY;
 
-        xercesc::DOMNodeList* adNodeChildren = adGrantNodes->item(gn)->getChildNodes();
+        xercesc::DOMNodeList* adNodeChildren = adGrantNode->getChildNodes();
 
-        for (XMLSize_t anc = 0; anc < adNodeChildren->getLength(); ++anc) {
-          const XStr anc_tag = adNodeChildren->item(anc)->getNodeName();
+        for (XMLSize_t anc = 0, anc_len = adNodeChildren->getLength(); anc < anc_len; ++anc) {
+
+          const xercesc::DOMNode* adNodeChild = adNodeChildren->item(anc);
+
+          const XStr anc_tag = adNodeChild->getNodeName();
 
           if (anc_tag == ACE_TEXT("domains")) {   //domain list
-            xercesc::DOMNodeList* domainIdNodes = adNodeChildren->item(anc)->getChildNodes();
+            xercesc::DOMNodeList* domainIdNodes = adNodeChild->getChildNodes();
 
-            for (XMLSize_t did = 0; did < domainIdNodes->getLength(); ++did) {
-              if (ACE_TEXT("id") == XStr(domainIdNodes->item(did)->getNodeName())) {
-                rule.domains.insert(toInt(domainIdNodes->item(did)->getTextContent()));
-              } else if (ACE_TEXT("id_range") == XStr(domainIdNodes->item(did)->getNodeName())) {
+            for (XMLSize_t did = 0, did_len = domainIdNodes->getLength(); did < did_len; ++did) {
+
+              const xercesc::DOMNode* domainIdNode = domainIdNodes->item(did);
+
+              if (ACE_TEXT("id") == XStr(domainIdNode->getNodeName())) {
+                rule.domains.insert(toInt(domainIdNode->getTextContent()));
+              } else if (ACE_TEXT("id_range") == XStr(domainIdNode->getNodeName())) {
                 int min_value = 0;
                 int max_value = 0;
-                xercesc::DOMNodeList* domRangeIdNodes = domainIdNodes->item(did)->getChildNodes();
+                xercesc::DOMNodeList* domRangeIdNodes = domainIdNode->getChildNodes();
 
-                for (XMLSize_t drid = 0; drid < domRangeIdNodes->getLength(); ++drid) {
-                  if (ACE_TEXT("min") == XStr(domRangeIdNodes->item(drid)->getNodeName())) {
-                    min_value = toInt(domRangeIdNodes->item(drid)->getTextContent());
-                  } else if (ACE_TEXT("max") == XStr(domRangeIdNodes->item(drid)->getNodeName())) {
-                    max_value = toInt(domRangeIdNodes->item(drid)->getTextContent());
+                for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; ++drid) {
+
+                  const xercesc::DOMNode* domRangeIdNode = domRangeIdNodes->item(did);
+
+                  if (ACE_TEXT("min") == XStr(domRangeIdNode->getNodeName())) {
+                    min_value = toInt(domRangeIdNode->getTextContent());
+                  } else if (ACE_TEXT("max") == XStr(domRangeIdNode->getNodeName())) {
+                    max_value = toInt(domRangeIdNode->getTextContent());
 
                     if (min_value > max_value) {
                       ACE_ERROR((LM_ERROR, ACE_TEXT(
@@ -195,24 +215,33 @@ int Permissions::load(const SSL::SignedDocument& doc)
             Action action;
 
             action.ps_type = (anc_tag == ACE_TEXT("publish")) ? PUBLISH : SUBSCRIBE;
-            xercesc::DOMNodeList* topicListNodes = adNodeChildren->item(anc)->getChildNodes();
+            xercesc::DOMNodeList* topicListNodes = adNodeChild->getChildNodes();
 
-            for (XMLSize_t tln = 0; tln < topicListNodes->getLength(); ++tln) {
-              if (ACE_TEXT("topics") == XStr(topicListNodes->item(tln)->getNodeName())) {
-                xercesc::DOMNodeList* topicNodes = topicListNodes->item(tln)->getChildNodes();
+            for (XMLSize_t tln = 0, tln_len = topicListNodes->getLength(); tln < tln_len; ++tln) {
 
-                for (XMLSize_t tn = 0; tn < topicNodes->getLength(); ++tn) {
-                  if (ACE_TEXT("topic") == XStr(topicNodes->item(tn)->getNodeName())) {
-                    action.topics.push_back(toString(topicNodes->item(tn)->getTextContent()));
+              const xercesc::DOMNode* topicListNode = topicListNodes->item(tln);
+
+              if (ACE_TEXT("topics") == XStr(topicListNode->getNodeName())) {
+                xercesc::DOMNodeList* topicNodes = topicListNode->getChildNodes();
+
+                for (XMLSize_t tn = 0, tn_len = topicNodes->getLength(); tn < tn_len; ++tn) {
+
+                  const xercesc::DOMNode* topicNode = topicNodes->item(tn);
+
+                  if (ACE_TEXT("topic") == XStr(topicNode->getNodeName())) {
+                    action.topics.push_back(toString(topicNode->getTextContent()));
                   }
                 }
 
-              } else if (ACE_TEXT("partitions") == XStr(topicListNodes->item(tln)->getNodeName())) {
-                xercesc::DOMNodeList* partitionNodes = topicListNodes->item(tln)->getChildNodes();
+              } else if (ACE_TEXT("partitions") == XStr(topicListNode->getNodeName())) {
+                xercesc::DOMNodeList* partitionNodes = topicListNode->getChildNodes();
 
-                for (XMLSize_t pn = 0; pn < partitionNodes->getLength(); ++pn) {
-                  if (ACE_TEXT("partition") == XStr(partitionNodes->item(pn)->getNodeName())) {
-                    action.partitions.push_back(toString(partitionNodes->item(pn)->getTextContent()));
+                for (XMLSize_t pn = 0, pn_len = partitionNodes->getLength(); pn < pn_len; ++pn) {
+
+                  const xercesc::DOMNode* partitionNode = partitionNodes->item(pn);
+
+                  if (ACE_TEXT("partition") == XStr(partitionNode->getNodeName())) {
+                    action.partitions.push_back(toString(partitionNode->getTextContent()));
                   }
                 }
               }

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -190,7 +190,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
 
                 for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; ++drid) {
 
-                  const xercesc::DOMNode* domRangeIdNode = domRangeIdNodes->item(did);
+                  const xercesc::DOMNode* domRangeIdNode = domRangeIdNodes->item(drid);
 
                   if (ACE_TEXT("min") == XStr(domRangeIdNode->getNodeName())) {
                     min_value = toInt(domRangeIdNode->getTextContent());

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -121,7 +121,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
 
         for (XMLSize_t vn = 0, vn_len = validityNodes->getLength(); vn < vn_len; ++vn) {
 
-          const xercesc::DOMNode* validityNode = validityNodes->item(gn);
+          const xercesc::DOMNode* validityNode = validityNodes->item(vn);
 
           const XStr v_tag = validityNode->getNodeName();
 

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -83,9 +83,9 @@ int Permissions::load(const SSL::SignedDocument& doc)
 
   // Successfully parsed the permissions file
 
-  xercesc::DOMDocument* xmlDoc = parser->getDocument();
+  const xercesc::DOMDocument* xmlDoc = parser->getDocument();
 
-  xercesc::DOMElement* elementRoot = xmlDoc->getDocumentElement();
+  const xercesc::DOMElement* elementRoot = xmlDoc->getDocumentElement();
   if (!elementRoot) {
     ACE_ERROR((LM_ERROR, ACE_TEXT(
         "(%P|%t) AccessControlBuiltInImpl::load_permissions_file: Empty XML document\n")));
@@ -93,7 +93,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
   }
 
   // Find the validity rules
-  xercesc::DOMNodeList* grantRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("grant")));
+  const xercesc::DOMNodeList* grantRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("grant")));
 
   for (XMLSize_t r = 0, r_len = grantRules->getLength(); r < r_len; ++r) {
     Grant_rch grant = DCPS::make_rch<Grant>();
@@ -105,7 +105,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
     grant->name = toString(rattrs->item(0)->getTextContent());
 
     // Pull out subject name, validity, and default
-    xercesc::DOMNodeList* grantNodes = grantRule->getChildNodes();
+    const xercesc::DOMNodeList* grantNodes = grantRule->getChildNodes();
 
     bool valid_subject = false, valid_default = false;
     for (XMLSize_t gn = 0, gn_len = grantNodes->getLength(); gn < gn_len; ++gn) {
@@ -117,7 +117,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
       if (g_tag == ACE_TEXT("subject_name")) {
         valid_subject = (grant->subject.parse(toString(grantNode->getTextContent())) == 0);
       } else if (g_tag == ACE_TEXT("validity")) {
-        xercesc::DOMNodeList* validityNodes = grantNode->getChildNodes();
+        const xercesc::DOMNodeList* validityNodes = grantNode->getChildNodes();
 
         for (XMLSize_t vn = 0, vn_len = validityNodes->getLength(); vn < vn_len; ++vn) {
 
@@ -153,7 +153,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
     }
 
     // Pull out allow/deny rules
-    xercesc::DOMNodeList* adGrantNodes = grantRule->getChildNodes();
+    const xercesc::DOMNodeList* adGrantNodes = grantRule->getChildNodes();
 
     for (XMLSize_t gn = 0, gn_len = adGrantNodes->getLength(); gn < gn_len; ++gn) {
 
@@ -166,7 +166,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
 
         rule.ad_type = (g_tag == ACE_TEXT("allow_rule")) ? ALLOW : DENY;
 
-        xercesc::DOMNodeList* adNodeChildren = adGrantNode->getChildNodes();
+        const xercesc::DOMNodeList* adNodeChildren = adGrantNode->getChildNodes();
 
         for (XMLSize_t anc = 0, anc_len = adNodeChildren->getLength(); anc < anc_len; ++anc) {
 
@@ -175,7 +175,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
           const XStr anc_tag = adNodeChild->getNodeName();
 
           if (anc_tag == ACE_TEXT("domains")) {   //domain list
-            xercesc::DOMNodeList* domainIdNodes = adNodeChild->getChildNodes();
+            const xercesc::DOMNodeList* domainIdNodes = adNodeChild->getChildNodes();
 
             for (XMLSize_t did = 0, did_len = domainIdNodes->getLength(); did < did_len; ++did) {
 
@@ -186,7 +186,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
               } else if (ACE_TEXT("id_range") == XStr(domainIdNode->getNodeName())) {
                 int min_value = 0;
                 int max_value = 0;
-                xercesc::DOMNodeList* domRangeIdNodes = domainIdNode->getChildNodes();
+                const xercesc::DOMNodeList* domRangeIdNodes = domainIdNode->getChildNodes();
 
                 for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; ++drid) {
 
@@ -215,14 +215,14 @@ int Permissions::load(const SSL::SignedDocument& doc)
             Action action;
 
             action.ps_type = (anc_tag == ACE_TEXT("publish")) ? PUBLISH : SUBSCRIBE;
-            xercesc::DOMNodeList* topicListNodes = adNodeChild->getChildNodes();
+            const xercesc::DOMNodeList* topicListNodes = adNodeChild->getChildNodes();
 
             for (XMLSize_t tln = 0, tln_len = topicListNodes->getLength(); tln < tln_len; ++tln) {
 
               const xercesc::DOMNode* topicListNode = topicListNodes->item(tln);
 
               if (ACE_TEXT("topics") == XStr(topicListNode->getNodeName())) {
-                xercesc::DOMNodeList* topicNodes = topicListNode->getChildNodes();
+                const xercesc::DOMNodeList* topicNodes = topicListNode->getChildNodes();
 
                 for (XMLSize_t tn = 0, tn_len = topicNodes->getLength(); tn < tn_len; ++tn) {
 
@@ -234,7 +234,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
                 }
 
               } else if (ACE_TEXT("partitions") == XStr(topicListNode->getNodeName())) {
-                xercesc::DOMNodeList* partitionNodes = topicListNode->getChildNodes();
+                const xercesc::DOMNodeList* partitionNodes = topicListNode->getChildNodes();
 
                 for (XMLSize_t pn = 0, pn_len = partitionNodes->getLength(); pn < pn_len; ++pn) {
 


### PR DESCRIPTION
Problem:
AccessControl's use of XercesC++ makes repeated unnecessary calls to DOMNodeList::length() and DOMNodeList::item(), both of which are relatively heavy weight tree operations that use dynamic casting internally.

Solution:
Use the stack to cache calls to these functions when reading from constant DOMs.