### PR TITLE
Improve ParameterList Growth Performance

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -34,6 +34,11 @@ namespace {
   void add_param(ParameterList& param_list, const Parameter& param)
   {
     const CORBA::ULong length = param_list.length();
+    // Grow by factor of 2 when length is a power of 2 in order to prevent every call to length(+1)
+    // allocating a new buffer & copying previous results. The maximum is kept when length is reduced.
+    if (length && !(length & (length - 1))) {
+      param_list.length(2 * length);
+    }
     param_list.length(length + 1);
     param_list[length] = param;
   }


### PR DESCRIPTION
Problem:
RTPS::ParameterList uses add_param() to grow a parameter lists by a single parameter, but add_param() simply increases the underlying TAO Unbounded_Value_Sequence's length by 1, which reallocates & copies values for every resize.

Solution:
As a simple improvement, occasionally resize the underlying sequence to be larger than necessary and then resize it back to the correct length in order to increase the maximum beyond what's necessary and avoid extra allocations. This particular scheme reallocates every time length() reaches the next power of 2.