### PR TITLE
Workaround TAO3 Setting Our SONAME Version

### DIFF
--- a/MPC/config/dcps_no_idl.mpb
+++ b/MPC/config/dcps_no_idl.mpb
@@ -1,4 +1,4 @@
-project: dds_taolib, dds_macros, dcps_optional_bidir_giop, dds_any_support, coverage_optional, dds_vc_warnings {
+project: dds_macros, dds_taolib, dcps_optional_bidir_giop, dds_any_support, coverage_optional, dds_vc_warnings {
   libs        += OpenDDS_Dcps
   after       += OpenDDS_Dcps
   libpaths    += $(DDS_ROOT)/lib

--- a/MPC/config/idl2jni.mpb
+++ b/MPC/config/idl2jni.mpb
@@ -2,7 +2,7 @@ feature(!java_pre_jpms) : java {
   javacflags += -classpath $(DDS_ROOT)/lib/i2jrt_corba.jar
 }
 
-project: taolib_with_idl, portableserver, java, dds_macros {
+project: dds_macros, taolib_with_idl, portableserver, java {
 
   includes   += $(DDS_ROOT)/java/idl2jni/runtime
   libpaths   += $(DDS_ROOT)/lib

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -1,5 +1,5 @@
 project(OpenDDS_Dcps): core, coverage_optional, \
-        dcps_optional_features, dcps_optional_safety, dds_macros, \
+        dds_macros, dcps_optional_features, dcps_optional_safety, \
         dds_suppress_any_support, dds_taolib, gen_ostream, install, valgrind, \
         dds_vc_warnings, dds_versioning_idl_defaults, msvc_bigobj, dcps_optional_rapidjson {
   sharedname   = OpenDDS_Dcps

--- a/examples/DCPS/Messenger_IOGR_Imr/Messenger_IOGR_Imr.mpc
+++ b/examples/DCPS/Messenger_IOGR_Imr/Messenger_IOGR_Imr.mpc
@@ -10,7 +10,7 @@ project(DDS*idl): dcps_idl_only_lib {
   }
 }
 
-project(DDS*Aggregator) : portableserver, orbsvcsexe, iormanip, ftorb, dds_macros {
+project(DDS*Aggregator) : dds_macros, portableserver, orbsvcsexe, iormanip, ftorb {
   exename = Aggregator
   requires += tao_orbsvcs
   requires += no_opendds_safety_profile

--- a/java/idl2jni/runtime/idl2jni_runtime.mpc
+++ b/java/idl2jni/runtime/idl2jni_runtime.mpc
@@ -1,4 +1,4 @@
-project: taolib, java, javah, optional_jni_check, dds_macros, i2jrt_optional, install {
+project: dds_macros, taolib, java, javah, optional_jni_check, i2jrt_optional, install {
 
   // make sure this can't be built as a static lib
   sharedname   = idl2jni_runtime

--- a/performance-tests/DCPS/InfoRepo_population/InfoRepo_population.mpc
+++ b/performance-tests/DCPS/InfoRepo_population/InfoRepo_population.mpc
@@ -10,7 +10,7 @@ project(*idl) : dcps_test {
   custom_only = 1
 }
 
-project(*SyncServer) : taoexe, portableserver, iortable, coverage_optional, dds_macros {
+project(*SyncServer) : dds_macros, taoexe, portableserver, iortable, coverage_optional {
   requires += no_opendds_safety_profile
   exename   = syncServer
   includes += ../Sync

--- a/performance-tests/DCPS/Sync/Sync.mpc
+++ b/performance-tests/DCPS/Sync/Sync.mpc
@@ -1,4 +1,4 @@
-project(*idl) : taoidldefaults, dds_macros {
+project(*idl) : dds_macros, taoidldefaults {
   requires += no_opendds_safety_profile
   idlflags    += -Wb,export_macro=Sync_Export -Wb,export_include=Sync_export.h
 
@@ -9,7 +9,7 @@ project(*idl) : taoidldefaults, dds_macros {
   custom_only = 1
 }
 
-project(*ServerLib) : taolib_with_idl, portableserver, iortable, dds_macros {
+project(*ServerLib) : dds_macros, taolib_with_idl, portableserver, iortable {
   requires += no_opendds_safety_profile
   sharedname   = SyncServer
   libout       = $(DDS_ROOT)/lib
@@ -27,7 +27,7 @@ project(*ServerLib) : taolib_with_idl, portableserver, iortable, dds_macros {
   }
 }
 
-project(*ClientLib) : taolib_with_idl, portableserver, dds_macros {
+project(*ClientLib) : dds_macros, taolib_with_idl, portableserver {
   requires += no_opendds_safety_profile
   sharedname   = SyncClient
   libout       = $(DDS_ROOT)/lib
@@ -44,7 +44,7 @@ project(*ClientLib) : taolib_with_idl, portableserver, dds_macros {
   }
 }
 
-project(*Server) : taoexe, taoidldefaults, portableserver, iortable, dds_macros {
+project(*Server) : dds_macros, taoexe, taoidldefaults, portableserver, iortable {
   requires += no_opendds_safety_profile
   exename = syncServer
   libs   += SyncServer


### PR DESCRIPTION
TAO3 added a [`tao_rules` base project](https://github.com/mcorino/ACE_TAO/blob/master/TAO/MPC/config/tao_rules.mpb) in https://github.com/DOCGroup/ACE_TAO/pull/1296. This base project serves the same purpose as our [`dds_macros` base project](https://github.com/objectcomputing/OpenDDS/blob/master/MPC/config/dds_macros.mpb), which is to insert a `rules.*.GNU` file into the final Makefile. The problem is that `rules.tao.GNU` is getting inserted before ours and that's setting `GNUACE_PROJECT_VERSION` first. This results in OpenDDS so libraries getting TAO3's version.

This change moves `dds_macros` before TAO base projects everywhere I could find to try to make sure our rules file is included first.

This is just a workaround though. The underlying issue is that `GNUACE_PROJECT_VERSION` can easily bleed between different projects. This would have to be fixed in gnuace.