### PR TITLE
Reduce WeakRcHandle Dynamic Casting With Cached Pointer

### DIFF
--- a/dds/DCPS/RcObject.h
+++ b/dds/DCPS/RcObject.h
@@ -33,12 +33,14 @@ namespace DCPS {
     {
     }
 
-    void _add_ref() {
-      ++this->ref_count_;
+    void _add_ref()
+    {
+      ++ref_count_;
     }
 
-    void _remove_ref(){
-      const long new_count = --this->ref_count_;
+    void _remove_ref()
+    {
+      const long new_count = --ref_count_;
 
       if (new_count == 0) {
         delete this;
@@ -47,6 +49,7 @@ namespace DCPS {
 
     RcObject* lock();
     bool set_expire();
+
   private:
 #ifdef ACE_HAS_CPP11
     std::atomic<long> ref_count_;
@@ -61,32 +64,36 @@ namespace DCPS {
   class OpenDDS_Dcps_Export RcObject : public PoolAllocationBase {
   public:
 
-    virtual ~RcObject(){
+    virtual ~RcObject()
+    {
       weak_object_->_remove_ref();
     }
 
-    virtual void _add_ref() {
-      ++this->ref_count_;
+    virtual void _add_ref()
+    {
+      ++ref_count_;
     }
 
-    virtual void _remove_ref() {
-      const long new_count = --this->ref_count_;
+    virtual void _remove_ref()
+    {
+      const long new_count = --ref_count_;
       if (new_count == 0 && weak_object_->set_expire()) {
         delete this;
       }
     }
 
     /// This accessor is purely for debugging purposes
-    long ref_count() const {
+    long ref_count() const
+    {
 #ifdef ACE_HAS_CPP11
-      return this->ref_count_;
+      return ref_count_;
 #else
-      return this->ref_count_.value();
+      return ref_count_.value();
 #endif
     }
 
-    WeakObject*
-    _get_weak_object() const {
+    WeakObject* _get_weak_object() const
+    {
       weak_object_->_add_ref();
       return weak_object_;
     }
@@ -94,7 +101,7 @@ namespace DCPS {
   protected:
     RcObject()
       : ref_count_(1)
-      , weak_object_( new WeakObject(this) )
+      , weak_object_(new WeakObject(this))
     {}
 
   private:
@@ -109,20 +116,17 @@ namespace DCPS {
     RcObject& operator=(const RcObject&);
   };
 
-
-  inline RcObject*
-  WeakObject::lock()
+  inline RcObject* WeakObject::lock()
   {
     ACE_Guard<ACE_SYNCH_MUTEX> guard(mx_);
-    if (! expired_) {
+    if (!expired_) {
       ptr_->_add_ref();
       return ptr_;
     }
     return 0;
   }
 
-  inline bool
-  WeakObject::set_expire()
+  inline bool WeakObject::set_expire()
   {
     ACE_Guard<ACE_SYNCH_MUTEX> guard(mx_);
     if (!expired_ && ptr_->ref_count() == 0) {
@@ -137,49 +141,67 @@ namespace DCPS {
   public:
     WeakRcHandle()
       : weak_object_(0)
+      , cached_(0)
     {
     }
 
     WeakRcHandle(const T& obj)
-      : weak_object_(obj._get_weak_object()) {
+      : weak_object_(obj._get_weak_object())
+      , cached_(const_cast<T*>(&obj))
+    {
     }
 
     WeakRcHandle(const RcHandle<T>& rch)
-      : weak_object_(rch.in() ? rch.in()->_get_weak_object() : 0) {
+      : weak_object_(rch.in() ? rch.in()->_get_weak_object() : 0)
+      , cached_(rch.in() ? rch.in() : 0)
+    {
     }
 
     WeakRcHandle(const WeakRcHandle& other)
-    : weak_object_(other.weak_object_){
-      if (weak_object_)
+      : weak_object_(other.weak_object_)
+      , cached_(other.cached_)
+    {
+      if (weak_object_) {
         weak_object_->_add_ref();
+      }
     }
 
-    ~WeakRcHandle(){
-      if (weak_object_)
+    ~WeakRcHandle()
+    {
+      if (weak_object_) {
         weak_object_->_remove_ref();
+      }
+      cached_ = 0;
     }
 
-    WeakRcHandle& operator = (const WeakRcHandle& other) {
+    WeakRcHandle& operator=(const WeakRcHandle& other)
+    {
        WeakRcHandle tmp(other);
        std::swap(weak_object_, tmp.weak_object_);
+       std::swap(cached_, tmp.cached_);
        return *this;
     }
 
-    WeakRcHandle& operator = (const RcHandle<T>& other) {
+    WeakRcHandle& operator=(const RcHandle<T>& other)
+    {
        WeakRcHandle tmp(other);
        std::swap(weak_object_, tmp.weak_object_);
+       std::swap(cached_, tmp.cached_);
        return *this;
     }
 
-    WeakRcHandle& operator = (const T& obj) {
+    WeakRcHandle& operator=(const T& obj)
+    {
       WeakRcHandle tmp(obj);
       std::swap(weak_object_, tmp.weak_object_);
+       std::swap(cached_, tmp.cached_);
       return *this;
     }
 
-    RcHandle<T> lock() const {
-      if (weak_object_){
-        return RcHandle<T>(dynamic_cast<T*>(weak_object_->lock()), keep_count());
+    RcHandle<T> lock() const
+    {
+      if (weak_object_ && weak_object_->lock()) {
+        return RcHandle<T>(cached_, keep_count());
       }
       return RcHandle<T>();
     }
@@ -194,35 +216,40 @@ namespace DCPS {
       return weak_object_ != rhs.weak_object_;
     }
 
-    bool operator < (const WeakRcHandle& rhs) const
+    bool operator<(const WeakRcHandle& rhs) const
     {
       return weak_object_ < rhs.weak_object_;
     }
 
-    operator bool() const {
+    operator bool() const
+    {
       return weak_object_;
     }
 
-    void reset() {
+    void reset()
+    {
       if (weak_object_) {
         weak_object_->_remove_ref();
         weak_object_ = 0;
       }
+      cached_ = 0;
     }
 
   private:
 
     WeakRcHandle(WeakObject* obj)
       : weak_object_(obj)
+      , cached_(dynamic_cast<T*>(obj))
     {
     }
 
     WeakObject* weak_object_;
+    T* cached_;
   };
 
-}// DCPS
-}// OPENDDS
+} // DCPS
+} // OPENDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#endif /* end of include guard: RCOBJECT_H_E92AD5BB */
+#endif /* end of include guard: OPENDDS_DCPS_RCOBJECT_H */


### PR DESCRIPTION
Problem:
Every time WeakRcHandle::lock() is called, the same dynamic cast is made from an RcObject* to a T*.

Solution:
Cache the dynamic cast, but only return it when underlying lock() is successful.
This slightly increases the size of WeakRcHandle, but does not change the size of RcHandle, RcObject, or WeakRcObject, nor does it require the widespread changes that templating WeakRcObject / RcObject would incur.