### PR TITLE
Fix for include of a tao pidl sequence using the tao_root based path

### DIFF
--- a/dds/idl/be_global.cpp
+++ b/dds/idl/be_global.cpp
@@ -600,7 +600,7 @@ namespace {
         0 == ACE_OS::strcasecmp(idl.c_str() + len - 5, ".pidl")) {
       base_name.assign(idl.c_str(), len - 5);
       size_t slash = base_name.find_last_of("/\\");
-      if (slash != std::string::npos && slash > 3 && base_name.size() > 3
+      if (slash != std::string::npos && slash >= 3 && base_name.size() > 3
           && base_name.substr(slash - 3, 3) == "tao"
           && base_name.substr(base_name.size() - 3) == "Seq") {
         base_name = "dds/CorbaSeq/" + base_name.substr(slash + 1);


### PR DESCRIPTION
 Include of a tao pidl sequence using the tao_root based path and tao_root as an include fails to transform it to the dds corba sequence.

The root cause is an unexpected interaction between the code we get from `tao_idl` (specifically `drv_preproc.cpp` adding an include that we don't know about in `BE_GlobalData::set_inc_paths`) and the use of `make_relative` before `transform_referenced`.  `transform_referenced` was expecting an absolute path so that there was at least one character to the left of `tao/DoubleSeq.pidl`.