### PR TITLE
Better Support for Thread BIT When There are Multiple Participants

### DIFF
--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -530,7 +530,8 @@ public:
     DDS::InstanceStateMask instance_states) = 0;
 
   virtual void set_instance_state(DDS::InstanceHandle_t instance,
-                                  DDS::InstanceStateKind state) = 0;
+                                  DDS::InstanceStateKind state,
+                                  const SystemTimePoint& timestamp = SystemTimePoint::now()) = 0;
 
 #endif
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -913,14 +913,18 @@ namespace OpenDDS {
   }
 
   void set_instance_state(DDS::InstanceHandle_t instance,
-                          DDS::InstanceStateKind state)
+                          DDS::InstanceStateKind state,
+                          const SystemTimePoint& timestamp = SystemTimePoint::now())
   {
     using namespace OpenDDS::DCPS;
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
 
     SubscriptionInstance_rch si = get_handle_instance(instance);
     if (si && state != DDS::ALIVE_INSTANCE_STATE) {
+      const DDS::Time_t now = timestamp.to_dds_time();
       DataSampleHeader header;
+      header.source_timestamp_sec_ = now.sec;
+      header.source_timestamp_nanosec_ = now.nanosec;
       const int msg = (state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE)
         ? DISPOSE_INSTANCE : UNREGISTER_INSTANCE;
       header.message_id_ = static_cast<char>(msg);

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -96,16 +96,16 @@ namespace OpenDDS {
         : drr_(drr), reader_(reader), wa_(wa), active_(active), dwr_(dwr)
         , reader_done_(false), writer_done_(false), cnd_(mtx_)
         , interval_(TheServiceParticipant->get_thread_status_interval())
-        , status_(TheServiceParticipant->get_thread_statuses())
-        , thread_key_(ThreadStatus::get_key("DcpsUpcalls"))
+        , thread_status_manager_(TheServiceParticipant->get_thread_status_manager())
+        , thread_key_(ThreadStatusManager::get_key("DcpsUpcalls"))
       {
       }
 
       int svc()
       {
         MonotonicTimePoint expire;
-        const bool use_expire = has_timeout();
-        if (use_expire) {
+        const bool update_thread_status = thread_status_manager_ && has_timeout();
+        if (update_thread_status) {
           expire = MonotonicTimePoint::now() + interval_;
         }
 
@@ -119,7 +119,7 @@ namespace OpenDDS {
           reader_done_ = true;
           cnd_.notify_one();
           while (!writer_done_) {
-            if (use_expire) {
+            if (update_thread_status) {
               switch (cnd_.wait_until(expire)) {
               case CvStatus_NoTimeout:
                 break;
@@ -127,18 +127,16 @@ namespace OpenDDS {
               case CvStatus_Timeout:
                 {
                   expire = MonotonicTimePoint::now() + interval_;
-                  if (status_) {
-                    if (DCPS_debug_level >= 4) {
-                      ACE_DEBUG((LM_DEBUG,
-                                 "(%P|%t) DcpsUpcalls::svc. Updating thread status.\n"));
+                  if (DCPS_debug_level >= 4) {
+                    ACE_DEBUG((LM_DEBUG,
+                               "(%P|%t) DcpsUpcalls::svc. Updating thread status.\n"));
+                  }
+                  if (!thread_status_manager_->update(thread_key_)) {
+                    if (DCPS_debug_level) {
+                      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DcpsUpcalls::svc: "
+                        "update failed\n"));
                     }
-                    if (!status_->update(thread_key_)) {
-                      if (DCPS_debug_level) {
-                        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DcpsUpcalls::svc: "
-                          "update failed\n"));
-                      }
-                      return -1;
-                    }
+                    return -1;
                   }
                 }
                 break;
@@ -157,6 +155,18 @@ namespace OpenDDS {
             }
           }
         }
+
+        if (update_thread_status) {
+          if (DCPS_debug_level >= 4) {
+            ACE_DEBUG((LM_DEBUG, "(%P|%t) DcpsUpcalls: "
+              "Updating thread status for the last time\n"));
+          }
+          if (!thread_status_manager_->update(thread_key_, ThreadStatus_Finished) &&
+              DCPS_debug_level) {
+            ACE_ERROR((LM_ERROR, "(%P|%t) DcpsUpcalls: final update failed\n"));
+          }
+        }
+
         return 0;
       }
 
@@ -173,12 +183,12 @@ namespace OpenDDS {
 
         wait(); // ACE_Task_Base::wait does not accept a timeout
 
-        if (status_ && has_timeout() && MonotonicTimePoint::now() > expire) {
+        if (thread_status_manager_ && has_timeout() && MonotonicTimePoint::now() > expire) {
           if (DCPS_debug_level >= 4) {
             ACE_DEBUG((LM_DEBUG,
                        "(%P|%t) DcpsUpcalls::writer_done. Updating thread status.\n"));
           }
-          if (!status_->update(thread_key_) && DCPS_debug_level) {
+          if (!thread_status_manager_->update(thread_key_) && DCPS_debug_level) {
             ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: DcpsUpcalls::writer_done: "
               "update failed\n"));
           }
@@ -196,7 +206,7 @@ namespace OpenDDS {
 
       // thread reporting
       const TimeDuration interval_;
-      ThreadStatus* const status_;
+      ThreadStatusManager* const thread_status_manager_;
       const String thread_key_;
     };
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -347,7 +347,8 @@ private:
     OPENDDS_LIST(DCPS::RepoId) directed_guids_;
     void process_lease_expirations(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpSporadic> lease_expiration_processor_;
-    DCPS::ThreadStatusManager* thread_status_manager_;
+    DCPS::ThreadStatusManager* global_thread_status_manager_;
+    DCPS::ThreadStatusManager local_thread_status_manager_;
     void thread_status_task(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpPeriodic> thread_status_sender_;
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -347,7 +347,7 @@ private:
     OPENDDS_LIST(DCPS::RepoId) directed_guids_;
     void process_lease_expirations(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpSporadic> lease_expiration_processor_;
-    DCPS::ThreadStatus* thread_status_;
+    DCPS::ThreadStatusManager* thread_status_manager_;
     void thread_status_task(const DCPS::MonotonicTimePoint& now);
     DCPS::RcHandle<SpdpPeriodic> thread_status_sender_;
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -341,11 +341,12 @@ bool ThreadStatusManager::sync_with_parent(ThreadStatusManager& parent,
         std::strcmp(ci->first.c_str(), pi->first.c_str()) : got_parent ? 1 : -1;
       if (cmp < 0) { // We're behind, this thread was removed
         finished.insert(*ci);
-        map_.erase(ci++);
+        ++ci;
       } else if (cmp > 0) { // We're ahead, this thread was added
-        map_.insert(*pi);
+        running.insert(*pi);
         ++pi;
-      } else { // Same Thread
+      } else { // Same Thread, Update
+        running.insert(*pi);
         ++ci;
         ++pi;
       }
@@ -354,7 +355,7 @@ bool ThreadStatusManager::sync_with_parent(ThreadStatusManager& parent,
     }
   }
 
-  running = map_;
+  map_ = running;
 
   return true;
 }

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -266,7 +266,7 @@ bool ThreadStatusManager::update(const String& thread_key, ThreadStatus status)
   const SystemTimePoint now = SystemTimePoint::now();
   if (DCPS_debug_level >= 4) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) ThreadStatus::update: "
-      "update for thread \"%C\" %C @ %d \n",
+      "update for thread \"%C\" %C @ %d\n",
       thread_key.c_str(), status_to_string(status), now.value().sec()));
   }
   switch (status) {

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -331,7 +331,6 @@ bool ThreadStatusManager::sync_with_parent(ThreadStatusManager& parent,
   {
     ACE_READ_GUARD_RETURN(ACE_Thread_Mutex, g2, parent.lock_, false);
 
-    // Compare threads to see if if threads were added or removed.
     Map::iterator ci = map_.begin();
     Map::iterator pi = parent.map_.begin();
     bool got_child = ci != map_.end();

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -30,13 +30,20 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-struct OpenDDS_Dcps_Export ThreadStatus {
+enum ThreadStatus {
+  ThreadStatus_Running,
+  ThreadStatus_Finished,
+};
+
+struct OpenDDS_Dcps_Export ThreadStatusManager {
   struct Thread {
     Thread() {}
-    explicit Thread(const SystemTimePoint& time)
+    Thread(const SystemTimePoint& time, ThreadStatus status)
       : timestamp(time)
+      , status(status)
     {}
     SystemTimePoint timestamp;
+    ThreadStatus status;
     // TODO(iguessthislldo): Add Participant GUID
   };
   typedef OPENDDS_MAP(String, Thread) Map;
@@ -51,7 +58,7 @@ struct OpenDDS_Dcps_Export ThreadStatus {
 
   /// Update the status of a thread to indicate it was able to check in at the
   /// given time. Returns false if failed.
-  bool update(const String& key);
+  bool update(const String& key, ThreadStatus status = ThreadStatus_Running);
 
 #ifdef ACE_HAS_GETTID
   static inline pid_t gettid()
@@ -71,7 +78,7 @@ public:
 
 public:
   int open_reactor_task(void*, TimeDuration timeout = TimeDuration(0),
-    ThreadStatus* thread_stat = 0, const String& name = "");
+    ThreadStatusManager* thread_status_manager = 0, const String& name = "");
   virtual int open(void* ptr) {
     return open_reactor_task(ptr);
   }
@@ -139,7 +146,7 @@ private:
   TimerQueueType* timer_queue_;
 
   // thread status reporting
-  ThreadStatus* thread_status_;
+  ThreadStatusManager* thread_status_manager_;
   TimeDuration timeout_;
   String name_;
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -452,7 +452,8 @@ Service_Participant::get_domain_participant_factory(int &argc,
 
       dp_factory_servant_ = make_rch<DomainParticipantFactoryImpl>();
 
-      reactor_task_.open_reactor_task(0, thread_status_interval_, &thread_status_, "Service_Participant");
+      reactor_task_.open_reactor_task(
+        0, thread_status_interval_, &thread_status_manager_, "Service_Participant");
 
       if (this->monitor_enabled_) {
 #if !defined(ACE_AS_STATIC_LIBS)
@@ -2796,10 +2797,9 @@ Service_Participant::set_thread_status_interval(TimeDuration interval)
   thread_status_interval_ = interval;
 }
 
-ThreadStatus*
-Service_Participant::get_thread_statuses()
+ThreadStatusManager* Service_Participant::get_thread_status_manager()
 {
-  return &thread_status_;
+  return &thread_status_manager_;
 }
 
 ACE_Thread_Mutex& Service_Participant::get_static_xtypes_lock()

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -649,7 +649,8 @@ public:
   /// getter for lock that protects the static initialization of XTypes related data structures
   ACE_Thread_Mutex& get_static_xtypes_lock();
 
-  ThreadStatus* get_thread_statuses();
+  /// Get the service participant's thread status manager.
+  ThreadStatusManager* get_thread_status_manager();
 
   /// Pointer to the monitor factory that is used to create
   /// monitor objects.
@@ -720,7 +721,7 @@ private:
   /// Enable Internal Thread Status Monitoring
   TimeDuration thread_status_interval_;
 
-  ThreadStatus thread_status_;
+  ThreadStatusManager thread_status_manager_;
 
   /// Thread mutex used to protect the static initialization of XTypes data structures
   ACE_Thread_Mutex xtypes_lock_;

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -174,7 +174,7 @@ public:
       }
       if (!thread_status_manager->update(thread_key, ThreadStatus_Finished) &&
           DCPS_debug_level) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) QueueTaskBase::svc: final updated failed\n"));
+        ACE_ERROR((LM_ERROR, "(%P|%t) QueueTaskBase::svc: final update failed\n"));
       }
     }
 

--- a/dds/DCPS/transport/framework/QueueTaskBase_T.h
+++ b/dds/DCPS/transport/framework/QueueTaskBase_T.h
@@ -112,8 +112,10 @@ public:
     thr_id_ = ACE_OS::thr_self();
 
     const TimeDuration interval = TheServiceParticipant->get_thread_status_interval();
-    ThreadStatus* const status = TheServiceParticipant->get_thread_statuses();
-    const String thread_key = ThreadStatus::get_key("QueueTaskBase", name_);
+    ThreadStatusManager* const thread_status_manager =
+      TheServiceParticipant->get_thread_status_manager();
+    const bool update_thread_status = thread_status_manager && !interval.is_zero();
+    const String thread_key = ThreadStatusManager::get_key("QueueTaskBase", name_);
 
     // Start the "GetWork-And-PerformWork" loop for the current worker thread.
     while (!this->shutdown_initiated_) {
@@ -122,7 +124,7 @@ public:
         GuardType guard(this->lock_);
 
         if (this->queue_.is_empty() && !shutdown_initiated_) {
-          if (interval > TimeDuration(0)) {
+          if (update_thread_status) {
             MonotonicTimePoint expire = MonotonicTimePoint::now() + interval;
 
             do {
@@ -131,15 +133,13 @@ public:
               MonotonicTimePoint now = MonotonicTimePoint::now();
               if (now > expire) {
                 expire = now + interval;
-                if (status) {
-                  if (DCPS_debug_level >= 4) {
-                    ACE_DEBUG((LM_DEBUG,
-                               "(%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
-                  }
-                  if (!status->update(thread_key) && DCPS_debug_level) {
-                    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: QueueTaskBase::svc: "
-                      "thread update failed\n"));
-                  }
+                if (DCPS_debug_level >= 4) {
+                  ACE_DEBUG((LM_DEBUG,
+                             "(%P|%t) QueueTaskBase::svc. Updating thread status.\n"));
+                }
+                if (!thread_status_manager->update(thread_key) && DCPS_debug_level) {
+                  ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: QueueTaskBase::svc: "
+                    "thread update failed\n"));
                 }
               }
             } while (this->queue_.is_empty() && !shutdown_initiated_);
@@ -165,6 +165,17 @@ public:
       }
 
       this->execute(req);
+    }
+
+    if (update_thread_status) {
+      if (DCPS_debug_level >= 4) {
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) QueueTaskBase::svc: "
+          "Updating thread status for the last time\n"));
+      }
+      if (!thread_status_manager->update(thread_key, ThreadStatus_Finished) &&
+          DCPS_debug_level) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) QueueTaskBase::svc: final updated failed\n"));
+      }
     }
 
     // This will never get executed.

--- a/dds/DCPS/transport/framework/TransportImpl.cpp
+++ b/dds/DCPS/transport/framework/TransportImpl.cpp
@@ -114,7 +114,8 @@ TransportImpl::create_reactor_task(bool useAsyncSend, const OPENDDS_STRING& name
 
   this->reactor_task_= make_rch<ReactorTask>(useAsyncSend);
 
-  if (0 != this->reactor_task_->open_reactor_task(0, TheServiceParticipant->get_thread_status_interval(), TheServiceParticipant->get_thread_statuses(), name.c_str())) {
+  if (reactor_task_->open_reactor_task(0, TheServiceParticipant->get_thread_status_interval(),
+      TheServiceParticipant->get_thread_status_manager(), name.c_str())) {
     throw Transport::MiscProblem(); // error already logged by TRT::open()
   }
 }

--- a/tests/DCPS/InternalThreadStatus/DataReaderListenerImpl.h
+++ b/tests/DCPS/InternalThreadStatus/DataReaderListenerImpl.h
@@ -21,7 +21,8 @@ typedef void (*callback_t)();
 class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
 public:
-  DataReaderListenerImpl(const OPENDDS_STRING& id, int expected_samples, callback_t done_callback)
+  DataReaderListenerImpl(
+    const OpenDDS::DCPS::String& id, int expected_samples, callback_t done_callback)
     : id_(id)
     , expected_samples_(expected_samples)
     , received_samples_(0)
@@ -60,7 +61,7 @@ public:
     const DDS::SampleLostStatus& status);
 
 private:
-  OPENDDS_STRING id_;
+  OpenDDS::DCPS::String id_;
   const int expected_samples_;
   int received_samples_;
   callback_t done_callback_;

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.cpp
@@ -13,11 +13,12 @@
 
 #include <ace/streams.h>
 
-#include <string>
-
 // Implementation skeleton constructor
-InternalThreadStatusListenerImpl::InternalThreadStatusListenerImpl(OpenDDS::DCPS::String id) :
-  id_(id), count_(0), disposes_(0)
+InternalThreadStatusListenerImpl::InternalThreadStatusListenerImpl(
+  const OpenDDS::DCPS::String& id)
+: id_(id)
+, count_(0)
+, disposes_(0)
 {
 }
 

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.h
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.h
@@ -8,9 +8,10 @@
 #ifndef INTERNAL_THREAD_STATUS_LISTENER_IMPL
 #define INTERNAL_THREAD_STATUS_LISTENER_IMPL
 
-#include <dds/DdsDcpsSubscriptionC.h>
 #include <dds/DCPS/LocalObject.h>
 #include <dds/DCPS/GuidUtils.h>
+
+#include <dds/DdsDcpsSubscriptionC.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -23,7 +24,7 @@ class InternalThreadStatusListenerImpl
 {
 public:
   //Constructor
-  explicit InternalThreadStatusListenerImpl(OpenDDS::DCPS::String id);
+  explicit InternalThreadStatusListenerImpl(const OpenDDS::DCPS::String& id);
 
   //Destructor
   virtual ~InternalThreadStatusListenerImpl();
@@ -55,7 +56,6 @@ private:
   OpenDDS::DCPS::String id_;
   int count_;
   size_t disposes_;
-
 };
 
 #endif /* INTERNAL_THREAD_STATUS_LISTENER_IMPL  */

--- a/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.h
+++ b/tests/DCPS/InternalThreadStatus/InternalThreadStatusListenerImpl.h
@@ -23,43 +23,38 @@ class InternalThreadStatusListenerImpl
 {
 public:
   //Constructor
-  explicit InternalThreadStatusListenerImpl(OPENDDS_STRING id);
+  explicit InternalThreadStatusListenerImpl(OpenDDS::DCPS::String id);
 
   //Destructor
   virtual ~InternalThreadStatusListenerImpl();
 
-  virtual void on_requested_deadline_missed(
-                                            DDS::DataReader_ptr reader,
+  virtual void on_requested_deadline_missed(DDS::DataReader_ptr reader,
                                             const DDS::RequestedDeadlineMissedStatus & status);
 
-  virtual void on_requested_incompatible_qos(
-                                             DDS::DataReader_ptr reader,
+  virtual void on_requested_incompatible_qos(DDS::DataReader_ptr reader,
                                              const DDS::RequestedIncompatibleQosStatus & status);
 
-  virtual void on_liveliness_changed(
-                                     DDS::DataReader_ptr reader,
+  virtual void on_liveliness_changed(DDS::DataReader_ptr reader,
                                      const DDS::LivelinessChangedStatus & status);
 
-  virtual void on_subscription_matched(
-                                       DDS::DataReader_ptr reader,
+  virtual void on_subscription_matched(DDS::DataReader_ptr reader,
                                        const DDS::SubscriptionMatchedStatus & status);
 
-  virtual void on_sample_rejected(
-                                  DDS::DataReader_ptr reader,
+  virtual void on_sample_rejected(DDS::DataReader_ptr reader,
                                   const DDS::SampleRejectedStatus& status);
 
-  virtual void on_data_available(
-                                 DDS::DataReader_ptr reader);
+  virtual void on_data_available(DDS::DataReader_ptr reader);
 
-  virtual void on_sample_lost(
-                              DDS::DataReader_ptr reader,
+  virtual void on_sample_lost(DDS::DataReader_ptr reader,
                               const DDS::SampleLostStatus& status);
 
   int get_count() const;
-private:
+  size_t disposes() const;
 
-  OPENDDS_STRING id_;
+private:
+  OpenDDS::DCPS::String id_;
   int count_;
+  size_t disposes_;
 
 };
 

--- a/tests/DCPS/InternalThreadStatus/publisher.cpp
+++ b/tests/DCPS/InternalThreadStatus/publisher.cpp
@@ -18,10 +18,32 @@
 #  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #endif
+#include <dds/DCPS/DCPS_Utils.h>
 
 #include <ace/Get_Opt.h>
 
 #include <iostream>
+
+const DDS::Duration_t max_wait_time = {10, 0};
+
+bool wait_for_samples(DDS::DataReader_var reader, bool disposed) {
+  DDS::ReadCondition_var read_condition = reader->create_readcondition(
+    DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE,
+    disposed ? DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE : DDS::ALIVE_INSTANCE_STATE);
+  DDS::WaitSet_var ws = new DDS::WaitSet;
+  ws->attach_condition(read_condition);
+  DDS::ConditionSeq active;
+  DDS::ReturnCode_t rc = ws->wait(active, max_wait_time);
+  ws->detach_condition(read_condition);
+  reader->delete_readcondition(read_condition);
+  if (rc != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l wait_for_samples() ERROR: ")
+      ACE_TEXT("wait failed: %C\n"),
+      OpenDDS::DCPS::retcode_to_string(rc)));
+    return false;
+  }
+  return true;
+}
 
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
@@ -125,7 +147,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     if (!thread_reader) {
       std::cerr << "Could not get " << OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC
                 << " DataReader." << std::endl;
-      ACE_OS::exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
     }
 
     InternalThreadStatusListenerImpl* listener = new InternalThreadStatusListenerImpl("Publisher");
@@ -135,7 +157,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       thread_reader->set_listener(listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (retcode != DDS::RETCODE_OK) {
       std::cerr << "set_listener for " << OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC << " failed." << std::endl;
-      ACE_OS::exit(EXIT_FAILURE);
+      return EXIT_FAILURE;
     }
 
     // wait for subscriber
@@ -164,8 +186,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
 
     ACE_DEBUG((LM_DEBUG, "(%P|%t) DataWriter is waiting for acknowledgments\n"));
-    DDS::Duration_t timeout = { 10, 0 };
-    message_writer->wait_for_acknowledgments(timeout);
+    message_writer->wait_for_acknowledgments(max_wait_time);
     // With static discovery, it's not an error for wait_for_acks to fail
     // since the peer process may have terminated before sending acks.
     ACE_DEBUG((LM_DEBUG, "(%P|%t) DataWriter is done\n"));
@@ -183,11 +204,62 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       std::cout << "Publisher received " << count << " internal thread status messages." << std::endl;
     }
 
-    // Clean-up!
+    // Create 2nd participant to witness disposes of the 1st participant's threads.
+    DDS::DomainParticipant_var part2 = dpf->create_participant(
+      42, part_qos, DDS::DomainParticipantListener::_nil(), OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!part2) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("%N:%l: main()")
+                        ACE_TEXT(" ERROR: create_participant (2nd) failed!\n")),
+                       EXIT_FAILURE);
+    }
+
+    DDS::Subscriber_var bit_subscriber2 = part2->get_builtin_subscriber();
+    DDS::DataReader_var thread_reader2 =
+      bit_subscriber2->lookup_datareader(OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC);
+    if (!thread_reader2) {
+      std::cerr << "ERROR: Could not get 2nd " << OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC
+                << " DataReader." << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    InternalThreadStatusListenerImpl* listener2 =
+      new InternalThreadStatusListenerImpl("Publisher part2");
+    DDS::DataReaderListener_var listener2_var(listener2);
+    if (thread_reader2->set_listener(listener2, OpenDDS::DCPS::DEFAULT_STATUS_MASK) != DDS::RETCODE_OK) {
+      std::cerr << "ERROR: set_listener for " << OpenDDS::DCPS::BUILT_IN_INTERNAL_THREAD_TOPIC
+        << " failed." << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    // Wait for valid thread status to come into the 2nd thread reader
+    if (!wait_for_samples(thread_reader2, false)) {
+      ACE_ERROR((LM_ERROR, "ERROR: wait for part2 thread status failed\n"));
+      return EXIT_FAILURE;
+    }
+    if (listener->disposes() > 0 || listener2->disposes() > 0) {
+      ACE_ERROR((LM_ERROR, "ERROR: thread listener has disposes before participant deletes\n"));
+      return EXIT_FAILURE;
+    }
+
+    // Clean-up first participant
     std::cerr << "publisher deleting contained entities" << std::endl;
     participant->delete_contained_entities();
     std::cerr << "publisher deleting participant" << std::endl;
     dpf->delete_participant(participant.in());
+
+    // Wait for disposes to come in to 2nd thread reader
+    if (!wait_for_samples(thread_reader2, true)) {
+      ACE_ERROR((LM_ERROR, "ERROR: wait for part2 thread status disposes failed\n"));
+      status = EXIT_FAILURE;
+    }
+    if (listener2->disposes() == 0) {
+      ACE_ERROR((LM_ERROR, "ERROR: 2nd thread listener has no disposes after 1st participant delete\n"));
+      return EXIT_FAILURE;
+    }
+
+    // Finish cleaning up
+    dpf->delete_participant(part2);
     std::cerr << "publisher shutdown" << std::endl;
     TheServiceParticipant->shutdown();
 

--- a/tests/DCPS/InternalThreadStatus/run_test.pl
+++ b/tests/DCPS/InternalThreadStatus/run_test.pl
@@ -19,7 +19,7 @@ my $status = 0;
 
 my $test = new PerlDDS::TestFramework();
 
-$test->{dcps_debug_level} = 1;
+$test->{dcps_debug_level} = 4; # Level where thread status info is logged.
 $test->{dcps_transport_debug_level} = 1;
 # will manually set -DCPSConfigFile
 $test->{add_transport_config} = 0;

--- a/tests/DCPS/unit/MyTypeSupportImpl.h
+++ b/tests/DCPS/unit/MyTypeSupportImpl.h
@@ -109,7 +109,7 @@ public:
   DDS::ReturnCode_t take(
     OpenDDS::DCPS::AbstractSamples&,
     DDS::SampleStateMask, DDS::ViewStateMask,
-    DDS::InstanceStateMask ) { return 0; }
+    DDS::InstanceStateMask) { return 0; }
 
   DDS::ReturnCode_t read_instance_generic(void*& data,
     DDS::SampleInfo& info, DDS::InstanceHandle_t instance,
@@ -120,7 +120,8 @@ public:
     DDS::SampleInfo&, DDS::InstanceHandle_t, DDS::SampleStateMask,
     DDS::ViewStateMask, DDS::InstanceStateMask);
 
-  void set_instance_state(DDS::InstanceHandle_t, DDS::InstanceStateKind)
+  void set_instance_state(DDS::InstanceHandle_t, DDS::InstanceStateKind,
+    const OpenDDS::DCPS::SystemTimePoint&)
   {}
 #endif
 };


### PR DESCRIPTION
- Rename `ThreadStatus` to `ThreadStatusManager` to better reflect what it is.
- Removes finished threads from the global `ThreadStatusManager` so they don't continue to get written in the Thread BIT if there is another participant that's already running or going to run.
- Each participant gets its own local `ThreadStatusManager` to sync with the global one so that each participant can correctly do a single dispose for each finished thread.
- Fix a `ACE_HAS_MINIMUM_BIT` that should be `DDS_HAS_MINIMUM_BIT`.
