### PR TITLE
Add Mutex Protection For DDS Entity Listeners

### DIFF
--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -585,6 +585,10 @@ public:
   void return_handle(DDS::InstanceHandle_t handle);
 
 protected:
+
+  // Perform cast to get extended version of listener (otherwise nil)
+  virtual DataReaderListener_ptr get_ext_listener();
+
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);
 
@@ -748,6 +752,7 @@ private:
   friend class ::DDS_TEST; //allows tests to get at private data
 
   DDS::TopicDescription_var    topic_desc_;
+  ACE_Thread_Mutex             listener_mutex_;
   DDS::StatusMask              listener_mask_;
   DDS::DataReaderListener_var  listener_;
   DDS::DomainId_t              domain_id_;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -587,7 +587,7 @@ public:
 protected:
 
   // Perform cast to get extended version of listener (otherwise nil)
-  virtual DataReaderListener_ptr get_ext_listener();
+  DataReaderListener_ptr get_ext_listener();
 
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);
   void remove_publication(const PublicationId& pub_id);

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -144,9 +144,7 @@ DataWriterImpl::init(
 
   qos_ = qos;
 
-  //Note: OK to _duplicate(nil).
-  listener_ = DDS::DataWriterListener::_duplicate(a_listener);
-  listener_mask_ = mask;
+  set_listener(a_listener, mask);
 
   // Only store the participant pointer, since it is our "grand"
   // parent, we will exist as long as it does.
@@ -980,6 +978,7 @@ DDS::ReturnCode_t
 DataWriterImpl::set_listener(DDS::DataWriterListener_ptr a_listener,
                              DDS::StatusMask mask)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   listener_mask_ = mask;
   //note: OK to duplicate  a nil object ref
   listener_ = DDS::DataWriterListener::_duplicate(a_listener);
@@ -989,7 +988,15 @@ DataWriterImpl::set_listener(DDS::DataWriterListener_ptr a_listener,
 DDS::DataWriterListener_ptr
 DataWriterImpl::get_listener()
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   return DDS::DataWriterListener::_duplicate(listener_.in());
+}
+
+DataWriterListener_ptr
+DataWriterImpl::get_ext_listener()
+{
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
+  return DataWriterListener::_narrow(listener_.in());
 }
 
 DDS::Topic_ptr
@@ -2411,7 +2418,9 @@ DataWriterImpl::listener_for(DDS::StatusKind kind)
   if (!publisher)
     return 0;
 
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   if (CORBA::is_nil(listener_.in()) || (listener_mask_ & kind) == 0) {
+    g.release();
     return publisher->listener_for(kind);
 
   } else {
@@ -2561,8 +2570,7 @@ DataWriterImpl::notify_publication_disconnected(const ReaderIdSeq& subids)
   if (!is_bit_) {
     // Narrow to DDS::DCPS::DataWriterListener. If a DDS::DataWriterListener
     // is given to this DataWriter then narrow() fails.
-    DataWriterListener_var the_listener =
-      DataWriterListener::_narrow(this->listener_.in());
+    DataWriterListener_var the_listener = get_ext_listener();
 
     if (!CORBA::is_nil(the_listener.in())) {
       PublicationDisconnectedStatus status;
@@ -2585,8 +2593,7 @@ DataWriterImpl::notify_publication_reconnected(const ReaderIdSeq& subids)
     // Narrow to DDS::DCPS::DataWriterListener. If a
     // DDS::DataWriterListener is given to this DataWriter then
     // narrow() fails.
-    DataWriterListener_var the_listener =
-      DataWriterListener::_narrow(this->listener_.in());
+    DataWriterListener_var the_listener = get_ext_listener();
 
     if (!CORBA::is_nil(the_listener.in())) {
       PublicationDisconnectedStatus status;
@@ -2608,8 +2615,7 @@ DataWriterImpl::notify_publication_lost(const ReaderIdSeq& subids)
     // Narrow to DDS::DCPS::DataWriterListener. If a
     // DDS::DataWriterListener is given to this DataWriter then
     // narrow() fails.
-    DataWriterListener_var the_listener =
-      DataWriterListener::_narrow(this->listener_.in());
+    DataWriterListener_var the_listener = get_ext_listener();
 
     if (!CORBA::is_nil(the_listener.in())) {
       PublicationLostStatus status;
@@ -2632,8 +2638,7 @@ DataWriterImpl::notify_publication_lost(const DDS::InstanceHandleSeq& handles)
     // Narrow to DDS::DCPS::DataWriterListener. If a
     // DDS::DataWriterListener is given to this DataWriter then
     // narrow() fails.
-    DataWriterListener_var the_listener =
-      DataWriterListener::_narrow(this->listener_.in());
+    DataWriterListener_var the_listener = get_ext_listener();
 
     if (!CORBA::is_nil(the_listener.in())) {
       PublicationLostStatus status;

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -468,6 +468,9 @@ public:
 
 protected:
 
+  // Perform cast to get extended version of listener (otherwise nil)
+  DataWriterListener_ptr get_ext_listener();
+
   DDS::ReturnCode_t wait_for_specific_ack(const AckToken& token);
 
   void prepare_to_delete();
@@ -588,6 +591,8 @@ private:
   /// The topic servant.
   TopicDescriptionPtr<TopicImpl>                 topic_servant_;
 
+  /// Mutex to protect listener info
+  ACE_Thread_Mutex                listener_mutex_;
   /// The StatusKind bit mask indicates which status condition change
   /// can be notified by the listener of this entity.
   DDS::StatusMask                 listener_mask_;

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1203,6 +1203,7 @@ DomainParticipantImpl::set_listener(
   DDS::DomainParticipantListener_ptr a_listener,
   DDS::StatusMask mask)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   listener_mask_ = mask;
   //note: OK to duplicate  a nil object ref
   listener_ = DDS::DomainParticipantListener::_duplicate(a_listener);
@@ -1212,6 +1213,7 @@ DomainParticipantImpl::set_listener(
 DDS::DomainParticipantListener_ptr
 DomainParticipantImpl::get_listener()
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   return DDS::DomainParticipantListener::_duplicate(listener_.in());
 }
 
@@ -2093,6 +2095,7 @@ DomainParticipantImpl::is_clean() const
 DDS::DomainParticipantListener_ptr
 DomainParticipantImpl::listener_for(DDS::StatusKind kind)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   if (CORBA::is_nil(listener_.in()) || (listener_mask_ & kind) == 0) {
     return DDS::DomainParticipantListener::_nil ();
   } else {

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -445,6 +445,8 @@ private:
 
   /// The qos of this DomainParticipant.
   DDS::DomainParticipantQos qos_;
+  /// Mutex to protect listener info
+  ACE_Thread_Mutex listener_mutex_;
   /// Used to notify the entity for relevant events.
   DDS::DomainParticipantListener_var listener_;
   /// The StatusKind bit mask indicates which status condition change

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -497,6 +497,7 @@ DDS::ReturnCode_t
 PublisherImpl::set_listener(DDS::PublisherListener_ptr a_listener,
     DDS::StatusMask            mask)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   listener_mask_ = mask;
   //note: OK to duplicate  a nil object ref
   listener_ = DDS::PublisherListener::_duplicate(a_listener);
@@ -506,6 +507,7 @@ PublisherImpl::set_listener(DDS::PublisherListener_ptr a_listener,
 DDS::PublisherListener_ptr
 PublisherImpl::get_listener()
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   return DDS::PublisherListener::_duplicate(listener_.in());
 }
 
@@ -883,7 +885,9 @@ PublisherImpl::listener_for(DDS::StatusKind kind)
   if (!participant)
     return 0;
 
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   if (CORBA::is_nil(listener_.in()) || (listener_mask_ & kind) == 0) {
+    g.release();
     return participant->listener_for(kind);
 
   } else {

--- a/dds/DCPS/PublisherImpl.h
+++ b/dds/DCPS/PublisherImpl.h
@@ -169,6 +169,8 @@ private:
   /// Default datawriter Qos policy list.
   DDS::DataWriterQos           default_datawriter_qos_;
 
+  /// Mutex to protect listener info
+  ACE_Thread_Mutex             listener_mutex_;
   /// The StatusKind bit mask indicates which status condition change
   /// can be notified by the listener of this entity.
   DDS::StatusMask              listener_mask_;

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -672,6 +672,7 @@ SubscriberImpl::set_listener(
   DDS::SubscriberListener_ptr a_listener,
   DDS::StatusMask             mask)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   listener_mask_ = mask;
   //note: OK to duplicate  a nil object ref
   listener_ = DDS::SubscriberListener::_duplicate(a_listener);
@@ -681,6 +682,7 @@ SubscriberImpl::set_listener(
 DDS::SubscriberListener_ptr
 SubscriberImpl::get_listener()
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   return DDS::SubscriberListener::_duplicate(listener_.in());
 }
 
@@ -913,7 +915,9 @@ SubscriberImpl::listener_for(::DDS::StatusKind kind)
   if (! participant)
     return 0;
 
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   if (CORBA::is_nil(listener_.in()) || (listener_mask_ & kind) == 0) {
+    g.release();
     return participant->listener_for(kind);
 
   } else {

--- a/dds/DCPS/SubscriberImpl.h
+++ b/dds/DCPS/SubscriberImpl.h
@@ -181,6 +181,7 @@ private:
   DDS::SubscriberQos           qos_;
   DDS::DataReaderQos           default_datareader_qos_;
 
+  ACE_Thread_Mutex             listener_mutex_;
   DDS::StatusMask              listener_mask_;
   DDS::SubscriberListener_var  listener_;
 

--- a/dds/DCPS/TopicImpl.cpp
+++ b/dds/DCPS/TopicImpl.cpp
@@ -99,6 +99,7 @@ TopicImpl::get_qos(DDS::TopicQos& qos)
 DDS::ReturnCode_t
 TopicImpl::set_listener(DDS::TopicListener_ptr a_listener, DDS::StatusMask mask)
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   listener_mask_ = mask;
   //note: OK to duplicate  a nil object ref
   listener_ = DDS::TopicListener::_duplicate(a_listener);
@@ -108,6 +109,7 @@ TopicImpl::set_listener(DDS::TopicListener_ptr a_listener, DDS::StatusMask mask)
 DDS::TopicListener_ptr
 TopicImpl::get_listener()
 {
+  ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
   return DDS::TopicListener::_duplicate(listener_.in());
 }
 
@@ -204,11 +206,15 @@ TopicImpl::inconsistent_topic(int count)
 
   set_status_changed_flag(DDS::INCONSISTENT_TOPIC_STATUS, true);
 
-  DDS::TopicListener_var listener = listener_;
-  if (!listener || !(listener_mask_ & DDS::INCONSISTENT_TOPIC_STATUS)) {
-    listener = participant_->listener_for(DDS::INCONSISTENT_TOPIC_STATUS);
+  DDS::TopicListener_var listener;
+  {
+    ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
+    listener = listener_;
+    if (!listener || !(listener_mask_ & DDS::INCONSISTENT_TOPIC_STATUS)) {
+      g.release();
+      listener = participant_->listener_for(DDS::INCONSISTENT_TOPIC_STATUS);
+    }
   }
-
   if (listener) {
     listener->on_inconsistent_topic(this, inconsistent_topic_status_);
     inconsistent_topic_status_.total_count_change = 0;

--- a/dds/DCPS/TopicImpl.h
+++ b/dds/DCPS/TopicImpl.h
@@ -95,6 +95,8 @@ private:
   /// The topic qos
   DDS::TopicQos                qos_;
 
+  /// Mutex to protect listener info
+  ACE_Thread_Mutex             listener_mutex_;
   /// The mask for which kind of events the listener
   ///  will be notified about.
   DDS::StatusMask              listener_mask_;


### PR DESCRIPTION
Problem:
Setting Listeners, especially setting them to NULL, is not thread safe.

Solution:
Add mutex protection around listener objects.