### PR TITLE
ICE password resets accumulate memory when disconnected from relay

### DIFF
--- a/dds/DCPS/RTPS/ICE/EndpointManager.cpp
+++ b/dds/DCPS/RTPS/ICE/EndpointManager.cpp
@@ -172,6 +172,10 @@ void EndpointManager::change_username()
 
 void EndpointManager::change_password(bool password_only)
 {
+  if (password_only && guid_pair_to_checklist_.empty()) {
+    return;
+  }
+
   unsigned char password[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
   TheSecurityRegistry->builtin_config()->get_utility()->generate_random_bytes(password, sizeof(password));
   agent_info_.password = OpenDDS::DCPS::to_hex_dds_string(password, 16, 0, 0);


### PR DESCRIPTION
Problem
-------

The ICE endpoint manager periodically changes the password.  This
causes new samples to be written to SEDP. If a participant is using
the relay but disconnected, these samples will be buffered.  (The long
term fix is for SEDP to replace the existig sample.)  Additionally,
these password changes generate useless traffic for the relay when
connected.

Solution
--------

Don't change the ICE password unless there are active checklists.