### PR TITLE
RtpsRelay doesn't publish statistics immediately

### DIFF
--- a/tools/rtpsrelay/DomainStatisticsReporter.h
+++ b/tools/rtpsrelay/DomainStatisticsReporter.h
@@ -89,21 +89,28 @@ public:
     report(now);
   }
 
-private:
-  void report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void report()
   {
-    log_report(now);
-    publish_report(now);
+    report(OpenDDS::DCPS::MonotonicTimePoint::now(), true);
   }
 
-  void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+private:
+  void report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+              bool force = false)
+  {
+    log_report(now, force);
+    publish_report(now, force);
+  }
+
+  void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+                  bool force)
   {
     if (config_.log_domain_statistics().is_zero()) {
       return;
     }
 
     const auto d = now - log_last_report_;
-    if (d < config_.log_domain_statistics()) {
+    if (!force && d < config_.log_domain_statistics()) {
       return;
     }
 
@@ -114,14 +121,15 @@ private:
     log_last_report_ = now;
   }
 
-  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+                      bool force)
   {
     if (config_.publish_domain_statistics().is_zero()) {
       return;
     }
 
     const auto d = now - publish_last_report_;
-    if (d < config_.publish_domain_statistics()) {
+    if (!force && d < config_.publish_domain_statistics()) {
       return;
     }
 

--- a/tools/rtpsrelay/HandlerStatisticsReporter.h
+++ b/tools/rtpsrelay/HandlerStatisticsReporter.h
@@ -151,22 +151,29 @@ public:
     report(now);
   }
 
-private:
-
-  void report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void report()
   {
-    log_report(now);
-    publish_report(now);
+    report(OpenDDS::DCPS::MonotonicTimePoint::now(), true);
   }
 
-  void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+private:
+
+  void report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+              bool force = false)
+  {
+    log_report(now, force);
+    publish_report(now, force);
+  }
+
+  void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+                  bool force)
   {
     if (config_.log_handler_statistics().is_zero()) {
       return;
     }
 
     const auto d = now - log_last_report_;
-    if (d < config_.log_handler_statistics()) {
+    if (!force && d < config_.log_handler_statistics()) {
       return;
     }
 
@@ -199,14 +206,15 @@ private:
     log_max_queue_latency_ = OpenDDS::DCPS::TimeDuration::zero_value;
   }
 
-  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+                      bool force)
   {
     if (config_.publish_handler_statistics().is_zero()) {
       return;
     }
 
     const auto d = now - publish_last_report_;
-    if (d < config_.publish_handler_statistics()) {
+    if (!force && d < config_.publish_handler_statistics()) {
       return;
     }
 

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -127,22 +127,29 @@ public:
     report(now);
   }
 
-private:
-
-  void report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void report()
   {
-    log_report(now);
-    publish_report(now);
+    report(OpenDDS::DCPS::MonotonicTimePoint::now(), true);
   }
 
-  void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+private:
+
+  void report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+              bool force = false)
+  {
+    log_report(now, force);
+    publish_report(now, force);
+  }
+
+  void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+                  bool force)
   {
     if (config_.log_relay_statistics().is_zero()) {
       return;
     }
 
     const auto d = now - log_last_report_;
-    if (d < config_.log_relay_statistics()) {
+    if (!force && d < config_.log_relay_statistics()) {
       return;
     }
 
@@ -174,14 +181,15 @@ private:
     log_max_queue_latency_ = OpenDDS::DCPS::TimeDuration::zero_value;
   }
 
-  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+                      bool force)
   {
     if (config_.publish_relay_statistics().is_zero()) {
       return;
     }
 
     const auto d = now - publish_last_report_;
-    if (d < config_.publish_relay_statistics()) {
+    if (!force && d < config_.publish_relay_statistics()) {
       return;
     }
 

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -621,19 +621,26 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   RelayStatisticsReporter relay_statistics_reporter(config, relay_statistics_writer);
+  relay_statistics_reporter.report();
 
   HandlerStatisticsReporter spdp_vertical_reporter(config, "VSPDP", handler_statistics_writer, relay_statistics_reporter);
+  spdp_vertical_reporter.report();
   SpdpHandler spdp_vertical_handler(config, "VSPDP", spdp_horizontal_addr, reactor, association_table, responsible_relay_writer, responsible_relay_reader, rtps_discovery, crypto, spdp, spdp_vertical_reporter);
   HandlerStatisticsReporter sedp_vertical_reporter(config, "VSEDP", handler_statistics_writer, relay_statistics_reporter);
+  sedp_vertical_reporter.report();
   SedpHandler sedp_vertical_handler(config, "VSEDP", sedp_horizontal_addr, reactor, association_table, responsible_relay_writer, responsible_relay_reader, rtps_discovery, crypto, sedp, sedp_vertical_reporter);
   HandlerStatisticsReporter data_vertical_reporter(config, "VDATA", handler_statistics_writer, relay_statistics_reporter);
+  data_vertical_reporter.report();
   DataHandler data_vertical_handler(config, "VDATA", data_horizontal_addr, reactor, association_table, responsible_relay_writer, responsible_relay_reader, rtps_discovery, crypto, data_vertical_reporter);
 
   HandlerStatisticsReporter spdp_horizontal_reporter(config, "HSPDP", handler_statistics_writer, relay_statistics_reporter);
+  spdp_horizontal_reporter.report();
   HorizontalHandler spdp_horizontal_handler(config, "HSPDP", reactor, spdp_horizontal_reporter);
   HandlerStatisticsReporter sedp_horizontal_reporter(config, "HSEDP", handler_statistics_writer, relay_statistics_reporter);
+  sedp_horizontal_reporter.report();
   HorizontalHandler sedp_horizontal_handler(config, "HSEDP", reactor, sedp_horizontal_reporter);
   HandlerStatisticsReporter data_horizontal_reporter(config, "HDATA", handler_statistics_writer, relay_statistics_reporter);
+  data_horizontal_reporter.report();
   HorizontalHandler data_horizontal_handler(config, "HDATA", reactor, data_horizontal_reporter);
 
   spdp_horizontal_handler.vertical_handler(&spdp_vertical_handler);
@@ -648,6 +655,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   DDS::DataReader_var participant_reader = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC);
   DomainStatisticsReporter domain_statistics_reporter(config, domain_statistics_writer);
+  domain_statistics_reporter.report();
 
   DDS::DataReaderListener_var participant_listener = new ParticipantListener(config,
                                                                              application_participant_impl,


### PR DESCRIPTION
Problem
-------

The RtpsRelay defers writing statistics until a new sample needs to be
written and sufficient time has elapsed for writing that sample.  This
means that relay instances will not write statistics samples until
there is traffic.

A load balancer for the RtpsRelay may wish to use these statistics.
If they are unavailable, the load balancer may incorrectly assume that
no instances exist.

This leads to a startup deadlock.

Solution
--------

Write statistics on startup.