### PR TITLE
RtpsRelay becomes non-responsive when mass disconnect

### DIFF
--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -15,6 +15,7 @@ ParticipantListener::ParticipantListener(const Config& config,
   , participant_(participant)
   , stats_reporter_(stats_reporter)
   , writer_(participant_writer)
+  , unregister_(OpenDDS::DCPS::make_rch<Unregister>(OpenDDS::DCPS::ref(*this)))
 {}
 
 void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
@@ -74,6 +75,20 @@ void ParticipantListener::write_sample(const DDS::ParticipantBuiltinTopicData& d
 void ParticipantListener::unregister_instance(const DDS::SampleInfo& info)
 {
   const auto repoid = participant_->get_repoid(info.instance_handle);
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+  unregister_queue_.push_back(repoid);
+}
+
+void ParticipantListener::unregister()
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  if (unregister_queue_.empty()) {
+    return;
+  }
+
+  const auto repoid = unregister_queue_.front();
+  unregister_queue_.pop_front();
   GUID_t guid;
   assign(guid, repoid);
 
@@ -81,12 +96,29 @@ void ParticipantListener::unregister_instance(const DDS::SampleInfo& info)
   entry.guid(guid);
 
   if (config_.log_discovery()) {
-    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::unregister_instance remove local participant %C\n"), guid_to_string(repoid).c_str()));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::unregister remove local participant %C\n"), guid_to_string(repoid).c_str()));
   }
   DDS::ReturnCode_t ret = writer_->unregister_instance(entry, DDS::HANDLE_NIL);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::unregister_instance failed to unregister_instance\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::unregister failed to unregister_instance\n")));
   }
+}
+
+ParticipantListener::Unregister::Unregister(ParticipantListener& listener)
+  : listener_(listener)
+  , unregister_task_(TheServiceParticipant->interceptor(), *this, &ParticipantListener::Unregister::execute)
+{
+  unregister_task_.enable(false, OpenDDS::DCPS::TimeDuration(1));
+}
+
+ParticipantListener::Unregister::~Unregister()
+{
+  unregister_task_.disable_and_wait();
+}
+
+void ParticipantListener::Unregister::execute(const OpenDDS::DCPS::MonotonicTimePoint&)
+{
+  listener_.unregister();
 }
 
 }

--- a/tools/rtpsrelay/ParticipantListener.h
+++ b/tools/rtpsrelay/ParticipantListener.h
@@ -5,6 +5,7 @@
 #include "DomainStatisticsReporter.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
+#include <dds/DCPS/PeriodicTask.h>
 
 namespace RtpsRelay {
 
@@ -14,16 +15,34 @@ public:
                       OpenDDS::DCPS::DomainParticipantImpl* participant,
                       DomainStatisticsReporter& stats_reporter,
                       ParticipantEntryDataWriter_var participant_writer);
+
 private:
   void on_data_available(DDS::DataReader_ptr reader) override;
   void write_sample(const DDS::ParticipantBuiltinTopicData& data,
                     const DDS::SampleInfo& info);
   void unregister_instance(const DDS::SampleInfo& info);
+  void unregister();
+
+  class Unregister : public OpenDDS::DCPS::RcObject {
+  public:
+    Unregister(ParticipantListener& listener);
+    ~Unregister();
+
+  private:
+    void execute(const OpenDDS::DCPS::MonotonicTimePoint& now);
+    typedef OpenDDS::DCPS::PmfPeriodicTask<Unregister> PeriodicTask;
+    ParticipantListener& listener_;
+    PeriodicTask unregister_task_;
+  };
 
   const Config& config_;
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   DomainStatisticsReporter& stats_reporter_;
   ParticipantEntryDataWriter_var writer_;
+  OpenDDS::DCPS::RcHandle<Unregister> unregister_;
+  ACE_Thread_Mutex mutex_;
+  std::list<OpenDDS::DCPS::GUID_t> unregister_queue_;
+  // mutex_
 };
 
 }

--- a/tools/rtpsrelay/PublicationListener.h
+++ b/tools/rtpsrelay/PublicationListener.h
@@ -6,6 +6,7 @@
 #include "DomainStatisticsReporter.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
+#include <dds/DCPS/PeriodicTask.h>
 
 namespace RtpsRelay {
 
@@ -20,11 +21,27 @@ private:
   void write_sample(const DDS::PublicationBuiltinTopicData& data,
                     const DDS::SampleInfo& info);
   void unregister_instance(const DDS::SampleInfo& info);
+  void unregister();
+
+  class Unregister : public OpenDDS::DCPS::RcObject {
+  public:
+    Unregister(PublicationListener& listener);
+    ~Unregister();
+
+  private:
+    void execute(const OpenDDS::DCPS::MonotonicTimePoint& now);
+    typedef OpenDDS::DCPS::PmfPeriodicTask<Unregister> PeriodicTask;
+    PublicationListener& listener_;
+    PeriodicTask unregister_task_;
+  };
 
   const Config& config_;
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   WriterEntryDataWriter_var writer_;
   DomainStatisticsReporter& stats_reporter_;
+  OpenDDS::DCPS::RcHandle<Unregister> unregister_;
+  ACE_Thread_Mutex mutex_;
+  std::list<OpenDDS::DCPS::GUID_t> unregister_queue_;
 };
 
 }

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -241,6 +241,12 @@ VerticalHandler::VerticalHandler(const Config& config,
 #endif
 {
   ACE_UNUSED_ARG(crypto);
+  this->reactor()->schedule_timer(this, 0, ACE_Time_Value(1), ACE_Time_Value(1));
+}
+
+VerticalHandler::~VerticalHandler()
+{
+  reactor()->cancel_timer(this);
 }
 
 void VerticalHandler::venqueue_message(const ACE_INET_Addr& addr,
@@ -676,20 +682,34 @@ void VerticalHandler::write_address(const OpenDDS::DCPS::RepoId& guid,
 }
 
 void VerticalHandler::unregister_address(const OpenDDS::DCPS::RepoId& guid,
-                                         const OpenDDS::DCPS::MonotonicTimePoint& now)
+                                         const OpenDDS::DCPS::MonotonicTimePoint&)
 {
+  unregister_queue_.push_back(guid);
+}
+
+int VerticalHandler::handle_timeout(const ACE_Time_Value& n, const void*)
+{
+  if (unregister_queue_.empty()) {
+    return 0;
+  }
+
+  const OpenDDS::DCPS::GUID_t guid = unregister_queue_.front();
+  unregister_queue_.pop_front();
   GuidNameAddress gna;
   assign(gna.guid(), guid);
   gna.name(name_);
 
   if (config_.log_activity()) {
-    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: VerticalHandler::unregister_address %C disclaiming %C\n"), name_.c_str(), guid_to_string(guid).c_str()));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: VerticalHandler::handle_timeout %C disclaiming %C\n"), name_.c_str(), guid_to_string(guid).c_str()));
   }
+  const OpenDDS::DCPS::MonotonicTimePoint now(n);
   stats_reporter_.disclaim(now);
   const auto ret = responsible_relay_writer_->unregister_instance(gna, DDS::HANDLE_NIL);
   if (ret != DDS::RETCODE_OK) {
-    HANDLER_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: VerticalHandler::unregister_address %C failed to unregister_instance for %C\n"), name_.c_str(), guid_to_string(guid).c_str()));
+    HANDLER_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: VerticalHandler::handle_timeout %C failed to unregister_instance for %C\n"), name_.c_str(), guid_to_string(guid).c_str()));
   }
+
+  return 0;
 }
 
 HorizontalHandler::HorizontalHandler(const Config& config,

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -97,6 +97,7 @@ public:
                   const CRYPTO_TYPE& crypto,
                   const ACE_INET_Addr& application_participant_addr,
                   HandlerStatisticsReporter& stats_reporter);
+  ~VerticalHandler();
 
   void horizontal_handler(HorizontalHandler* horizontal_handler) { horizontal_handler_ = horizontal_handler; }
 
@@ -171,9 +172,11 @@ private:
   ACE_INET_Addr read_address(const OpenDDS::DCPS::RepoId& guid, const OpenDDS::DCPS::MonotonicTimePoint& now) const;
   void write_address(const OpenDDS::DCPS::RepoId& guid, const OpenDDS::DCPS::MonotonicTimePoint& now);
   void unregister_address(const OpenDDS::DCPS::RepoId& guid, const OpenDDS::DCPS::MonotonicTimePoint& now);
+  int handle_timeout(const ACE_Time_Value& now, const void* act) override;
 
   const ACE_INET_Addr horizontal_address_;
   const std::string horizontal_address_str_;
+  std::list<OpenDDS::DCPS::GUID_t> unregister_queue_;
 
   OpenDDS::RTPS::RtpsDiscovery_rch rtps_discovery_;
 #ifdef OPENDDS_SECURITY

--- a/tools/rtpsrelay/SubscriptionListener.h
+++ b/tools/rtpsrelay/SubscriptionListener.h
@@ -6,6 +6,7 @@
 #include "DomainStatisticsReporter.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
+#include <dds/DCPS/PeriodicTask.h>
 
 namespace RtpsRelay {
 
@@ -20,11 +21,27 @@ private:
   void write_sample(const DDS::SubscriptionBuiltinTopicData& data,
                     const DDS::SampleInfo& info);
   void unregister_instance(const DDS::SampleInfo& info);
+  void unregister();
+
+  class Unregister : public OpenDDS::DCPS::RcObject {
+  public:
+    Unregister(SubscriptionListener& listener);
+    ~Unregister();
+
+  private:
+    void execute(const OpenDDS::DCPS::MonotonicTimePoint& now);
+    typedef OpenDDS::DCPS::PmfPeriodicTask<Unregister> PeriodicTask;
+    SubscriptionListener& listener_;
+    PeriodicTask unregister_task_;
+  };
 
   const Config& config_;
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   ReaderEntryDataWriter_var writer_;
   DomainStatisticsReporter& stats_reporter_;
+  OpenDDS::DCPS::RcHandle<Unregister> unregister_;
+  ACE_Thread_Mutex mutex_;
+  std::list<OpenDDS::DCPS::GUID_t> unregister_queue_;
 };
 
 }


### PR DESCRIPTION
Problem
-------

If all of the clients of the RtpsRelay go down at the same time and
they have the same lease duration, then they will timeout in the relay
at the same time.  Given enough clients, the number of unregister
dispose messages floods the network at make the relay instance
unresponsive.

Solution
--------

Distribute the unregisters in time by queuing them and processing them
with a periodic task.  The proposed solution can be improved in at
least three ways:

1. Eliminate redundant code.

2. Use a sporadic task.

3. Make the period configurable and/or come up with a better heuristic.