### PR TITLE
RtpsRelay gets overloaded when too many new clients

### DIFF
--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -12,6 +12,9 @@ public:
   Config()
     : application_participant_guid_(OpenDDS::DCPS::GUID_UNKNOWN)
     , lifespan_(60) // 1 minute
+    , pending_(1) // 1 second
+    , static_limit_(0)
+    , dynamic_limit_(0)
     , application_domain_(1)
     , log_entries_(false)
     , log_discovery_(false)
@@ -36,6 +39,36 @@ public:
   const OpenDDS::DCPS::TimeDuration& lifespan() const
   {
     return lifespan_;
+  }
+
+  void pending(const OpenDDS::DCPS::TimeDuration& value)
+  {
+    pending_ = value;
+  }
+
+  const OpenDDS::DCPS::TimeDuration& pending() const
+  {
+    return pending_;
+  }
+
+  void static_limit(size_t value)
+  {
+    static_limit_ = value;
+  }
+
+  size_t static_limit() const
+  {
+    return static_limit_;
+  }
+
+  void dynamic_limit(size_t value)
+  {
+    dynamic_limit_ = value;
+  }
+
+  size_t dynamic_limit() const
+  {
+    return dynamic_limit_;
   }
 
   void application_domain(DDS::DomainId_t value)
@@ -161,6 +194,9 @@ public:
 private:
   OpenDDS::DCPS::RepoId application_participant_guid_;
   OpenDDS::DCPS::TimeDuration lifespan_;
+  OpenDDS::DCPS::TimeDuration pending_;
+  size_t static_limit_;
+  size_t dynamic_limit_;
   DDS::DomainId_t application_domain_;
   bool log_entries_;
   bool log_discovery_;

--- a/tools/rtpsrelay/HandlerStatisticsReporter.h
+++ b/tools/rtpsrelay/HandlerStatisticsReporter.h
@@ -46,6 +46,17 @@ public:
     report(now);
   }
 
+  void ignored_message(size_t byte_count,
+                       const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    relay_statistics_reporter_.ignored_message(byte_count, now);
+    log_handler_statistics_.bytes_ignored() += byte_count;
+    ++log_handler_statistics_.messages_ignored();
+    publish_handler_statistics_.bytes_ignored() += byte_count;
+    ++publish_handler_statistics_.messages_ignored();
+    report(now);
+  }
+
   void output_message(size_t byte_count,
                       const OpenDDS::DCPS::TimeDuration& time,
                       const OpenDDS::DCPS::TimeDuration& queue_latency,
@@ -188,6 +199,8 @@ private:
 
     log_handler_statistics_.messages_in(0);
     log_handler_statistics_.bytes_in(0);
+    log_handler_statistics_.messages_ignored(0);
+    log_handler_statistics_.bytes_ignored(0);
     log_handler_statistics_.messages_out(0);
     log_handler_statistics_.bytes_out(0);
     log_handler_statistics_.messages_dropped(0);
@@ -232,6 +245,8 @@ private:
 
     publish_handler_statistics_.messages_in(0);
     publish_handler_statistics_.bytes_in(0);
+    publish_handler_statistics_.messages_ignored(0);
+    publish_handler_statistics_.bytes_ignored(0);
     publish_handler_statistics_.messages_out(0);
     publish_handler_statistics_.bytes_out(0);
     publish_handler_statistics_.messages_dropped(0);

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -130,6 +130,8 @@ protected:
   void process_message(const ACE_INET_Addr& remote,
                        const OpenDDS::DCPS::MonotonicTimePoint& now,
                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg) override;
+  bool ignore(const OpenDDS::DCPS::GUID_t& guid,
+              const OpenDDS::DCPS::MonotonicTimePoint& now);
   ParticipantStatisticsReporter& record_activity(const ACE_INET_Addr& remote_address,
                                                  const OpenDDS::DCPS::MonotonicTimePoint& now,
                                                  const OpenDDS::DCPS::RepoId& src_guid,
@@ -180,6 +182,7 @@ private:
   const DDS::Security::CryptoTransform_var crypto_;
   const DDS::Security::ParticipantCryptoHandle application_participant_crypto_handle_;
 #endif
+  std::list<OpenDDS::DCPS::MonotonicTimePoint> new_guids_;
 };
 
 // Sends to and receives from other relays.

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -39,6 +39,16 @@ public:
     report(now);
   }
 
+  void ignored_message(size_t byte_count,
+                     const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    log_relay_statistics_.bytes_ignored() += byte_count;
+    ++log_relay_statistics_.messages_ignored();
+    publish_relay_statistics_.bytes_ignored() += byte_count;
+    ++publish_relay_statistics_.messages_ignored();
+    report(now);
+  }
+
   void output_message(size_t byte_count,
                       const OpenDDS::DCPS::TimeDuration& time,
                       const OpenDDS::DCPS::TimeDuration& queue_latency,
@@ -164,6 +174,8 @@ private:
 
     log_relay_statistics_.messages_in(0);
     log_relay_statistics_.bytes_in(0);
+    log_relay_statistics_.messages_ignored(0);
+    log_relay_statistics_.bytes_ignored(0);
     log_relay_statistics_.messages_out(0);
     log_relay_statistics_.bytes_out(0);
     log_relay_statistics_.messages_dropped(0);
@@ -207,6 +219,8 @@ private:
 
     publish_relay_statistics_.messages_in(0);
     publish_relay_statistics_.bytes_in(0);
+    publish_relay_statistics_.messages_ignored(0);
+    publish_relay_statistics_.bytes_ignored(0);
     publish_relay_statistics_.messages_out(0);
     publish_relay_statistics_.bytes_out(0);
     publish_relay_statistics_.messages_dropped(0);

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -109,6 +109,15 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-Lifespan"))) {
       config.lifespan(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-Pending"))) {
+      config.pending(OpenDDS::DCPS::TimeDuration::from_msec(ACE_OS::atoi(arg)));
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-StaticLimit"))) {
+      config.static_limit(ACE_OS::atoi(arg));
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-DynamicLimit"))) {
+      config.dynamic_limit(ACE_OS::atoi(arg));
+      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-UserData"))) {
       user_data = arg;
       args.consume_arg();

--- a/tools/rtpsrelay/lib/Relay.idl
+++ b/tools/rtpsrelay/lib/Relay.idl
@@ -112,6 +112,8 @@ module RtpsRelay {
     Duration_t interval;
     unsigned long messages_in;
     unsigned long long bytes_in;
+    unsigned long messages_ignored;
+    unsigned long long bytes_ignored;
     Duration_t input_processing_time;
     unsigned long messages_out;
     unsigned long long bytes_out;
@@ -138,6 +140,8 @@ module RtpsRelay {
     Duration_t interval;
     unsigned long messages_in;
     unsigned long long bytes_in;
+    unsigned long messages_ignored;
+    unsigned long long bytes_ignored;
     Duration_t input_processing_time;
     unsigned long messages_out;
     unsigned long long bytes_out;


### PR DESCRIPTION
Problem
-------

A new relay client introduces overhead in its instance via discovery
and then distribution since the information about the new client must
be distributed to other relays.  The message required can easily flood
a network when too many new client arrive in a time interval.

Solution
--------

Implement admission control in the relay.  The relay will ignore
messages from new clients whenever 1) the total number of clients
meets or exceeds a static limit or 2) the total number of new clients
exceeds a dynamic limit.