### PR TITLE
Properly Detect XCDR1 in Combination with Appendable or Mutable

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,6 +50,7 @@ on:
       - '!**/.gitignore'
       - '!**/.lint_config'
       - '!**/README*'
+  workflow_dispatch:
 
 env:
   TRIGGERING_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/dds/DCPS/DCPS_Utils.cpp
+++ b/dds/DCPS/DCPS_Utils.cpp
@@ -359,7 +359,7 @@ compatibleQOS(const DDS::DataWriterQos * writerQos,
     DDS::DataRepresentationIdSeq readerIds =
       get_effective_data_rep_qos(readerQos->representation.value, true);
     DDS::DataRepresentationIdSeq writerIds =
-      get_effective_data_rep_qos(writerQos->representation.value);
+      get_effective_data_rep_qos(writerQos->representation.value, false);
     const CORBA::ULong reader_count = readerIds.length();
     const CORBA::ULong writer_count = writerIds.length();
     for (CORBA::ULong wi = 0; !found && wi < writer_count; ++wi) {

--- a/dds/DCPS/DCPS_Utils.h
+++ b/dds/DCPS/DCPS_Utils.h
@@ -100,7 +100,7 @@ OpenDDS_Dcps_Export
 bool repr_to_encoding_kind(DDS::DataRepresentationId_t repr, Encoding::Kind& kind);
 
 OpenDDS_Dcps_Export
-DDS::DataRepresentationIdSeq get_effective_data_rep_qos(const DDS::DataRepresentationIdSeq& qos, bool reader = false);
+DDS::DataRepresentationIdSeq get_effective_data_rep_qos(const DDS::DataRepresentationIdSeq& qos, bool reader);
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1326,7 +1326,7 @@ DataWriterImpl::enable()
     dp_id_ = participant->get_id();
   }
 
-  if (!topic_servant_->check_data_representation(get_effective_data_rep_qos(qos_.representation.value), true)) {
+  if (!topic_servant_->check_data_representation(get_effective_data_rep_qos(qos_.representation.value, false), true)) {
     if (DCPS_debug_level) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::enable: ")
         ACE_TEXT("none of the data representation QoS is allowed by the ")

--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -1522,22 +1522,16 @@ namespace OpenDDS {
           const XTypes::TypeIdentifier& writer_type_id = writer_type_info->minimal.typeid_with_size.type_id;
           const XTypes::TypeIdentifier& reader_type_id = reader_type_info->minimal.typeid_with_size.type_id;
           if (writer_type_id.kind() != XTypes::TK_NONE && reader_type_id.kind() != XTypes::TK_NONE) {
-            if (!writer_local || !reader_local) {
-              const DDS::DataRepresentationIdSeq repIds =
-                get_effective_data_rep_qos(writer_local ? tempDrQos.representation.value : tempDwQos.representation.value);
-              for (CORBA::ULong i = 0; i < repIds.length(); ++i) {
-                Encoding::Kind encoding_kind;
-                if (repr_to_encoding_kind(repIds[i], encoding_kind) && encoding_kind == Encoding::KIND_XCDR1) {
-                  const XTypes::TypeFlag extensibility_mask = XTypes::IS_APPENDABLE;
-
-                  if (type_lookup_service_->extensibility(extensibility_mask,
-                                                          writer_local ? reader_type_id : writer_type_id)) {
-                    if (OpenDDS::DCPS::DCPS_debug_level) {
-                      ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: ")
-                        ACE_TEXT("EndpointManager::match_continue: ")
-                        ACE_TEXT("Encountered unsupported combination of XCDR1 encoding and appendable extensibility\n")));
-                    }
-                  }
+            const DDS::DataRepresentationIdSeq repIds =
+              get_effective_data_rep_qos(tempDwQos.representation.value, false);
+            Encoding::Kind encoding_kind;
+            if (repr_to_encoding_kind(repIds[0], encoding_kind) && encoding_kind == Encoding::KIND_XCDR1) {
+              const XTypes::TypeFlag extensibility_mask = XTypes::IS_APPENDABLE;
+              if (type_lookup_service_->extensibility(extensibility_mask, writer_type_id)) {
+                if (OpenDDS::DCPS::DCPS_debug_level) {
+                  ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: ")
+                    ACE_TEXT("EndpointManager::match_continue: ")
+                    ACE_TEXT("Encountered unsupported combination of XCDR1 encoding and appendable extensibility\n")));
                 }
               }
             }


### PR DESCRIPTION
We were incorrectly detecting if XCDR1 was really being used or was just in the list of the QoS.  This PR changes to only use the writer QoS which should only have 1 item in it.