### PR TITLE
Remove PendingRemoteAuthTokenMap from Spdp

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -2460,11 +2460,6 @@ namespace OpenDDS {
       DDS::Subscriber_var bit_subscriber_;
       DDS::DomainParticipantQos qos_;
       DiscoveredParticipantMap participants_;
-
-#ifdef OPENDDS_SECURITY
-      PendingRemoteAuthTokenMap pending_remote_auth_tokens_;
-#endif
-
     };
 
     template<typename Participant>

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1030,7 +1030,7 @@ Spdp::handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg)
     return;
   }
 
-  pending_remote_auth_tokens_[guid] = msg.message_data[0];
+
   DiscoveredParticipantMap::iterator iter = participants_.find(guid);
 
   if (iter != participants_.end()) {
@@ -1041,6 +1041,8 @@ Spdp::handle_auth_request(const DDS::Security::ParticipantStatelessMessage& msg)
       }
       return;
     }
+
+    iter->second.remote_auth_request_token_ = msg.message_data[0];
     iter->second.auth_req_sequence_number_ = msg.message_identity.sequence_number;
 
     attempt_authentication(iter, false);
@@ -1176,14 +1178,6 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
 {
   const DCPS::RepoId& guid = iter->first;
   DiscoveredParticipant& dp = iter->second;
-
-  PendingRemoteAuthTokenMap::iterator token_iter = pending_remote_auth_tokens_.find(guid);
-  if (token_iter == pending_remote_auth_tokens_.end()) {
-    dp.remote_auth_request_token_ = DDS::Security::Token();
-  } else {
-    dp.remote_auth_request_token_ = token_iter->second;
-    pending_remote_auth_tokens_.erase(token_iter);
-  }
 
   if (DCPS::security_debug.auth_debug) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication "


### PR DESCRIPTION
- only track recvd AuthReq as an attribute of Discovered Participant
- requires discovery to happen "first" but both are resent periodically
- allows a reauthentication scenario to work when the Requester has
  expired the peer and should be sending it a new AuthReq