### PR TITLE
Update Sphinx to use Pygments 2.9.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ imagesize==1.2.0
 Jinja2==2.11.3
 MarkupSafe==1.1.1
 packaging==20.4
-Pygments==2.7.4
+Pygments==2.9.0
 pyparsing==2.4.7
 pytz==2020.1
 recommonmark==0.6.0


### PR DESCRIPTION
This is the Pygments release with OMG IDL support from https://github.com/pygments/pygments/pull/1595.