### PR TITLE
Memory Leak Fix: Security Attributes Test

### DIFF
--- a/tests/security/attributes/Writer.cpp
+++ b/tests/security/attributes/Writer.cpp
@@ -58,13 +58,18 @@ Writer::svc()
     ws->attach_condition(condition);
 
     DDS::Duration_t timeout =
-      { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+      { 5, DDS::DURATION_INFINITE_NSEC };
 
     DDS::ConditionSeq conditions;
     DDS::PublicationMatchedStatus matches = {0, 0, 0, 0, 0};
 
     do {
-      if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
+      DDS::ReturnCode_t ret = ws->wait(conditions, timeout);
+      if (ret == DDS::RETCODE_TIMEOUT) {
+        ACE_DEBUG((LM_DEBUG, ACE_TEXT("match timed out\n")));
+        return 0;
+      }
+      if (ret != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%N:%l: svc()")
                    ACE_TEXT(" ERROR: wait failed!\n")));

--- a/tests/security/attributes/Writer.h
+++ b/tests/security/attributes/Writer.h
@@ -10,6 +10,8 @@
 
 #include "Args.h"
 
+#include <dds/DCPS/GuardCondition.h>
+
 #include <dds/DdsDcpsPublicationC.h>
 
 #include <ace/Task.h>
@@ -32,6 +34,7 @@ private:
   DDS::DataWriter_var writer_;
   const Args args_;
   ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
+  DDS::GuardCondition_var guard_condition_;
 };
 
 #endif /* WRITER_H */

--- a/tests/security/attributes/publisher.cpp
+++ b/tests/security/attributes/publisher.cpp
@@ -204,6 +204,8 @@ int run_test(int argc, ACE_TCHAR *argv[], Args& my_args)
       }
 
       if (current_time >= deadline) {
+        writer->end();
+        delete writer;
         CLEAN_ERROR_RETURN((LM_WARNING,
                             ACE_TEXT("(%P|%t) %N:%l - WARNING: ")
                             ACE_TEXT("main() - timeout exceeded!\n")),


### PR DESCRIPTION
Problem: 

The security attributes test had a memory leak that occurs when the publisher/writer and subscriber/reader are never supposed to match.

Solution:  

I have added better handling for the timeout scenario in Writer.cpp to preempt the ending of the waitset and allow cleanup of the writer.  Currently the find match timeout is set to 5 seconds if a match doesn't happen. Considering we give most of the test scenarios 10 or 20 seconds, I think 5 seconds will work but am open to changing it. 

When this timeout occurs, I added additional cleanup to publisher.cpp which will properly clean up the writer before a CLEAN_ERROR_RETURN which then cleans everything else up.