### PR TITLE
RtpsUdpDataLink can't handle more than one unicast address

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1464,18 +1464,31 @@ RtpsUdpDataLink::RtpsWriter::add_gap_submsg_i(RTPS::SubmessageSeq& msg,
   msg[i].gap_sm(gap);
 }
 
+void RtpsUdpDataLink::update_last_recv_addr(const RepoId& src, const ACE_INET_Addr& addr)
+{
+  if (addr == config().rtps_relay_address()) {
+    return;
+  }
+
+  ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
+  const RemoteInfoMap::iterator pos = locators_.find(src);
+  if (pos != locators_.end()) {
+    pos->second.last_recv_addr_ = addr;
+    pos->second.last_recv_time_ = MonotonicTimePoint::now();
+  }
+}
 
 // DataReader's side of Reliability
 
 void
 RtpsUdpDataLink::received(const RTPS::DataSubmessage& data,
-                          const GuidPrefix_t& src_prefix)
+                          const GuidPrefix_t& src_prefix,
+                          const ACE_INET_Addr& remote_addr)
 {
   const RepoId local = make_id(local_prefix_, data.readerId);
+  const RepoId src = make_id(src_prefix, data.writerId);
 
-  RepoId src;
-  std::memcpy(src.guidPrefix, src_prefix, sizeof(GuidPrefix_t));
-  src.entityId = data.writerId;
+  update_last_recv_addr(src, remote_addr);
 
   OPENDDS_VECTOR(RtpsReader_rch) to_call;
   {
@@ -1672,8 +1685,10 @@ RtpsUdpDataLink::RtpsReader::process_data_i(const RTPS::DataSubmessage& data,
 void
 RtpsUdpDataLink::received(const RTPS::GapSubmessage& gap,
                           const GuidPrefix_t& src_prefix,
-                          bool directed)
+                          bool directed,
+                          const ACE_INET_Addr& remote_addr)
 {
+  update_last_recv_addr(make_id(src_prefix, gap.writerId), remote_addr);
   datareader_dispatch(gap, src_prefix, directed, &RtpsReader::process_gap_i);
 }
 
@@ -1785,10 +1800,13 @@ RtpsUdpDataLink::send_interesting_ack_nack(const RepoId& writerid,
 void
 RtpsUdpDataLink::received(const RTPS::HeartBeatSubmessage& heartbeat,
                           const GuidPrefix_t& src_prefix,
-                          bool directed)
+                          bool directed,
+                          const ACE_INET_Addr& remote_addr)
 {
   const RepoId src = make_id(src_prefix, heartbeat.writerId);
   const MonotonicTimePoint now = MonotonicTimePoint::now();
+
+  update_last_recv_addr(src, remote_addr);
 
   MetaSubmessageVec meta_submessages;
   OPENDDS_VECTOR(InterestingRemote) callbacks;
@@ -2764,8 +2782,10 @@ RtpsUdpDataLink::extend_bitmap_range(RTPS::FragmentNumberSet& fnSet,
 void
 RtpsUdpDataLink::received(const RTPS::HeartBeatFragSubmessage& hb_frag,
                           const GuidPrefix_t& src_prefix,
-                          bool directed)
+                          bool directed,
+                          const ACE_INET_Addr& remote_addr)
 {
+  update_last_recv_addr(make_id(src_prefix, hb_frag.writerId), remote_addr);
   datareader_dispatch(hb_frag, src_prefix, directed, &RtpsReader::process_heartbeat_frag_i);
 }
 
@@ -2824,12 +2844,15 @@ RtpsUdpDataLink::RtpsReader::process_heartbeat_frag_i(const RTPS::HeartBeatFragS
 
 void
 RtpsUdpDataLink::received(const RTPS::AckNackSubmessage& acknack,
-                          const GuidPrefix_t& src_prefix)
+                          const GuidPrefix_t& src_prefix,
+                          const ACE_INET_Addr& remote_addr)
 {
   // local side is DW
   const RepoId local = make_id(local_prefix_, acknack.writerId); // can't be ENTITYID_UNKNOWN
 
   const RepoId remote = make_id(src_prefix, acknack.readerId);
+
+  update_last_recv_addr(remote, remote_addr);
 
   const MonotonicTimePoint now = MonotonicTimePoint::now();
   OPENDDS_VECTOR(DiscoveryListener*) callbacks;
@@ -3163,8 +3186,10 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
 void
 RtpsUdpDataLink::received(const RTPS::NackFragSubmessage& nackfrag,
-                          const GuidPrefix_t& src_prefix)
+                          const GuidPrefix_t& src_prefix,
+                          const ACE_INET_Addr& remote_addr)
 {
+  update_last_recv_addr(make_id(src_prefix, nackfrag.readerId), remote_addr);
   datawriter_dispatch(nackfrag, src_prefix, &RtpsWriter::process_nackfrag);
 }
 
@@ -4301,15 +4326,22 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
 
   AddrSet normal_addrs;
   ACE_INET_Addr ice_addr;
+  bool valid_last_recv_addr = false;
   static const ACE_INET_Addr NO_ADDR;
 
   typedef OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan)::const_iterator iter_t;
   iter_t pos = locators_.find(remote);
   if (pos != locators_.end()) {
-    if (prefer_unicast && !pos->second.unicast_addrs_.empty()) {
+    if (prefer_unicast && pos->second.last_recv_addr_ != ACE_INET_Addr()) {
+      normal_addrs.insert(pos->second.last_recv_addr_);
+      valid_last_recv_addr = (MonotonicTimePoint::now() - pos->second.last_recv_time_) <= config().receive_address_duration_;
+    } else if (prefer_unicast && !pos->second.unicast_addrs_.empty()) {
       normal_addrs = pos->second.unicast_addrs_;
     } else if (!pos->second.multicast_addrs_.empty()) {
       normal_addrs = pos->second.multicast_addrs_;
+    } else if (pos->second.last_recv_addr_ != ACE_INET_Addr()) {
+      normal_addrs.insert(pos->second.last_recv_addr_);
+      valid_last_recv_addr = (MonotonicTimePoint::now() - pos->second.last_recv_time_) <= config().receive_address_duration_;
     } else {
       normal_addrs = pos->second.unicast_addrs_;
     }
@@ -4338,7 +4370,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   if (ice_addr == NO_ADDR) {
     addresses.insert(normal_addrs.begin(), normal_addrs.end());
     const ACE_INET_Addr relay_addr = config().rtps_relay_address();
-    if (relay_addr != NO_ADDR) {
+    if (!valid_last_recv_addr && relay_addr != NO_ADDR) {
       addresses.insert(relay_addr);
     }
     return;
@@ -4349,9 +4381,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
     return;
   }
 
-  if (!normal_addrs.empty()) {
-    addresses.insert(normal_addrs.begin(), normal_addrs.end());
-  }
+  addresses.insert(normal_addrs.begin(), normal_addrs.end());
 }
 
 ICE::Endpoint*

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -131,8 +131,8 @@ public:
   typedef OPENDDS_SET(ACE_INET_Addr) AddrSet;
 
   void add_locators(const RepoId& remote_id,
-                    const AddrSet& narrow_addresses,
-                    const AddrSet& wide_addresses,
+                    const AddrSet& unicast_addresses,
+                    const AddrSet& multicast_addresses,
                     bool requires_inline_qos);
 
   /// Given a 'local' id and a 'remote' id of a publication or
@@ -236,11 +236,11 @@ private:
   GuidPrefix_t local_prefix_;
 
   struct RemoteInfo {
-    RemoteInfo() : narrow_addrs_(), wide_addrs_(), requires_inline_qos_(false) {}
-    RemoteInfo(const AddrSet& narrow_addrs, const AddrSet& wide_addrs, bool iqos)
-      : narrow_addrs_(narrow_addrs), wide_addrs_(wide_addrs), requires_inline_qos_(iqos) {}
-    AddrSet narrow_addrs_;
-    AddrSet wide_addrs_;
+    RemoteInfo() : unicast_addrs_(), multicast_addrs_(), requires_inline_qos_(false) {}
+    RemoteInfo(const AddrSet& unicast_addrs, const AddrSet& multicast_addrs, bool iqos)
+      : unicast_addrs_(unicast_addrs), multicast_addrs_(multicast_addrs), requires_inline_qos_(iqos) {}
+    AddrSet unicast_addrs_;
+    AddrSet multicast_addrs_;
     bool requires_inline_qos_;
   };
 
@@ -812,7 +812,7 @@ private:
   DDS::Security::ParticipantCryptoHandle local_crypto_handle_;
 #endif
 
-  void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses, bool prefer_narrow = false) const;
+  void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses, bool prefer_unicast = false) const;
 
   struct ChangeMulticastGroup : public JobQueue::Job {
     enum CmgAction {CMG_JOIN, CMG_LEAVE};

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -106,25 +106,31 @@ public:
             );
 
   void received(const RTPS::DataSubmessage& data,
-                const GuidPrefix_t& src_prefix);
+                const GuidPrefix_t& src_prefix,
+                const ACE_INET_Addr& remote_addr);
 
   void received(const RTPS::GapSubmessage& gap,
                 const GuidPrefix_t& src_prefix,
-                bool directed);
+                bool directed,
+                const ACE_INET_Addr& remote_addr);
 
   void received(const RTPS::HeartBeatSubmessage& heartbeat,
                 const GuidPrefix_t& src_prefix,
-                bool directed);
+                bool directed,
+                const ACE_INET_Addr& remote_addr);
 
   void received(const RTPS::HeartBeatFragSubmessage& hb_frag,
                 const GuidPrefix_t& src_prefix,
-                bool directed);
+                bool directed,
+                const ACE_INET_Addr& remote_addr);
 
   void received(const RTPS::AckNackSubmessage& acknack,
-                const GuidPrefix_t& src_prefix);
+                const GuidPrefix_t& src_prefix,
+                const ACE_INET_Addr& remote_addr);
 
   void received(const RTPS::NackFragSubmessage& nackfrag,
-                const GuidPrefix_t& src_prefix);
+                const GuidPrefix_t& src_prefix,
+                const ACE_INET_Addr& remote_addr);
 
   const GuidPrefix_t& local_prefix() const { return local_prefix_; }
 
@@ -242,10 +248,14 @@ private:
     AddrSet unicast_addrs_;
     AddrSet multicast_addrs_;
     bool requires_inline_qos_;
+    ACE_INET_Addr last_recv_addr_;
+    MonotonicTimePoint last_recv_time_;
   };
 
   typedef OPENDDS_MAP_CMP(RepoId, RemoteInfo, GUID_tKeyLessThan) RemoteInfoMap;
   RemoteInfoMap locators_;
+
+  void update_last_recv_addr(const RepoId& src, const ACE_INET_Addr& addr);
 
   ACE_SOCK_Dgram unicast_socket_;
   ACE_SOCK_Dgram_Mcast multicast_socket_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -128,10 +128,12 @@ public:
 
   const GuidPrefix_t& local_prefix() const { return local_prefix_; }
 
-  void add_locators(const RepoId& remote_id, const ACE_INET_Addr& narrow_address,
-                    const ACE_INET_Addr& wide_address, bool requires_inline_qos);
-
   typedef OPENDDS_SET(ACE_INET_Addr) AddrSet;
+
+  void add_locators(const RepoId& remote_id,
+                    const AddrSet& narrow_addresses,
+                    const AddrSet& wide_addresses,
+                    bool requires_inline_qos);
 
   /// Given a 'local' id and a 'remote' id of a publication or
   /// subscription, return the set of addresses of the remote peers.
@@ -158,7 +160,7 @@ public:
 
   void register_for_reader(const RepoId& writerid,
                            const RepoId& readerid,
-                           const ACE_INET_Addr& address,
+                           const AddrSet& addresses,
                            DiscoveryListener* listener);
 
   void unregister_for_reader(const RepoId& writerid,
@@ -166,7 +168,7 @@ public:
 
   void register_for_writer(const RepoId& readerid,
                            const RepoId& writerid,
-                           const ACE_INET_Addr& address,
+                           const AddrSet& addresses,
                            DiscoveryListener* listener);
 
   void unregister_for_writer(const RepoId& readerid,
@@ -234,11 +236,11 @@ private:
   GuidPrefix_t local_prefix_;
 
   struct RemoteInfo {
-    RemoteInfo() : narrow_addr_(), wide_addr_(), requires_inline_qos_(false) {}
-    RemoteInfo(const ACE_INET_Addr& narrow_addr, const ACE_INET_Addr& wide_addr, bool iqos)
-      : narrow_addr_(narrow_addr), wide_addr_(wide_addr), requires_inline_qos_(iqos) {}
-    ACE_INET_Addr narrow_addr_;
-    ACE_INET_Addr wide_addr_;
+    RemoteInfo() : narrow_addrs_(), wide_addrs_(), requires_inline_qos_(false) {}
+    RemoteInfo(const AddrSet& narrow_addrs, const AddrSet& wide_addrs, bool iqos)
+      : narrow_addrs_(narrow_addrs), wide_addrs_(wide_addrs), requires_inline_qos_(iqos) {}
+    AddrSet narrow_addrs_;
+    AddrSet wide_addrs_;
     bool requires_inline_qos_;
   };
 
@@ -745,8 +747,8 @@ private:
   struct InterestingRemote {
     /// id of local entity that is interested in this remote.
     RepoId localid;
-    /// address of this entity
-    ACE_INET_Addr address;
+    /// addresses of this entity
+    AddrSet addresses;
     /// Callback to invoke.
     DiscoveryListener* listener;
     /**
@@ -758,9 +760,9 @@ private:
     enum { DOES_NOT_EXIST, EXISTS } status;
 
     InterestingRemote() { }
-    InterestingRemote(const RepoId& w, const ACE_INET_Addr& a, DiscoveryListener* l)
+    InterestingRemote(const RepoId& w, const AddrSet& a, DiscoveryListener* l)
       : localid(w)
-      , address(a)
+      , addresses(a)
       , listener(l)
       , status(DOES_NOT_EXIST)
     { }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -39,6 +39,7 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , heartbeat_period_(1) // no default in RTPS spec
   , heartbeat_response_delay_(0, 500*1000 /*microseconds*/) // default from RTPS
   , durable_data_timeout_(60)
+  , receive_address_duration_(5)
   , responsive_mode_(false)
   , send_delay_(0, 10 * 1000)
   , opendds_discovery_guid_(GUID_UNKNOWN)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -42,6 +42,7 @@ public:
   TimeDuration heartbeat_period_;
   TimeDuration heartbeat_response_delay_;
   TimeDuration durable_data_timeout_;
+  TimeDuration receive_address_duration_;
   bool responsive_mode_;
   TimeDuration send_delay_;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -98,7 +98,8 @@ private:
   virtual void finish_message();
 
   void deliver_sample_i(ReceivedDataSample& sample,
-                        const RTPS::Submessage& submessage);
+                        const RTPS::Submessage& submessage,
+                        const ACE_INET_Addr& remote_addr);
 
   virtual int start_i();
   virtual void stop_i();
@@ -114,7 +115,8 @@ private:
   void sec_submsg_to_octets(DDS::OctetSeq& encoded,
                             const RTPS::Submessage& postfix);
 
-  void deliver_from_secure(const RTPS::Submessage& submessage);
+  void deliver_from_secure(const RTPS::Submessage& submessage,
+                           const ACE_INET_Addr& remote_addr);
 
   bool decode_payload(ReceivedDataSample& sample,
                       const RTPS::DataSubmessage& submessage);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -289,8 +289,8 @@ RtpsUdpTransport::use_datalink(const RepoId& local_id,
 {
   bool requires_inline_qos;
   unsigned int blob_bytes_read;
-  std::pair<ACE_INET_Addr, ACE_INET_Addr> addrs = get_connection_addrs(remote_data, &requires_inline_qos,
-                                                                       &blob_bytes_read);
+  std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet> addrs =
+    get_connection_addrs(remote_data, &requires_inline_qos, &blob_bytes_read);
 
   if (link_) {
     link_->add_locators(remote_id, addrs.first, addrs.second, requires_inline_qos);
@@ -302,7 +302,7 @@ RtpsUdpTransport::use_datalink(const RepoId& local_id,
   return true;
 }
 
-std::pair<ACE_INET_Addr, ACE_INET_Addr>
+std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet>
 RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
                                        bool* requires_inline_qos,
                                        unsigned int* blob_bytes_read) const
@@ -312,43 +312,26 @@ RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
   DDS::ReturnCode_t result =
     blob_to_locators(remote, locators, requires_inline_qos, blob_bytes_read);
   if (result != DDS::RETCODE_OK) {
-    return std::make_pair(ACE_INET_Addr(), ACE_INET_Addr());
+    return std::make_pair(RtpsUdpDataLink::AddrSet(), RtpsUdpDataLink::AddrSet());
   }
 
-  ACE_INET_Addr uc_addr;
-  ACE_INET_Addr mc_addr;
-  bool uc_addr_valid = false;
-  bool mc_addr_valid = false;
+  RtpsUdpDataLink::AddrSet uc_addrs;
+  RtpsUdpDataLink::AddrSet mc_addrs;
   for (CORBA::ULong i = 0; i < locators.length(); ++i) {
     ACE_INET_Addr addr;
     // If conversion was successful
     if (locator_to_address(addr, locators[i], false) == 0) {
       if (addr.is_multicast()) {
-        if (mc_addr == ACE_INET_Addr()) {
-          mc_addr = addr;
-          mc_addr_valid = true;
+        if (config().use_multicast_) {
+          mc_addrs.insert(addr);
         }
       } else {
-        if (uc_addr == ACE_INET_Addr()) {
-          uc_addr = addr;
-          uc_addr_valid = true;
-        }
-      }
-      if (uc_addr_valid && (!config().use_multicast_ || mc_addr_valid)) {
-        return std::make_pair(uc_addr, config().use_multicast_ ? mc_addr : uc_addr);
+        uc_addrs.insert(addr);
       }
     }
   }
 
-  // If we didn't return early, something was 'missing'
-  if (uc_addr == ACE_INET_Addr() && !(mc_addr == ACE_INET_Addr())) {
-    uc_addr = mc_addr;
-  }
-  if (mc_addr == ACE_INET_Addr() && !(uc_addr == ACE_INET_Addr())) {
-    mc_addr = uc_addr;
-  }
-
-  return std::make_pair(uc_addr, config().use_multicast_ ? mc_addr : uc_addr);
+  return std::make_pair(uc_addrs, mc_addrs);
 }
 
 bool
@@ -376,7 +359,7 @@ RtpsUdpTransport::register_for_reader(const RepoId& participant,
     link_ = make_datalink(participant.guidPrefix);
   }
 
-  link_->register_for_reader(writerid, readerid, get_connection_addrs(*blob).second,
+  link_->register_for_reader(writerid, readerid, get_connection_addrs(*blob).first,
                              listener);
 }
 
@@ -436,8 +419,8 @@ RtpsUdpTransport::update_locators(const RepoId& remote,
   if (link_) {
     bool requires_inline_qos;
     unsigned int blob_bytes_read;
-    std::pair<ACE_INET_Addr, ACE_INET_Addr> addrs = get_connection_addrs(*blob, &requires_inline_qos,
-                                                                         &blob_bytes_read);
+    std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet> addrs =
+      get_connection_addrs(*blob, &requires_inline_qos, &blob_bytes_read);
     link_->add_locators(remote, addrs.first, addrs.second, requires_inline_qos);
   }
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -87,9 +87,10 @@ private:
                                      const RepoId& /*writerid*/);
 
   virtual bool connection_info_i(TransportLocator& info, ConnectionInfoFlags flags) const;
-  std::pair<ACE_INET_Addr, ACE_INET_Addr> get_connection_addrs(const TransportBLOB& data,
-                                                               bool* requires_inline_qos = 0,
-                                                               unsigned int* blob_bytes_read = 0) const;
+  std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet>
+    get_connection_addrs(const TransportBLOB& data,
+                         bool* requires_inline_qos = 0,
+                         unsigned int* blob_bytes_read = 0) const;
 
   virtual void release_datalink(DataLink* link);
 


### PR DESCRIPTION
Problem
-------

A participant A with multiple IP addresses may advertise all of them
in the locators of SPDP and SEDP.  The RtpsUdpDataLink of a peer B
will pick the first of each type, unicast and multicast, to determine
the addresses of entities in A.  Thus, participant B may use the wrong
address and fail to communicate with A.

Solution
--------

Use all of the unicast addresses.

Notes
-----

* ICE is useful in these situations as it will determine the correct
  address to use.

* When security is enabled, ICE will not start until secure discovery
  is complete meaning authentication and key exchange may fail without
  this feature.