### PR TITLE
RtpsRelay logs too many warnings

### DIFF
--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -15,6 +15,7 @@ public:
     , static_limit_(0)
     , max_pending_(0)
     , application_domain_(1)
+    , log_warnings_(false)
     , log_entries_(false)
     , log_discovery_(false)
     , log_activity_(false)
@@ -68,6 +69,16 @@ public:
   DDS::DomainId_t application_domain() const
   {
     return application_domain_;
+  }
+
+  void log_warnings(bool flag)
+  {
+    log_warnings_ = flag;
+  }
+
+  bool log_warnings() const
+  {
+    return log_warnings_;
   }
 
   void log_entries(bool flag)
@@ -186,6 +197,7 @@ private:
   size_t static_limit_;
   size_t max_pending_;
   DDS::DomainId_t application_domain_;
+  bool log_warnings_;
   bool log_entries_;
   bool log_discovery_;
   bool log_activity_;

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -121,6 +121,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-UserData"))) {
       user_data = arg;
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-LogWarnings"))) {
+      config.log_warnings(ACE_OS::atoi(arg));
+      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-LogEntries"))) {
       config.log_entries(ACE_OS::atoi(arg));
       args.consume_arg();


### PR DESCRIPTION
Problem
-------

Due to the way security + association is implemented, the RtpsRelay
often receives messages that is cannot decrypt or verify.  This
creates noise in the log.

Solution
--------

Don't log these warnings by default and provide an option to turn them
on.