### PR TITLE
handle unknown entityid in sedp.cpp

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4472,10 +4472,8 @@ Sedp::Reader::data_received(const DCPS::ReceivedDataSample& sample)
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::Reader::data_received: "
           "entity id extensibility error over %C: both is_final and is_mutable are %d\n",
           to_string(entity_id).c_str(), is_mutable));
-        break;
-      } else {
-        return;
       }
+      break;
     }
     const DCPS::Extensibility extensibility =
       is_mutable ? DCPS::MUTABLE : DCPS::FINAL;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4468,10 +4468,14 @@ Sedp::Reader::data_received(const DCPS::ReceivedDataSample& sample)
 #endif
       false;
     if (is_mutable == is_final) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::Reader::data_received: "
-        "entity id extensibility error over %C: both is_final and is_mutable are %d\n",
-        to_string(entity_id).c_str(), is_mutable));
-      break;
+      if (is_mutable) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::Reader::data_received: "
+          "entity id extensibility error over %C: both is_final and is_mutable are %d\n",
+          to_string(entity_id).c_str(), is_mutable));
+        break;
+      } else {
+        return;
+      }
     }
     const DCPS::Extensibility extensibility =
       is_mutable ? DCPS::MUTABLE : DCPS::FINAL;


### PR DESCRIPTION
Previously we were erroring if both is_final and is_mutable were false.  instead we should silently return, and only error if both are true.