### PR TITLE
Improved keyword and escape handling in TypeSupport code generation

### DIFF
--- a/dds/idl/dds_generator.cpp
+++ b/dds/idl/dds_generator.cpp
@@ -77,6 +77,7 @@ string dds_generator::to_string(Identifier* id, EscapeContext ec)
     }
     break;
   case EscapeContext_FromGenIdl:
+  case EscapeContext_StripEscapes:
     if (id->escaped() && cxx_escaped(str)) {
       // If this is a C++ keyword that was inserted into generated IDL, the
       // "_cxx_" was stripped.

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -36,6 +36,8 @@ enum EscapeContext {
   EscapeContext_ForGenIdl,
   /// This is for a name coming from generated IDL. (Like *TypeSupportC.h)
   EscapeContext_FromGenIdl,
+  /// Strip any escapes
+  EscapeContext_StripEscapes,
   /// This is for everything else.
   EscapeContext_Normal,
 };

--- a/dds/idl/ts_generator.cpp
+++ b/dds/idl/ts_generator.cpp
@@ -153,7 +153,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
     ScopedNamespaceGuard hGuard(name, be_global->header_);
 
     be_global->header_ <<
-      "class " << short_name << "TypeSupportImpl;\n";
+      "class " << ts_short_name << "TypeSupportImpl;\n";
   }
   be_global->header_ << be_global->versioning_end() << "\n";
 
@@ -166,7 +166,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
     "  typedef " << cxxName << " MessageType;\n"
     "  typedef " << ts_name << "Seq MessageSequenceType;\n"
     "  typedef " << ts_name << "TypeSupport TypeSupportType;\n"
-    "  typedef " << cxxName << "TypeSupportImpl TypeSupportTypeImpl;\n"
+    "  typedef " << ts_name << "TypeSupportImpl TypeSupportTypeImpl;\n"
     "  typedef " << ts_name << "DataWriter DataWriterType;\n"
     "  typedef " << ts_name << "DataReader DataReaderType;\n"
     "  typedef " << cxxName << "_OpenDDS_KeyLessThan LessThanType;\n"
@@ -185,7 +185,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
     ScopedNamespaceGuard hGuard(name, be_global->header_);
 
     be_global->header_ <<
-      "class " << be_global->export_macro() << " " << short_name << "TypeSupportImpl\n"
+      "class " << be_global->export_macro() << " " << ts_short_name << "TypeSupportImpl\n"
       "  : public virtual OpenDDS::DCPS::LocalObject<" << ts_short_name << "TypeSupport>\n"
       "  , public virtual OpenDDS::DCPS::TypeSupportImpl\n"
       "{\n"
@@ -196,8 +196,8 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
       "  typedef " << ts_short_name << "TypeSupport::_var_type _var_type;\n"
       "  typedef " << ts_short_name << "TypeSupport::_ptr_type _ptr_type;\n"
       "\n"
-      "  " << short_name << "TypeSupportImpl() {}\n"
-      "  virtual ~" << short_name << "TypeSupportImpl() {}\n"
+      "  " << ts_short_name << "TypeSupportImpl() {}\n"
+      "  virtual ~" << ts_short_name << "TypeSupportImpl() {}\n"
       "\n"
       "  virtual " << be_global->versioning_name() << "::DDS::DataWriter_ptr create_datawriter();\n"
       "  virtual " << be_global->versioning_name() << "::DDS::DataReader_ptr create_datareader();\n"
@@ -226,7 +226,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
   {
     ScopedNamespaceGuard cppGuard(name, be_global->impl_);
     be_global->impl_ <<
-      "::DDS::DataWriter_ptr " << short_name << "TypeSupportImpl::create_datawriter()\n"
+      "::DDS::DataWriter_ptr " << ts_short_name << "TypeSupportImpl::create_datawriter()\n"
       "{\n"
       "  typedef OpenDDS::DCPS::DataWriterImpl_T<" << short_name << "> DataWriterImplType;\n"
       "  ::DDS::DataWriter_ptr writer_impl = ::DDS::DataWriter::_nil();\n"
@@ -234,7 +234,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
       "                   DataWriterImplType());\n"
       "  return writer_impl;\n"
       "}\n\n"
-      "::DDS::DataReader_ptr " << short_name << "TypeSupportImpl::create_datareader()\n"
+      "::DDS::DataReader_ptr " << ts_short_name << "TypeSupportImpl::create_datareader()\n"
       "{\n"
       "  typedef OpenDDS::DCPS::DataReaderImpl_T<" << short_name << "> DataReaderImplType;\n"
       "  ::DDS::DataReader_ptr reader_impl = ::DDS::DataReader::_nil();\n"
@@ -243,7 +243,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
       "  return reader_impl;\n"
       "}\n\n"
       "#ifndef OPENDDS_NO_MULTI_TOPIC\n"
-      "::DDS::DataReader_ptr " << short_name << "TypeSupportImpl::create_multitopic_datareader()\n"
+      "::DDS::DataReader_ptr " << ts_short_name << "TypeSupportImpl::create_multitopic_datareader()\n"
       "{\n"
       "  typedef OpenDDS::DCPS::DataReaderImpl_T<" << short_name << "> DataReaderImplType;\n"
       "  typedef OpenDDS::DCPS::MultiTopicDataReader_T<" << short_name << ", DataReaderImplType> MultiTopicDataReaderImplType;\n"
@@ -254,39 +254,39 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
       "}\n"
       "#endif /* !OPENDDS_NO_MULTI_TOPIC */\n\n"
       "#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE\n"
-      "const OpenDDS::DCPS::MetaStruct& " << short_name << "TypeSupportImpl::getMetaStructForType()\n"
+      "const OpenDDS::DCPS::MetaStruct& " << ts_short_name << "TypeSupportImpl::getMetaStructForType()\n"
       "{\n"
       "  return OpenDDS::DCPS::getMetaStruct<" << short_name << ">();\n"
       "}\n"
       "#endif /* !OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE */\n\n"
-      "bool " << short_name << "TypeSupportImpl::has_dcps_key()\n"
+      "bool " << ts_short_name << "TypeSupportImpl::has_dcps_key()\n"
       "{\n"
       "  return TraitsType::gen_has_key();\n"
       "}\n\n"
-      "const char* " << short_name << "TypeSupportImpl::default_type_name() const\n"
+      "const char* " << ts_short_name << "TypeSupportImpl::default_type_name() const\n"
       "{\n"
       "  return TraitsType::type_name();\n"
       "}\n"
       "\n"
-      "void " << short_name << "TypeSupportImpl::representations_allowed_by_type(\n"
+      "void " << ts_short_name << "TypeSupportImpl::representations_allowed_by_type(\n"
       "  ::DDS::DataRepresentationIdSeq& seq)\n"
       "{\n"
       "  MarshalTraitsType::representations_allowed_by_type(seq);\n"
       "}\n"
       "\n"
-      "const OpenDDS::XTypes::TypeIdentifier& " << short_name << "TypeSupportImpl::getMinimalTypeIdentifier() const\n"
+      "const OpenDDS::XTypes::TypeIdentifier& " << ts_short_name << "TypeSupportImpl::getMinimalTypeIdentifier() const\n"
       "{\n"
       "  return OpenDDS::DCPS::getMinimalTypeIdentifier<OpenDDS::DCPS::" << typeobject_generator::tag_type(name) << ">();\n"
       "}\n\n"
-      "const OpenDDS::XTypes::TypeMap& " << short_name << "TypeSupportImpl::getMinimalTypeMap() const\n"
+      "const OpenDDS::XTypes::TypeMap& " << ts_short_name << "TypeSupportImpl::getMinimalTypeMap() const\n"
       "{\n"
       "  return OpenDDS::DCPS::getMinimalTypeMap<OpenDDS::DCPS::" << typeobject_generator::tag_type(name) << ">();\n"
       "}\n\n"
-      "OpenDDS::DCPS::Extensibility " << short_name << "TypeSupportImpl::getExtensibility() const\n"
+      "OpenDDS::DCPS::Extensibility " << ts_short_name << "TypeSupportImpl::getExtensibility() const\n"
       "{\n"
       "  return MarshalTraitsType::extensibility();\n"
       "}\n\n"
-      << ts_short_name << "TypeSupport::_ptr_type " << short_name << "TypeSupportImpl::_narrow(CORBA::Object_ptr obj)\n"
+      << ts_short_name << "TypeSupport::_ptr_type " << ts_short_name << "TypeSupportImpl::_narrow(CORBA::Object_ptr obj)\n"
       "{\n"
       "  return TypeSupportType::_narrow(obj);\n"
       "}\n";

--- a/dds/idl/ts_generator.cpp
+++ b/dds/idl/ts_generator.cpp
@@ -157,6 +157,8 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
   }
   be_global->header_ << be_global->versioning_end() << "\n";
 
+  const std::string unescaped_name =
+    dds_generator::scoped_helper(name, "::", EscapeContext_StripEscapes);
   be_global->header_ <<
     "OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL\n"
     "namespace OpenDDS {\n"
@@ -172,7 +174,7 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
     "  typedef " << cxxName << "_OpenDDS_KeyLessThan LessThanType;\n"
     "  typedef OpenDDS::DCPS::KeyOnly<const " << cxxName << "> KeyOnlyType;\n"
     "\n"
-    "  static const char* type_name() { return \"" << replacements["SCOPED_NOT_GLOBAL"] << "\"; }\n"
+    "  static const char* type_name() { return \"" << unescaped_name << "\"; }\n"
     "  static bool gen_has_key() { return " << (key_count ? "true" : "false") << "; }\n"
     "  static size_t key_count() { return " << key_count << "; }\n"
     "};\n"

--- a/tests/DCPS/Compiler/keywords/classic/keywords_classic.mpc
+++ b/tests/DCPS/Compiler/keywords/classic/keywords_classic.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, msvc_bigobj {
+project: dcps_test, googletest, msvc_bigobj {
   exename = keywords-classic
   includes += .
   macros += CPP11_MAPPING=0

--- a/tests/DCPS/Compiler/keywords/cpp11/keywords_cpp11.mpc
+++ b/tests/DCPS/Compiler/keywords/cpp11/keywords_cpp11.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, opendds_cxx11, msvc_bigobj {
+project: dcps_test, opendds_cxx11, googletest, msvc_bigobj {
   exename = keywords-cpp11
   includes += .
   macros += CPP11_MAPPING=1

--- a/tests/DCPS/Compiler/keywords/main.cpp
+++ b/tests/DCPS/Compiler/keywords/main.cpp
@@ -1,12 +1,14 @@
 #include <testTypeSupportImpl.h>
 
+#include <gtest/gtest.h>
+
 #if CPP11_MAPPING
 #  define REF(WHAT) (WHAT)()
 #else
 #  define REF(WHAT) (WHAT)
 #endif
 
-int ACE_TMAIN(int, ACE_TCHAR**)
+TEST(EscapedNonKeywords, struct_topic_type)
 {
   the_module::the_struct a;
   REF(a.the_field) = the_module::the_const;
@@ -14,49 +16,96 @@ int ACE_TMAIN(int, ACE_TCHAR**)
   the_module::the_structDataWriter* a_dw = 0;
   ACE_UNUSED_ARG(a_dw);
 
+  the_module::the_structTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "the_module::the_struct");
+}
+
+TEST(EscapedNonKeywords, union_topic_type)
+{
   the_module::the_union au;
   au.the_field(the_module::the_const);
   ACE_UNUSED_ARG(au);
   the_module::the_unionDataWriter* au_dw = 0;
   ACE_UNUSED_ARG(au_dw);
 
+  the_module::the_unionTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "the_module::the_union");
+}
+
+TEST(IdlKeywords, struct_topic_type)
+{
   boolean::attribute b;
   REF(b.component) = boolean::oneway;
   ACE_UNUSED_ARG(b);
   boolean::attributeDataWriter* b_dw = 0;
   ACE_UNUSED_ARG(b_dw);
 
+  boolean::attributeTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "boolean::attribute");
+}
+
+TEST(IdlKeywords, union_topic_type)
+{
   boolean::primarykey bu;
   bu.truncatable(boolean::oneway);
   ACE_UNUSED_ARG(bu);
   boolean::primarykeyDataWriter* bu_dw = 0;
   ACE_UNUSED_ARG(bu_dw);
 
+  boolean::primarykeyTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "boolean::primarykey");
+}
+
+TEST(CppKeywords, struct_topic_type)
+{
   _cxx_bool::_cxx_class c;
   REF(c._cxx_else) = _cxx_bool::_cxx_continue;
   ACE_UNUSED_ARG(c);
   _cxx_bool::classDataWriter* c_dw = 0;
   ACE_UNUSED_ARG(c_dw);
 
+  _cxx_bool::classTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "bool::class");
+}
+
+TEST(CppKeywords, union_topic_type)
+{
   _cxx_bool::_cxx_goto cu;
   cu._cxx_asm(_cxx_bool::_cxx_continue);
   ACE_UNUSED_ARG(cu);
   _cxx_bool::gotoDataWriter* cu_dw = 0;
   ACE_UNUSED_ARG(cu_dw);
 
+  _cxx_bool::gotoTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "bool::goto");
+}
+
+TEST(DoubleKeywords, struct_topic_type)
+{
   _cxx_case::_cxx_struct d;
-  REF(d._cxx_union) = _cxx_case::_cxx_typeid;
+  REF(d._cxx_private) = _cxx_case::_cxx_typeid;
   ACE_UNUSED_ARG(d);
   _cxx_case::structDataWriter* d_dw = 0;
   ACE_UNUSED_ARG(d_dw);
 
-  _cxx_case::_cxx_private du;
+  _cxx_case::structTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "case::struct");
+}
+
+TEST(DoubleKeywords, union_topic_type)
+{
+  _cxx_case::_cxx_union du;
   du._cxx_public(_cxx_case::_cxx_typeid);
   ACE_UNUSED_ARG(du);
-  _cxx_case::privateDataWriter* du_dw = 0;
+  _cxx_case::unionDataWriter* du_dw = 0;
   ACE_UNUSED_ARG(du_dw);
-  _cxx_case::privateTypeSupportImpl* du_tsi = 0;
-  ACE_UNUSED_ARG(du_tsi);
 
-  return 0;
+  _cxx_case::unionTypeSupportImpl ts;
+  EXPECT_STREQ(ts.default_type_name(), "case::union");
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/tests/DCPS/Compiler/keywords/main.cpp
+++ b/tests/DCPS/Compiler/keywords/main.cpp
@@ -55,6 +55,8 @@ int ACE_TMAIN(int, ACE_TCHAR**)
   ACE_UNUSED_ARG(du);
   _cxx_case::privateDataWriter* du_dw = 0;
   ACE_UNUSED_ARG(du_dw);
+  _cxx_case::privateTypeSupportImpl* du_tsi = 0;
+  ACE_UNUSED_ARG(du_tsi);
 
   return 0;
 }

--- a/tests/DCPS/Compiler/keywords/run_test.pl
+++ b/tests/DCPS/Compiler/keywords/run_test.pl
@@ -11,7 +11,6 @@ use PerlDDS::Run_Test;
 
 my $kind = $ARGV[0];
 my $path = "$kind/keywords-$kind";
-die("ERROR: Invalid argument. Pass classic or cpp11.") if (!-f $path);
 
 my $test = new PerlDDS::TestFramework();
 $test->process('test', $path);

--- a/tests/DCPS/Compiler/keywords/run_test.pl
+++ b/tests/DCPS/Compiler/keywords/run_test.pl
@@ -1,0 +1,19 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+use strict;
+use warnings;
+
+use lib "$ENV{ACE_ROOT}/bin";
+use lib "$ENV{DDS_ROOT}/bin";
+use PerlDDS::Run_Test;
+
+my $kind = $ARGV[0];
+my $path = "$kind/keywords-$kind";
+die("ERROR: Invalid argument. Pass classic or cpp11.") if (!-f $path);
+
+my $test = new PerlDDS::TestFramework();
+$test->process('test', $path);
+$test->start_process('test');
+exit $test->finish(5) ? 1 : 0;

--- a/tests/DCPS/Compiler/keywords/test.idl
+++ b/tests/DCPS/Compiler/keywords/test.idl
@@ -60,12 +60,12 @@ module _case {
   struct _struct;
   @topic
   struct _struct {
-    @key long _union;
+    @key long _private;
   };
 
-  union _private;
+  union _union;
   @topic
-  union _private switch (@key long) {
+  union _union switch (@key long) {
     case 2: short _public;
   };
 };

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -72,6 +72,8 @@ tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Compiler/xcdr/run_test.pl
 tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN
+tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN
+tests/DCPS/Compiler/keywords/run_test.pl cpp11: !DCPS_MIN CXX11
 
 tests/DCPS/C++11/Messenger/run_test.pl: !DCPS_MIN CXX11 !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 


### PR DESCRIPTION
…ause short_name is the escaped C++ name

    * dds/idl/ts_generator.cpp:
