### PR TITLE
GHA Remove send_graceful_disconnect_message Suppression From ASAN Job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2451,7 +2451,6 @@ jobs:
         </autobuild>
         EOF
         echo "leak:getaddrinfo" >> $GITHUB_WORKSPACE/OpenDDS/suppr.txt
-        echo "leak:send_graceful_disconnect_message" >> $GITHUB_WORKSPACE/OpenDDS/suppr.txt
         export LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/OpenDDS/suppr.txt
         export ASAN_OPTIONS=detect_leaks=1:fast_unwind_on_malloc=0
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"


### PR DESCRIPTION
PR #2644 Seems to have fixed the TcpReconnect / send_graceful_disconnect_message leak, so hopefully we can remove the ASAN suppression for it now.