### PR TITLE
RtpsUdp: expiring durable data has no practical value

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1403,9 +1403,8 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const MonotonicTimePoint& /*now*/)
     return;
   }
 
-  TqeVector pendingCallbacks;
   MetaSubmessageVec meta_submessages;
-  gather_heartbeats_i(pendingCallbacks, meta_submessages);
+  gather_heartbeats_i(meta_submessages);
 
   if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
     heartbeat_.schedule(link->config().heartbeat_period_);
@@ -1414,10 +1413,6 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const MonotonicTimePoint& /*now*/)
   g.release();
 
   link->queue_submessages(meta_submessages);
-
-  for (size_t i = 0; i < pendingCallbacks.size(); ++i) {
-    pendingCallbacks[i]->data_dropped();
-  }
 }
 
 void
@@ -3869,29 +3864,6 @@ RtpsUdpDataLink::send_heartbeats(const MonotonicTimePoint& now)
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::expire_durable_data(const ReaderInfo_rch& reader,
-                                                 const RtpsUdpInst& cfg,
-                                                 const MonotonicTimePoint& now,
-                                                 TqeVector& pendingCallbacks)
-{
-  if (!reader->durable_data_.empty()) {
-    const MonotonicTimePoint expiration = reader->durable_timestamp_ + cfg.durable_data_timeout_;
-    if (now > expiration) {
-      typedef OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator dd_iter;
-      for (dd_iter it = reader->durable_data_.begin(); it != reader->durable_data_.end(); ++it) {
-        pendingCallbacks.push_back(it->second);
-      }
-      reader->durable_data_.clear();
-      if (Transport_debug_level > 3) {
-        VDBG_LVL((LM_INFO, "(%P|%t) RtpsUdpDataLink::gather_heartbeats - "
-                  "removed expired durable data for %C -> %C\n",
-                  LogGuid(id_).c_str(), LogGuid(reader->id_).c_str()), 3);
-      }
-    }
-  }
-}
-
-void
 RtpsUdpDataLink::RtpsWriter::initialize_heartbeat(const SingleSendBuffer::Proxy& proxy,
                                                   MetaSubmessage& meta_submessage)
 {
@@ -3942,8 +3914,7 @@ RtpsUdpDataLink::RtpsWriter::gather_directed_heartbeat_i(const SingleSendBuffer:
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(TqeVector& pendingCallbacks,
-                                                 MetaSubmessageVec& meta_submessages)
+RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(MetaSubmessageVec& meta_submessages)
 {
   if (preassociation_readers_.empty() && lagging_readers_.empty()) {
     return;
@@ -3957,7 +3928,6 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(TqeVector& pendingCallbacks,
   }
 
   const MonotonicTimePoint now = MonotonicTimePoint::now();
-  const RtpsUdpInst& cfg = link->config();
 
   using namespace OpenDDS::RTPS;
 
@@ -3993,8 +3963,6 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(TqeVector& pendingCallbacks,
       meta_submessage.sm_.heartbeat_sm().firstSN = to_rtps_seqnum(firstSN);
       meta_submessage.sm_.heartbeat_sm().lastSN = to_rtps_seqnum(lastSN);
       for (ReaderInfoMap::const_iterator pos = remote_readers_.begin(), limit = remote_readers_.end(); pos != limit; ++pos) {
-        // TODO: This should be factored out in a sporadic task.
-        expire_durable_data(pos->second, cfg, now, pendingCallbacks);
         meta_submessage.to_guids_.insert(pos->first);
       }
       meta_submessages.push_back(meta_submessage);
@@ -4006,8 +3974,6 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(TqeVector& pendingCallbacks,
                limit = snris_pos->second->readers.end();
              pos != limit; ++pos) {
           const ReaderInfo_rch& reader = *pos;
-          // TODO: This should be factored out in a sporadic task.
-          expire_durable_data(reader, cfg, now, pendingCallbacks);
           gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
         }
       }
@@ -4126,7 +4092,7 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats_manual_i(MetaSubmessageVec& meta_su
 
 RtpsUdpDataLink::ReaderInfo::~ReaderInfo()
 {
-  expire_durable_data();
+  expunge_durable_data();
 }
 
 void
@@ -4136,7 +4102,7 @@ RtpsUdpDataLink::ReaderInfo::swap_durable_data(OPENDDS_MAP(SequenceNumber, Trans
 }
 
 void
-RtpsUdpDataLink::ReaderInfo::expire_durable_data()
+RtpsUdpDataLink::ReaderInfo::expunge_durable_data()
 {
   typedef OPENDDS_MAP(SequenceNumber, TransportQueueElement*)::iterator iter_t;
   for (iter_t it = durable_data_.begin(); it != durable_data_.end(); ++it) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -339,7 +339,7 @@ private:
     {}
     ~ReaderInfo();
     void swap_durable_data(OPENDDS_MAP(SequenceNumber, TransportQueueElement*)& dd);
-    void expire_durable_data();
+    void expunge_durable_data();
     bool expecting_durable_data() const;
     SequenceNumber acked_sn() const { return cur_cumulative_ack_.previous(); }
     bool reflects_heartbeat_count() const;
@@ -432,10 +432,6 @@ private:
     bool is_lagging(const ReaderInfo_rch& reader) const;
     void check_leader_lagger() const;
     void record_directed(const RepoId& reader, SequenceNumber seq);
-    void expire_durable_data(const ReaderInfo_rch& reader,
-                             const RtpsUdpInst& cfg,
-                             const MonotonicTimePoint& now,
-                             TqeVector& pendingCallbacks);
 
 #ifdef OPENDDS_SECURITY
     bool is_pvs_writer() const { return is_pvs_writer_; }
@@ -492,8 +488,7 @@ private:
                           MetaSubmessageVec& meta_submessages);
     void process_acked_by_all();
     void gather_nack_replies_i(MetaSubmessageVec& meta_submessages);
-    void gather_heartbeats_i(TqeVector& pendingCallbacks,
-                             MetaSubmessageVec& meta_submessages);
+    void gather_heartbeats_i(MetaSubmessageVec& meta_submessages);
     void gather_heartbeats(const RepoIdSet& additional_guids,
                            MetaSubmessageVec& meta_submessages);
     typedef OPENDDS_MAP_CMP(RepoId, SequenceNumber, GUID_tKeyLessThan) ExpectedMap;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -38,7 +38,6 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
   , nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
   , heartbeat_period_(1) // no default in RTPS spec
   , heartbeat_response_delay_(0, 500*1000 /*microseconds*/) // default from RTPS
-  , durable_data_timeout_(60)
   , receive_address_duration_(5)
   , responsive_mode_(false)
   , send_delay_(0, 10 * 1000)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -41,7 +41,6 @@ public:
   TimeDuration nak_response_delay_;
   TimeDuration heartbeat_period_;
   TimeDuration heartbeat_response_delay_;
-  TimeDuration durable_data_timeout_;
   TimeDuration receive_address_duration_;
   bool responsive_mode_;
   TimeDuration send_delay_;


### PR DESCRIPTION
Problem
-------

By default, the RtpsUdpDataLink expires durable data for a reader
after 60 seconds.  Practically, there is no value to doing this as a
severe communication problem will eventually lead to a disassociation
which then purges the data.

Solution
--------

Remove the `durable_data_timeout_` parameter and all associated logic.