### PR TITLE
extension to the XTypes test

### DIFF
--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -464,6 +464,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return 1;
   }
 
+  if (!wait_for_reader (true, control_dw)) {
+    return 1;
+  }
+
   ACE_DEBUG((LM_DEBUG, "Writer sending echo at %T\n"));
 
   ControlStruct cs;
@@ -474,28 +478,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return 1;
   }
 
-  condition = control_dw->get_statuscondition();
-  condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
-
-  ws->attach_condition(condition);
-  DDS::Duration_t p = { 5, 0 };
-  DDS::PublicationMatchedStatus pms;
-  control_dw->get_publication_matched_status(pms);
-  for (int retries = 3; retries > 0 && pms.current_count > 0; --retries) {
-    conditions.length(0);
-    ret = ws->wait(conditions, p);
-    if (ret != RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, "ERROR: wait on control_dw condition returned %C\n",
-        OpenDDS::DCPS::retcode_to_string(ret)));
-      return 1;
-    }
-    control_dw->get_publication_matched_status(pms);
+  if (!wait_for_reader (false, control_dw)) {
+    return 1;
   }
-  if (pms.current_count > 0) {
-    ACE_DEBUG((LM_DEBUG, "Data reader shutdown not detected at %T\n"));
-  }
-  ws->detach_condition(condition);
-
   topic = 0;
   ACE_DEBUG((LM_DEBUG, "Writer cleanup at %T\n"));
 

--- a/tests/DCPS/XTypes/XTypes.h
+++ b/tests/DCPS/XTypes/XTypes.h
@@ -68,7 +68,7 @@ bool check_inconsistent_topic_status(Topic_var topic)
   if (retcode != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, "ERROR: get_inconsistent_topic_status failed\n"));
     return false;
-  } else if (status.total_count != (expect_to_match ? 0 : 1)) {
+  } else if (expect_to_match xor (status.total_count == 0)) {
     ACE_ERROR((LM_ERROR, "ERROR: inconsistent topic count is %d\n", status.total_count));
     return false;
   }

--- a/tests/DCPS/XTypes/XTypes.h
+++ b/tests/DCPS/XTypes/XTypes.h
@@ -103,7 +103,7 @@ bool check_inconsistent_topic_status(Topic_var topic)
   if (retcode != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, "ERROR: get_inconsistent_topic_status failed\n"));
     return false;
-  } else if (expect_to_match xor (status.total_count == 0)) {
+  } else if (expect_to_match !=  (status.total_count == 0)) {
     ACE_ERROR((LM_ERROR, "ERROR: inconsistent topic count is %d\n", status.total_count));
     return false;
   }

--- a/tests/DCPS/XTypes/XTypes.h
+++ b/tests/DCPS/XTypes/XTypes.h
@@ -58,7 +58,42 @@ bool get_topic(T ts, const DomainParticipant_var dp, const std::string& topic_na
   return true;
 }
 
-
+bool wait_for_reader(bool tojoin, DataWriter_var &dw) {
+  DDS::WaitSet_var ws = new DDS::WaitSet;
+  DDS::StatusCondition_var condition = dw->get_statuscondition();
+  condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
+  bool success = true;
+  DDS::ConditionSeq conditions;
+  ReturnCode_t ret = RETCODE_OK;
+  ws->attach_condition(condition);
+  DDS::Duration_t p = { 5, 0 };
+  DDS::PublicationMatchedStatus pms;
+  dw->get_publication_matched_status(pms);
+  ACE_DEBUG((LM_DEBUG,"Starting wait for reader %s count = %d at %T\n", (tojoin ? "startup":"shutdown"), pms.current_count));
+  for (int retries = 3; retries > 0 && (tojoin == (pms.current_count == 0)); --retries) {
+    conditions.length(0);
+    ret = ws->wait(conditions, p);
+    if (ret != RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "ERROR: wait on control_dw condition returned %C\n",
+                 OpenDDS::DCPS::retcode_to_string(ret)));
+      success = false;
+      break;
+    }
+    dw->get_publication_matched_status(pms);
+  }
+  if (success) {
+    ACE_DEBUG((LM_DEBUG, "After wait for reader %s count = %d at %T\n", (tojoin
+                                                                         ? "startup"
+                                                                         : "shutdown"), pms.current_count));
+    if (tojoin != (pms.current_count > 0)) {
+      ACE_ERROR((LM_ERROR, "Data reader %s not detected at %T\n", (tojoin
+                                                                   ? "startup"
+                                                                   : "shutdown")));
+    }
+  }
+  ws->detach_condition(condition);
+  return success;
+}
 bool check_inconsistent_topic_status(Topic_var topic)
 {
   DDS::InconsistentTopicStatus status;


### PR DESCRIPTION
Catching some late-emerging scoreboard failures.
1. an inconsistent topic count went to 2 and thus was counted as a failure (addressed)
2. reader still failed to detect a message sent by the writer or the writer failed to detect the reader was still subscribed.