### PR TITLE
Updates for EntityLifecycleStress Test

### DIFF
--- a/dds/DCPS/transport/framework/PacketRemoveVisitor.cpp
+++ b/dds/DCPS/transport/framework/PacketRemoveVisitor.cpp
@@ -24,7 +24,8 @@ PacketRemoveVisitor::PacketRemoveVisitor(
   ACE_Message_Block*& unsent_head_block,
   ACE_Message_Block* header_block,
   MessageBlockAllocator& mb_allocator,
-  DataBlockAllocator& db_allocator)
+  DataBlockAllocator& db_allocator,
+  bool remove_all)
   : match_(match)
   , head_(unsent_head_block)
   , header_block_(header_block)
@@ -33,6 +34,7 @@ PacketRemoveVisitor::PacketRemoveVisitor(
   , previous_block_(0)
   , replaced_element_mb_allocator_(mb_allocator)
   , replaced_element_db_allocator_(db_allocator)
+  , remove_all_(remove_all)
 {
   DBG_ENTRY_LVL("PacketRemoveVisitor", "PacketRemoveVisitor", 6);
 }
@@ -466,7 +468,7 @@ PacketRemoveVisitor::visit_element_ref(TransportQueueElement*& element)
     // is retained sample and no callback is made to writer.
     this->status_ = orig_elem->data_dropped() ? REMOVE_RELEASED : REMOVE_FOUND;
 
-    if (this->status_ == REMOVE_RELEASED || this->match_.unique()) {
+    if ((!remove_all_ && status_ == REMOVE_RELEASED) || match_.unique()) {
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "Return 0 to halt visitation.\n"));
       // Replace a single sample if one is specified, otherwise visit the

--- a/dds/DCPS/transport/framework/PacketRemoveVisitor.h
+++ b/dds/DCPS/transport/framework/PacketRemoveVisitor.h
@@ -31,7 +31,8 @@ public:
                       ACE_Message_Block*&          unsent_head_block,
                       ACE_Message_Block*           header_block,
                       MessageBlockAllocator& mb_allocator,
-                      DataBlockAllocator& db_allocator);
+                      DataBlockAllocator& db_allocator,
+                      bool remove_all = false);
 
   virtual ~PacketRemoveVisitor();
 
@@ -68,6 +69,8 @@ private:
   MessageBlockAllocator& replaced_element_mb_allocator_;
   /// Cached allocator for DataSampleHeader data block
   DataBlockAllocator& replaced_element_db_allocator_;
+  // Continue removing for non-unique elements even when status is RELEASED
+  bool remove_all_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/QueueRemoveVisitor.cpp
+++ b/dds/DCPS/transport/framework/QueueRemoveVisitor.cpp
@@ -54,7 +54,7 @@ QueueRemoveVisitor::visit_element_remove(TransportQueueElement* element,
     // the sample.
     this->status_ = released ? REMOVE_RELEASED : REMOVE_FOUND;
 
-    if (released || this->mc_.unique()) {
+    if ((!remove_all_ && released) || this->mc_.unique()) {
       // Stop visitation since we've handled the element that matched
       // our sample_.
       // N.B. This unique() test means that if we are comparing by sample, we

--- a/dds/DCPS/transport/framework/QueueRemoveVisitor.h
+++ b/dds/DCPS/transport/framework/QueueRemoveVisitor.h
@@ -27,7 +27,7 @@ class OpenDDS_Dcps_Export QueueRemoveVisitor
   : public BasicQueueVisitor<TransportQueueElement> {
 public:
 
-  explicit QueueRemoveVisitor(const TransportQueueElement::MatchCriteria& mc);
+  explicit QueueRemoveVisitor(const TransportQueueElement::MatchCriteria& mc, bool remove_all = false);
 
   virtual ~QueueRemoveVisitor();
 
@@ -51,6 +51,8 @@ private:
   RemoveResult status_;
 
   size_t removed_bytes_;
+
+  bool remove_all_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/QueueRemoveVisitor.inl
+++ b/dds/DCPS/transport/framework/QueueRemoveVisitor.inl
@@ -14,10 +14,12 @@ namespace DCPS {
 
 ACE_INLINE
 QueueRemoveVisitor::QueueRemoveVisitor(
-  const TransportQueueElement::MatchCriteria& mc)
+  const TransportQueueElement::MatchCriteria& mc,
+  bool remove_all)
   : mc_(mc)
   , status_(REMOVE_NOT_FOUND)
   , removed_bytes_(0)
+  , remove_all_(remove_all)
 {
   DBG_ENTRY_LVL("QueueRemoveVisitor", "QueueRemoveVisitor", 6);
 }

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -1362,7 +1362,7 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
           "The mode is MODE_DIRECT, or the queue is empty and no "
           "transport packet is in progress.\n"));
 
-    QueueRemoveVisitor simple_rem_vis(criteria);
+    QueueRemoveVisitor simple_rem_vis(criteria, remove_all);
     this->elems_.accept_remove_visitor(simple_rem_vis);
 
     const RemoveResult status = simple_rem_vis.status();
@@ -1381,7 +1381,7 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Visit the queue_ with the RemoveElementVisitor.\n"));
 
-  QueueRemoveVisitor simple_rem_vis(criteria);
+  QueueRemoveVisitor simple_rem_vis(criteria, remove_all);
   this->queue_.accept_remove_visitor(simple_rem_vis);
 
   RemoveResult status = simple_rem_vis.status();

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -1422,7 +1422,8 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
                                   this->pkt_chain_,
                                   this->header_block_,
                                   this->replaced_element_mb_allocator_,
-                                  this->replaced_element_db_allocator_);
+                                  this->replaced_element_db_allocator_,
+                                  remove_all);
 
   this->elems_.accept_replace_visitor(pac_rem_vis);
 

--- a/tests/DCPS/EntityLifecycleStress/publisher.cpp
+++ b/tests/DCPS/EntityLifecycleStress/publisher.cpp
@@ -115,7 +115,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     for (size_t i = 0; i < count; ++i) {
       ACE_OS::sleep(delay);
       ++message.count;
-      message_dw->write(message, handle);
+      DDS::ReturnCode_t error =  message_dw->write(message, handle);
+
+      if (error != DDS::RETCODE_OK) {
+        cerr << "Messenger::MessageDataWriter::write() failed." << endl;
+        exit(1);
+      }
     }
 
     {

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -229,7 +229,7 @@ tests/DCPS/RecorderReplayer/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
 
 examples/DCPS/Messenger_Imr/run_test.pl: !DCPS_MIN !MIN_CORBA !CORBA_E_COMPACT !CORBA_E_MICRO !DDS_NO_ORBSVCS !OPENDDS_SAFETY_PROFILE
 
-tests/DCPS/EntityLifecycleStress/run_test.pl publishers 10 subscribers 10
+tests/DCPS/EntityLifecycleStress/run_test.pl publishers 5 subscribers 5
 tests/DCPS/EntityLifecycleStress/run_test.pl rtps_disc publishers 10 subscribers 10: RTPS
 
 tests/DCPS/LivelinessKeepAliveTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
Problems:
 - Coverity Scan complained about checking write()'s return value
 - Still encountering occasional issues in TransportSendStrategy cleanup due to QueueRemoveVisitor and PacketRemoveVisitor ignoring non-unique match criteria when the status is RELEASED (vs FOUND).

Solution:
 - Fix publisher.cpp to check the return value of write()
 - Pass "remove_all" flag into QueueRemoveVisitor and PacketRemoveVisitor and enforce compliance with non-unique flag when it's set to true (but default to false to preserve existing behaviors).