### PR TITLE
GitHub Actions: Normalize Calling 'apt-get update' Across Related Jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1952,9 +1952,6 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c01_${{ github.job }}_master_${{ env.ACE_COMMIT }}
-    - name: update apt
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get update
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -2001,10 +1998,10 @@ jobs:
     needs: ACE_TAO_u20_ace7_j_qt_ws_sec
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
     - name: install wireshark
       run: sudo apt-get -y install wireshark-dev
     - name: install qt
@@ -2108,10 +2105,14 @@ jobs:
     timeout-minutes: 150
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
+    - name: install wireshark
+      run: sudo apt-get -y install wireshark-dev
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:
@@ -3328,9 +3329,6 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
-    - name: update apt
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get update
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3377,10 +3375,10 @@ jobs:
     needs: ACE_TAO_u18_stat_qt_ws_sec
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
     - name: install wireshark
       run: sudo apt-get -y install wireshark-dev
     - name: install qt
@@ -3461,10 +3459,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
     - name: install qt
       run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
@@ -3540,10 +3538,10 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
     - name: install qt
       run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
@@ -3682,10 +3680,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:
@@ -3808,10 +3808,12 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - name: update apt
-      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
       uses: actions/checkout@v2.3.4
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3382,7 +3382,7 @@ jobs:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install wireshark
-      run:  sudo apt-get -y install wireshark-dev
+      run: sudo apt-get -y install wireshark-dev
     - name: install qt
       run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1952,6 +1952,9 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c01_${{ github.job }}_master_${{ env.ACE_COMMIT }}
+    - name: update apt
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get update
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -1998,12 +2001,12 @@ jobs:
     needs: ACE_TAO_u20_ace7_j_qt_ws_sec
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install wireshark
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install wireshark-dev
+      run: sudo apt-get -y install wireshark-dev
     - name: install qt
       run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
@@ -2105,6 +2108,8 @@ jobs:
     timeout-minutes: 150
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -3323,6 +3328,9 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}
+    - name: update apt
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get update
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3369,12 +3377,12 @@ jobs:
     needs: ACE_TAO_u18_stat_qt_ws_sec
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install wireshark
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install wireshark-dev
+      run:  sudo apt-get -y install wireshark-dev
     - name: install qt
       run: sudo apt-get -y install qtbase5-dev
     - name: checkout MPC
@@ -3445,7 +3453,6 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-
   cmake_u18_stat_qt_ws_sec:
 
     runs-on: ubuntu-18.04
@@ -3454,6 +3461,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install qt
@@ -3531,6 +3540,8 @@ jobs:
     timeout-minutes: 40
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: install qt
@@ -3671,6 +3682,8 @@ jobs:
     timeout-minutes: 30
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -3795,6 +3808,8 @@ jobs:
     timeout-minutes: 15
 
     steps:
+    - name: update apt
+      run: sudo apt-get update
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -5460,7 +5475,7 @@ jobs:
         echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
-      uses: actions/cache@v2.1.4
+      uses: actions/cache@v2.1.5
       with:
         path: ${{ github.job }}.tar.xz
         key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}


### PR DESCRIPTION
So we don't have a weird mix of xerces / qt / wireshark versions, and so that these larger dependency installations continue to work over time (QT has been causing trouble on other builds).

And upgrade that one cache 2.1.4 action to match the others (2.1.5)
