### PR TITLE
Align auto_run_test.pl Output With Autobuild Subsection Expectations

### DIFF
--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -23,7 +23,7 @@ my $dry_run = 0;
 
 sub cd {
     my $dir = shift;
-    chdir($dir) or die "auto_run_tests: Error: Cannot chdir to $dir: $!";
+    chdir($dir) or die "auto_run_tests.pl: Error: Cannot chdir to $dir: $!";
 }
 
 sub run_command {
@@ -65,7 +65,7 @@ sub run_command {
     if ($failed) {
         $exit_status = $system_status >> 8;
         my $signal = $system_status & 127;
-        die("auto_run_tests: \"$what\" was interrupted") if ($signal == SIGINT);
+        die("auto_run_tests.pl: \"$what\" was interrupted") if ($signal == SIGINT);
         my $coredump = $system_status & 128;
         my $error_message;
         if (!$ran) {
@@ -78,7 +78,7 @@ sub run_command {
         else {
             $error_message = sprintf("returned with status %d", $exit_status);
         }
-        print STDERR "auto_run_tests: Error: \"$what\" $error_message\n";
+        print STDERR "auto_run_tests.pl: Error: \"$what\" $error_message\n";
     }
 
     if (defined($capture_stdout) && $ran) {
@@ -329,7 +329,7 @@ foreach my $test_lst (@file_list) {
         if ($program =~ /(.*?) (.*)/) {
             $progNoArgs = $1;
             if (! -e $progNoArgs) {
-                print STDERR "auto_run_tests: Error: $directory/$1 does not exist\n";
+                print STDERR "auto_run_tests.pl: Error: $directory/$1 does not exist\n";
                 next;
             }
         }
@@ -337,7 +337,7 @@ foreach my $test_lst (@file_list) {
             my $cmd = $program;
             $cmd = $subdir.$cmd if ($program !~ /\.pl$/);
             if ((! -e $cmd) && (! -e "$cmd.exe")) {
-                print STDERR "auto_run_tests: Error: $directory/$cmd does not exist\n";
+                print STDERR "auto_run_tests.pl: Error: $directory/$cmd does not exist\n";
                 next;
             }
         }


### PR DESCRIPTION
Problem:
Autobuild uses the string "auto_run_tests:" to determine new subsections, but recent changes to auto_run_tests.pl print that string for error messages as well as test sections.

Solution:
Reserve that exact string for test sections only.