### PR TITLE
Mass Spelling Correction

### DIFF
--- a/DevGuideExamples/DCPS/Messenger.minimal/README
+++ b/DevGuideExamples/DCPS/Messenger.minimal/README
@@ -1,10 +1,10 @@
 Minimal Messenger Example
 
 This example is provided so users can have a simpler example than the
-current Messenger.  It makes use of the Sync objects for syncronization
+current Messenger.  It makes use of the Sync objects for synchronization
 and moves the setup/cleanup code out of main to boilerplate namespace
 for a simpler view on how to publish samples and process received samples.
-Boilerplate also replaces NULL pointers with execptions to eliminate the need
+Boilerplate also replaces NULL pointers with exceptions to eliminate the need
 for main to check return values and write out individual log messages.
 
 To be explained in-depth in the upcoming getting started guide.

--- a/MPC/modules/IDLBase.pm
+++ b/MPC/modules/IDLBase.pm
@@ -925,7 +925,7 @@ sub replace_macros {
                   $usee = $i + 1;
                 }
                 else {
-                  ## This isn't the end of the paramters, so keep going
+                  ## This isn't the end of the parameters, so keep going
                   next;
                 }
               }
@@ -963,7 +963,7 @@ sub replace_macros {
         }
       }
       else {
-        ## There were no macro paramters, so just do a simple search and
+        ## There were no macro parameters, so just do a simple search and
         ## replace.
         $line =~ s/\b$macro\b/$val/g;
       }

--- a/dds/CORBA/tao/String_Alloc.cpp
+++ b/dds/CORBA/tao/String_Alloc.cpp
@@ -35,7 +35,7 @@ CORBA::string_dup (const char *str)
 char *
 CORBA::string_alloc (CORBA::ULong len)
 {
-  // Allocate 1 + strlen to accomodate the null terminating character.
+  // Allocate 1 + strlen to accommodate the null terminating character.
   char *s = 0;
   ACE_ALLOCATOR_NEW (s,
                      char[size_t (len + 1)],

--- a/dds/CORBA/tao/SystemException.cpp
+++ b/dds/CORBA/tao/SystemException.cpp
@@ -507,7 +507,7 @@ CORBA::SystemException::_tao_get_omg_exception_description (
       "wchar or wstring data erroneously returned by server over GIOP 1.0 connection.", //6
       "Unsupported RMI/IDL custom value type stream format.", // 7
       "Custom data not compatible with ValueHandler read operation.", // 8
-      "Codeset service contexts with different values recieved on the same connection." // 9
+      "Codeset service contexts with different values received on the same connection." // 9
 
     };
 

--- a/dds/DCPS/DCPS_Utils.h
+++ b/dds/DCPS/DCPS_Utils.h
@@ -31,7 +31,7 @@ OpenDDS_Dcps_Export
 bool
 is_wildcard(const char *str);
 
-/// Increments the count of occurances of the incompatible policy
+/// Increments the count of occurrences of the incompatible policy
 ///  for the status
 OpenDDS_Dcps_Export
 void

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1223,7 +1223,7 @@ DataReaderImpl::enable()
   // enable the type specific part of this DataReader
   this->enable_specific();
 
-  //Note: the QoS used to set n_chunks_ is Changable=No so
+  //Note: the QoS used to set n_chunks_ is Changeable=No so
   // it is OK that we cannot change the size of our allocators.
   rd_allocator_.reset(new ReceivedDataAllocator(n_chunks_));
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -2331,7 +2331,7 @@ private:
       if (data->second.message) {
         const bool NOT_DISPOSE_MSG = false;
         const bool NOT_UNREGISTER_MSG = false;
-        // clear the message, since ownership is being transfered to finish_store_instance_data.
+        // clear the message, since ownership is being transferred to finish_store_instance_data.
 
         instance->last_accepted_.set_to_now();
         const DataSampleHeader_ptr header = data->second.header;

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1380,7 +1380,7 @@ DataWriterImpl::enable()
     TheServiceParticipant->get_data_durability_cache(qos_.durability);
 #endif
 
-  //Note: the QoS used to set n_chunks_ is Changable=No so
+  //Note: the QoS used to set n_chunks_ is Changeable=No so
   // it is OK that we cannot change the size of our allocators.
   data_container_ = RcHandle<WriteDataContainer>
     (new WriteDataContainer

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -430,7 +430,7 @@ public:
 
   /**
    * Set deadline to complete wait_pending by. If 0, then wait_pending will
-   * wait indefinately if needed.
+   * wait indefinitely if needed.
    */
   void set_wait_pending_deadline(const MonotonicTimePoint& deadline);
 

--- a/dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h
+++ b/dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h
@@ -168,7 +168,7 @@ public:
         if (frees_to_heap_.value() % 500 == 0) {
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::free %@"
-                     " %Lu heap allocs with %Lu oustanding\n",
+                     " %Lu heap allocs with %Lu outstanding\n",
                      this, this->allocs_from_heap_.value(),
                      this->allocs_from_heap_.value() - this->frees_to_heap_.value()));
         }

--- a/dds/DCPS/FileSystemStorage.h
+++ b/dds/DCPS/FileSystemStorage.h
@@ -28,7 +28,7 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-// This can be overriden by the user, but make sure that it's less than
+// This can be overridden by the user, but make sure that it's less than
 // the actual operating system and filesystem limit so that the "overflow"
 // directories can be created as needed.
 #ifndef OPENDDS_FILESYSTEMSTORAGE_MAX_FILES_PER_DIR

--- a/dds/DCPS/InfoRepoDiscovery/Info.idl
+++ b/dds/DCPS/InfoRepoDiscovery/Info.idl
@@ -175,7 +175,7 @@ module OpenDDS {
                Invalid_Participant,
                Invalid_Publication);
 
-      //Note: the ignore_xxx methods are not reversable - per DDS spec.
+      //Note: the ignore_xxx methods are not reversible - per DDS spec.
 
       // ignore participant when matching/associating pubs & subs
       void ignore_domain_participant (in ::DDS::DomainId_t domainId,

--- a/dds/DCPS/InstanceDataSampleList.h
+++ b/dds/DCPS/InstanceDataSampleList.h
@@ -27,7 +27,7 @@ class DataSampleElement;
 /**
 * A list of DataSampleElement pointers to be queued by the order the
 * samples are written to the instance (within
-* PRESENTAION.access_scope==INSTANCE).  It is mainly used on the
+* PRESENTATION.access_scope==INSTANCE).  It is mainly used on the
 * send side to count the depth of instance data and to allow the
 * removal of elements by instance.
 * Manages DataSampleElement's next_instance_sample pointer

--- a/dds/DCPS/Qos_Helper.inl
+++ b/dds/DCPS/Qos_Helper.inl
@@ -1104,7 +1104,7 @@ bool Qos_Helper::valid(const DDS::DataRepresentationQosPolicy& qos)
     default:
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("Qos_Helper::valid(const DataRepresentationQosPolicy&): ")
-        ACE_TEXT("Unkown DataRepresentationId_t: %d\n"), value));
+        ACE_TEXT("Unknown DataRepresentationId_t: %d\n"), value));
       return false;
     };
   }

--- a/dds/DCPS/RTPS/ICE/Checklist.cpp
+++ b/dds/DCPS/RTPS/ICE/Checklist.cpp
@@ -56,7 +56,7 @@ ACE_UINT64 CandidatePair::compute_priority()
 ConnectivityCheck::ConnectivityCheck(const CandidatePair& a_candidate_pair,
                                      const AgentInfo& a_local_agent_info, const AgentInfo& a_remote_agent_info,
                                      ACE_UINT64 a_ice_tie_breaker, const MonotonicTimePoint& a_expiration_date)
-  : candiate_pair_(a_candidate_pair), cancelled_(false), expiration_date_(a_expiration_date)
+  : candidate_pair_(a_candidate_pair), cancelled_(false), expiration_date_(a_expiration_date)
 {
   request_.class_ = STUN::REQUEST;
   request_.method = STUN::BINDING;

--- a/dds/DCPS/RTPS/ICE/Checklist.h
+++ b/dds/DCPS/RTPS/ICE/Checklist.h
@@ -103,7 +103,7 @@ struct ConnectivityCheck {
 
   const CandidatePair& candidate_pair() const
   {
-    return candiate_pair_;
+    return candidate_pair_;
   }
   const STUN::Message& request() const
   {
@@ -126,7 +126,7 @@ struct ConnectivityCheck {
     request_.password = a_password;
   }
 private:
-  CandidatePair candiate_pair_;
+  CandidatePair candidate_pair_;
   STUN::Message request_;
   bool cancelled_;
   DCPS::MonotonicTimePoint expiration_date_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -862,7 +862,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         process_location_updates_i(iter, secure_part_user_data());
 #endif
       }
-    // Else a reset has occured and check if we should remove the participant
+    // Else a reset has occurred and check if we should remove the participant
     } else if (iter->second.seq_reset_count_ >= config_->max_spdp_sequence_msg_reset_check()) {
 #ifdef OPENDDS_SECURITY
       purge_handshake_deadlines(iter);

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -151,7 +151,7 @@ public:
   /**
    * Write Secured Updated DP QOS
    *
-   * lock_ must be aquired before calling this.
+   * lock_ must be acquired before calling this.
    */
   void write_secure_updates();
   void write_secure_disposes();

--- a/dds/DCPS/SafetyProfilePool.h
+++ b/dds/DCPS/SafetyProfilePool.h
@@ -28,7 +28,7 @@ namespace DCPS {
 
 /// Memory pool for use when the Safety Profile is enabled.
 ///
-/// Saftey Profile disallows std::free() and the delete operators
+/// Safety Profile disallows std::free() and the delete operators
 /// See PoolAllocator.h for a class that allows STL containers to use an
 /// instance of SafetyProfilePool managed by our Service_Participant singleton.
 class OpenDDS_Dcps_Export SafetyProfilePool : public ACE_Allocator

--- a/dds/DCPS/SequenceNumber.h
+++ b/dds/DCPS/SequenceNumber.h
@@ -125,7 +125,7 @@ public:
     return low_;
   }
 
-  // SEQUENCENUMBER_UNKOWN is defined by the RTPS spec.
+  // SEQUENCENUMBER_UNKNOWN is defined by the RTPS spec.
   static SequenceNumber SEQUENCENUMBER_UNKNOWN() {
     return SequenceNumber(-1, 0);
   }

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -931,7 +931,7 @@ Service_Participant::set_repo_ior(const char* ior,
                key.c_str(), ior));
   }
 
-  // This is a global used for the bizzare commandline/configfile
+  // This is a global used for the bizarre commandline/configfile
   // processing done for this class.
   got_info = true;
 

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -349,7 +349,7 @@ bool Permissions::Action::partitions_match(const DDS::StringSeq& entity_partitio
       // In order for an action to be denied it must meet the denied partitions condition.
       // For this to happen one [or] more of the partition names associated with the DDS Entity
       // ... must match one [of] the partitions ... listed in the partitions condition section.
-      return true; // i'th QoS partition name matches some <partition> in Permissons
+      return true; // i'th QoS partition name matches some <partition> in Permissions
     }
   }
 

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -1673,7 +1673,7 @@ AccessControlBuiltInImpl::RevokePermissionsTask::~RevokePermissionsTask()
 
 namespace {
   // Some platforms cannot schedule timers far enough into the future
-  // to accomodate expiration times so the scheduling interval is
+  // to accommodate expiration times so the scheduling interval is
   // capped at an hour.
   const TimeDuration MAX_DURATION = TimeDuration(3600, 0);
 }

--- a/dds/DCPS/security/CryptoBuiltIn.idl
+++ b/dds/DCPS/security/CryptoBuiltIn.idl
@@ -9,7 +9,7 @@ module OpenDDS {
   module Security {
 
     // The CRYPTO_TRANSFORMATION_KIND_* constants below are used in this
-    // index of the CryptoTransfromKind array.  (Other elements are 0.)
+    // index of the CryptoTransformKind array.  (Other elements are 0.)
     const unsigned long TransformKindIndex = 3;
 
     /* No encryption, no authentication tag */
@@ -18,7 +18,7 @@ module OpenDDS {
     /*
       No encryption.
       One AES128-GMAC authentication tag using the sender_key
-      Zero or more AES128-GMAC auth. tags with receiver specfic keys
+      Zero or more AES128-GMAC auth. tags with receiver specific keys
     */
     const octet CRYPTO_TRANSFORMATION_KIND_AES128_GMAC = 1;
 
@@ -26,7 +26,7 @@ module OpenDDS {
       Authenticated Encryption using AES-128 in Galois Counter Mode
       (GCM) using the sender key.
       The authentication tag using the sender_key obtained from GCM
-      Zero or more AES128-GMAC auth. tags with receiver specfic keys
+      Zero or more AES128-GMAC auth. tags with receiver specific keys
     */
     const octet CRYPTO_TRANSFORMATION_KIND_AES128_GCM = 2;
 
@@ -34,7 +34,7 @@ module OpenDDS {
       No encryption.
       One AES256-GMAC authentication tag using the sender_key
       Zero or more AES256-GMAC auth.
-      tags with receiver specfic keys
+      tags with receiver specific keys
     */
     const octet CRYPTO_TRANSFORMATION_KIND_AES256_GMAC = 3;
 
@@ -43,7 +43,7 @@ module OpenDDS {
       (GCM) using the sender key.
       The authentication tag using the sender_key obtained from GCM
       Zero or more AES256-GMAC auth.
-      tags with receiver specfic keys
+      tags with receiver specific keys
     */
     const octet CRYPTO_TRANSFORMATION_KIND_AES256_GCM = 4;
 

--- a/dds/DCPS/security/OpenSSL_init.h
+++ b/dds/DCPS/security/OpenSSL_init.h
@@ -4,7 +4,7 @@
  */
 
 /**
- * This is seperate from OpenSSL_legacy.h to use in the SSL Unit Test Main.cpp
+ * This is separate from OpenSSL_legacy.h to use in the SSL Unit Test Main.cpp
  */
 
 #ifndef OPENDDS_DCPS_SECURITY_OPENSSL_INIT_H

--- a/dds/DCPS/transport/framework/PacketRemoveVisitor.cpp
+++ b/dds/DCPS/transport/framework/PacketRemoveVisitor.cpp
@@ -317,7 +317,7 @@ PacketRemoveVisitor::visit_element_ref(TransportQueueElement*& element)
     }
 
     // Finally!At this point we have broken the unsent packet chain of
-    // blocks into three seperate chains:
+    // blocks into three separate chains:
     //
     //   (1) this->previous_block_ is either 0, or it points to the block
     //       (from the unsent packet chain) that immediately preceded the

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -35,7 +35,7 @@ namespace DCPS {
 
 class EntityImpl;
 class TransportInst;
-class AssocationInfo;
+class AssociationInfo;
 class ReaderIdSeq;
 class WriterIdSeq;
 class SendStateDataSampleList;

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -40,7 +40,7 @@ public:
   /// Useful as a simpler altnernative to handle_dds_input
   /// when dealing with UDP protocols with maximum packet size.
   /// Behaves the same as handle_dds_input, but only makes use
-  /// of a single recieve buffer and doesn't require message block
+  /// of a single receive buffer and doesn't require message block
   /// chains that need to be updated / maintained
   int handle_simple_dds_input(ACE_HANDLE fd);
 

--- a/dds/DCPS/transport/framework/TransportSendControlElement.h
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.h
@@ -45,7 +45,7 @@ public:
 
   virtual ~TransportSendControlElement();
 
-  /// Overriden to always return true for Send Control elements.
+  /// Overridden to always return true for Send Control elements.
   virtual bool requires_exclusive_packet() const;
 
   /// Accessor for the publisher id.

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -115,7 +115,7 @@ public:
   void terminate_send(bool graceful_disconnecting = false);
   virtual void terminate_send_if_suspended();
 
-  // Moved clear() declaration below as Enums can't be foward declared.
+  // Moved clear() declaration below as Enums can't be forward declared.
 
   /// Let the subclass stop.
   virtual void stop_i() = 0;
@@ -364,7 +364,7 @@ private:
   /// Incremented once for each call to our send_start() method,
   /// and decremented once for each call to our send_stop() method.
   /// We only care about the transitions of the start_counter_
-  /// value from 0 to 1, and from 1 to 0.  This accomodates the
+  /// value from 0 to 1, and from 1 to 0.  This accommodates the
   /// case where more than one TransportClient is sending to
   /// us at the same time.  We use this counter to enable a
   /// "composite" send_start() and send_stop().

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -289,7 +289,7 @@ OpenDDS::DCPS::TcpDataLink::send_graceful_disconnect_message()
   // not receive the message when the message has no sample data and is sent
   // in a single packet.
 
-  // To work arround this problem, I have to add bogus data to chain with the
+  // To work around this problem, I have to add bogus data to chain with the
   // DataSampleHeader to make the receiving work.
 
   Message_Block_Ptr data(

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -59,7 +59,7 @@ public:
   /// The default value is 2.0.
   double conn_retry_backoff_multiplier_;
 
-  /// Number of attemps to reconnect before giving up and calling
+  /// Number of attempts to reconnect before giving up and calling
   /// on_publication_lost() and on_subscription_lost() callbacks.
   /// The default is 3.
   int conn_retry_attempts_;

--- a/dds/InfoRepo/DCPS_IR_Domain.h
+++ b/dds/InfoRepo/DCPS_IR_Domain.h
@@ -86,7 +86,7 @@ public:
 
   ///@{
   /// Add a topic to the domain
-  /// Returns OpenDDS::DCPS::CREATED if successfull
+  /// Returns OpenDDS::DCPS::CREATED if successful
   OpenDDS::DCPS::TopicStatus add_topic(OpenDDS::DCPS::RepoId_out topicId,
                                        const char * topicName,
                                        const char * dataTypeName,

--- a/dds/InfoRepo/DCPS_IR_Publication.cpp
+++ b/dds/InfoRepo/DCPS_IR_Publication.cpp
@@ -686,7 +686,7 @@ DCPS_IR_Publication::reevaluate_association(DCPS_IR_Subscription* subscription)
   int status = this->associations_.find(subscription);
 
   if (status == 0) {
-    // verify if they are still compatiable after change
+    // verify if they are still compatible after change
 
 
     if (!OpenDDS::DCPS::compatibleQOS(this->get_incompatibleQosStatus(),

--- a/dds/InfoRepo/DCPS_IR_Subscription.cpp
+++ b/dds/InfoRepo/DCPS_IR_Subscription.cpp
@@ -641,7 +641,7 @@ DCPS_IR_Subscription::reevaluate_association(DCPS_IR_Publication* publication)
   int status = this->associations_.find(publication);
 
   if (status == 0) {
-    // verify if they are still compatiable after change
+    // verify if they are still compatible after change
 
     if (!OpenDDS::DCPS::compatibleQOS(publication->get_incompatibleQosStatus(),
                                       this->get_incompatibleQosStatus(),

--- a/dds/InfoRepo/UpdateManager.cpp
+++ b/dds/InfoRepo/UpdateManager.cpp
@@ -45,7 +45,7 @@ Manager::add(Updater* updater)
 void
 Manager::remove()
 {
-  // Clean the refrence to the InfoRepo.
+  // Clean the reference to the InfoRepo.
   info_ = 0;
 }
 
@@ -122,7 +122,7 @@ Manager::pushImage(const DImage& image)
   /***************************
   // The downstream image needs to be converted to a
   // format compatible with the upstream layers (Dimage -> UImage)
-  // The Uimage cotains a lot of refrences to the complex data
+  // The Uimage cotains a lot of references to the complex data
   // types. These are collecetd in several buckets (see below) and
   // passed by reference. Usage of a custom guard class 'SeqGuard'
   // automates memory cleanup.

--- a/dds/idl/annotations.h
+++ b/dds/idl/annotations.h
@@ -397,7 +397,7 @@ namespace OpenDDS {
   };
 
   /**
-   * Used to specifiy the allowed RTPS data representations in XTypes.
+   * Used to specify the allowed RTPS data representations in XTypes.
    * Replacement for @::data_representation which requires bitmask.
    */
   class DataRepresentationAnnotation :

--- a/dds/monitor/monitor.idl
+++ b/dds/monitor/monitor.idl
@@ -84,7 +84,7 @@ module OpenDDS {
 
     @topic
     struct PublisherReport {
-      /// Instance handle of this Publisher. Unique withing the DP.
+      /// Instance handle of this Publisher. Unique within the DP.
       @key DDS::InstanceHandle_t handle;
       /// GUID of the Domain Participant this Publisher belongs to
       @key GUID_t dp_id;
@@ -95,7 +95,7 @@ module OpenDDS {
 
     @topic
     struct SubscriberReport {
-      /// Instance handle of this Subscriber. Unique withing the DP.
+      /// Instance handle of this Subscriber. Unique within the DP.
       @key DDS::InstanceHandle_t handle;
       /// GUID of the Domain Participant this Subscriber belongs to
       @key GUID_t dp_id;

--- a/docs/android.md
+++ b/docs/android.md
@@ -686,7 +686,7 @@ given the singleton nature of both.
 This might not be ideal or efficient though, because deleting and recreating
 participants will happen every time the app loses focus, like during
 orientation changes. An alternative to this is to run OpenDDS within an
-[Android Sevice](https://developer.android.com/guide/components/services)
+[Android Service](https://developer.android.com/guide/components/services)
 separate from the main app with the service configured so that it does not
 stopped when the Application's `onStop()` is called. The service should be
 specified in `AndroidManifest.xml`.

--- a/docs/internal/bench2.rst
+++ b/docs/internal/bench2.rst
@@ -772,7 +772,7 @@ The frequency for set action, per second
           },
 
 Lists of allowed values to set to, for each parameter. Worker will iterate
-throught the list sequentially unless "random_order" flag (below) is specified
+thought the list sequentially unless "random_order" flag (below) is specified
 
 ::
 

--- a/docs/qt.md
+++ b/docs/qt.md
@@ -119,7 +119,7 @@ official Qt Windows installer and the default location.
 It is possible to build OpenDDS without using the configure script, although
 this is not recommended unless one is familiar with OpenDDS and its build
 system, MPC. To enable Qt5 support the `qt5` feature must be enabled (e.g.
-`-features qt5=1`) and enviroment variables must be set to configure the build
+`-features qt5=1`) and environment variables must be set to configure the build
 to use Qt correctly:
 
 | Env. Variable | Description           | MPC Default     |

--- a/etc/xtypes/opendds_typeobject.idl
+++ b/etc/xtypes/opendds_typeobject.idl
@@ -277,7 +277,7 @@ module OpenDDS { module XTypes {    // spec: DDS::XTypes
         @external TypeIdentifier key_identifier;
     };
 
-    // Used for Types that have cyclic depencencies with other types
+    // Used for Types that have cyclic dependencies with other types
     @extensibility(APPENDABLE) @nested
     struct StronglyConnectedComponentId {
         TypeObjectHashId sc_component_id; // Hash StronglyConnectedComponent

--- a/tests/DCPS/Messenger/pub.ini
+++ b/tests/DCPS/Messenger/pub.ini
@@ -73,7 +73,7 @@ transport_type=tcp
 # The default value is 2.0.
 #conn_retry_backoff_multiplier=
 
-# Number of attemps to reconnect before giving up and calling
+# Number of attempts to reconnect before giving up and calling
 # on_publication_lost() and on_subscription_lost() callbacks.
 # The default is 3.
 #conn_retry_attempts=
@@ -87,7 +87,7 @@ transport_type=tcp
 
 # Determine if the transport needs create a new thread for a
 # datalink/connection to send samples under normal traffic (no backpressure).
-# If thread_per_connection is 1, the publisher creates a seperate thread
+# If thread_per_connection is 1, the publisher creates a separate thread
 # for each datalink/connection to send samples instead of using the same
 # thread to send to different datalinks/connections sequentially.
 # The default value is 0 (using same thread send to all datalinks)

--- a/tests/DCPS/Messenger/pub_ipv6.ini
+++ b/tests/DCPS/Messenger/pub_ipv6.ini
@@ -70,7 +70,7 @@ local_address=[::1]
 # The default value is 2.0.
 #conn_retry_backoff_multiplier=
 
-# Number of attemps to reconnect before giving up and calling
+# Number of attempts to reconnect before giving up and calling
 # on_publication_lost() and on_subscription_lost() callbacks.
 # The default is 3.
 #conn_retry_attempts=
@@ -84,7 +84,7 @@ local_address=[::1]
 
 # Determine if the transport needs create a new thread for a
 # datalink/connection to send samples under normal traffic (no backpressure).
-# If thread_per_connection is 1, the publisher creates a seperate thread
+# If thread_per_connection is 1, the publisher creates a separate thread
 # for each datalink/connection to send samples instead of using the same
 # thread to send to different datalinks/connections sequentially.
 # The default value is 0 (using same thread send to all datalinks)

--- a/tests/DCPS/Messenger/sub.ini
+++ b/tests/DCPS/Messenger/sub.ini
@@ -73,7 +73,7 @@ transport_type=tcp
 # The default value is 2.0.
 #conn_retry_backoff_multiplier=
 
-# Number of attemps to reconnect before giving up and calling
+# Number of attempts to reconnect before giving up and calling
 # on_publication_lost() and on_subscription_lost() callbacks.
 # The default is 3.
 #conn_retry_attempts=

--- a/tests/DCPS/Messenger/sub_ipv6.ini
+++ b/tests/DCPS/Messenger/sub_ipv6.ini
@@ -70,7 +70,7 @@ local_address=[::1]
 # The default value is 2.0.
 #conn_retry_backoff_multiplier=
 
-# Number of attemps to reconnect before giving up and calling
+# Number of attempts to reconnect before giving up and calling
 # on_publication_lost() and on_subscription_lost() callbacks.
 # The default is 3.
 #conn_retry_attempts=

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -4,7 +4,7 @@
 # auto_run_tests.pl.
 # Each line has its own test, and a test can be followed by a
 # list of configurations required to be enabled (or not
-# enabled if preceeded by !). For example,
+# enabled if preceded by !). For example,
 #
 # tests/DCPS/SomeText/run_test.pl rtps: !DCPS_MIN RTPS
 

--- a/tools/dissector/README.md
+++ b/tools/dissector/README.md
@@ -17,7 +17,7 @@ from within Wireshark.
 - [See Also](#see-also)
 - [Building](#building)
 - [Usage](#usage)
-  - [Enviroment Variables](#enviroment-variables)
+  - [Environment Variables](#environment-variables)
   - [Display Filters](#display-filters)
   - [Color Filters](#color-filters)
 - [Sample Dissection](#sample-dissection)
@@ -157,7 +157,7 @@ can usually be found somewhere under the "Help" or "Internals" menus.
 The `OpenDDS_Dissector` library we created above should appear in the
 list of plugins or protocols.
 
-<a name="enviroment-variables"></a>
+<a name="environment-variables"></a>
 ### Environment Variables
 
   - `OPENDDS_DISSECTORS`

--- a/tools/dissector/macos_postbuild.sh
+++ b/tools/dissector/macos_postbuild.sh
@@ -8,7 +8,7 @@
 #   $DDS_ROOT/lib.
 #
 #   It produces dylib files which Wireshark will accept but only if they have
-#   a "so" file extention. To remedy this we just make a copy with the "so"
+#   a "so" file extension. To remedy this we just make a copy with the "so"
 #   extension.
 
 filename="OpenDDS_Dissector"

--- a/tools/dissector/sample_dissector.cpp
+++ b/tools/dissector/sample_dissector.cpp
@@ -246,7 +246,7 @@ namespace OpenDDS
     Field_Context* Sample_Base::create_context(ftenum ft, field_display_e fd) {
       if (field_contexts_.count(get_ns())) {
         throw Sample_Dissector_Error(
-          std::string("Could not create context becuase it already exists for: ") +
+          std::string("Could not create context because it already exists for: ") +
           get_ns()
         );
       }

--- a/tools/scripts/create_universal_linux_dds_idl_binaries.sh
+++ b/tools/scripts/create_universal_linux_dds_idl_binaries.sh
@@ -25,7 +25,7 @@ fi
 
 if [ ! -d ACE_wrappers/MPC ]; then
   if [ ! -f $MPC_ROOT/mwc.pl ]; then
-    echo "Cannnot find MPC installation, please set the MPC_ROOT environment variable."
+    echo "Cannot find MPC installation, please set the MPC_ROOT environment variable."
     exit 1
   else
     EXTRA_DOCKER_FLAGS="-v $MPC_ROOT:/MPC -e MPC_ROOT=/MPC"

--- a/tools/scripts/lcov.pl
+++ b/tools/scripts/lcov.pl
@@ -224,7 +224,7 @@ for (my $i = 0; $i <= $#ARGV; ++$i) {
         $create_final_cov = 0;
     }
     else {
-        print "Ignoring unkown argument: $ARGV[$i]\n";
+        print "Ignoring unknown argument: $ARGV[$i]\n";
     }
 }
 

--- a/tools/scripts/lint.pl
+++ b/tools/scripts/lint.pl
@@ -130,13 +130,13 @@ my $help_message = $usage_message .
   "--all | -a          Run all checks\n" .
   "--try-fix           ATTEMPT to fix issues that support fixing. THIS IS POWERED\n" .
   "                    BY REGEX, NOT MAGIC. Don't try this unless your existing\n" .
-  "                    work is commited or otherwise safe from this script.\n" .
+  "                    work is committed or otherwise safe from this script.\n" .
   "                    See --list to see what checks support this.\n" .
   "--include PATH      Add PATH to preproccessor include paths for the sake of\n" .
   "                    checks that care about them. Can be specified multiple\n" .
   "                    times. Default is root of OpenDDS source tree.\n" .
   "--[no-]color        Force enable or disable ANSI escape code color output.\n" .
-  "                    Can also be done with NO_COLOR enviroment variable.\n" .
+  "                    Can also be done with NO_COLOR environment variable.\n" .
   "                    By default it uses isatty like most programs\n" .
   "\n" .
   "If run with DDS_ROOT being defined, it will use that path. If not it will\n" .
@@ -153,7 +153,7 @@ my $help_message = $usage_message .
   "check and path can optionally be plural for readability.\n" .
   "If there are no checks then the entire file is ignored. If PATH is \".\", then\n" .
   "all the files in the directory are ignored except the .lint_config file itself.\n" .
-  "For comments and .lint_config files the checks and paths are space seperated.\n";
+  "For comments and .lint_config files the checks and paths are space separated.\n";
 #  ###############################################################################
 
 if (!GetOptions(
@@ -426,7 +426,7 @@ sub match_prefix_get_suffix {
 #     - If left out no message is printed
 #   default => do not run this check unless told to explicitly. default is true.
 #   strip_fix => If line_matched is being used with a regex with capture groups
-#     around error and it can be fixed by simply omited the contents of the
+#     around error and it can be fixed by simply omitted the contents of the
 #     capture groups, allow --try-fix to do that.
 #   can_fix => Simply indicate that this check **could** be fixed by running
 #     --try-fix. This just inserts a messsage during --list.


### PR DESCRIPTION
After [seeing it on Hackaday](https://hackaday.com/2021/05/29/spell-checking-your-programming-from-the-linux-command-line/) I wanted to try to use [the typos source code spell checker](https://github.com/crate-ci/typos) on select locations, namely `dds`. I didn't really want to fix things like `docs/design`, `doc/history`, `tools/modeling`, and most of tests. I've gone through them all and they seem correct.

Seems pretty lax and will only go after something it really thinks is a misspelled word. The only false positive I think saw for the entire tree was for stuff inside `docs/logo.svg`.