### PR TITLE
RtpsRelay `on_data_available` logging is incorrect and uninformative

### DIFF
--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -2,8 +2,9 @@
 
 #include "lib/Utility.h"
 
-#include <dds/DdsDcpsCoreTypeSupportImpl.h>
+#include <dds/DCPS/DCPS_Utils.h>
 #include <dds/DCPS/JsonValueWriter.h>
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
 
 namespace RtpsRelay {
 
@@ -34,7 +35,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -2,6 +2,7 @@
 
 #include "lib/Utility.h"
 
+#include <dds/DCPS/DCPS_Utils.h>
 #include <dds/DCPS/JsonValueWriter.h>
 
 namespace RtpsRelay {
@@ -33,7 +34,7 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: PublicationListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: PublicationListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 

--- a/tools/rtpsrelay/RelayAddressListener.cpp
+++ b/tools/rtpsrelay/RelayAddressListener.cpp
@@ -2,6 +2,8 @@
 
 #include "lib/RelayTypeSupportImpl.h"
 
+#include <dds/DCPS/DCPS_Utils.h>
+
 namespace RtpsRelay {
 
 RelayAddressListener::RelayAddressListener(RelayPartitionTable& relay_partition_table)
@@ -12,7 +14,7 @@ void RelayAddressListener::on_data_available(DDS::DataReader_ptr reader)
 {
   RelayAddressDataReader_var dr = RelayAddressDataReader::_narrow(reader);
   if (!dr) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to narrow RtpsRelay::ReaderEntryDataReader\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayAddressListener::on_data_available failed to narrow RtpsRelay::ReaderEntryDataReader\n")));
     return;
   }
 
@@ -25,7 +27,7 @@ void RelayAddressListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayAddressListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 

--- a/tools/rtpsrelay/RelayPartitionsIncrementListener.cpp
+++ b/tools/rtpsrelay/RelayPartitionsIncrementListener.cpp
@@ -2,6 +2,8 @@
 
 #include "lib/RelayTypeSupportImpl.h"
 
+#include <dds/DCPS/DCPS_Utils.h>
+
 namespace RtpsRelay {
 
 RelayPartitionsIncrementListener::RelayPartitionsIncrementListener(RelayPartitionTable& relay_partition_table)
@@ -12,7 +14,7 @@ void RelayPartitionsIncrementListener::on_data_available(DDS::DataReader_ptr rea
 {
   RelayPartitionsIncrementDataReader_var dr = RelayPartitionsIncrementDataReader::_narrow(reader);
   if (!dr) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to narrow RtpsRelay::RelayPartitionsIncrementDataReader\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayPartitionsIncrementListener::on_data_available failed to narrow RtpsRelay::RelayPartitionsIncrementDataReader\n")));
     return;
   }
 
@@ -25,7 +27,7 @@ void RelayPartitionsIncrementListener::on_data_available(DDS::DataReader_ptr rea
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayPartitionsIncrementListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 

--- a/tools/rtpsrelay/RelayPartitionsListener.cpp
+++ b/tools/rtpsrelay/RelayPartitionsListener.cpp
@@ -2,6 +2,8 @@
 
 #include "lib/RelayTypeSupportImpl.h"
 
+#include <dds/DCPS/DCPS_Utils.h>
+
 namespace RtpsRelay {
 
 RelayPartitionsListener::RelayPartitionsListener(RelayPartitionTable& relay_partition_table)
@@ -12,7 +14,7 @@ void RelayPartitionsListener::on_data_available(DDS::DataReader_ptr reader)
 {
   RelayPartitionsDataReader_var dr = RelayPartitionsDataReader::_narrow(reader);
   if (!dr) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to narrow RtpsRelay::RelayPartitionsDataReader\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayPartitionsListener::on_data_available failed to narrow RtpsRelay::RelayPartitionsDataReader\n")));
     return;
   }
 
@@ -25,7 +27,7 @@ void RelayPartitionsListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayPartitionsListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 

--- a/tools/rtpsrelay/SpdpReplayListener.cpp
+++ b/tools/rtpsrelay/SpdpReplayListener.cpp
@@ -1,5 +1,7 @@
 #include "SpdpReplayListener.h"
 
+#include <dds/DCPS/DCPS_Utils.h>
+
 namespace RtpsRelay {
 
 SpdpReplayListener::SpdpReplayListener(SpdpHandler& spdp_handler)
@@ -23,7 +25,7 @@ void SpdpReplayListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ReaderListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: SpdpReplayListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -2,6 +2,7 @@
 
 #include "lib/Utility.h"
 
+#include <dds/DCPS/DCPS_Utils.h>
 #include <dds/DCPS/JsonValueWriter.h>
 
 namespace RtpsRelay {
@@ -33,7 +34,7 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
   if (ret != DDS::RETCODE_OK) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: SubscriptionListener::on_data_available failed to read\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: SubscriptionListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;
   }
 


### PR DESCRIPTION
Problem
-------

The log messages for `on_data_available` in various listeners is
incorrect and doesn't describe why the take failed.

Solution
--------

Fix the log messages and add the status as a string.