### PR TITLE
changed copyright to OpenDDS Foundation

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -85,7 +85,7 @@
   <div class="wrapper">
     <p>{{ site.description }}</p>
     <a href="{{ site.github.repository_url }}/blob/gh-pages/{{ page.path }}">Edit this page on GitHub</a>
-    <p>&copy; 2021 Object Computing, Inc. All rights reserved.</p>
+    <p>&copy; 2021 The OpenDDS Foundation. All rights reserved.</p>
   </div>
 </footer>
 


### PR DESCRIPTION
@mitza-oci I had a note that this needed to be done once we launched the foundation, so it just needs to be updated now.

Replaced Object Computing, Inc. with the OpenDDS Foundation (legal department asked for this change to be made once the foundation was live, which it now is)