### PR TITLE
More Fixes for CMake Tests on Windows

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -17,6 +17,7 @@
   * [Boost](#boost)
   * [Xerces](#xerces)
   * [OpenSSL](#openssl)
+  * [Python](#python)
 
 ## Required to Build the Core OpenDDS Libraries
 
@@ -26,7 +27,7 @@ downloaded automatically by the configure script by default.**
 ### Perl
 
 Perl is an interpreted language used in the configure script, the tests, and
-any other scripting in OpenDDS codebase. Even if the configure script is not
+most other scripting in OpenDDS codebase. Even if the configure script is not
 used, it is also required to run MPC, so it is required to build OpenDDS.
 
 Testing scripts are written in Perl and use the common PerlACE modules provided
@@ -191,3 +192,15 @@ security XML configuration files.
 
 OpenSSL is used for DDS Security for verifying security configurations and
 encryption and decryption. Version 1.0 and version 1.1 are supported.
+
+### Python
+
+Python is used for some scripts where Perl isn't as suitable. Most notably this
+includes the [Sphinx-based documentation](README.md#sphinx-documentation) and
+processing the results of the CMake tests in `auto_run_tests.pl` if `--cmake`
+is passed.
+
+Unless noted otherwise, Python should be version 3.6 or later. Because it's an
+optional dependency, Python should not be required for any script used for
+building and testing the core functionality of OpenDDS. Right now only Perl can
+be used for situations like that.

--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -161,6 +161,8 @@ sub print_help {
         "Executes test list files (*.lst), which contain commands with conditions called\n" .
         "configurations under which the commands are run.\n" .
         "\n" .
+        "<list_file> can be a path or - to use stdin.\n" .
+        "\n" .
         "Options:\n" .
         "    --help | -h              Display this help\n";
 
@@ -273,9 +275,6 @@ foreach my $list (@builtin_test_lists) {
     push(@file_list, "$DDS_ROOT/$list->{file}") if ($query || $list->{enabled});
 }
 push(@file_list, @ARGV);
-foreach my $list (@file_list) {
-    die("$list is not a readable file!") if (!-r $list);
-}
 
 if ($show_configs) {
     foreach my $test_list (@file_list) {

--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -10,18 +10,6 @@ use warnings;
 
 use Env qw(ACE_ROOT DDS_ROOT PATH);
 
-my $exe_sub_dir;
-BEGIN {
-    for (my $i = 0; $i <= $#ARGV; ++$i) {
-        if ($ARGV[$i] eq '-ExeSubDir') {
-            if (defined($ARGV[$i + 1])) {
-                $exe_sub_dir = $ARGV[++$i];
-                print("ExeSubDir: $ARGV[$i]\n");
-            } # else let Process.pm deal with that
-        }
-    }
-}
-
 use lib "$ACE_ROOT/bin";
 use lib "$DDS_ROOT/bin";
 use PerlDDS::Run_Test;
@@ -30,6 +18,8 @@ use Getopt::Long;
 use Cwd;
 use POSIX qw(SIGINT);
 use File::Temp qw(tempfile);
+
+use constant windows => $^O eq "MSWin32";
 
 sub cd {
     my $dir = shift;
@@ -149,7 +139,6 @@ my @builtin_test_lists = (
         file => "tools/modeling/tests/modeling_tests.lst",
     },
 );
-my %builtin_test_lists_hash = map { $_->{name} => $_ } @builtin_test_lists;
 
 sub print_usage {
     my $error = shift // 1;
@@ -189,12 +178,18 @@ sub print_help {
         "                             Not included by default\n" .
         "    --cmake-build-dir <path> Path to the CMake tests binary directory\n" .
         "                             Default is \$DDS_ROOT/tests/cmake/build\n" .
+        "    --cmake-build-cfg <cfg>  CMake build configuration, like the one passed to\n" .
+        "                             `cmake --config`. Mostly used by Visual Studio.\n" .
+        "                             Default is \"Debug\" on Windows, no default\n" .
+        "                             elsewhere.\n" .
         "    --ctest <cmd>            CTest to use to run CMake Tests\n" .
         "                             Default is `ctest`\n" .
         "    --ctest-args <args>      Additional arguments to pass to CTest\n" .
         "    --python <cmd>           Python command to use to run\n" .
         "                             ctest-to-auto-run-tests.py.\n" .
-        "                             Default is `python3`\n" .
+        "                             Default is `python` on Windows, `python3`\n" .
+        "                             elsewhere.\n" .
+
         # These two are processed by PerlACE/ConfigList.pm
         "    -Config <cfg>            Include tests with <cfg> configuration\n" .
         "    -Exclude <cfg>           Exclude tests with <cfg> configuration\n" .
@@ -227,9 +222,12 @@ my $list_configs = 0;
 my $list_tests = 0;
 my $cmake = 0;
 my $cmake_build_dir = "$cmake_tests/build";
+my $cmake_build_cfg = windows ? 'Debug' : undef;
 my $ctest = 'ctest';
 my $ctest_args = '';
-my $python = 'python3';
+# Python on Windows is called python from what I can see. On other platforms
+# that are legacy-mindful python is Python 2, but we can rely on python3.
+my $python = windows ? 'python' : 'python3';
 my %opts = (
     'help|h' => \$help,
     'sandbox|s=s' => \$sandbox,
@@ -240,6 +238,7 @@ my %opts = (
     'stop-on-fail|x' => \$stop_on_fail,
     'cmake' => \$cmake,
     'cmake-build-dir=s' => \$cmake_build_dir,
+    'cmake-build-cfg=s' => \$cmake_build_cfg,
     'ctest=s' => \$ctest,
     'ctest-args=s' => \$ctest_args,
     'python=s' => \$python,
@@ -394,8 +393,8 @@ if ($cmake) {
     if ($ctest_args) {
         push(@cmd, $ctest_args);
     }
-    if ($ctest_args !~ /--build-config/ && defined($exe_sub_dir)) {
-        push(@cmd, "--build-config $exe_sub_dir");
+    if ($ctest_args !~ /--build-config/ && defined($cmake_build_cfg)) {
+        push(@cmd, "--build-config $cmake_build_cfg");
     }
     if ($list_tests) {
         run_command($fake_name, join(' ', @cmd));

--- a/tests/cmake/ctest-to-auto-run-tests.py
+++ b/tests/cmake/ctest-to-auto-run-tests.py
@@ -71,6 +71,12 @@ def generate_test_results(build_path, source_path, debug=False):
             sys.exit('ERROR: Test output in XML file is not usable, ' +
                 'pass --no-compress-output to ctest')
 
+        status = get_named_measurement(test_node, 'Completion Status')
+        if status == "Missing Configuration":
+            sys.exit('ERROR: Build has a configuration and ctest needs to know it. ' +
+                'Pass --cmake-build-cfg with the config if using auto_run_tests.pl. ' +
+                'Pass --build-config with the config if using ctest directly')
+
         abs_source_path = source_path.resolve()
 
         results = dict(

--- a/tests/cmake/ctest-to-auto-run-tests.py
+++ b/tests/cmake/ctest-to-auto-run-tests.py
@@ -38,7 +38,7 @@ def relative_to(a, b):
 
 
 def fix_ctest_path(abs_source_path, path):
-    '''Work around ctest puting C_ instead of C: in the path
+    '''Work around ctest putting C_ instead of C: in the path
     '''
     drive = abs_source_path.drive
     if drive and path.upper().startswith(drive[0].upper() + '_'):

--- a/tests/cmake/generated_global/README.md
+++ b/tests/cmake/generated_global/README.md
@@ -4,7 +4,7 @@ As a result, running this test with without the creation of the \_export.h file 
 
 Explanation of issue: the top level CMakeLists delegates to the two subdirectories: idl and cpp. The idl directory creates the idl\_messenger library which is needed by the cpp directory. At makefile creation time, the cpp CMakeLists.txt "target\_link\_libraries section finds the idl\_messenger library and tries to add files that do not have the property `GENERATED` to the add\_executable section. Despite the fact the idl\_messenger directory had set the `GENERATED` property to true, the cpp directory is unable to access that property, and thus tries to add idl\_messenger\_export.h to the add\_executable.
 
-By having the file created at makefile creation time, we have eliminated the dependancy on the `GENERATED` flag, avoiding the problem.
+By having the file created at makefile creation time, we have eliminated the dependency on the `GENERATED` flag, avoiding the problem.
 
 These changes should not force the user to have to do anything, as they should be automatic in OpenDDS.
 


### PR DESCRIPTION
Follow up to #2712

- `auto_run_tests.pl`:
  - Make a separate ` --cmake-build-cfg`  for `ctest --build-config` because using the same value of `-ExeSubDir` as the MPC-based tests seems impossible. Default this to `"Debug"` on Windows for convenience.
  - Default `--python` on Windows to `python`.
- Detect when a required build configuration is missing in `ctest-to-auto-run-tests.py` to give a friendly error instead of a confusing stack trace.

Also:
- Add Python to `docs/dependencies.md`
- Fixed spelling in `tests/cmake`