### PR TITLE
Parallel builds for safety profile 

### DIFF
--- a/MPC/config/dcps_idl_only_lib.mpb
+++ b/MPC/config/dcps_idl_only_lib.mpb
@@ -1,6 +1,6 @@
 // Base project for libraries that only contains IDL Typesupport
 
-project: dcps {
+project: dcps, dds_corbaseq {
   libout = .
 
   Header_Files {


### PR DESCRIPTION
see jira ticket 341. This change adds a dependency to ensure IDL related artifacts are built in proper order.