### PR TITLE
rtps_udp: make data_delivered callbacks in order

### DIFF
--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -648,10 +648,11 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
-                 ACE_TEXT("domain %d topic %C publication %C %s.\n"),
+                 ACE_TEXT("domain %d topic %C publication %C seq# %q %s.\n"),
                  this->domain_id_,
                  this->topic_name_,
                  OPENDDS_STRING(converter).c_str(),
+                 acked_seq.getValue(),
                  max_durable_per_instance_
                  ? ACE_TEXT("stored for durability")
                  : ACE_TEXT("released")));
@@ -1301,6 +1302,11 @@ WriteDataContainer::copy_and_prepend(SendStateDataSampleList& list,
 
     element->set_num_subs(1);
     element->set_sub_id(0, reader_id);
+
+    if (DCPS_debug_level > 9) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) WriteDataContainer::copy_and_prepend added seq# %q\n",
+                 cur->get_header().sequence_.getValue()));
+    }
 
     list.enqueue_head(element);
     --max_resend_samples;

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -163,7 +163,8 @@ public:
   struct OrderBySequenceNumber {
     bool operator()(const TransportQueueElement* lhs, const TransportQueueElement* rhs) const
     {
-      return lhs->sequence() < rhs->sequence();
+      const SequenceNumber seq_l = lhs->sequence(), seq_r = rhs->sequence();
+      return seq_l < seq_r || (seq_l == seq_r && lhs < rhs);
     }
   };
 

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -160,6 +160,13 @@ public:
 
   virtual bool is_retained_replaced() const { return false; }
 
+  struct OrderBySequenceNumber {
+    bool operator()(const TransportQueueElement* lhs, const TransportQueueElement* rhs) const
+    {
+      return lhs->sequence() < rhs->sequence();
+    }
+  };
+
 protected:
 
   /// Ctor.  The initial_count is the number of DataLinks to which

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -397,7 +397,7 @@ private:
     ReaderInfoSet readers_expecting_heartbeat_;
     RcHandle<SingleSendBuffer> send_buff_;
     SequenceNumber max_sn_;
-    typedef OPENDDS_SET(TransportQueueElement*) TqeSet;
+    typedef OPENDDS_SET_CMP(TransportQueueElement*, TransportQueueElement::OrderBySequenceNumber) TqeSet;
     typedef OPENDDS_MULTIMAP(SequenceNumber, TransportQueueElement*) SnToTqeMap;
     SnToTqeMap elems_not_acked_;
     WeakRcHandle<RtpsUdpDataLink> link_;

--- a/tests/DCPS/DelayedDurable/DelayedDurable.cpp
+++ b/tests/DCPS/DelayedDurable/DelayedDurable.cpp
@@ -1,14 +1,21 @@
 #include "DelayedDurableTypeSupportImpl.h"
 
+#include <tests/Utils/StatusMatching.h>
+
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/PoolAllocator.h>
 #include <dds/DCPS/WaitSet.h>
+
 #include <dds/DCPS/transport/framework/TransportSendStrategy.h>
 #ifdef ACE_AS_STATIC_LIBS
 #  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #endif
 
+#include <ace/ace_wchar.h>
+
+#include <fstream>
 #include <set>
 
 using namespace DDS;
@@ -39,6 +46,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   bool writer = false;
   bool reader = false;
   bool large_samples = false;
+  bool has_early_reader = false;
+  int argv_index_report_file = 0;
+
   for (int i = 1; i < argc; ++i) {
     ACE_TString arg(argv[i]);
     if (arg == ACE_TEXT("--verbose")) {
@@ -49,6 +59,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       reader = true;
     } else if (arg == ACE_TEXT("--large-samples")) {
       large_samples = true;
+    } else if (arg == ACE_TEXT("--has-early-reader")) {
+      has_early_reader = true;
+    } else if (arg == ACE_TEXT("--report-last-value")) {
+      argv_index_report_file = ++i;
     } else {
       ACE_ERROR((LM_ERROR, "ERROR: Invalid argument: %s\n", argv[i]));
       return 1;
@@ -56,6 +70,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   bool failed = false;
+  const int num_instances = has_early_reader ? 1 : scale(100, large_samples);
+  const char* const name = writer ? "writer" : "reader";
+  ACE_DEBUG((LM_DEBUG, "(%P|%t) %C starting at %T\n", name));
 
   if (writer) {
     Publisher_var pub = dp->create_publisher(PUBLISHER_QOS_DEFAULT, 0,
@@ -67,6 +84,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
                                                DEFAULT_STATUS_MASK);
     PropertyDataWriter_var pdw = PropertyDataWriter::_narrow(dw);
 
+    if (has_early_reader) {
+      Utils::wait_match(dw, 1);
+    }
+
     Property p;
     if (large_samples) {
       p.extra.length(large_sample_seq_size);
@@ -77,28 +98,34 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       p.extra.length(0);
     }
 
-    for (int i = 1; i <= scale(100, large_samples); ++i) {
+    for (int i = 1; i <= num_instances; ++i) {
       p.key = i;
       p.value = i;
       pdw->write(p, HANDLE_NIL);
     }
 
     for (int c = 1; c < 75; ++c) {
-      for (int i = 1; i <= scale(100, large_samples); i += scale(5, large_samples)) {
+      for (int i = 1; i <= num_instances; i += scale(5, large_samples)) {
         p.key = i;
         p.value = i + c;
         pdw->write(p, HANDLE_NIL);
       }
-      ACE_OS::sleep(ACE_Time_Value(0, 500 * 1000)); // 1/2 sec
+      if (!has_early_reader) {
+        ACE_OS::sleep(ACE_Time_Value(0, 500 * 1000)); // 1/2 sec
+      }
       if (verbose) {
         ACE_DEBUG((LM_DEBUG, "writer: Count: %d\n", c));
       }
     }
+
     DDS::Duration_t duration = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
     pdw->wait_for_acknowledgments(duration);
-  } else if (reader) {
-    ACE_DEBUG((LM_DEBUG, "Reader starting at %T\n"));
 
+    if (has_early_reader) {
+      Utils::wait_match(dw, 2);
+    }
+
+  } else if (reader) {
     Subscriber_var sub = dp->create_subscriber(SUBSCRIBER_QOS_DEFAULT, 0,
                                                DEFAULT_STATUS_MASK);
     DataReaderQos dr_qos;
@@ -114,8 +141,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     WaitSet_var ws = new WaitSet;
     ws->attach_condition(dr_rc);
     unsigned counter = 0;
-    const unsigned minimum_sample_count = large_samples ? 95 : 981;
+    const unsigned minimum_sample_count = has_early_reader ? 1 : large_samples ? 95 : 981;
     std::set<int> instances;
+    int last_value = 0;
     while (true) {
       ConditionSeq active;
       const Duration_t max_wait = {10, 0};
@@ -136,8 +164,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         for (unsigned int i = 0; i < data.length(); ++i) {
           ++counter;
           instances.insert(data[i].key);
+          last_value = data[i].value;
           if (verbose) {
-            ACE_DEBUG((LM_DEBUG, "reader: Counter: %u Instance: %d\n", counter, data[i].key));
+            ACE_DEBUG((LM_DEBUG, "reader: Counter: %u Instance: %d Value: %d\n", counter, data[i].key, data[i].value));
           }
 
           if (counter == minimum_sample_count) {
@@ -156,7 +185,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         minimum_sample_count, counter));
       failed = true;
     }
-    for (int i = 1; i <= scale(100, large_samples); ++i) {
+    for (int i = 1; i <= num_instances; ++i) {
       if (instances.count(i) == 0) {
         ACE_ERROR((LM_ERROR, "ERROR: Reader Missing Instance %d\n", i));
         failed = true;
@@ -164,10 +193,22 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     }
     ws->detach_condition(dr_rc);
     dr->delete_readcondition(dr_rc);
+
+    if (argv_index_report_file) {
+      const OpenDDS::DCPS::String filename = ACE_TEXT_ALWAYS_CHAR(argv[argv_index_report_file]);
+      std::ofstream file(filename.c_str());
+      file << last_value;
+    }
+
+    if (has_early_reader) {
+      Utils::wait_match(dr, 0);
+    }
+
   } else {
     ACE_ERROR((LM_ERROR, "ERROR: Must pass either --writer or --reader\n"));
     return 1;
   }
+  ACE_DEBUG((LM_DEBUG, "(%P|%t) %C ending at %T\n", name));
 
   topic = 0;
   dp->delete_contained_entities();

--- a/tests/DCPS/DelayedDurable/DelayedDurable.mpc
+++ b/tests/DCPS/DelayedDurable/DelayedDurable.mpc
@@ -1,4 +1,5 @@
 project: dcps_test, dcps_rtps_udp {
+  idlflags += -SS
   TypeSupport_Files {
     DelayedDurable.idl
   }

--- a/tests/DCPS/DelayedDurable/README.txt
+++ b/tests/DCPS/DelayedDurable/README.txt
@@ -1,0 +1,27 @@
+DelayedDurable tests a few aspects of durability QoS support in the rtps_udp transport
+
+This test consists of a single executable that can act as a publisher or a subscriber.
+Depending on the mode selected, the Perl script starts 2 or 3 processes using this same executable.
+
+- default mode
+
+A writer process is started first.  It writes data with no reader associated.
+This populates the WriteDataContainer with samples that belong to multiple instances.
+After a delay, a reader process starts.  The reader will receive a subset of the
+written samples according to the history QoS (default policy - keep last 1).
+
+- large samples
+
+Similar to the default mode, but with a tenth of the instances and a sample size
+that requires fragmentation.
+
+- early reader
+
+This mode starts a reading process first.  Thus when the writer starts writing it is
+not just popluating WriteDataContainer but also writing to the transport.
+Once the writer associates with this "early" reader, it starts writing to a single instance.
+The early reader writes the number of its last-read sample to a file.
+The late reader starts after the writer is done writing so it only sees a single sample.
+The late reader writes the number of this single sample to a file.
+The Perl script verifies that these two files are equal.
+

--- a/tests/DCPS/DelayedDurable/run_test.pl
+++ b/tests/DCPS/DelayedDurable/run_test.pl
@@ -5,33 +5,70 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 use lib "$ENV{ACE_ROOT}/bin";
 use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
+use File::Compare;
 use Getopt::Long;
 use strict;
 
 my $test = new PerlDDS::TestFramework();
 $test->enable_console_logging();
 
+my $large_samples = 0;
 my $verbose = 0;
-my $large_samples= 0;
+my $early_reader = 0;
 GetOptions(
   "large-samples" => \$large_samples,
   "verbose" => \$verbose,
+  "early-reader" => \$early_reader,
 );
 
 my @common_args = ('-DCPSConfigFile', 'rtps_disc.ini');
 push(@common_args, "--verbose") if ($verbose);
 push(@common_args, "--large-samples") if ($large_samples);
+push(@common_args, "--has-early-reader") if $early_reader;
 
 my @writer_args = ('--writer');
 push(@writer_args, @common_args);
-$test->process('writer', 'DelayedDurable', join(' ', @writer_args));
-$test->start_process('writer');
-
-sleep 15;
 
 my @reader_args = ('--reader');
 push(@reader_args, @common_args);
-$test->process('reader', 'DelayedDurable', join(' ', @reader_args));
-$test->start_process('reader');
 
-exit $test->finish(60);
+my $readerAfile = 'readerA.txt';
+if ($early_reader) {
+  unlink $readerAfile;
+  $test->process('readerA', 'DelayedDurable',
+                 join(' ', @reader_args, '--report-last-value', $readerAfile));
+  $test->start_process('readerA');
+}
+
+$test->process('writer', 'DelayedDurable', join(' ', @writer_args));
+$test->start_process('writer');
+
+if ($early_reader) {
+  if (PerlACE::waitforfile_timed($readerAfile, 30) == -1) {
+    print STDERR "ERROR: waiting for reader data file\n";
+    $test->finish();
+    exit 1;
+  }
+}
+else {
+  sleep 15;
+}
+
+my $readerBfile = 'readerB.txt';
+unlink $readerBfile;
+push(@reader_args, '--report-last-value', $readerBfile) if $early_reader;
+
+$test->process('readerB', 'DelayedDurable', join(' ', @reader_args));
+$test->start_process('readerB');
+
+my $ret = $test->finish(60);
+if ($early_reader) {
+  if (compare($readerAfile, $readerBfile)) {
+    print STDERR "ERROR: Readers got different last-sample values\n";
+    PerlDDS::print_file($readerAfile);
+    PerlDDS::print_file($readerBfile);
+    exit 1;
+  }
+  unlink $readerAfile, $readerBfile;
+}
+exit $ret;

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -122,6 +122,7 @@ tests/DCPS/TransientLocalTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DD
 tests/DCPS/TransientLocalTest/run_test.pl rtps: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/DelayedDurable/run_test.pl: !DCPS_MIN RTPS
 tests/DCPS/DelayedDurable/run_test.pl --large-samples: !DCPS_MIN RTPS
+tests/DCPS/DelayedDurable/run_test.pl --early-reader: !DCPS_MIN RTPS
 tests/DCPS/MultiRepoTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/MultiRepoTest/run_test.pl fileconfig: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Presentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE


### PR DESCRIPTION
based on sequence numbers since WriteDataContainer uses this to keep the
list of durable data in order