### PR TITLE
Delay TransportQueue memcpy Until Required

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -228,6 +228,14 @@ SingleSendBuffer::retain_buffer(const RepoId& pub_id, BufferType& buffer)
                               replaced_db_allocator_);
 
   buffer.first->accept_replace_visitor(visitor);
+  if (visitor.status() != REMOVE_ERROR) {
+    // Copy sample's message/data block descriptors:
+    ACE_Message_Block* data = buffer.second;
+    buffer.second = TransportQueueElement::clone_mb(data,
+                                           &retained_mb_allocator_,
+                                           &retained_db_allocator_);
+    data->release();
+  }
   return visitor.status();
 }
 
@@ -285,11 +293,7 @@ SingleSendBuffer::insert_buffer(BufferType& buffer,
                            &retained_db_allocator_);
   queue->accept_visitor(visitor);
 
-  // Copy sample's message/data block descriptors:
-  ACE_Message_Block*& data = buffer.second;
-  data = TransportQueueElement::clone_mb(chain,
-                                         &retained_mb_allocator_,
-                                         &retained_db_allocator_);
+  buffer.second = chain->duplicate();
 }
 
 void

--- a/dds/DCPS/transport/multicast/MulticastDataLink.cpp
+++ b/dds/DCPS/transport/multicast/MulticastDataLink.cpp
@@ -434,6 +434,15 @@ MulticastDataLink::stop_i()
   this->socket_.close();
 }
 
+void
+MulticastDataLink::client_stop(const RepoId& localId)
+{
+  if (send_buffer_) {
+    send_buffer_->retain_all(localId);
+    send_buffer_.reset();
+  }
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/transport/multicast/MulticastDataLink.h
+++ b/dds/DCPS/transport/multicast/MulticastDataLink.h
@@ -86,6 +86,7 @@ public:
   void release_reservations_i(const RepoId& remote_id,
                               const RepoId& local_id);
 
+  void client_stop(const RepoId& localId);
 
 private:
 

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -414,6 +414,24 @@ MulticastTransport::release_datalink(DataLink* /*link*/)
   // until the transport is shut down.
 }
 
+void MulticastTransport::client_stop(const RepoId& localId)
+{
+  GuardThreadType guard_links(this->links_lock_);
+  const MulticastPeer local_peer = (ACE_INT64)RepoIdConverter(localId).federationId() << 32
+                                 | RepoIdConverter(localId).participantId();
+  Links::const_iterator link_iter = this->client_links_.find(local_peer);
+  MulticastDataLink_rch link;
+
+  if (link_iter != this->client_links_.end()) {
+    link = link_iter->second;
+  }
+  guard_links.release();
+
+  if (link) {
+    link->client_stop(localId);
+  }
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/transport/multicast/MulticastTransport.h
+++ b/dds/DCPS/transport/multicast/MulticastTransport.h
@@ -58,6 +58,8 @@ protected:
 
   virtual std::string transport_type() const { return "multicast"; }
 
+  void client_stop(const RepoId& localId);
+
 private:
 
   typedef ACE_SYNCH_MUTEX         LockType;


### PR DESCRIPTION
Eventually, we should probably do the same optimization for the TransportQueueElements above (calling duplicate instead of clone_mb), but it requires more extensive changes to the transport framework.