### PR TITLE
Fix BestEffort Multicast, Restore Test Coverage

### DIFF
--- a/dds/DCPS/transport/multicast/BestEffortSession.cpp
+++ b/dds/DCPS/transport/multicast/BestEffortSession.cpp
@@ -74,6 +74,7 @@ BestEffortSession::start(bool active, bool /*acked*/)
   if (this->started_) return true;  // already started
 
   this->active_ = active;
+  set_acked();
 
   if (active && !this->start_syn()) {
     ACE_ERROR_RETURN((LM_ERROR,

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -198,7 +198,6 @@ MulticastTransport::connect_datalink(const RemoteTransport& remote,
     }
   }
 
-  link->remove_on_start_callback(client, remote.repo_id_);
   return AcceptConnectResult(link);
 }
 
@@ -232,6 +231,7 @@ MulticastTransport::accept_datalink(const RemoteTransport& remote,
 
   MulticastPeer remote_peer = (ACE_INT64)RepoIdConverter(remote.repo_id_).federationId() << 32
                             | RepoIdConverter(remote.repo_id_).participantId();
+
   GuardThreadType guard(this->connections_lock_);
 
   if (connections_.count(std::make_pair(remote_peer, local_peer))) {
@@ -250,18 +250,24 @@ MulticastTransport::accept_datalink(const RemoteTransport& remote,
 
   } else {
 
-    this->pending_connections_[std::make_pair(remote_peer, local_peer)].
-    push_back(std::make_pair(client, remote.repo_id_));
+    if (config().is_reliable()) {
+      pending_connections_[std::make_pair(remote_peer, local_peer)].
+      push_back(std::make_pair(client, remote.repo_id_));
+    }
+
     //can't call start session with connections_lock_ due to reactor
     //call in session->start which could deadlock with passive_connection
     guard.release();
     MulticastSession_rch session(
       this->start_session(link, remote_peer, false /*!active*/));
 
-    return AcceptConnectResult(
-      session ? AcceptConnectResult::ACR_SUCCESS : AcceptConnectResult::ACR_FAILED
-    );
-
+    if (!session) {
+      return AcceptConnectResult(AcceptConnectResult::ACR_FAILED);
+    } else if (config().is_reliable()) {
+      return AcceptConnectResult(AcceptConnectResult::ACR_SUCCESS);
+    } else {
+      return AcceptConnectResult(link);
+    }
   }
 }
 
@@ -309,6 +315,7 @@ MulticastTransport::passive_connection(MulticastPeer local_peer, MulticastPeer r
   const PendConnMap::iterator pend = this->pending_connections_.find(peers);
   //if connection was pending, calls to use_datalink finalized the connection
   //if it was not previously pending, accept_datalink() will finalize connection
+
   this->connections_.insert(peers);
 
   Links::const_iterator server_link = this->server_links_.find(local_peer);
@@ -333,8 +340,9 @@ MulticastTransport::passive_connection(MulticastPeer local_peer, MulticastPeer r
           RepoId remote_repo = tmp.at(i).second;
           guard.release();
           TransportClient_rch client = pend_client.lock();
-          if (client)
+          if (client) {
             client->use_datalink(remote_repo, link);
+          }
           guard.acquire();
         }
       }

--- a/java/tests/messenger/publisher/run_test.pl
+++ b/java/tests/messenger/publisher/run_test.pl
@@ -33,8 +33,8 @@ if ($config eq 'udp') {
   $reliable = '';
 }
 
-my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini $reliable";
-my $pub_opts = $opts;
+my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini";
+my $pub_opts = "$opts $reliable";
 my $sub_opts = $opts;
 if ($debug ne '0') {
     my $debug_opt = "-ORBDebugLevel $debug -DCPSDebugLevel $debug " .

--- a/java/tests/messenger/subscriber/run_test.pl
+++ b/java/tests/messenger/subscriber/run_test.pl
@@ -33,9 +33,9 @@ if ($config eq 'udp') {
   $reliable = '';
 }
 
-my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini $reliable";
+my $opts = "-DCPSBit 0 -DCPSConfigFile ../$config.ini";
 my $pub_opts = $opts;
-my $sub_opts = $opts;
+my $sub_opts = "$opts $reliable";
 if ($debug ne '0') {
     my $debug_opt = "-ORBDebugLevel $debug -DCPSDebugLevel $debug " .
                     "-DCPSTransportDebugLevel $debug";

--- a/tests/DCPS/Messenger/Args.h
+++ b/tests/DCPS/Messenger/Args.h
@@ -19,12 +19,11 @@
 #include <cstdlib>
 
 const size_t num_messages = 40;
-extern bool reliable;
 
 inline
 int parse_args(int argc, ACE_TCHAR* argv[])
 {
-  ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("t:prw"));
+  ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("t:pw"));
 
   OpenDDS::DCPS::String transport_type;
   int c;
@@ -46,9 +45,6 @@ int parse_args(int argc, ACE_TCHAR* argv[])
       break;
     case 'p':
       thread_per_connection = true;
-      break;
-    case 'r':
-      reliable = true;
       break;
     case '?':
     default:

--- a/tests/DCPS/Messenger/DataReaderListener.cpp
+++ b/tests/DCPS/Messenger/DataReaderListener.cpp
@@ -33,7 +33,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 bool DataReaderListenerImpl::is_reliable()
 {
   OpenDDS::DCPS::TransportConfig_rch gc = TheTransportRegistry->global_config();
-  return gc->instances_[0]->transport_type_ != "udp";
+  return gc->instances_[0]->transport_type_ != "udp" &&
+         !(gc->instances_[0]->transport_type_ == "multicast" && !gc->instances_[0]->is_reliable());
 }
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)

--- a/tests/DCPS/Messenger/Writer.cpp
+++ b/tests/DCPS/Messenger/Writer.cpp
@@ -18,11 +18,11 @@
 #include <cstdlib>
 
 const int num_instances_per_writer = 1;
-bool reliable = false;
 
-Writer::Writer(DDS::DataWriter_ptr writer)
-  : writer_(DDS::DataWriter::_duplicate(writer)),
-    finished_instances_(0)
+Writer::Writer(DDS::DataWriter_ptr writer, bool reliable)
+  : writer_(DDS::DataWriter::_duplicate(writer))
+  , finished_instances_(0)
+  , reliable_(reliable)
 {
 }
 
@@ -108,6 +108,10 @@ int Writer::svc()
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%N:%l: svc()")
                    ACE_TEXT(" ERROR: write returned %d!\n"), error));
+      }
+
+      if (!reliable_) {
+        ACE_OS::sleep(ACE_Time_Value(0, 20000));
       }
 
       message.count++;

--- a/tests/DCPS/Messenger/Writer.h
+++ b/tests/DCPS/Messenger/Writer.h
@@ -13,7 +13,7 @@
 class Writer : public ACE_Task_Base {
 public:
 
-  Writer(DDS::DataWriter_ptr writer);
+  Writer(DDS::DataWriter_ptr writer, bool reliable);
 
   void start();
 
@@ -27,6 +27,7 @@ public:
 private:
   DDS::DataWriter_var writer_;
   ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
+  bool reliable_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/Messenger/pub_multicast_be.ini
+++ b/tests/DCPS/Messenger/pub_multicast_be.ini
@@ -1,0 +1,13 @@
+#
+#
+
+[common]
+DCPSInfoRepo=file://repo.ior
+DCPSBit=0
+DCPSGlobalTransportConfig=$file
+
+[transport/3]
+transport_type=multicast
+ttl=3
+group_address=224.1.0.129:49401
+reliable=0

--- a/tests/DCPS/Messenger/pub_udp_free.ini
+++ b/tests/DCPS/Messenger/pub_udp_free.ini
@@ -1,0 +1,10 @@
+#
+#
+
+[common]
+DCPSInfoRepo=file://repo.ior
+DCPSBit=0
+DCPSGlobalTransportConfig=$file
+
+[transport/t1]
+transport_type=udp

--- a/tests/DCPS/Messenger/publisher.cpp
+++ b/tests/DCPS/Messenger/publisher.cpp
@@ -46,7 +46,8 @@ const char permissions_file[] = "file:./permissions_1_signed.p7s";
 bool dw_reliable()
 {
   OpenDDS::DCPS::TransportConfig_rch gc = TheTransportRegistry->global_config();
-  return gc->instances_[0]->transport_type_ != "udp";
+  return gc->instances_[0]->transport_type_ != "udp" &&
+         !(gc->instances_[0]->transport_type_ == "multicast" && !gc->instances_[0]->is_reliable());
 }
 
 void append(DDS::PropertySeq& props, const char* name, const char* value, bool propagate = false)
@@ -181,7 +182,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
       // Start writing threads
       std::cout << "Creating Writer" << std::endl;
-      Writer* writer = new Writer(dw.in());
+      Writer* writer = new Writer(dw.in(), dw_reliable());
       std::cout << "Starting Writer" << std::endl;
       writer->start();
 

--- a/tests/DCPS/Messenger/run_test.pl
+++ b/tests/DCPS/Messenger/run_test.pl
@@ -37,9 +37,17 @@ if ($test->flag('udp')) {
     $pub_opts .= " -DCPSConfigFile pub_udp.ini";
     $sub_opts .= " -DCPSConfigFile sub_udp.ini";
 }
+elsif ($test->flag('udp_free')) {
+    $pub_opts .= " -DCPSConfigFile pub_udp_free.ini";
+    $sub_opts .= " -DCPSConfigFile sub_udp_free.ini";
+}
 elsif ($test->flag('multicast')) {
     $pub_opts .= " -DCPSConfigFile pub_multicast.ini";
     $sub_opts .= " -DCPSConfigFile sub_multicast.ini";
+}
+elsif ($test->flag('multicast_be')) {
+    $pub_opts .= " -DCPSConfigFile pub_multicast_be.ini";
+    $sub_opts .= " -DCPSConfigFile sub_multicast_be.ini";
 }
 elsif ($test->flag('default_tcp')) {
     $pub_opts .= " -t tcp";

--- a/tests/DCPS/Messenger/run_test.pl
+++ b/tests/DCPS/Messenger/run_test.pl
@@ -38,6 +38,7 @@ if ($test->flag('udp')) {
     $sub_opts .= " -DCPSConfigFile sub_udp.ini";
 }
 elsif ($test->flag('udp_free')) {
+    #similar to udp, but don't set localaddress / use localhost
     $pub_opts .= " -DCPSConfigFile pub_udp_free.ini";
     $sub_opts .= " -DCPSConfigFile sub_udp_free.ini";
 }

--- a/tests/DCPS/Messenger/stack_subscriber.cpp
+++ b/tests/DCPS/Messenger/stack_subscriber.cpp
@@ -22,8 +22,6 @@
 
 #include <cstdlib>
 
-bool reliable = false;
-
 int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
   int status = EXIT_SUCCESS;

--- a/tests/DCPS/Messenger/sub_multicast_be.ini
+++ b/tests/DCPS/Messenger/sub_multicast_be.ini
@@ -1,0 +1,12 @@
+#
+#
+
+[common]
+DCPSInfoRepo=file://repo.ior
+DCPSBit=0
+DCPSGlobalTransportConfig=$file
+
+[transport/3]
+transport_type=multicast
+group_address=224.1.0.129:49401
+reliable=0

--- a/tests/DCPS/Messenger/sub_udp_free.ini
+++ b/tests/DCPS/Messenger/sub_udp_free.ini
@@ -1,0 +1,10 @@
+#
+#
+
+[common]
+DCPSInfoRepo=file://repo.ior
+DCPSBit=0
+DCPSGlobalTransportConfig=$file
+
+[transport/t2]
+transport_type=udp

--- a/tests/DCPS/Messenger/subscriber.cpp
+++ b/tests/DCPS/Messenger/subscriber.cpp
@@ -39,8 +39,6 @@ const char governance_file[] = "file:./governance_signed.p7s";
 const char permissions_file[] = "file:./permissions_2_signed.p7s";
 #endif
 
-bool reliable = false;
-
 void append(DDS::PropertySeq& props, const char* name, const char* value, bool propagate = false)
 {
   const DDS::Property_t prop = {name, value, propagate};

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -198,6 +198,7 @@ tests/DCPS/Messenger/run_test.pl thread_per: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !
 tests/DCPS/Messenger/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Messenger/run_test.pl default_udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
 tests/DCPS/Messenger/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Messenger/run_test.pl multicast_be: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl default_multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
 tests/DCPS/Messenger/run_test.pl nobits: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE


### PR DESCRIPTION
At some point we seem to have gotten rid of test coverage for best effort (reliable=0 in the transport config) multicast. This restores test coverage and get it working again enough to process with performance testing.