### PR TITLE
Test for IDL unions with aliased default cases

### DIFF
--- a/tests/DCPS/Compiler/XtypesExtensibility/Extensibility.idl
+++ b/tests/DCPS/Compiler/XtypesExtensibility/Extensibility.idl
@@ -92,4 +92,12 @@ module extensibility {
    case 1: short B;
   };
 
+  enum disc { A, B, C };
+  union union_empty_label switch(disc) {
+   case A: long a_long;
+   case B: short b_short;
+   case C:
+   default: float f_float;
+  };
+
 };

--- a/tests/DCPS/Compiler/XtypesExtensibility/XtypesExtensibility.cpp
+++ b/tests/DCPS/Compiler/XtypesExtensibility/XtypesExtensibility.cpp
@@ -85,6 +85,19 @@ TEST(TestDefault, flags_match)
             .minimal.union_type.union_flags, IS_APPENDABLE | IS_NESTED);
 }
 
+//tests that the enum value for an otherwise empty label used as an alias to the default case
+//is correctly assigned.
+TEST(TestDefault, empty_label)
+{
+  TypeMap type_map = getMinimalTypeMap<extensibility_union_empty_label_xtag>();
+
+  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_union_empty_label_xtag>()]
+  .minimal.union_type.member_seq[2].common.member_flags, TRY_CONSTRUCT1 | IS_DEFAULT);
+
+  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_union_empty_label_xtag>()]
+  .minimal.union_type.member_seq[2].common.label_seq[0], 2);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
When the discriminator type for a union is an enum, and one or more labels are used as explicit aliases to the default case, the TAO_IDL compiler was skipping the evaluation of the labels' enum value. The fix for this problem is applied to TAO_IDL's FE library in the function AST_Union_Branch::add_labels(). 
This PR is simply a validation test for the specific problem identified in jira 333.