### PR TITLE
Increase pool_size for SetQosPartition Test

### DIFF
--- a/tests/DCPS/SetQosPartition/rtps_rtps.ini
+++ b/tests/DCPS/SetQosPartition/rtps_rtps.ini
@@ -1,5 +1,6 @@
 [common]
 DCPSGlobalTransportConfig=$file
+pool_size=500000000
 
 [domain/311]
 DiscoveryConfig=fast_rtps


### PR DESCRIPTION
This should fix the SEGV for u18_esafe_js0.