### PR TITLE
java: installation of jar files

### DIFF
--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -126,8 +126,8 @@ project: idl2jni, javah, dcpslib, optional_jni_check, dcps_java_optional, dcps_t
 
   verbatim(gnuace, postinstall) {
 "	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)"
-"	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/idl2jni.mpb"
-"	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/dcps_java.mpb"
+"	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/$(INSTALL_LIB)!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/idl2jni.mpb"
+"	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/$(INSTALL_LIB)!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/dcps_java.mpb"
 "	rm $(DESTDIR)$(INSTALL_PREFIX)/dds/*.idl && rmdir $(DESTDIR)$(INSTALL_PREFIX)/dds"
   }
 }

--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -125,7 +125,7 @@ project: idl2jni, javah, dcpslib, optional_jni_check, dcps_java_optional, dcps_t
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/OpenDDS_DCPS.jar $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/idl2jni.mpb"
 "	perl -pi -e 's!\\$$[(]DDS_ROOT[)]/lib!$(INSTALL_PREFIX)/lib!g' $(DESTDIR)$(INSTALL_PREFIX)/share/dds/MPC/config/dcps_java.mpb"
 "	rm $(DESTDIR)$(INSTALL_PREFIX)/dds/*.idl && rmdir $(DESTDIR)$(INSTALL_PREFIX)/dds"

--- a/java/idl2jni/corba/idl2jni_corba.mpc
+++ b/java/idl2jni/corba/idl2jni_corba.mpc
@@ -13,6 +13,6 @@ project: java, dds_macros, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/i2jrt_corba.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/i2jrt_corba.jar $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)"
   }
 }

--- a/java/idl2jni/runtime/idl2jni_runtime.mpc
+++ b/java/idl2jni/runtime/idl2jni_runtime.mpc
@@ -23,7 +23,7 @@ project: taolib, java, javah, optional_jni_check, dds_macros, i2jrt_optional, in
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/i2jrt.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/i2jrt.jar $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)"
 "	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java/build_scripts"
 "	cp ../../build_scripts/java?_wrapper.pl $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java/build_scripts"
 "	cp *.h $(DESTDIR)$(INSTALL_PREFIX)/share/dds/java"

--- a/java/tao/tao_java.mpc
+++ b/java/tao/tao_java.mpc
@@ -34,6 +34,6 @@ project: taolib, idl2jni, install {
   }
 
   verbatim(gnuace, postinstall) {
-"	cp $(DDS_ROOT)/lib/tao_java.jar $(DESTDIR)$(INSTALL_PREFIX)/lib"
+"	cp $(DDS_ROOT)/lib/tao_java.jar $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)"
   }
 }


### PR DESCRIPTION
This patch install the jar files into INSTALL_LIBDIR directory instead the `lib` directory.
This allows to be uniform with the rest of the installation of OpenDDS libraries.
And it removes an error when the installation uses the DESTDIR variable and with the `lib` directory doesn't exist. This is particularly true for the packaging of OpenDDS. The rpm packaging renames the opendds_dcps.jar file to $(DESTIDR)$(INSTALL_PREFIX)/lib, and it is impossible to copy the other files inside the directory.