### PR TITLE
Don't use get_host_name, use get_host_addr as alternative

### DIFF
--- a/dds/DCPS/transport/framework/NetworkAddress.cpp
+++ b/dds/DCPS/transport/framework/NetworkAddress.cpp
@@ -514,8 +514,8 @@ ACE_INET_Addr tie_breaker(const T& addrs, const String& name)
       }
     }
   }
-  VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - Choosing Address %C:%d (%C)\n",
-        addrs.begin()->get_host_addr(), addrs.begin()->get_port_number(), addrs.begin()->get_host_name()));
+  VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - Choosing Address %C:%d\n",
+        addrs.begin()->get_host_addr(), addrs.begin()->get_port_number()));
   return *addrs.begin();
 }
 
@@ -538,25 +538,25 @@ ACE_INET_Addr choose_single_coherent_address(const OPENDDS_VECTOR(ACE_INET_Addr)
     if (it->get_type() == AF_INET6 && !it->is_multicast()) {
       if (it->is_loopback()) {
         VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - "
-                   "Considering Address %C:%d (%C) - ADDING TO IPv6 LOOPBACK LIST\n",
-                   it->get_host_addr(), it->get_port_number(), it->get_host_name()));
+                   "Considering Address %C:%d - ADDING TO IPv6 LOOPBACK LIST\n",
+                   it->get_host_addr(), it->get_port_number()));
         set6_loopback.insert(*it);
       } else if (it->is_ipv4_mapped_ipv6() || it->is_ipv4_compat_ipv6()) {
 #ifndef IPV6_V6ONLY
         VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - "
-                   "Considering Address %C:%d (%C) - ADDING TO IPv6 MAPPED / COMPATIBLE IPv4 LIST\n",
-                   it->get_host_addr(), it->get_port_number(), it->get_host_name()));
+                   "Considering Address %C:%d - ADDING TO IPv6 MAPPED / COMPATIBLE IPv4 LIST\n",
+                   it->get_host_addr(), it->get_port_number()));
         set6_mapped_v4.insert(*it);
 #endif  // ! IPV6_V6ONLY
       } else if (it->is_linklocal()) {
         VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - "
-                   "Considering Address %C:%d (%C) - ADDING TO IPv6 LINK-LOCAL LIST\n",
-                   it->get_host_addr(), it->get_port_number(), it->get_host_name()));
+                   "Considering Address %C:%d - ADDING TO IPv6 LINK-LOCAL LIST\n",
+                   it->get_host_addr(), it->get_port_number()));
         set6_linklocal.insert(*it);
       } else {
         VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - "
-                   "Considering Address %C:%d (%C) - ADDING TO IPv6 NORMAL LIST\n",
-                   it->get_host_addr(), it->get_port_number(), it->get_host_name()));
+                   "Considering Address %C:%d - ADDING TO IPv6 NORMAL LIST\n",
+                   it->get_host_addr(), it->get_port_number()));
         set6.insert(*it);
       }
     }
@@ -564,13 +564,13 @@ ACE_INET_Addr choose_single_coherent_address(const OPENDDS_VECTOR(ACE_INET_Addr)
     if (it->get_type() == AF_INET && !it->is_multicast()) {
       if (it->is_loopback()) {
         VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - "
-                   "Considering Address %C:%d (%C) - ADDING TO IPv4 LOOPBACK LIST\n",
-                   it->get_host_addr(), it->get_port_number(), it->get_host_name()));
+                   "Considering Address %C:%d - ADDING TO IPv4 LOOPBACK LIST\n",
+                   it->get_host_addr(), it->get_port_number()));
         set4_loopback.insert(*it);
       } else {
         VDBG((LM_DEBUG, "(%P|%t) choose_single_coherent_address(list) - "
-                   "Considering Address %C:%d (%C) - ADDING TO IPv4 NORMAL LIST\n",
-                   it->get_host_addr(), it->get_port_number(), it->get_host_name()));
+                   "Considering Address %C:%d - ADDING TO IPv4 NORMAL LIST\n",
+                   it->get_host_addr(), it->get_port_number()));
         set4.insert(*it);
       }
     }

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
@@ -91,7 +91,7 @@ OpenDDS::DCPS::TcpReceiveStrategy::start_i()
                ACE_TEXT("link:\n%C connected to %C:%d ")
                ACE_TEXT("registering with reactor to receive.\n"),
                buffer.str().c_str(),
-               connection->get_remote_address().get_host_name(),
+               connection->get_remote_address().get_host_addr(),
                connection->get_remote_address().get_port_number()));
   }
 

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -591,7 +591,7 @@ TcpTransport::passive_connection(const ACE_INET_Addr& remote_address,
 
   VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) TcpTransport::passive_connection() - ")
             ACE_TEXT("established with %C:%d.\n"),
-            remote_address.get_host_name(),
+            remote_address.get_host_addr(),
             remote_address.get_port_number()), 2);
 
   GuardType connection_guard(connections_lock_);
@@ -631,7 +631,7 @@ TcpTransport::passive_connection(const ACE_INET_Addr& remote_address,
                ACE_TEXT("(%P|%t) TcpTransport::passive_connection() - ")
                ACE_TEXT("ERROR: connection with %C:%d at priority %d already exists, ")
                ACE_TEXT("overwriting previously established connection.\n"),
-               remote_address.get_host_name(),
+               remote_address.get_host_addr(),
                remote_address.get_port_number(),
                connection->transport_priority()));
   }

--- a/dds/InfoRepo/InfoRepoMulticastResponder.cpp
+++ b/dds/InfoRepo/InfoRepoMulticastResponder.cpp
@@ -332,7 +332,7 @@ InfoRepoMulticastResponder::handle_input(ACE_HANDLE)
                "sent to %C:%u.\n"
                "result from send = %d\n",
                ior.c_str(),
-               peer_addr.get_host_name(),
+               peer_addr.get_host_addr(),
                peer_addr.get_port_number(),
                result));
 

--- a/dds/InfoRepo/InfoRepoMulticastResponder.cpp
+++ b/dds/InfoRepo/InfoRepoMulticastResponder.cpp
@@ -213,7 +213,7 @@ InfoRepoMulticastResponder::handle_input(ACE_HANDLE)
     remote_addr.addr_to_string(addr, sizeof(addr), 0);
     ACE_DEBUG((LM_DEBUG,
                "(%P|%t) Received multicast from %s.\n"
-               "Service Name received : %C\n"
+               "Service Name received : %s\n"
                "Port received : %u\n",
                addr,
                object_key,
@@ -229,7 +229,6 @@ InfoRepoMulticastResponder::handle_input(ACE_HANDLE)
 
   if (CORBA::is_nil(locator.in())) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("Nil IORTable\n")));
-
   }
 
   std::string ior;


### PR DESCRIPTION
On Windows with a broken DNS setup the usage of `get_host_name()` could take seconds to return. Use `get_host_addr()` as alternative which is fast and tells more as it gives the concrete network interface used when multiple NICs are installed. 

We see it happen often on Windows that DNS is not setup correctly, when we stay away of using hostnames OpenDDS does work without problems when DNS is broken but the logging of the hostname is problematic.