### PR TITLE
RtpsRelay Pending set saturates

### DIFF
--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -137,7 +137,8 @@ public:
 
   void process_expirations(const OpenDDS::DCPS::MonotonicTimePoint& now);
 
-  bool ignore(const OpenDDS::DCPS::GUID_t& guid);
+  bool ignore(const OpenDDS::DCPS::GUID_t& guid,
+              const OpenDDS::DCPS::MonotonicTimePoint& now);
 
   void remove(const OpenDDS::DCPS::RepoId& guid);
 
@@ -210,7 +211,8 @@ private:
   typedef std::multimap<OpenDDS::DCPS::MonotonicTimePoint, GuidAddr> ExpirationGuidAddrMap;
   ExpirationGuidAddrMap expiration_guid_addr_map_;
   GuidSet pending_;
-
+  typedef std::multimap<OpenDDS::DCPS::MonotonicTimePoint, OpenDDS::DCPS::GUID_t> PendingExpirationMap;
+  PendingExpirationMap pending_expiration_map_;
   mutable ACE_Thread_Mutex mutex_;
 };
 

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -115,6 +115,13 @@ public:
     report(now);
   }
 
+  void expired_pending(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ++log_relay_statistics_.expired_pending_count();
+    ++publish_relay_statistics_.expired_pending_count();
+    report(now);
+  }
+
   void max_queue_size(size_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     log_relay_statistics_.max_queue_size() = std::max(log_relay_statistics_.max_queue_size(), static_cast<ACE_CDR::ULong>(size));
@@ -169,6 +176,7 @@ private:
     log_relay_statistics_.error_count(0);
     log_relay_statistics_.new_address_count(0);
     log_relay_statistics_.expired_address_count(0);
+    log_relay_statistics_.expired_pending_count(0);
     log_relay_statistics_.max_queue_size(0);
     log_input_processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;
     log_output_processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;
@@ -211,6 +219,7 @@ private:
     publish_relay_statistics_.error_count(0);
     publish_relay_statistics_.new_address_count(0);
     publish_relay_statistics_.expired_address_count(0);
+    publish_relay_statistics_.expired_pending_count(0);
     publish_relay_statistics_.max_queue_size(0);
     publish_input_processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;
     publish_output_processing_time_ = OpenDDS::DCPS::TimeDuration::zero_value;

--- a/tools/rtpsrelay/lib/Relay.idl
+++ b/tools/rtpsrelay/lib/Relay.idl
@@ -135,6 +135,7 @@ module RtpsRelay {
     unsigned long local_active_participants;
     unsigned long new_address_count;
     unsigned long expired_address_count;
+    unsigned long expired_pending_count;
     unsigned long max_queue_size;
     Duration_t max_queue_latency;
   };


### PR DESCRIPTION
Problem
-------

The pending set used to limit the discovery rate can saturate if a
client is able to send SPDP but unable to complete discovery for some
reason.  Upon saturation, discovery halts.

Solution
--------

Time out guids in the pending set after a lifespan.