### PR TITLE
ICE password changes increase load on RtpsRelay

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -584,6 +584,12 @@ bool to_param_list(const ParticipantProxy_t& proxy,
     add_param(param_list, param_opf);
   }
 
+  if (proxy.opendds_rtps_relay_application_participant) {
+    Parameter param;
+    param.opendds_rtps_relay_application_participant(proxy.opendds_rtps_relay_application_participant);
+    add_param(param_list, param);
+  }
+
   return true;
 }
 
@@ -596,6 +602,8 @@ bool from_param_list(const ParameterList& param_list,
   proxy.availableExtendedBuiltinEndpoints = 0;
 #endif
   proxy.expectsInlineQos = false;
+  proxy.opendds_participant_flags.bits = 0;
+  proxy.opendds_rtps_relay_application_participant = false;
 
   CORBA::ULong length = param_list.length();
   for (CORBA::ULong i = 0; i < length; ++i) {
@@ -669,6 +677,9 @@ bool from_param_list(const ParameterList& param_list,
         break;
       case PID_OPENDDS_PARTICIPANT_FLAGS:
         proxy.opendds_participant_flags = param.participant_flags();
+        break;
+      case PID_OPENDDS_RTPS_RELAY_APPLICATION_PARTICIPANT:
+        proxy.opendds_rtps_relay_application_participant = param.opendds_rtps_relay_application_participant();
         break;
       case PID_SENTINEL:
       case PID_PAD:

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -338,7 +338,7 @@ module OpenDDS {
     const ParameterId_t PID_OPENDDS_ICE_GENERAL       = PID_OPENDDS_BASE + 3;
     const ParameterId_t PID_OPENDDS_ICE_CANDIDATE     = PID_OPENDDS_BASE + 4;
     const ParameterId_t PID_OPENDDS_PARTICIPANT_FLAGS = PID_OPENDDS_BASE + 5;
-
+    const ParameterId_t PID_OPENDDS_RTPS_RELAY_APPLICATION_PARTICIPANT = PID_OPENDDS_BASE + 6;
 
     /* Always used inside a ParameterList */
     /* custom de/serializer implemented in opendds_idl */
@@ -426,6 +426,9 @@ module OpenDDS {
 
       case PID_OPENDDS_PARTICIPANT_FLAGS:
         OpenDDSParticipantFlags_t participant_flags;
+
+      case PID_OPENDDS_RTPS_RELAY_APPLICATION_PARTICIPANT:
+        boolean opendds_rtps_relay_application_participant;
 
       case PID_BUILTIN_ENDPOINT_SET:
         BuiltinEndpointSet_t builtin_endpoints;
@@ -606,6 +609,7 @@ module OpenDDS {
       Count_t manualLivelinessCount;
       DDS::PropertyQosPolicy property;
       OpenDDSParticipantFlags_t opendds_participant_flags;
+      boolean opendds_rtps_relay_application_participant;
 #ifdef OPENDDS_SECURITY
       DDS::Security::ExtendedBuiltinEndpointSet_t availableExtendedBuiltinEndpoints;
 #endif

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -949,6 +949,16 @@ RtpsDiscovery::spdp_rtps_relay_address(const ACE_INET_Addr& address)
     return;
   }
 
+  if (prev != ACE_INET_Addr()) {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    for (DomainParticipantMap::const_iterator dom_pos = participants_.begin(), dom_limit = participants_.end();
+         dom_pos != dom_limit; ++dom_pos) {
+      for (ParticipantMap::const_iterator part_pos = dom_pos->second.begin(), part_limit = dom_pos->second.end(); part_pos != part_limit; ++part_pos) {
+        part_pos->second->remove_application_participant();
+      }
+    }
+  }
+
   config_->spdp_rtps_relay_address(address);
 
   if (address == ACE_INET_Addr()) {

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -31,6 +31,7 @@ namespace RTPS {
 
 const char RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS[] = "OpenDDS.RtpsDiscovery.EndpointAnnouncements";
 const char RTPS_DISCOVERY_TYPE_LOOKUP_SERVICE[] = "OpenDDS.RtpsDiscovery.TypeLookupService";
+const char RTPS_RELAY_APPLICATION_PARTICIPANT[] = "OpenDDS.Rtps.RelayApplicationParticipant";
 const char RTPS_REFLECT_HEARTBEAT_COUNT[] = "OpenDDS.Rtps.ReflectHeartbeatCount";
 
 class OpenDDS_Rtps_Export RtpsDiscoveryConfig : public OpenDDS::DCPS::RcObject {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -215,6 +215,7 @@ public:
   );
 
   DCPS::RcHandle<RtpsDiscoveryConfig> config() const { return config_; }
+  void remove_application_participant();
   void send_to_relay();
 
 protected:
@@ -243,6 +244,7 @@ private:
   const DDS::DomainId_t domain_;
   DCPS::RepoId guid_;
   const DCPS::MonotonicTime_t participant_discovered_at_;
+  bool is_application_participant_;
 
   void data_received(const DataSubmessage& data, const ParameterList& plist, const ACE_INET_Addr& from);
 

--- a/tests/transport/spdp/spdp_transport.cpp
+++ b/tests/transport/spdp/spdp_transport.cpp
@@ -360,6 +360,7 @@ bool run_test()
       , { 0 /*manualLivelinessCount*/ }
       , qos.property
       , {PFLAGS_THIS_VERSION} // opendds_participant_flags
+      , false // opendds_rtps_relay_application_participant
 #ifdef OPENDDS_SECURITY
       , availableExtendedBuiltinEndpoints
 #endif

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -516,6 +516,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   append(application_properties, OpenDDS::RTPS::RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS, "false");
   append(application_properties, OpenDDS::RTPS::RTPS_DISCOVERY_TYPE_LOOKUP_SERVICE, "false");
   append(application_properties, OpenDDS::RTPS::RTPS_REFLECT_HEARTBEAT_COUNT, "true");
+  append(application_properties, OpenDDS::RTPS::RTPS_RELAY_APPLICATION_PARTICIPANT, "true");
 
 #ifdef OPENDDS_SECURITY
   if (secure) {


### PR DESCRIPTION
Problem
-------

A participant that is using the RtpsRelay and ICE will send ICE
password changes to the application participant of the relay.  If the
participant changes to a different relay, then the participant will
changes its ICE password, send the samples, and then heartbeat.  The
new relay will not ack these heartbeats.  Relay application
participants typically have long lease durations so the unwanted
heartbeats could go on for a significant amount of time.

Solution
--------

1. Provide a PID that allow the application participant to identify
itself.

2. Provide logic that purges application participants when changing
the relay address.