### PR TITLE
Make use of DCPS::AddrToStringSize instead of hardcoded 256

### DIFF
--- a/dds/DCPS/RTPS/ICE/Checklist.cpp
+++ b/dds/DCPS/RTPS/ICE/Checklist.cpp
@@ -355,8 +355,8 @@ void Checklist::generate_triggered_check(const ACE_INET_Addr& local_address,
   bool flag = get_local_candidate(local_address, local);
   if (!flag) {
     // Network addresses may have changed so that local_address is not valid.
-    ACE_TCHAR addr_buff[256] = {};
-    local_address.addr_to_string(addr_buff, 256);
+    ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+    local_address.addr_to_string(addr_buff, DCPS::AddrToStringSize);
     ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) Checklist::generate_triggered_check: WARNING local_address %s is no longer a local candidate\n"), addr_buff));
     return;
   }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -496,13 +496,12 @@ void Spdp::process_location_updates_i(DiscoveredParticipantIter& iter, bool forc
     DCPS::ParticipantLocationBuiltinTopicData& location_data = iter->second.location_data_;
 
     OPENDDS_STRING addr = "";
-    ACE_TCHAR buffer[256];
-
     const DCPS::ParticipantLocation old_mask = location_data.location;
 
     if (pos->from_ != ACE_INET_Addr()) {
       location_data.location |= pos->mask_;
-      pos->from_.addr_to_string(buffer, 256);
+      ACE_TCHAR buffer[DCPS::AddrToStringSize];
+      pos->from_.addr_to_string(buffer, DCPS::AddrToStringSize);
       addr = ACE_TEXT_ALWAYS_CHAR(buffer);
     } else {
       location_data.location &= ~(pos->mask_);
@@ -649,8 +648,8 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     partBitData(pdata).key = repo_id_to_bit_key(guid);
 
     if (DCPS::DCPS_debug_level) {
-      ACE_TCHAR addr_buff[256] = {};
-      from.addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      from.addr_to_string(addr_buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) Spdp::handle_participant_data - %C discovered %C lease %ds from %s\n"),
         DCPS::LogGuid(guid_).c_str(), DCPS::LogGuid(guid).c_str(),
@@ -2753,8 +2752,8 @@ Spdp::SpdpTransport::send(const ACE_INET_Addr& addr)
   if (res < 0) {
     const int err = errno;
     if (err != ENETUNREACH || !network_is_unreachable_) {
-      ACE_TCHAR addr_buff[256] = {};
-      addr.addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      addr.addr_to_string(addr_buff, DCPS::AddrToStringSize);
       errno = err;
       ACE_ERROR((LM_WARNING,
                  ACE_TEXT("(%P|%t) WARNING: Spdp::SpdpTransport::send() - ")
@@ -3082,15 +3081,14 @@ Spdp::SendStun::execute()
   const_cast<STUN::Message&>(message_).block = &tport->wbuff_;
   serializer << message_;
 
-  ssize_t res;
   const ACE_SOCK_Dgram& socket = tport->choose_send_socket(address_);
-  res = socket.send(tport->wbuff_.rd_ptr(), tport->wbuff_.length(), address_);
+  const ssize_t res = socket.send(tport->wbuff_.rd_ptr(), tport->wbuff_.length(), address_);
 
   if (res < 0) {
     const int err = errno;
     if (err != ENETUNREACH || !tport->network_is_unreachable_) {
-      ACE_TCHAR addr_buff[256] = {};
-      address_.addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      address_.addr_to_string(addr_buff, DCPS::AddrToStringSize);
       errno = err;
       ACE_ERROR((LM_WARNING,
                  ACE_TEXT("(%P|%t) WARNING: Spdp::SendStun::execute() - ")
@@ -3299,8 +3297,8 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
 
   if (joined_interfaces_.count(nic.name()) == 0 && nic.has_ipv4()) {
     if (DCPS::DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      multicast_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) Spdp::SpdpTransport::join_multicast_group ")
                  ACE_TEXT("joining group %s on %C\n"),
@@ -3319,8 +3317,8 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
 
       shorten_local_sender_delay_i();
     } else {
-      ACE_TCHAR buff[256];
-      multicast_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::join_multicast_group() - ")
                  ACE_TEXT("failed to join multicast group %s on %C: %p\n"),
@@ -3333,8 +3331,8 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
 #ifdef ACE_HAS_IPV6
   if (joined_ipv6_interfaces_.count(nic.name()) == 0 && nic.has_ipv6()) {
     if (DCPS::DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      multicast_ipv6_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_ipv6_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) Spdp::SpdpTransport::join_multicast_group ")
                  ACE_TEXT("joining group %s on %C\n"),
@@ -3356,8 +3354,8 @@ Spdp::SpdpTransport::join_multicast_group(const DCPS::NetworkInterface& nic,
 
       shorten_local_sender_delay_i();
     } else {
-      ACE_TCHAR buff[256];
-      multicast_ipv6_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_ipv6_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::join_multicast_group() - ")
                  ACE_TEXT("failed to join multicast group %s on %C: %p\n"),
@@ -3379,8 +3377,8 @@ Spdp::SpdpTransport::leave_multicast_group(const DCPS::NetworkInterface& nic)
 
   if (joined_interfaces_.count(nic.name()) != 0 && !nic.has_ipv4()) {
     if (DCPS::DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      multicast_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) Spdp::SpdpTransport::leave_multicast_group ")
                  ACE_TEXT("leaving group %s on %C\n"),
@@ -3389,8 +3387,8 @@ Spdp::SpdpTransport::leave_multicast_group(const DCPS::NetworkInterface& nic)
     }
 
     if (0 != multicast_socket_.leave(multicast_address_, ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
-      ACE_TCHAR buff[256];
-      multicast_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::leave_multicast_group() - ")
                  ACE_TEXT("failed to leave multicast group %s on %C: %p\n"),
@@ -3404,8 +3402,8 @@ Spdp::SpdpTransport::leave_multicast_group(const DCPS::NetworkInterface& nic)
 #ifdef ACE_HAS_IPV6
   if (joined_ipv6_interfaces_.count(nic.name()) != 0 && !nic.has_ipv6()) {
     if (DCPS::DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      multicast_ipv6_address_.addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      multicast_ipv6_address_.addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) Spdp::SpdpTransport::leave_multicast_group ")
                  ACE_TEXT("leaving group %s on %C\n"),

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -435,8 +435,8 @@ RtpsUdpDataLink::join_multicast_group(const NetworkInterface& nic,
 
   if (joined_interfaces_.count(nic.name()) == 0 && nic.has_ipv4()) {
     if (DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      config().multicast_group_address().addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      config().multicast_group_address().addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::join_multicast_group ")
                  ACE_TEXT("joining group %s on %C\n"),
@@ -462,8 +462,8 @@ RtpsUdpDataLink::join_multicast_group(const NetworkInterface& nic,
 #ifdef ACE_HAS_IPV6
   if (ipv6_joined_interfaces_.count(nic.name()) == 0 && nic.has_ipv6()) {
     if (DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      config().ipv6_multicast_group_address().addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      config().ipv6_multicast_group_address().addr_to_string(buff, DCPS::AddrToStringSize);
 
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::join_multicast_group ")
@@ -494,8 +494,8 @@ RtpsUdpDataLink::leave_multicast_group(const NetworkInterface& nic)
 {
   if (joined_interfaces_.count(nic.name()) != 0 && !nic.has_ipv4()) {
     if (DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      config().multicast_group_address().addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      config().multicast_group_address().addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::leave_multicast_group ")
                  ACE_TEXT("leaving group %s on %C\n"),
@@ -515,8 +515,8 @@ RtpsUdpDataLink::leave_multicast_group(const NetworkInterface& nic)
 #ifdef ACE_HAS_IPV6
   if (ipv6_joined_interfaces_.count(nic.name()) != 0 && !nic.has_ipv6()) {
     if (DCPS_debug_level > 3) {
-      ACE_TCHAR buff[256];
-      config().multicast_group_address().addr_to_string(buff, 256);
+      ACE_TCHAR buff[DCPS::AddrToStringSize];
+      config().multicast_group_address().addr_to_string(buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::leave_ipv6_multicast_group ")
                  ACE_TEXT("leaving group %s on %C\n"),
@@ -561,16 +561,16 @@ RtpsUdpDataLink::update_locators(const RepoId& remote_id,
   if (log_unicast_change) {
     for (AddrSet::const_iterator pos = unicast_addresses.begin(), limit = unicast_addresses.end();
          pos != limit; ++pos) {
-      ACE_TCHAR addr_buff[256] = {};
-      pos->addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      pos->addr_to_string(addr_buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) RtpsUdpDataLink::update_locators %C is now at %s\n"), LogGuid(remote_id).c_str(), addr_buff));
     }
   }
   if (log_multicast_change) {
     for (AddrSet::const_iterator pos = multicast_addresses.begin(), limit = multicast_addresses.end();
          pos != limit; ++pos) {
-      ACE_TCHAR addr_buff[256] = {};
-      pos->addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      pos->addr_to_string(addr_buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) RtpsUdpDataLink::update_locators %C is now at %s\n"), LogGuid(remote_id).c_str(), addr_buff));
     }
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -133,8 +133,8 @@ namespace {
   ssize_t recv_err(const char* msg, const ACE_INET_Addr& remote, const DCPS::RepoId& peer, bool& stop)
   {
     if (security_debug.encdec_warn) {
-      ACE_TCHAR addr_buff[256] = {};
-      remote.addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      remote.addr_to_string(addr_buff, DCPS::AddrToStringSize);
       GuidConverter gc(peer);
       ACE_ERROR((LM_WARNING, "(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy::receive_bytes - "
                  "from %s %C secure RTPS processing failed: %C\n", addr_buff, OPENDDS_STRING(gc).c_str(), msg));

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -297,8 +297,8 @@ RtpsUdpSendStrategy::send_single_i(const iovec iov[], int n,
   if (result < 0) {
     const int err = errno;
     if (err != ENETUNREACH || !network_is_unreachable_) {
-      ACE_TCHAR addr_buff[256] = {};
-      addr.addr_to_string(addr_buff, 256);
+      ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+      addr.addr_to_string(addr_buff, DCPS::AddrToStringSize);
       errno = err;
       const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
       ACE_ERROR((prio, "(%P|%t) RtpsUdpSendStrategy::send_single_i() - "

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -647,8 +647,8 @@ namespace {
     if (result < 0) {
       const int err = errno;
       if (err != ENETUNREACH || !network_is_unreachable) {
-        ACE_TCHAR addr_buff[256] = {};
-        addr.addr_to_string(addr_buff, 256);
+        ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
+        addr.addr_to_string(addr_buff, DCPS::AddrToStringSize);
         errno = err;
         const ACE_Log_Priority prio = shouldWarn(errno) ? LM_WARNING : LM_ERROR;
         ACE_ERROR((prio, "(%P|%t) RtpsUdpTransport.cpp send_single_i() - "

--- a/dds/InfoRepo/InfoRepoMulticastResponder.cpp
+++ b/dds/InfoRepo/InfoRepoMulticastResponder.cpp
@@ -7,6 +7,7 @@
 
 #include "InfoRepoMulticastResponder.h"
 #include "dds/DCPS/debug.h"
+#include "dds/DCPS/Definitions.h"
 
 #include "tao/debug.h"
 #include "tao/Object.h"
@@ -209,8 +210,8 @@ InfoRepoMulticastResponder::handle_input(ACE_HANDLE)
                      0);
 
   if (OpenDDS::DCPS::DCPS_debug_level > 0) {
-    ACE_TCHAR addr[64];
-    remote_addr.addr_to_string(addr, sizeof(addr), 0);
+    ACE_TCHAR addr[DCPS::AddrToStringSize];
+    remote_addr.addr_to_string(addr, DCPS::AddrToStringSize, 0);
     ACE_DEBUG((LM_DEBUG,
                "(%P|%t) Received multicast from %s.\n"
                "Service Name received : %s\n"
@@ -289,8 +290,8 @@ InfoRepoMulticastResponder::handle_input(ACE_HANDLE)
 #endif /* ACE_HAS_IPV6 */
 
   if (OpenDDS::DCPS::DCPS_debug_level > 0) {
-    ACE_TCHAR addr[64];
-    peer_addr.addr_to_string(addr, sizeof(addr), 0);
+    ACE_TCHAR addr[DCPS::AddrToStringSize];
+    peer_addr.addr_to_string(addr, DCPS::AddrToStringSize, 0);
     ACE_DEBUG((LM_DEBUG,
                "(%P|%t) Replying to peer %s.\n",
                addr));


### PR DESCRIPTION
    * dds/DCPS/RTPS/ICE/Checklist.cpp:
    * dds/DCPS/RTPS/Spdp.cpp:
    * dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp:
    * dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp:
    * dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp:
    * dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp:
    * dds/InfoRepo/InfoRepoMulticastResponder.cpp: