### PR TITLE
RtpsRelay application participant purge is not robust

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -949,16 +949,6 @@ RtpsDiscovery::spdp_rtps_relay_address(const ACE_INET_Addr& address)
     return;
   }
 
-  if (prev != ACE_INET_Addr()) {
-    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    for (DomainParticipantMap::const_iterator dom_pos = participants_.begin(), dom_limit = participants_.end();
-         dom_pos != dom_limit; ++dom_pos) {
-      for (ParticipantMap::const_iterator part_pos = dom_pos->second.begin(), part_limit = dom_pos->second.end(); part_pos != part_limit; ++part_pos) {
-        part_pos->second->remove_application_participant();
-      }
-    }
-  }
-
   config_->spdp_rtps_relay_address(address);
 
   if (address == ACE_INET_Addr()) {

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -289,6 +289,7 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , domain_(domain)
   , guid_(guid)
   , participant_discovered_at_(MonotonicTimePoint::now().to_monotonic_time())
+  , is_application_participant_(false)
   , tport_(DCPS::make_rch<SpdpTransport>(rchandle_from(this)))
   , initialized_flag_(false)
   , eh_shutdown_(false)
@@ -639,6 +640,14 @@ Spdp::handle_participant_data(DCPS::MessageId id,
   const DCPS::ParticipantLocation location_mask = compute_location_mask(from, from_relay);
 #endif
 
+  // Don't trust SPDP for the RtpsRelay application participant.
+  // Otherwise, anyone can reset the application participant.
+#ifdef OPENDDS_SECURITY
+  if (is_security_enabled() && !from_sedp) {
+    pdata.participantProxy.opendds_rtps_relay_application_participant = false;
+  }
+#endif
+
   // Find the participant - iterator valid only as long as we hold the lock
   DiscoveredParticipantIter iter = participants_.find(guid);
 
@@ -671,6 +680,12 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     iter = p.first;
     iter->second.discovered_at_ = now;
     update_lease_expiration_i(iter, now);
+    update_rtps_relay_application_participant_i(iter);
+    iter = participants_.find(guid);
+    if (iter == participants_.end()) {
+      return;
+    }
+
     if (!from_relay && from != ACE_INET_Addr()) {
       iter->second.local_address_ = from;
     }
@@ -851,6 +866,11 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         iter->second.pdata_ = pdata;
         iter->second.pdata_.discoveredAt = da;
         update_lease_expiration_i(iter, now);
+        update_rtps_relay_application_participant_i(iter);
+        iter = participants_.find(guid);
+        if (iter == participants_.end()) {
+          return;
+        }
         if (!from_relay && from != ACE_INET_Addr()) {
           iter->second.local_address_ = from;
         }
@@ -2628,14 +2648,29 @@ Spdp::SpdpTransport::write_i(WriteFlags flags)
 }
 
 void
-Spdp::remove_application_participant()
+Spdp::update_rtps_relay_application_participant_i(DiscoveredParticipantIter iter)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  if (!iter->second.pdata_.participantProxy.opendds_rtps_relay_application_participant) {
+    return;
+  }
 
-  for (DiscoveredParticipantIter pos = participants_.begin(), limit = participants_.end(); pos != limit; ++pos) {
-    if (pos->second.pdata_.participantProxy.opendds_rtps_relay_application_participant) {
-      remove_discovered_participant(pos);
-      break;
+  if (DCPS::DCPS_debug_level) {
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("(%P|%t) Spdp::update_rtps_relay_application_participant - %C is an RtpsRelay application participant\n"),
+               DCPS::LogGuid(iter->first).c_str()));
+  }
+
+  for (DiscoveredParticipantIter pos = participants_.begin(), limit = participants_.end(); pos != limit;) {
+    if (pos != iter && pos->second.pdata_.participantProxy.opendds_rtps_relay_application_participant) {
+      if (DCPS::DCPS_debug_level) {
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("(%P|%t) Spdp::update_rtps_relay_application_participant - removing previous RtpsRelay application participant %C\n"),
+                   DCPS::LogGuid(pos->first).c_str()));
+      }
+      DiscoveredParticipantIter iter = pos++;
+      remove_discovered_participant(iter);
+    } else {
+      ++pos;
     }
   }
 }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2667,8 +2667,8 @@ Spdp::update_rtps_relay_application_participant_i(DiscoveredParticipantIter iter
                    ACE_TEXT("(%P|%t) Spdp::update_rtps_relay_application_participant - removing previous RtpsRelay application participant %C\n"),
                    DCPS::LogGuid(pos->first).c_str()));
       }
-      DiscoveredParticipantIter iter = pos++;
-      remove_discovered_participant(iter);
+      DiscoveredParticipantIter to_erase = pos++;
+      remove_discovered_participant(to_erase);
     } else {
       ++pos;
     }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -215,7 +215,6 @@ public:
   );
 
   DCPS::RcHandle<RtpsDiscoveryConfig> config() const { return config_; }
-  void remove_application_participant();
   void send_to_relay();
 
 protected:
@@ -260,6 +259,8 @@ private:
    * updates should be withheld from the user.
    */
   bool secure_part_user_data() const;
+
+  void update_rtps_relay_application_participant_i(DiscoveredParticipantIter iter);
 
 #ifdef OPENDDS_SECURITY
   DDS::ReturnCode_t send_handshake_message(const DCPS::RepoId& guid,


### PR DESCRIPTION
Problem
-------

If an RtpsRelay is restarted without changing network connectivity,
then a user has no incentive to reset the address and purge the old
application participant.

Solution
--------

When a new application participant is detected, remove all of the old
application participants.