### PR TITLE
make install: use relative links in prefix/share

### DIFF
--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -84,7 +84,7 @@ project(OpenDDS_Dcps): core, coverage_optional, \
   verbatim(gnuace, postinstall, 1) {
 "	echo export DDS_ROOT=$(INSTALL_PREFIX)/share/dds> $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds-devel.sh"
 "	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds"
-"	ln -sf $(INSTALL_PREFIX)/include/dds/Version.h $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds"
+"	ln -sf ../../../include/dds/Version.h $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds"
 "	cp $(DDS_ROOT)/user_macros.GNU $(DESTDIR)$(INSTALL_PREFIX)/share/dds $(ACE_NUL_STDERR)"
 "	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)/cmake/OpenDDS"
 "	cp $(DDS_ROOT)/cmake/*.cmake $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)/cmake/OpenDDS"

--- a/dds/idl/opendds_idl.mpc
+++ b/dds/idl/opendds_idl.mpc
@@ -35,7 +35,7 @@ project: aceexe, dds_macros, crosscompile, install, opendds_util, dds_corbaseq {
 
   verbatim(gnuace, postinstall) {
 "	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
-"	ln -sf $(INSTALL_PREFIX)/bin/opendds_idl $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
+"	ln -sf ../../../bin/opendds_idl $(DESTDIR)$(INSTALL_PREFIX)/share/dds/bin"
   }
 
 }


### PR DESCRIPTION
allows the installed tree to be moved without breaking the links