### PR TITLE
Avoid Allocation of ACE_Message_Block in Rtps Parameter Deserialization

### DIFF
--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -364,11 +364,12 @@ Serializer::~Serializer()
 {
 }
 
-Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser)
+Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser, size_t min_read)
   : ser_(ser)
   , max_align_(ser.encoding().max_align())
   , start_rpos_(ser.rpos())
   , rblock_(max_align_ ? (ptrdiff_t(ser.current_->rd_ptr()) - ser.align_rshift_) % max_align_ : 0)
+  , min_read_(min_read)
   , start_wpos_(ser.wpos())
   , wblock_(max_align_ ? (ptrdiff_t(ser.current_->wr_ptr()) - ser.align_wshift_) % max_align_ : 0)
 {
@@ -378,6 +379,10 @@ Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser)
 void
 Serializer::ScopedAlignmentContext::restore(Serializer& ser) const
 {
+  if (min_read_ != 0 && (ser.rpos() - start_rpos_) < min_read_) {
+    ser.skip(min_read_ - (ser.rpos() - start_rpos_));
+  }
+
   if (ser.current_ && max_align_) {
     ser.align_rshift_ = offset(ser.current_->rd_ptr(), ser.rpos() - start_rpos_ + rblock_, max_align_);
     ser.align_wshift_ = offset(ser.current_->wr_ptr(), ser.wpos() - start_wpos_ + wblock_, max_align_);

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -684,7 +684,7 @@ public:
   void set_construction_status(ConstructionStatus cs);
 
   struct OpenDDS_Dcps_Export ScopedAlignmentContext {
-    explicit ScopedAlignmentContext(Serializer& ser);
+    explicit ScopedAlignmentContext(Serializer& ser, size_t min_read = 0);
     virtual ~ScopedAlignmentContext() { restore(ser_); }
 
     void restore(Serializer& ser) const;
@@ -693,6 +693,7 @@ public:
     const size_t max_align_;
     const size_t start_rpos_;
     const size_t rblock_;
+    const size_t min_read_;
     const size_t start_wpos_;
     const size_t wblock_;
   };

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -3612,35 +3612,28 @@ namespace {
     }
     {
       Function extraction("operator>>", "bool");
-      extraction.addArg("outer_strm", "Serializer&");
+      extraction.addArg("strm", "Serializer&");
       extraction.addArg("uni", cxx + "&");
       extraction.endArgs();
       be_global->impl_ <<
         "  ACE_CDR::UShort disc, size;\n"
-        "  if (!(outer_strm >> disc) || !(outer_strm >> size)) {\n"
+        "  if (!(strm >> disc) || !(strm >> size)) {\n"
         "    return false;\n"
         "  }\n"
         "  if (disc == OpenDDS::RTPS::PID_SENTINEL) {\n"
         "    uni._d(OpenDDS::RTPS::PID_SENTINEL);\n"
         "    return true;\n"
         "  }\n"
-        "  ACE_Message_Block param(size);\n"
-        "  ACE_CDR::Octet* data = reinterpret_cast<ACE_CDR::Octet*>("
-        "param.wr_ptr());\n"
-        "  if (!outer_strm.read_octet_array(data, size)) {\n"
-        "    return false;\n"
-        "  }\n"
-        "  param.wr_ptr(size);\n"
+        "  const Serializer::ScopedAlignmentContext sac(strm, size);\n"
         "  if (disc == RTPS::PID_XTYPES_TYPE_INFORMATION) {\n"
         "    DDS::OctetSeq type_info(size);\n"
         "    type_info.length(size);\n"
-        "    std::memcpy(type_info.get_buffer(), data, size);\n"
+        "    if (!strm.read_octet_array(type_info.get_buffer(), size)) {\n"
+        "      return false;\n"
+        "    }\n"
         "    uni.type_information(type_info);\n"
         "    return true;\n"
         "  }\n"
-        "  const Encoding encoding(\n"
-        "    Encoding::KIND_XCDR1, outer_strm.swap_bytes());\n"
-        "  Serializer strm(&param, encoding);\n"
         "  switch (disc) {\n";
       generateSwitchBody(u, streamCommon, branches, discriminator,
                          "", ">> ", cxx.c_str(), true);
@@ -3649,7 +3642,9 @@ namespace {
         "    {\n"
         "      uni.unknown_data(DDS::OctetSeq(size));\n"
         "      uni.unknown_data().length(size);\n"
-        "      std::memcpy(uni.unknown_data().get_buffer(), data, size);\n"
+        "      if (!strm.read_octet_array(uni.unknown_data().get_buffer(), size)) {\n"
+        "        return false;\n"
+        "      }\n"
         "      uni._d(disc);\n"
         "    }\n"
         "  }\n"

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -635,6 +635,10 @@ namespace {
       be_global->impl_ <<
         "  while (true) {\n"
         "    const CORBA::ULong len = seq.length();\n"
+        "    // Improves growth behavior. See note in ParameterListConverter's add_param()\n"
+        "    if (len && !(len & (len - 1))) {\n"
+        "      seq.length(2 * len);\n"
+        "    }\n"
         "    seq.length(len + 1);\n"
         "    if (!(strm >> seq[len])) {\n"
         "      return false;\n"


### PR DESCRIPTION
Makes use of the ScopedAllocationContext from previous PR, but also adds "min read" to it in order to force reading of full parameter size when deserialized objects don't take full size (e.g. vendor id).