### PR TITLE
Removed usage of ACE_OSCALL_RETURN, that macro expands to just a return

### DIFF
--- a/dds/DCPS/FileSystemStorage.cpp
+++ b/dds/DCPS/FileSystemStorage.cpp
@@ -127,7 +127,7 @@ int dds_chdir(const ACE_TCHAR* path)
     throw std::runtime_error("GetShortPathNameW failed.");
   }
 
-  ACE_OSCALL_RETURN(::_wchdir(spath), int, -1);
+  return ::_wchdir(spath);
 }
 
 bool is_dir(const ACE_TCHAR* path)


### PR DESCRIPTION
    * dds/DCPS/FileSystemStorage.cpp: