### PR TITLE
TypeObject hash consistency fix

### DIFF
--- a/dds/DCPS/XTypes/TypeObject.h
+++ b/dds/DCPS/XTypes/TypeObject.h
@@ -1330,9 +1330,9 @@ namespace XTypes {
     CompleteCollectionElement element;
 
     CompleteSequenceType()
-    : collection_flag(0)
-    , header()
-    , element()
+      : collection_flag(0)
+      , header()
+      , element()
     {}
   };
 
@@ -1342,12 +1342,12 @@ namespace XTypes {
     MinimalCollectionElement element;
 
     MinimalSequenceType()
-    : collection_flag(0)
-    , header()
-    , element()
+      : collection_flag(0)
+      , header()
+      , element()
     {}
 
-      MinimalSequenceType(CollectionTypeFlag a_collection_flag,
+    MinimalSequenceType(CollectionTypeFlag a_collection_flag,
                         const MinimalCollectionHeader& a_header,
                         const MinimalCollectionElement& a_element)
       : collection_flag(a_collection_flag)
@@ -1385,9 +1385,9 @@ namespace XTypes {
     CompleteCollectionElement element;
 
     CompleteArrayType()
-    : collection_flag(0)
-    , header()
-    , element()
+      : collection_flag(0)
+      , header()
+      , element()
     {}
 
   };
@@ -1398,9 +1398,9 @@ namespace XTypes {
     MinimalCollectionElement element;
 
     MinimalArrayType()
-    : collection_flag(0)
-    , header()
-    , element()
+      : collection_flag(0)
+      , header()
+      , element()
     {}
 
     MinimalArrayType(CollectionTypeFlag a_collection_flag,

--- a/dds/DCPS/XTypes/TypeObject.h
+++ b/dds/DCPS/XTypes/TypeObject.h
@@ -1328,6 +1328,12 @@ namespace XTypes {
     CollectionTypeFlag collection_flag;
     CompleteCollectionHeader header;
     CompleteCollectionElement element;
+
+    CompleteSequenceType()
+    : collection_flag(0)
+    , header()
+    , element()
+    {}
   };
 
   struct MinimalSequenceType {
@@ -1335,8 +1341,13 @@ namespace XTypes {
     MinimalCollectionHeader header;
     MinimalCollectionElement element;
 
-    MinimalSequenceType() {}
-    MinimalSequenceType(CollectionTypeFlag a_collection_flag,
+    MinimalSequenceType()
+    : collection_flag(0)
+    , header()
+    , element()
+    {}
+
+      MinimalSequenceType(CollectionTypeFlag a_collection_flag,
                         const MinimalCollectionHeader& a_header,
                         const MinimalCollectionElement& a_element)
       : collection_flag(a_collection_flag)
@@ -1362,6 +1373,7 @@ namespace XTypes {
     CommonArrayHeader common;
 
     MinimalArrayHeader() {}
+
     MinimalArrayHeader(const CommonArrayHeader& a_common)
       : common(a_common)
     {}
@@ -1371,6 +1383,13 @@ namespace XTypes {
     CollectionTypeFlag collection_flag;
     CompleteArrayHeader header;
     CompleteCollectionElement element;
+
+    CompleteArrayType()
+    : collection_flag(0)
+    , header()
+    , element()
+    {}
+
   };
 
   struct MinimalArrayType  {
@@ -1378,7 +1397,12 @@ namespace XTypes {
     MinimalArrayHeader header;
     MinimalCollectionElement element;
 
-    MinimalArrayType() {}
+    MinimalArrayType()
+    : collection_flag(0)
+    , header()
+    , element()
+    {}
+
     MinimalArrayType(CollectionTypeFlag a_collection_flag,
                      const MinimalArrayHeader& a_header,
                      const MinimalCollectionElement& a_element)

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -7,7 +7,7 @@ use lib "$DDS_ROOT/bin";
 
 use strict;
 
-my $gencmd = "$ENV{DDS_ROOT}/bin/opendds_idl -Sa -St --no-dcps-data-type-warnings sample.idl";
+my $gencmd = "$ENV{DDS_ROOT}/bin/opendds_idl -Sa -St sample.idl";
 system($gencmd);
 system("mv sampleTypeSupportImpl.cpp pass1");
 system($gencmd);

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -1,0 +1,16 @@
+#!/usr/bin/perl
+    $gencmd = "opendds_idl -Sa -St --no-dcps-data-type-warnings sample.idl";
+    system($gencmd);
+    system("mv sampleTypeSupportImpl.cpp pass1");
+    system($gencmd);
+    $result = system("diff pass1 sampleTypeSupportImpl.cpp");
+    system("rm pass1 sampleT*");
+    if ($result == "")
+    {
+        print "test PASSED\n";
+        exit 0;
+    }
+
+    print "test FAILED\n";
+    exit 1;
+

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -1,16 +1,26 @@
-#!/usr/bin/perl
-    $gencmd = "opendds_idl -Sa -St --no-dcps-data-type-warnings sample.idl";
-    system($gencmd);
-    system("mv sampleTypeSupportImpl.cpp pass1");
-    system($gencmd);
-    $result = system("diff pass1 sampleTypeSupportImpl.cpp");
-    system("rm pass1 sampleT*");
-    if ($result == "")
-    {
-        print "test PASSED\n";
-        exit 0;
-    }
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
 
-    print "test FAILED\n";
-    exit 1;
+use Env (DDS_ROOT);
+use lib "$DDS_ROOT/bin";
+use Env (ACE_ROOT);
+use lib "$ACE_ROOT/bin";
+use PerlDDS::Run_Test;
+use strict;
+
+my $gencmd = "opendds_idl -Sa -St --no-dcps-data-type-warnings sample.idl";
+system($gencmd);
+system("mv sampleTypeSupportImpl.cpp pass1");
+system($gencmd);
+my $result = system("diff pass1 sampleTypeSupportImpl.cpp");
+system("rm pass1 sampleT*");
+if ($result == "")
+{
+    print "test PASSED\n";
+    exit 0;
+}
+
+print "test FAILED\n";
+exit 1;
 

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -8,9 +8,9 @@ use File::Compare;
 use strict;
 
 my $gencmd = "$ENV{DDS_ROOT}/bin/opendds_idl -Sa -St sample.idl";
-system($gencmd);
+system($gencmd) == 0 or die "ERROR: could not run $gencmd $?\n";
 rename("sampleTypeSupportImpl.cpp","pass1");
-system($gencmd);
+system($gencmd) == 0 or die "ERROR: could not run $gencmd $?\n";
 my $result = compare("pass1","sampleTypeSupportImpl.cpp");
 unlink("pass1");
 unlink("sampleT*");

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -4,12 +4,10 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 
 use Env (DDS_ROOT);
 use lib "$DDS_ROOT/bin";
-use Env (ACE_ROOT);
-use lib "$ACE_ROOT/bin";
-use PerlDDS::Run_Test;
+
 use strict;
 
-my $gencmd = "opendds_idl -Sa -St --no-dcps-data-type-warnings sample.idl";
+my $gencmd = "$ENV{DDS_ROOT}/bin/opendds_idl -Sa -St --no-dcps-data-type-warnings sample.idl";
 system($gencmd);
 system("mv sampleTypeSupportImpl.cpp pass1");
 system($gencmd);

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -4,16 +4,17 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 
 use Env (DDS_ROOT);
 use lib "$DDS_ROOT/bin";
-
+use File::Compare;
 use strict;
 
 my $gencmd = "$ENV{DDS_ROOT}/bin/opendds_idl -Sa -St sample.idl";
 system($gencmd);
-system("mv sampleTypeSupportImpl.cpp pass1");
+rename("sampleTypeSupportImpl.cpp","pass1");
 system($gencmd);
-my $result = system("diff pass1 sampleTypeSupportImpl.cpp");
-system("rm pass1 sampleT*");
-if ($result == "")
+my $result = compare("pass1","sampleTypeSupportImpl.cpp");
+unlink("pass1");
+unlink("sampleT*");
+if ($result == 0)
 {
     print "test PASSED\n";
     exit 0;

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
@@ -9,11 +9,11 @@ use strict;
 
 my $gencmd = "$ENV{DDS_ROOT}/bin/opendds_idl -Sa -St sample.idl";
 system($gencmd) == 0 or die "ERROR: could not run $gencmd $?\n";
-rename("sampleTypeSupportImpl.cpp","pass1");
+rename("sampleTypeSupportImpl.cpp", "sampleTy1");
 system($gencmd) == 0 or die "ERROR: could not run $gencmd $?\n";
-my $result = compare("pass1","sampleTypeSupportImpl.cpp");
-unlink("pass1");
-unlink("sampleT*");
+my $result = compare("sampleTy1", "sampleTypeSupportImpl.cpp");
+my @intfiles = <sampleTy*>;
+unlink(@intfiles) == @intfiles or die "ERROR: could not clean up intermediate files\n";
 if ($result == 0)
 {
     print "test PASSED\n";

--- a/tests/DCPS/Compiler/typeobject_hash_consistency/sample.idl
+++ b/tests/DCPS/Compiler/typeobject_hash_consistency/sample.idl
@@ -1,0 +1,37 @@
+#include <tao/LongSeq.pidl>
+
+module MyMod {
+
+  @topic
+  @mutable
+  struct MyStruct {
+    long l;
+  };
+
+  struct CircularStruct2;
+
+  @topic
+  @mutable
+  struct CircularStruct {
+    sequence<CircularStruct2> circular_struct2_seq;
+  };
+
+  @topic
+  @mutable
+  struct CircularStruct2 {
+    sequence<CircularStruct> circular_struct_seq;
+    CircularStruct circular_struct_arr[3];
+  };
+
+  enum MyEnum { A, B };
+
+  @topic
+  union MyUnion switch (MyEnum) {
+    case A: long l1;
+    case B: long l2;
+  };
+
+  typedef sequence<long> LSeq;
+
+  typedef long LArr[5];
+};

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -70,6 +70,7 @@ tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11
 tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
 tests/DCPS/Compiler/xcdr/run_test.pl
 tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -70,7 +70,7 @@ tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11
 tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl
+tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Compiler/xcdr/run_test.pl
 tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN
 tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN


### PR DESCRIPTION
see jira ticket 352. The problem was that the type objects for complete and minimal sequences and arrays had a field that was left uninitialized by the default constructor. so when those objects were serialized, hashed, then written out in a type support impl file, the hash would vary from one run to the next.

This patch solves theproblemby explicitly initializing the otherwise unused collection flag value.