### PR TITLE
rtps_udp: address caching for locators / bundling

### DIFF
--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -118,10 +118,12 @@ public:
   void store(const Key& key, const AddrSet& addrs, const MonotonicTimePoint& expires = MonotonicTimePoint::max_value)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-    std::pair<typename MapType::iterator, bool> ins = map_.insert(typename MapType::value_type(key, make_rch<AddressCacheEntry>(addrs, expires)));
-    if (!ins.second) {
-      ins.first->second->addrs_ = addrs;
-      ins.first->second->expires_ = expires;
+    RcHandle<AddressCacheEntry>& rch = map_[key];
+    if (rch) {
+      rch->addrs_ = addrs;
+      rch->expires_ = expires;
+    } else {
+      rch = make_rch<AddressCacheEntry>(addrs, expires);
     }
   }
 

--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -40,8 +40,7 @@ template <typename Key>
 class AddressCache {
 public:
 
-  typedef Key KeyType;
-  typedef OPENDDS_MAP(KeyType, AddressCacheEntry) MapType;
+  typedef OPENDDS_MAP(Key, AddressCacheEntry) MapType;
 
   AddressCache() {}
   virtual ~AddressCache() {}

--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -40,7 +40,8 @@ template <typename Key>
 class AddressCache {
 public:
 
-  typedef OPENDDS_MAP(Key, AddressCacheEntry) MapType;
+  typedef Key KeyType;
+  typedef OPENDDS_MAP(KeyType, AddressCacheEntry) MapType;
 
   AddressCache() {}
   virtual ~AddressCache() {}

--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -1,0 +1,141 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_ADDRESSCACHE_H
+#define OPENDDS_DCPS_ADDRESSCACHE_H
+
+#include "dcps_export.h"
+
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include "Definitions.h"
+#include "PoolAllocator.h"
+#include "TimeTypes.h"
+#include "GuidUtils.h"
+
+#include "ace/INET_Addr.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+template <typename Key>
+class AddressCache {
+public:
+
+  typedef OPENDDS_SET(ACE_INET_Addr) AddrSet;
+  struct MapValue {
+    MapValue() : addrs_(), expires_(MonotonicTimePoint::max_value) {}
+    MapValue(const AddrSet& addrs, const MonotonicTimePoint& expires) : addrs_(addrs), expires_(expires) {}
+
+    AddrSet addrs_;
+    MonotonicTimePoint expires_;
+  };
+  typedef OPENDDS_MAP(Key, MapValue) MapType;
+
+  AddressCache() {}
+  virtual ~AddressCache() {}
+
+  struct ScopedAccess
+  {
+    ScopedAccess(AddressCache& cache, const Key& key)
+      : guard_(cache.mutex_)
+      , find_result_(cache.map_.find(key))
+      , value_(find_result_ == cache.map_.end() ? cache.map_[key] : find_result_->second)
+      , previous_expired_(value_.expires_ < MonotonicTimePoint::now())
+      , is_new_(find_result_ == cache.map_.end() || previous_expired_)
+    {
+      if (previous_expired_) {
+        value_.addrs_.clear();
+        value_.expires_ = MonotonicTimePoint::max_value;
+      }
+    }
+
+    ACE_Guard<ACE_Thread_Mutex> guard_;
+    typename MapType::iterator find_result_;
+    MapValue& value_;
+    bool previous_expired_;
+    bool is_new_;
+
+  private:
+    ScopedAccess();
+    ScopedAccess(const ScopedAccess&);
+    ScopedAccess& operator=(const ScopedAccess&);
+  };
+
+  bool load(const Key& key, AddrSet& addrs) const
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    typename MapType::const_iterator pos = map_.find(key);
+    if (pos != map_.end()) {
+      if (MonotonicTimePoint::now() < pos->second.expires_) {
+        const AddrSet& as = pos->second.addrs_;
+        for (AddrSet::const_iterator it = as.begin(); it != as.end(); ++it) {
+          addrs.insert(*it);
+        }
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void store(const Key& key, const AddrSet& addrs, const MonotonicTimePoint& expires = MonotonicTimePoint::max_value)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    std::pair<typename MapType::iterator, bool> ins = map_.insert(typename MapType::value_type(key, MapValue(addrs, expires)));
+    if (!ins.second) {
+      ins.first->second.addrs_ = addrs;
+      ins.first->second.expires_ = expires;
+    }
+  }
+
+  bool remove(const Key& key)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    return map_.erase(key) != 0;
+  }
+
+  void remove(const Key& start_key, const Key& end_key)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    typename MapType::iterator start = map_.lower_bound(start_key);
+    if (start != map_.end()) {
+      typename MapType::iterator end = map_.upper_bound(end_key);
+      while (start != end) {
+        map_.erase(start++);
+      }
+    }
+  }
+
+  template <typename T>
+  void remove_contains(const T& val)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    for (typename MapType::iterator it = map_.begin(); it != map_.end(); /* inc in loop */) {
+      if (it->first.contains(val)) {
+        map_.erase(it++);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+private:
+
+  mutable ACE_Thread_Mutex mutex_;
+  MapType map_;
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_RADDRESSCACHE_H */

--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -113,13 +113,13 @@ typedef std::basic_string<char, std::char_traits<char>, OPENDDS_ALLOCATOR(char)>
 typedef std::basic_string<wchar_t, std::char_traits<wchar_t>, OPENDDS_ALLOCATOR(wchar_t)>
   WString;
 #define OPENDDS_MAP(K, V) std::map<K, V, std::less<K >, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MAP_CMP(K, V, C) std::map<K, V, C, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MULTIMAP(K, T) std::multimap<K, T, std::less<K >, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, T > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, T > > >
 #define OPENDDS_MULTIMAP_CMP(K, T, C) std::multimap<K, T, C, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, T > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, T > > >
 #define OPENDDS_MAP_T(K, V) std::map<K, V, std::less<K >, \
           OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MAP_CMP_T(K, V, C) std::map<K, V, C, \

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2365,7 +2365,7 @@ RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVecVecVec& meta_submess
 {
   size_t cache_hits = 0;
   size_t cache_misses = 0;
-  size_t addrset_min_size = std::numeric_limits<size_t>::max());
+  size_t addrset_min_size = std::numeric_limits<size_t>::max();
   size_t addrset_max_size = 0;
 
   // Sort meta_submessages by address set and destination

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2365,7 +2365,7 @@ RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVecVecVec& meta_submess
 {
   size_t cache_hits = 0;
   size_t cache_misses = 0;
-  size_t addrset_min_size = -1;
+  size_t addrset_min_size = std::numeric_limits<size_t>::max());
   size_t addrset_max_size = 0;
 
   // Sort meta_submessages by address set and destination

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4344,19 +4344,19 @@ RtpsUdpDataLink::receive_strategy()
   return static_cast<RtpsUdpReceiveStrategy*>(receive_strategy_.in());
 }
 
-RtpsUdpDataLink::AddrSet
+AddrSet
 RtpsUdpDataLink::get_addresses(const RepoId& local, const RepoId& remote) const {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, locators_lock_, AddrSet());
   return get_addresses_i(local, remote);
 }
 
-RtpsUdpDataLink::AddrSet
+AddrSet
 RtpsUdpDataLink::get_addresses(const RepoId& local) const {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, locators_lock_, AddrSet());
   return get_addresses_i(local);
 }
 
-RtpsUdpDataLink::AddrSet
+AddrSet
 RtpsUdpDataLink::get_addresses_i(const RepoId& local, const RepoId& remote) const {
   AddrSet retval;
 
@@ -4365,7 +4365,7 @@ RtpsUdpDataLink::get_addresses_i(const RepoId& local, const RepoId& remote) cons
   return retval;
 }
 
-RtpsUdpDataLink::AddrSet
+AddrSet
 RtpsUdpDataLink::get_addresses_i(const RepoId& local) const {
   AddrSet retval;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -37,6 +37,7 @@
 #include "dds/DCPS/RcEventHandler.h"
 #include "dds/DCPS/JobQueue.h"
 #include "dds/DCPS/SequenceNumber.h"
+#include "dds/DCPS/AddressCache.h"
 
 #ifdef OPENDDS_SECURITY
 #include "dds/DdsSecurityCoreC.h"
@@ -63,6 +64,47 @@ class ReceivedDataSample;
 typedef RcHandle<RtpsUdpInst> RtpsUdpInst_rch;
 typedef RcHandle<RtpsUdpTransport> RtpsUdpTransport_rch;
 typedef RcHandle<TransportClient> TransportClient_rch;
+
+struct LocatorCacheKey {
+  LocatorCacheKey(const RepoId& remote, const RepoId& local, bool prefer_unicast) : remote_(remote), local_(local), prefer_unicast_(prefer_unicast) {}
+  bool operator<(const LocatorCacheKey& rhs) const {
+    return std::memcmp(this, &rhs, sizeof (LocatorCacheKey)) < 0;
+  }
+
+  const RepoId remote_;
+  const RepoId local_;
+  const bool prefer_unicast_;
+};
+typedef AddressCache<LocatorCacheKey> LocatorCache;
+
+struct BundlingCacheKey {
+  BundlingCacheKey(const RepoId& dst_guid, const RepoId& from_guid, const RepoIdSet& to_guids) : dst_guid_(dst_guid), from_guid_(from_guid), to_guids_(to_guids) {}
+  bool operator<(const BundlingCacheKey& rhs) const {
+    int r1 = std::memcmp(&dst_guid_, &rhs.dst_guid_, sizeof (RepoId));
+    if (r1 < 0) {
+      return true;
+    }
+    else if (r1 == 0) {
+      int r2 = std::memcmp(&from_guid_, &rhs.from_guid_, sizeof (RepoId));
+      if (r2 < 0) {
+        return true;
+      }
+      else if (r2 == 0) {
+        return to_guids_ < rhs.to_guids_;
+      }
+    }
+    return false;
+  }
+
+  bool contains(const RepoId& id) const {
+    return dst_guid_ == id || from_guid_ == id || to_guids_.count(id) != 0;
+  }
+
+  const RepoId dst_guid_;
+  const RepoId from_guid_;
+  const RepoIdSet to_guids_;
+};
+typedef AddressCache<BundlingCacheKey> BundlingCache;
 
 struct SeqReaders {
   SequenceNumber seq;
@@ -135,6 +177,8 @@ public:
   const GuidPrefix_t& local_prefix() const { return local_prefix_; }
 
   typedef OPENDDS_SET(ACE_INET_Addr) AddrSet;
+
+  void remove_locator_and_bundling_cache(const RepoId& remote_id);
 
   void update_locators(const RepoId& remote_id,
                        const AddrSet& unicast_addresses,
@@ -260,6 +304,9 @@ private:
   RemoteInfoMap locators_;
 
   void update_last_recv_addr(const RepoId& src, const ACE_INET_Addr& addr);
+
+  mutable LocatorCache locator_cache_;
+  mutable BundlingCache bundling_cache_;
 
   ACE_SOCK_Dgram unicast_socket_;
   ACE_SOCK_Dgram_Mcast multicast_socket_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -97,7 +97,7 @@ struct BundlingCacheKey {
   }
 
   bool contains(const RepoId& id) const {
-    return dst_guid_ == id || from_guid_ == id || to_guids_.count(id) != 0;
+    return to_guids_.count(id) != 0;
   }
 
   const RepoId dst_guid_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -176,8 +176,6 @@ public:
 
   const GuidPrefix_t& local_prefix() const { return local_prefix_; }
 
-  typedef OPENDDS_SET(ACE_INET_Addr) AddrSet;
-
   void remove_locator_and_bundling_cache(const RepoId& remote_id);
 
   void update_locators(const RepoId& remote_id,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -66,7 +66,7 @@ typedef RcHandle<RtpsUdpTransport> RtpsUdpTransport_rch;
 typedef RcHandle<TransportClient> TransportClient_rch;
 
 struct LocatorCacheKey {
-  LocatorCacheKey(const RepoId& remote, const RepoId& local, bool prefer_unicast) 
+  LocatorCacheKey(const RepoId& remote, const RepoId& local, bool prefer_unicast)
     : remote_(remote)
     , local_(local)
     , prefer_unicast_(prefer_unicast)
@@ -84,7 +84,7 @@ struct LocatorCacheKey {
 typedef AddressCache<LocatorCacheKey> LocatorCache;
 
 struct BundlingCacheKey {
-  BundlingCacheKey(const RepoId& dst_guid, const RepoId& from_guid, const RepoIdSet& to_guids) 
+  BundlingCacheKey(const RepoId& dst_guid, const RepoId& from_guid, const RepoIdSet& to_guids)
     : dst_guid_(dst_guid)
     , from_guid_(from_guid)
     , to_guids_(to_guids)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -66,8 +66,14 @@ typedef RcHandle<RtpsUdpTransport> RtpsUdpTransport_rch;
 typedef RcHandle<TransportClient> TransportClient_rch;
 
 struct LocatorCacheKey {
-  LocatorCacheKey(const RepoId& remote, const RepoId& local, bool prefer_unicast) : remote_(remote), local_(local), prefer_unicast_(prefer_unicast) {}
-  bool operator<(const LocatorCacheKey& rhs) const {
+  LocatorCacheKey(const RepoId& remote, const RepoId& local, bool prefer_unicast) 
+    : remote_(remote)
+    , local_(local)
+    , prefer_unicast_(prefer_unicast)
+  {
+  }
+  bool operator<(const LocatorCacheKey& rhs) const
+  {
     return std::memcmp(this, &rhs, sizeof (LocatorCacheKey)) < 0;
   }
 
@@ -78,8 +84,14 @@ struct LocatorCacheKey {
 typedef AddressCache<LocatorCacheKey> LocatorCache;
 
 struct BundlingCacheKey {
-  BundlingCacheKey(const RepoId& dst_guid, const RepoId& from_guid, const RepoIdSet& to_guids) : dst_guid_(dst_guid), from_guid_(from_guid), to_guids_(to_guids) {}
-  bool operator<(const BundlingCacheKey& rhs) const {
+  BundlingCacheKey(const RepoId& dst_guid, const RepoId& from_guid, const RepoIdSet& to_guids) 
+    : dst_guid_(dst_guid)
+    , from_guid_(from_guid)
+    , to_guids_(to_guids)
+  {
+  }
+  bool operator<(const BundlingCacheKey& rhs) const
+  {
     int r1 = std::memcmp(&dst_guid_, &rhs.dst_guid_, sizeof (RepoId));
     if (r1 < 0) {
       return true;
@@ -96,7 +108,8 @@ struct BundlingCacheKey {
     return false;
   }
 
-  bool contains(const RepoId& id) const {
+  bool contains(const RepoId& id) const
+  {
     return to_guids_.count(id) != 0;
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -250,6 +250,9 @@ RtpsUdpSendStrategy::send_multi_i(const iovec iov[], int n,
   ssize_t result = -1;
   typedef OPENDDS_SET(ACE_INET_Addr)::const_iterator iter_t;
   for (iter_t iter = addrs.begin(); iter != addrs.end(); ++iter) {
+    if (*iter == ACE_INET_Addr()) {
+      continue;
+    }
     const ssize_t result_per_dest = send_single_i(iov, n, *iter);
     if (result_per_dest >= 0) {
       result = result_per_dest;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -289,7 +289,7 @@ RtpsUdpTransport::use_datalink(const RepoId& local_id,
 {
   bool requires_inline_qos;
   unsigned int blob_bytes_read;
-  std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet> addrs =
+  std::pair<AddrSet, AddrSet> addrs =
     get_connection_addrs(remote_data, &requires_inline_qos, &blob_bytes_read);
 
   if (link_) {
@@ -302,7 +302,7 @@ RtpsUdpTransport::use_datalink(const RepoId& local_id,
   return true;
 }
 
-std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet>
+std::pair<AddrSet, AddrSet>
 RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
                                        bool* requires_inline_qos,
                                        unsigned int* blob_bytes_read) const
@@ -312,11 +312,11 @@ RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
   DDS::ReturnCode_t result =
     blob_to_locators(remote, locators, requires_inline_qos, blob_bytes_read);
   if (result != DDS::RETCODE_OK) {
-    return std::make_pair(RtpsUdpDataLink::AddrSet(), RtpsUdpDataLink::AddrSet());
+    return std::make_pair(AddrSet(), AddrSet());
   }
 
-  RtpsUdpDataLink::AddrSet uc_addrs;
-  RtpsUdpDataLink::AddrSet mc_addrs;
+  AddrSet uc_addrs;
+  AddrSet mc_addrs;
   for (CORBA::ULong i = 0; i < locators.length(); ++i) {
     ACE_INET_Addr addr;
     // If conversion was successful
@@ -419,7 +419,7 @@ RtpsUdpTransport::update_locators(const RepoId& remote,
   if (link_) {
     bool requires_inline_qos;
     unsigned int blob_bytes_read;
-    std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet> addrs =
+    std::pair<AddrSet, AddrSet> addrs =
       get_connection_addrs(*blob, &requires_inline_qos, &blob_bytes_read);
     link_->update_locators(remote, addrs.first, addrs.second, requires_inline_qos, false);
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -87,7 +87,7 @@ private:
                                      const RepoId& /*writerid*/);
 
   virtual bool connection_info_i(TransportLocator& info, ConnectionInfoFlags flags) const;
-  std::pair<RtpsUdpDataLink::AddrSet, RtpsUdpDataLink::AddrSet>
+  std::pair<AddrSet, AddrSet>
     get_connection_addrs(const TransportBLOB& data,
                          bool* requires_inline_qos = 0,
                          unsigned int* blob_bytes_read = 0) const;

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -72,7 +72,7 @@ TEST(address_cache_test, scoped_access_load_success)
   AddressCache<TestKey> test_cache_;
   {
     AddressCache<TestKey>::ScopedAccess entry(test_cache_, TestKey(GUID_UNKNOWN, GUID_UNKNOWN));
-    AddrSet& addrs = entry.value_.addrs_;
+    AddrSet& addrs = entry.value().addrs_;
 
     addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
     addrs.insert(ACE_INET_Addr("127.0.1.1:4321"));

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -6,8 +6,7 @@
 
 using namespace OpenDDS::DCPS;
 
-struct TestKey
-{
+struct TestKey {
   TestKey(const RepoId& from, const RepoId& to) : from_(from), to_(to) {}
   bool operator<(const TestKey& rhs) const {
     return std::memcmp(this, &rhs, sizeof (TestKey)) < 0;

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -22,14 +22,14 @@ struct TestKey
 TEST(address_cache_test, load_fail)
 {
   AddressCache<TestKey> test_cache_;
-  AddressCache<TestKey>::AddrSet addrs;
+  AddrSet addrs;
   ASSERT_FALSE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
 }
 
 TEST(address_cache_test, store_load_success)
 {
   AddressCache<TestKey> test_cache_;
-  AddressCache<TestKey>::AddrSet addrs;
+  AddrSet addrs;
   addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
 
   test_cache_.store(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs);
@@ -43,7 +43,7 @@ TEST(address_cache_test, store_load_success)
 TEST(address_cache_test, store_remove_load_fail)
 {
   AddressCache<TestKey> test_cache_;
-  AddressCache<TestKey>::AddrSet addrs;
+  AddrSet addrs;
   addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
 
   test_cache_.store(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs);
@@ -57,7 +57,7 @@ TEST(address_cache_test, store_remove_load_fail)
 TEST(address_cache_test, store_remove_contains_load_fail)
 {
   AddressCache<TestKey> test_cache_;
-  AddressCache<TestKey>::AddrSet addrs;
+  AddrSet addrs;
   addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
 
   test_cache_.store(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs);
@@ -73,13 +73,13 @@ TEST(address_cache_test, scoped_access_load_success)
   AddressCache<TestKey> test_cache_;
   {
     AddressCache<TestKey>::ScopedAccess entry(test_cache_, TestKey(GUID_UNKNOWN, GUID_UNKNOWN));
-    AddressCache<TestKey>::AddrSet& addrs = entry.value_.addrs_;
+    AddrSet& addrs = entry.value_.addrs_;
 
     addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
     addrs.insert(ACE_INET_Addr("127.0.1.1:4321"));
   }
 
-  AddressCache<TestKey>::AddrSet addrs;
+  AddrSet addrs;
   ASSERT_TRUE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
   ASSERT_EQ(addrs.size(), 2u);
   ASSERT_EQ(*(addrs.begin()),ACE_INET_Addr("127.0.0.1:1234"));

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -1,0 +1,87 @@
+#include <dds/DCPS/AddressCache.h>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+using namespace OpenDDS::DCPS;
+
+struct TestKey
+{
+  TestKey(const RepoId& from, const RepoId& to) : from_(from), to_(to) {}
+  bool operator<(const TestKey& rhs) const {
+    return std::memcmp(this, &rhs, sizeof (TestKey)) < 0;
+  }
+  bool contains(const RepoId& id) const {
+    return from_ == id || to_ == id;
+  }
+  RepoId from_;
+  RepoId to_;
+};
+
+TEST(address_cache_test, load_fail)
+{
+  AddressCache<TestKey> test_cache_;
+  AddressCache<TestKey>::AddrSet addrs;
+  ASSERT_FALSE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
+}
+
+TEST(address_cache_test, store_load_success)
+{
+  AddressCache<TestKey> test_cache_;
+  AddressCache<TestKey>::AddrSet addrs;
+  addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
+
+  test_cache_.store(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs);
+  addrs.clear();
+
+  ASSERT_TRUE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
+  ASSERT_EQ(addrs.size(), 1u);
+  ASSERT_EQ(*(addrs.begin()),ACE_INET_Addr("127.0.0.1:1234"));
+}
+
+TEST(address_cache_test, store_remove_load_fail)
+{
+  AddressCache<TestKey> test_cache_;
+  AddressCache<TestKey>::AddrSet addrs;
+  addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
+
+  test_cache_.store(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs);
+  addrs.clear();
+
+  test_cache_.remove(TestKey(GUID_UNKNOWN, GUID_UNKNOWN));
+
+  ASSERT_FALSE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
+}
+
+TEST(address_cache_test, store_remove_contains_load_fail)
+{
+  AddressCache<TestKey> test_cache_;
+  AddressCache<TestKey>::AddrSet addrs;
+  addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
+
+  test_cache_.store(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs);
+  addrs.clear();
+
+  test_cache_.remove_contains(GUID_UNKNOWN);
+
+  ASSERT_FALSE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
+}
+
+TEST(address_cache_test, scoped_access_load_success)
+{
+  AddressCache<TestKey> test_cache_;
+  {
+    AddressCache<TestKey>::ScopedAccess entry(test_cache_, TestKey(GUID_UNKNOWN, GUID_UNKNOWN));
+    AddressCache<TestKey>::AddrSet& addrs = entry.value_.addrs_;
+
+    addrs.insert(ACE_INET_Addr("127.0.0.1:1234"));
+    addrs.insert(ACE_INET_Addr("127.0.1.1:4321"));
+  }
+
+  AddressCache<TestKey>::AddrSet addrs;
+  ASSERT_TRUE(test_cache_.load(TestKey(GUID_UNKNOWN, GUID_UNKNOWN), addrs));
+  ASSERT_EQ(addrs.size(), 2u);
+  ASSERT_EQ(*(addrs.begin()),ACE_INET_Addr("127.0.0.1:1234"));
+  ASSERT_EQ(*(++(addrs.begin())),ACE_INET_Addr("127.0.1.1:4321"));
+}


### PR DESCRIPTION
Problem: We spend quite a bit of time calculating the lists of addresses needed to send each bundled message, but in reality these lists don't change all that often.

Solution: Cache them... both at the locator level and at the bundling level.
