### PR TITLE
Fix failing unit tests on static builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3971,7 +3971,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         cd tests/DCPS/Messenger
-        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features ipv6=1 -features no_opendds_security=0 -features no_cxx11=0
+        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0 -features no_cxx11=0
     - name: make messenger tests
       shell: bash
       run: |
@@ -3985,7 +3985,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         cd tests/DCPS/C++11
-        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features ipv6=1 -features no_opendds_security=0 -features no_cxx11=0
+        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0 -features no_cxx11=0
     - name: make C++11 messenger test
       shell: bash
       run: |
@@ -4113,7 +4113,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         cd tests/DCPS/Compiler
-        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features ipv6=1 -features no_opendds_security=0
+        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
     - name: make compiler tests
       shell: bash
       run: |
@@ -4241,7 +4241,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         cd tests/unit-tests
-        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features ipv6=1 -features no_opendds_security=0
+        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
     - name: make unit tests
       shell: bash
       run: |

--- a/dds/DCPS/security/BuiltInPluginLoader.cpp
+++ b/dds/DCPS/security/BuiltInPluginLoader.cpp
@@ -18,16 +18,21 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace Security {
 
-static const char * PLUGIN_NAME = "BuiltIn";
+//static const char * PLUGIN_NAME = "BuiltIn";
 
 int
 BuiltInPluginLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 {
+  const OPENDDS_STRING PLUGIN_NAME("BuiltIn");
+  ACE_DEBUG((LM_DEBUG,"BIPloader init, name = '%C'\n",PLUGIN_NAME.c_str()));
   SecurityPluginInst_rch plugin = TheSecurityRegistry->get_plugin_inst(
     PLUGIN_NAME, false /* don't attempt to load the plugin */);
   if (!plugin) {
+    ACE_DEBUG((LM_DEBUG,"BIPloader registering plugin\n"));
     plugin = DCPS::make_rch<BuiltInSecurityPluginInst>();
     TheSecurityRegistry->register_plugin(PLUGIN_NAME, plugin);
+  } else {
+    ACE_DEBUG((LM_DEBUG,"BIPloader found plugin\n"));
   }
 
   SecurityConfig_rch default_config =

--- a/dds/DCPS/security/BuiltInPluginLoader.cpp
+++ b/dds/DCPS/security/BuiltInPluginLoader.cpp
@@ -18,7 +18,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace Security {
 
-static const std::string PLUGIN_NAME("BuiltIn");
+static const char * PLUGIN_NAME = "BuiltIn";
 
 int
 BuiltInPluginLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])

--- a/dds/DCPS/security/BuiltInPluginLoader.cpp
+++ b/dds/DCPS/security/BuiltInPluginLoader.cpp
@@ -18,8 +18,6 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace Security {
 
-//static const char * PLUGIN_NAME = "BuiltIn";
-
 int
 BuiltInPluginLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 {

--- a/dds/DCPS/security/BuiltInPluginLoader.cpp
+++ b/dds/DCPS/security/BuiltInPluginLoader.cpp
@@ -24,15 +24,11 @@ int
 BuiltInPluginLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 {
   const OPENDDS_STRING PLUGIN_NAME("BuiltIn");
-  ACE_DEBUG((LM_DEBUG,"BIPloader init, name = '%C'\n",PLUGIN_NAME.c_str()));
   SecurityPluginInst_rch plugin = TheSecurityRegistry->get_plugin_inst(
     PLUGIN_NAME, false /* don't attempt to load the plugin */);
   if (!plugin) {
-    ACE_DEBUG((LM_DEBUG,"BIPloader registering plugin\n"));
     plugin = DCPS::make_rch<BuiltInSecurityPluginInst>();
     TheSecurityRegistry->register_plugin(PLUGIN_NAME, plugin);
-  } else {
-    ACE_DEBUG((LM_DEBUG,"BIPloader found plugin\n"));
   }
 
   SecurityConfig_rch default_config =

--- a/dds/DCPS/security/framework/SecurityRegistry.cpp
+++ b/dds/DCPS/security/framework/SecurityRegistry.cpp
@@ -94,7 +94,6 @@ SecurityRegistry::close()
 SecurityRegistry::SecurityRegistry()
 {
   DBG_ENTRY_LVL("SecurityRegistry", "SecurityRegistry", 6);
-  ACE_DEBUG((LM_DEBUG,"SecurityRegistry ctor called\n"));
   lib_directive_map_[DEFAULT_PLUGIN_NAME] = "dynamic OpenDDS_Security Service_Object * OpenDDS_Security:_make_BuiltInPluginLoader()";
 }
 
@@ -107,7 +106,6 @@ SecurityRegistry::release()
   for (InstMap::iterator iter = registered_plugins_.begin(); iter != registered_plugins_.end(); ++iter) {
     iter->second->shutdown();
   }
-  ACE_DEBUG((LM_DEBUG,"SecurityRegistry release clearing plugins\n"));
   registered_plugins_.clear();
   config_map_.clear();
 }

--- a/dds/DCPS/security/framework/SecurityRegistry.cpp
+++ b/dds/DCPS/security/framework/SecurityRegistry.cpp
@@ -94,7 +94,7 @@ SecurityRegistry::close()
 SecurityRegistry::SecurityRegistry()
 {
   DBG_ENTRY_LVL("SecurityRegistry", "SecurityRegistry", 6);
-
+  ACE_DEBUG((LM_DEBUG,"SecurityRegistry ctor called\n"));
   lib_directive_map_[DEFAULT_PLUGIN_NAME] = "dynamic OpenDDS_Security Service_Object * OpenDDS_Security:_make_BuiltInPluginLoader()";
 }
 
@@ -107,7 +107,7 @@ SecurityRegistry::release()
   for (InstMap::iterator iter = registered_plugins_.begin(); iter != registered_plugins_.end(); ++iter) {
     iter->second->shutdown();
   }
-
+  ACE_DEBUG((LM_DEBUG,"SecurityRegistry release clearing plugins\n"));
   registered_plugins_.clear();
   config_map_.clear();
 }

--- a/tests/unit-tests/dds/DCPS/security/framework/SecurityConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/security/framework/SecurityConfig.cpp
@@ -2,6 +2,8 @@
 
 #if defined (ACE_AS_STATIC_LIBS)
 #include <dds/DCPS/security/BuiltInPlugins.h>
+#include <dds/DCPS/security/BuiltInPluginLoader.h>
+#include <ace/Dynamic_Service.h>
 #endif
 #include "dds/DCPS/security/framework/SecurityConfig.h"
 #include "dds/DCPS/security/framework/SecurityRegistry.h"
@@ -31,6 +33,15 @@ public:
 
   static void SetUpTestCase()
   {
+    #if defined(ACE_AS_STATIC_LIBS)
+    BuiltInPluginLoader *loader =
+    ACE_Dynamic_Service<BuiltInPluginLoader>::instance("OpenDDS_Security");
+    if (loader == 0) {
+      ACE_ERROR ((LM_ERROR,"could not locate loader\n"));
+    } else {
+      loader->init(0,0);
+    }
+    #endif
     cf_.open();
     ACE_Ini_ImpExp import(cf_);
     ASSERT_EQ(0, import.import_config(ACE_TEXT("dds/DCPS/security/framework/test1.ini")));

--- a/tests/unit-tests/dds/DCPS/security/framework/SecurityConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/security/framework/SecurityConfig.cpp
@@ -33,15 +33,15 @@ public:
 
   static void SetUpTestCase()
   {
-    #if defined(ACE_AS_STATIC_LIBS)
+#if defined(ACE_AS_STATIC_LIBS)
     BuiltInPluginLoader *loader =
     ACE_Dynamic_Service<BuiltInPluginLoader>::instance("OpenDDS_Security");
     if (loader == 0) {
-      ACE_ERROR ((LM_ERROR,"could not locate loader\n"));
+      ACE_ERROR ((LM_ERROR,"could not locate BuiltIn plugin loader\n"));
     } else {
       loader->init(0,0);
     }
-    #endif
+#endif
     cf_.open();
     ACE_Ini_ImpExp import(cf_);
     ASSERT_EQ(0, import.import_config(ACE_TEXT("dds/DCPS/security/framework/test1.ini")));

--- a/tests/unit-tests/dds/DCPS/security/framework/SecurityConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/security/framework/SecurityConfig.cpp
@@ -1,5 +1,8 @@
 #ifdef OPENDDS_SECURITY
 
+#if defined (ACE_AS_STATIC_LIBS)
+#include <dds/DCPS/security/BuiltInPlugins.h>
+#endif
 #include "dds/DCPS/security/framework/SecurityConfig.h"
 #include "dds/DCPS/security/framework/SecurityRegistry.h"
 #include "dds/DCPS/security/framework/SecurityPluginInst_rch.h"


### PR DESCRIPTION
Issue 1: SecuityConfigTest fails with an assertion 
Solution has a straight forward component and a surprise. The straight forward part was to explicitly include a header related to the ACE service object that will be "loaded" when needed. This is necessary because the ACE Service Configuration framework abstracts away those details and so the linker doesn't see the need to include the appropriate object files in the final executable.

The surprise was that the loader class for this service object was using a locally defined static instance of a std::string initialized with a literal, but when that string was referenced during loader initialization which is also done during static initialization phase, the std::string value was empty or null. 

Issue 2: NetworkAddressTest 
On the github acion host the tests involved with comparing IPV6 addresses literals are failing.