### PR TITLE
RtpsUdpDataLink leaks remote writers on failed associations

### DIFF
--- a/dds/DCPS/DiscoveryBase.h
+++ b/dds/DCPS/DiscoveryBase.h
@@ -2399,7 +2399,7 @@ namespace OpenDDS {
           if (DCPS_debug_level > 3) {
             GuidConverter conv(iter->first);
             ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) LocalParticipant::remove_discovered_participant")
-                       ACE_TEXT(" - erasing %C\n"), OPENDDS_STRING(conv).c_str()));
+                       ACE_TEXT(" - erasing %C (%B)\n"), OPENDDS_STRING(conv).c_str(), participants_.size()));
           }
 
           remove_discovered_participant_i(iter);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -663,9 +663,9 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       ACE_TCHAR addr_buff[DCPS::AddrToStringSize] = {};
       from.addr_to_string(addr_buff, DCPS::AddrToStringSize);
       ACE_DEBUG((LM_DEBUG,
-        ACE_TEXT("(%P|%t) Spdp::handle_participant_data - %C discovered %C lease %ds from %s\n"),
-        DCPS::LogGuid(guid_).c_str(), DCPS::LogGuid(guid).c_str(),
-        pdata.leaseDuration.seconds, addr_buff));
+                 ACE_TEXT("(%P|%t) Spdp::handle_participant_data - %C discovered %C lease %ds from %s (%B)\n"),
+                 DCPS::LogGuid(guid_).c_str(), DCPS::LogGuid(guid).c_str(),
+                 pdata.leaseDuration.seconds, addr_buff, participants_.size()));
     }
 
     if (tport_->directed_sender_) {

--- a/dds/DCPS/Time_Helper.h
+++ b/dds/DCPS/Time_Helper.h
@@ -103,6 +103,9 @@ ACE_INLINE OpenDDS_Dcps_Export
 DDS::Duration_t operator-(const MonotonicTime_t& t1, const MonotonicTime_t& t2);
 
 ACE_INLINE OpenDDS_Dcps_Export
+bool operator<(const MonotonicTime_t& t1, const MonotonicTime_t& t2);
+
+ACE_INLINE OpenDDS_Dcps_Export
 ACE_UINT32 uint32_fractional_seconds_to_nanoseconds(ACE_UINT32 fraction);
 
 ACE_INLINE OpenDDS_Dcps_Export

--- a/dds/DCPS/Time_Helper.inl
+++ b/dds/DCPS/Time_Helper.inl
@@ -147,6 +147,12 @@ operator-(const MonotonicTime_t& t1, const MonotonicTime_t& t2)
   return t;
 }
 
+ACE_INLINE bool
+operator<(const MonotonicTime_t& t1, const MonotonicTime_t& t2)
+{
+  return t1.sec < t2.sec || (t1.sec == t2.sec && t1.nanosec < t2.nanosec);
+}
+
 ACE_INLINE
 ACE_Time_Value time_to_time_value(const DDS::Time_t& t)
 {

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -61,7 +61,7 @@ TransportClient::~TransportClient()
     for (size_t i = 0; i < impls_.size(); ++i) {
       RcHandle<TransportImpl> impl = impls_[i].lock();
       if (impl) {
-        impl->stop_accepting_or_connecting(it->second->client_, it->second->data_.remote_id_, false);
+        impl->stop_accepting_or_connecting(it->second->client_, it->second->data_.remote_id_, false, false);
       }
     }
   }
@@ -570,7 +570,7 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
   for (size_t i = 0; i < pend->impls_.size(); ++i) {
     RcHandle<TransportImpl> impl = pend->impls_[i].lock();
     if (impl) {
-      impl->stop_accepting_or_connecting(*this, pend->data_.remote_id_, false);
+      impl->stop_accepting_or_connecting(*this, pend->data_.remote_id_, false, !ok);
     }
   }
 
@@ -655,7 +655,7 @@ TransportClient::disassociate(const RepoId& peerId)
     for (size_t i = 0; i < iter->second->impls_.size(); ++i) {
       RcHandle<TransportImpl> impl = iter->second->impls_[i].lock();
       if (impl) {
-        impl->stop_accepting_or_connecting(*this, iter->second->data_.remote_id_, true);
+        impl->stop_accepting_or_connecting(*this, iter->second->data_.remote_id_, true, true);
       }
     }
     iter->second->reset_client();
@@ -686,14 +686,14 @@ TransportClient::disassociate(const RepoId& peerId)
   data_link_index_.erase(found);
   DataLinkSetMap released;
 
-    if (DCPS_debug_level > 4) {
-      ACE_DEBUG((LM_DEBUG,
-                 ACE_TEXT("(%P|%t) TransportClient::disassociate: ")
-                 ACE_TEXT("about to release_reservations for link[%@]\n"),
-                 link.in()));
-    }
+  if (DCPS_debug_level > 4) {
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("(%P|%t) TransportClient::disassociate: ")
+               ACE_TEXT("about to release_reservations for link[%@]\n"),
+               link.in()));
+  }
 
-    link->release_reservations(peerId, repo_id_, released);
+  link->release_reservations(peerId, repo_id_, released);
 
   if (!released.empty()) {
 

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -200,7 +200,8 @@ protected:
   /// valid after this method is called.
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
                                             const RepoId& remote_id,
-                                            bool disassociate) = 0;
+                                            bool disassociate,
+                                            bool association_failed) = 0;
 
 
   /// Called during the shutdown() method in order to give the

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -274,7 +274,8 @@ MulticastTransport::accept_datalink(const RemoteTransport& remote,
 void
 MulticastTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
                                                  const RepoId& remote_id,
-                                                 bool /*disassociate*/)
+                                                 bool /*disassociate*/,
+                                                 bool /*association_failed*/)
 {
   VDBG((LM_DEBUG, "(%P|%t) MulticastTransport::stop_accepting_or_connecting\n"));
 

--- a/dds/DCPS/transport/multicast/MulticastTransport.h
+++ b/dds/DCPS/transport/multicast/MulticastTransport.h
@@ -46,7 +46,8 @@ protected:
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
                                             const RepoId& remote_id,
-                                            bool disassociate);
+                                            bool disassociate,
+                                            bool association_failed);
 
   bool configure_i(MulticastInst& config);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -704,7 +704,7 @@ void
 RtpsUdpDataLink::disassociated(const RepoId& local_id,
                                const RepoId& remote_id)
 {
-  release_reservations_i(local_id, remote_id);
+  release_reservations_i(remote_id, local_id);
 
   ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -252,9 +252,10 @@ RtpsUdpTransport::accept_datalink(const RemoteTransport& remote,
 void
 RtpsUdpTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
                                                const RepoId& remote_id,
-                                               bool disassociate)
+                                               bool disassociate,
+                                               bool association_failed)
 {
-  if (disassociate) {
+  if (disassociate || association_failed) {
     GuardThreadType guard_links(links_lock_);
     if (link_) {
       TransportClient_rch c = client.lock();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -58,7 +58,8 @@ private:
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
                                             const RepoId& remote_id,
-                                            bool disassociate);
+                                            bool disassociate,
+                                            bool association_failed);
 
   bool configure_i(RtpsUdpInst& config);
 

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -93,7 +93,7 @@ ShmemTransport::accept_datalink(const RemoteTransport& remote,
 }
 
 void
-ShmemTransport::stop_accepting_or_connecting(const TransportClient_wrch&, const RepoId&, bool)
+ShmemTransport::stop_accepting_or_connecting(const TransportClient_wrch&, const RepoId&, bool, bool)
 {
   // no-op: accept and connect either complete or fail immediately
 }

--- a/dds/DCPS/transport/shmem/ShmemTransport.h
+++ b/dds/DCPS/transport/shmem/ShmemTransport.h
@@ -47,7 +47,8 @@ protected:
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
                                             const RepoId& remote_id,
-                                            bool disassociate);
+                                            bool disassociate,
+                                            bool association_failed);
 
   bool configure_i(ShmemInst& config);
 

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -290,7 +290,8 @@ TcpTransport::accept_datalink(const RemoteTransport& remote,
 void
 TcpTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
                                            const RepoId& remote_id,
-                                           bool /*disassociate*/)
+                                           bool /*disassociate*/,
+                                           bool /*association_failed*/)
 {
   GuidConverter remote_converted(remote_id);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TcpTransport::stop_accepting_or_connecting "

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -68,7 +68,8 @@ private:
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
                                             const RepoId& remote_id,
-                                            bool disassociate);
+                                            bool disassociate,
+                                            bool association_failed);
 
   virtual bool configure_i(TcpInst& config);
 

--- a/dds/DCPS/transport/udp/UdpTransport.cpp
+++ b/dds/DCPS/transport/udp/UdpTransport.cpp
@@ -145,7 +145,8 @@ UdpTransport::accept_datalink(const RemoteTransport& remote,
 void
 UdpTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
                                            const RepoId& remote_id,
-                                           bool /*disassociate*/)
+                                           bool /*disassociate*/,
+                                           bool /*association_failed*/)
 {
   VDBG((LM_DEBUG, "(%P|%t) UdpTransport::stop_accepting_or_connecting\n"));
 

--- a/dds/DCPS/transport/udp/UdpTransport.h
+++ b/dds/DCPS/transport/udp/UdpTransport.h
@@ -45,7 +45,8 @@ protected:
 
   virtual void stop_accepting_or_connecting(const TransportClient_wrch& client,
                                             const RepoId& remote_id,
-                                            bool disassociate);
+                                            bool disassociate,
+                                            bool association_failed);
 
   bool configure_i(UdpInst& config);
 


### PR DESCRIPTION
Problem
-------

An association for a local reader that times out is removed from the
`pending_` set of the TransportClient and not added to the
`data_link_index_`.  A subsequent call to `disassociate` when
discovery times out is effectively a no-op.  For RTPS, this means that
the reader has a pre-association writer and will send pre-association
acknacks forever since the writer may never associate and never be
removed.

Solution
--------

- Add a parameter to `stop_accepting_or_connecting` that indicates
  association failure.  RTPS will release its reservations when the
  association fails.

- Fix a bug in `RtpsUdpDataLink::disassociated` where the parameters
  to `release_reservations_i` were reversed.