### PR TITLE
Have Check Test Results Protect Against Relative Paths In Test Names

### DIFF
--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -79,6 +79,12 @@ jobs:
           export TRIGGERING_COMMIT=$(cat ./SHA)
           echo "TRIGGERING_COMMIT=$TRIGGERING_COMMIT" >> $GITHUB_ENV
 
+      - name: 'Avoid relative paths in XML testcase names'
+        shell: bash
+        run: |
+          sed '/<testcase name="/s/\.\.\///g' -i ${{ matrix.info[0] }}_autobuild_output/Tests_JUnit.xml
+          sed '/<testcase name="/s/\.\///g' -i ${{ matrix.info[0] }}_autobuild_output/Tests_JUnit.xml
+
       - name: 'Publish Unit Test Results'
         uses: simpsont-oci/action-junit-report@v2.2.0.1
         if: always()


### PR DESCRIPTION
A short-term fix (but longer-term protection) against the cmake test relative path issue.

Successful "Check Test Results" run & publishing on my repo [here](https://github.com/simpsont-oci/OpenDDS/actions/runs/1013641824) despite test failures with relative paths as seen [here](https://github.com/simpsont-oci/OpenDDS/actions/runs/1013217234).