### PR TITLE
Revert PoolAllocator 'typename' Macro Changes, Fix AddressCache Macro Usage

### DIFF
--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -52,7 +52,7 @@ template <typename Key>
 class AddressCache {
 public:
 
-  typedef OPENDDS_MAP(Key, RcHandle<AddressCacheEntry>) MapType;
+  typedef OPENDDS_MAP_T(Key, RcHandle<AddressCacheEntry>) MapType;
 
   AddressCache() {}
   virtual ~AddressCache() {}

--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -113,13 +113,13 @@ typedef std::basic_string<char, std::char_traits<char>, OPENDDS_ALLOCATOR(char)>
 typedef std::basic_string<wchar_t, std::char_traits<wchar_t>, OPENDDS_ALLOCATOR(wchar_t)>
   WString;
 #define OPENDDS_MAP(K, V) std::map<K, V, std::less<K >, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MAP_CMP(K, V, C) std::map<K, V, C, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MULTIMAP(K, T) std::multimap<K, T, std::less<K >, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, T > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, T > > >
 #define OPENDDS_MULTIMAP_CMP(K, T, C) std::multimap<K, T, C, \
-          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, T > > >
+          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, T > > >
 #define OPENDDS_MAP_T(K, V) std::map<K, V, std::less<K >, \
           OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_MAP_CMP_T(K, V, C) std::map<K, V, C, \


### PR DESCRIPTION
Previous changes misunderstood purpose of different macros, broke safety profile builds. Need to revert changes and adjust AddressCache to use the correct macro.