### PR TITLE
Performance Improvements From Profiling Fragmentation Tests

### DIFF
--- a/dds/DCPS/transport/framework/BuildChainVisitor.cpp
+++ b/dds/DCPS/transport/framework/BuildChainVisitor.cpp
@@ -15,29 +15,29 @@
 
 OpenDDS::DCPS::BuildChainVisitor::~BuildChainVisitor()
 {
-  DBG_ENTRY_LVL("BuildChainVisitor","~BuildChainVisitor",6);
+  DBG_ENTRY_LVL("BuildChainVisitor", "~BuildChainVisitor", 6);
 }
 
 int
 OpenDDS::DCPS::BuildChainVisitor::visit_element(TransportQueueElement* element)
 {
-  DBG_ENTRY_LVL("BuildChainVisitor","visit_element",6);
+  DBG_ENTRY_LVL("BuildChainVisitor", "visit_element", 6);
 
-  if (this->head_ == 0) {
+  if (head_ == 0) {
     // This is the first element that we have visited.
-    this->head_ = element->msg()->duplicate();
-    this->tail_ = this->head_;
+    head_ = element->msg()->duplicate();
+    tail_ = head_;
 
-    while (this->tail_->cont() != 0) {
-      this->tail_ = this->tail_->cont();
+    while (tail_->cont() != 0) {
+      tail_ = tail_->cont();
     }
 
   } else {
     // This is not the first element that we have visited.
-    this->tail_->cont(element->msg()->duplicate());
+    tail_->cont(element->msg()->duplicate());
 
-    while (this->tail_->cont() != 0) {
-      this->tail_ = this->tail_->cont();
+    while (tail_->cont() != 0) {
+      tail_ = tail_->cont();
     }
   }
 

--- a/dds/DCPS/transport/framework/BuildChainVisitor.inl
+++ b/dds/DCPS/transport/framework/BuildChainVisitor.inl
@@ -12,16 +12,16 @@ OpenDDS::DCPS::BuildChainVisitor::BuildChainVisitor()
   : head_(0),
     tail_(0)
 {
-  DBG_ENTRY_LVL("BuildChainVisitor","BuildChainVisitor",6);
+  DBG_ENTRY_LVL("BuildChainVisitor", "BuildChainVisitor", 6);
 }
 
 ACE_INLINE
 ACE_Message_Block*
 OpenDDS::DCPS::BuildChainVisitor::chain()
 {
-  DBG_ENTRY_LVL("BuildChainVisitor","chain",6);
+  DBG_ENTRY_LVL("BuildChainVisitor", "chain", 6);
 
-  ACE_Message_Block* head = this->head_;
-  this->head_ = this->tail_ = 0;
+  ACE_Message_Block* head = head_;
+  head_ = tail_ = 0;
   return head;
 }

--- a/dds/DCPS/transport/framework/CopyChainVisitor.cpp
+++ b/dds/DCPS/transport/framework/CopyChainVisitor.cpp
@@ -15,13 +15,13 @@
 
 OpenDDS::DCPS::CopyChainVisitor::~CopyChainVisitor()
 {
-  DBG_ENTRY_LVL("CopyChainVisitor","~CopyChainVisitor",6);
+  DBG_ENTRY_LVL("CopyChainVisitor", "~CopyChainVisitor", 6);
 }
 
 int
 OpenDDS::DCPS::CopyChainVisitor::visit_element(TransportQueueElement* element)
 {
-  DBG_ENTRY_LVL("CopyChainVisitor","visit_element",6);
+  DBG_ENTRY_LVL("CopyChainVisitor", "visit_element", 6);
 
   TransportRetainedElement* copiedElement = 0;
   if (duplicate_) {

--- a/dds/DCPS/transport/framework/CopyChainVisitor.cpp
+++ b/dds/DCPS/transport/framework/CopyChainVisitor.cpp
@@ -23,22 +23,28 @@ OpenDDS::DCPS::CopyChainVisitor::visit_element(TransportQueueElement* element)
 {
   DBG_ENTRY_LVL("CopyChainVisitor","visit_element",6);
 
-  // Create a new copy of the current element.
-  // fails.
-  TransportRetainedElement* copiedElement = new
-    TransportRetainedElement(
-      element->msg(),
-      element->publication_id(),
-      this->mb_allocator_,
-      this->db_allocator_
-    );
-
+  TransportRetainedElement* copiedElement = 0;
+  if (duplicate_) {
+    // Create a new copy of the current element.
+    copiedElement = new
+      TransportRetainedElement(
+        element->duplicate_msg(),
+        element->publication_id()
+      );
+  } else {
+    // Create a new copy of the current element.
+    copiedElement = new
+      TransportRetainedElement(
+        element->msg(),
+        element->publication_id(),
+        mb_allocator_,
+        db_allocator_
+      );
+  }
 
   // Add the copy to the target.
-  this->target_.put( copiedElement);
+  target_.put(copiedElement);
 
   // Visit entire queue.
   return 1;
-
-
 }

--- a/dds/DCPS/transport/framework/CopyChainVisitor.h
+++ b/dds/DCPS/transport/framework/CopyChainVisitor.h
@@ -29,7 +29,8 @@ public:
   CopyChainVisitor(
     BasicQueue<TransportQueueElement>& target,
     MessageBlockAllocator*             mb_allocator,
-    DataBlockAllocator*                db_allocator
+    DataBlockAllocator*                db_allocator,
+    bool duplicate = false
   );
 
   virtual ~CopyChainVisitor();
@@ -49,6 +50,7 @@ private:
 
   /// Status of visitation.
   int status_;
+  bool duplicate_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/CopyChainVisitor.inl
+++ b/dds/DCPS/transport/framework/CopyChainVisitor.inl
@@ -11,11 +11,13 @@ ACE_INLINE
 OpenDDS::DCPS::CopyChainVisitor::CopyChainVisitor(
   BasicQueue<TransportQueueElement>& target,
   MessageBlockAllocator* mb_allocator,
-  DataBlockAllocator* db_allocator
-) : target_( target)
+  DataBlockAllocator* db_allocator,
+  bool duplicate
+) : target_(target)
   , mb_allocator_(mb_allocator)
   , db_allocator_(db_allocator)
-  , status_( 0)
+  , status_(0)
+  , duplicate_(duplicate)
 {
   DBG_ENTRY_LVL("CopyChainVisitor","CopyChainVisitor",6);
 }

--- a/dds/DCPS/transport/framework/CopyChainVisitor.inl
+++ b/dds/DCPS/transport/framework/CopyChainVisitor.inl
@@ -19,12 +19,12 @@ OpenDDS::DCPS::CopyChainVisitor::CopyChainVisitor(
   , status_(0)
   , duplicate_(duplicate)
 {
-  DBG_ENTRY_LVL("CopyChainVisitor","CopyChainVisitor",6);
+  DBG_ENTRY_LVL("CopyChainVisitor", "CopyChainVisitor", 6);
 }
 
 ACE_INLINE
 int
 OpenDDS::DCPS::CopyChainVisitor::status() const
 {
-  return this->status_;
+  return status_;
 }

--- a/dds/DCPS/transport/framework/RemoveAllVisitor.cpp
+++ b/dds/DCPS/transport/framework/RemoveAllVisitor.cpp
@@ -15,14 +15,14 @@
 
 OpenDDS::DCPS::RemoveAllVisitor::~RemoveAllVisitor()
 {
-  DBG_ENTRY_LVL("RemoveAllVisitor","~RemoveAllVisitor",6);
+  DBG_ENTRY_LVL("RemoveAllVisitor", "~RemoveAllVisitor", 6);
 }
 
 int
 OpenDDS::DCPS::RemoveAllVisitor::visit_element_remove(TransportQueueElement* element,
                                                       int&                   remove)
 {
-  DBG_ENTRY_LVL("RemoveAllVisitor","visit_element_remove",6);
+  DBG_ENTRY_LVL("RemoveAllVisitor", "visit_element_remove", 6);
 
   // Always remove the element passed in. Always set the remove flag
   // to true (1).  The BasicQueue<T> will perform the actual removal
@@ -32,7 +32,7 @@ OpenDDS::DCPS::RemoveAllVisitor::visit_element_remove(TransportQueueElement* ele
   // Add the total_length() of the element->msg() chain to our
   // removed_bytes_ (running) total.
   if (element->msg()) {
-    this->removed_bytes_ += element->msg()->total_length();
+    removed_bytes_ += element->msg()->total_length();
   }
 
   // Inform the element that we've made a decision - and it is
@@ -46,7 +46,7 @@ OpenDDS::DCPS::RemoveAllVisitor::visit_element_remove(TransportQueueElement* ele
 
   // Adjust our status_ to indicate that we actually found (and removed)
   // the sample.
-  this->status_ = 1;
+  status_ = 1;
 
   // Continue visitation.
   return 1;

--- a/dds/DCPS/transport/framework/RemoveAllVisitor.inl
+++ b/dds/DCPS/transport/framework/RemoveAllVisitor.inl
@@ -12,19 +12,19 @@ OpenDDS::DCPS::RemoveAllVisitor::RemoveAllVisitor()
   : status_(0),
     removed_bytes_(0)
 {
-  DBG_ENTRY_LVL("RemoveAllVisitor","RemoveAllVisitor",6);
+  DBG_ENTRY_LVL("RemoveAllVisitor", "RemoveAllVisitor", 6);
 }
 
 ACE_INLINE int
 OpenDDS::DCPS::RemoveAllVisitor::status() const
 {
-  DBG_ENTRY_LVL("RemoveAllVisitor","status",6);
-  return this->status_;
+  DBG_ENTRY_LVL("RemoveAllVisitor", "status", 6);
+  return status_;
 }
 
 ACE_INLINE int
 OpenDDS::DCPS::RemoveAllVisitor::removed_bytes() const
 {
-  DBG_ENTRY_LVL("RemoveAllVisitor","removed_bytes",6);
-  return static_cast<int>(this->removed_bytes_);
+  DBG_ENTRY_LVL("RemoveAllVisitor", "removed_bytes", 6);
+  return static_cast<int>(removed_bytes_);
 }

--- a/dds/DCPS/transport/framework/ThreadPerConRemoveVisitor.cpp
+++ b/dds/DCPS/transport/framework/ThreadPerConRemoveVisitor.cpp
@@ -30,7 +30,7 @@ ThreadPerConRemoveVisitor::visit_element_remove(SendRequest* req,
 {
   DBG_ENTRY("ThreadPerConRemoveVisitor", "visit_element_remove");
 
-  TransportQueueElement::MatchOnDataPayload modp(this->sample_->rd_ptr());
+  TransportQueueElement::MatchOnDataPayload modp(sample_->rd_ptr());
   if ((req->op_ == SEND) && modp.matches(*req->element_)) {
     // We are visiting the element that we want to remove, since the
     // element "matches" our sample_.
@@ -47,7 +47,7 @@ ThreadPerConRemoveVisitor::visit_element_remove(SendRequest* req,
 
     // Adjust our status_ to indicate that we actually found (and removed)
     // the sample.
-    this->status_ = released ? REMOVE_RELEASED : REMOVE_FOUND;
+    status_ = released ? REMOVE_RELEASED : REMOVE_FOUND;
 
     // Stop visitation since we've handled the element that matched
     // our sample_.

--- a/dds/DCPS/transport/framework/TransportControlElement.cpp
+++ b/dds/DCPS/transport/framework/TransportControlElement.cpp
@@ -18,12 +18,12 @@ OpenDDS::DCPS::TransportControlElement::TransportControlElement(
 ) : TransportQueueElement(1),
     msg_( msg_block.release())
 {
-  DBG_ENTRY_LVL("TransportControlElement","TransportControlElement",6);
+  DBG_ENTRY_LVL("TransportControlElement", "TransportControlElement", 6);
 }
 
 OpenDDS::DCPS::TransportControlElement::~TransportControlElement()
 {
-  DBG_ENTRY_LVL("TransportControlElement","~TransportControlElement",6);
+  DBG_ENTRY_LVL("TransportControlElement", "~TransportControlElement", 6);
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportControlElement.h
+++ b/dds/DCPS/transport/framework/TransportControlElement.h
@@ -43,6 +43,8 @@ protected:
 
   virtual RepoId publication_id() const;
 
+  virtual ACE_Message_Block* duplicate_msg() const;
+
   virtual const ACE_Message_Block* msg() const;
 
   virtual const ACE_Message_Block* msg_payload() const;

--- a/dds/DCPS/transport/framework/TransportControlElement.inl
+++ b/dds/DCPS/transport/framework/TransportControlElement.inl
@@ -11,7 +11,7 @@ ACE_INLINE
 bool
 OpenDDS::DCPS::TransportControlElement::requires_exclusive_packet() const
 {
-  DBG_ENTRY_LVL("TransportControlElement","requires_exclusive_packet",6);
+  DBG_ENTRY_LVL("TransportControlElement", "requires_exclusive_packet", 6);
   return true;
 }
 
@@ -19,7 +19,7 @@ ACE_INLINE
 void
 OpenDDS::DCPS::TransportControlElement::data_delivered()
 {
-  DBG_ENTRY_LVL("TransportControlElement","data_delivered",6);
+  DBG_ENTRY_LVL("TransportControlElement", "data_delivered", 6);
 }
 
 ACE_INLINE
@@ -30,17 +30,24 @@ OpenDDS::DCPS::TransportControlElement::publication_id() const
 }
 
 ACE_INLINE
+ACE_Message_Block*
+OpenDDS::DCPS::TransportControlElement::duplicate_msg() const
+{
+  return msg_->duplicate();
+}
+
+ACE_INLINE
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportControlElement::msg() const
 {
-  return this->msg_.get();
+  return msg_.get();
 }
 
 ACE_INLINE
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportControlElement::msg_payload() const
 {
-  return this->msg_->cont();
+  return msg_->cont();
 }
 
 ACE_INLINE

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
@@ -40,6 +40,13 @@ TransportCustomizedElement::release_element(bool dropped_by_transport)
   }
 }
 
+ACE_Message_Block*
+TransportCustomizedElement::duplicate_msg() const
+{
+  DBG_ENTRY_LVL("TransportCustomizedElement", "duplicate_msg", 6);
+  return msg_->duplicate();
+}
+
 const ACE_Message_Block*
 TransportCustomizedElement::msg() const
 {
@@ -62,17 +69,24 @@ TransportCustomizedElement::msg_payload() const
 }
 
 const TransportSendElement*
-TransportCustomizedElement::original_send_element() const
+TransportCustomizedElement::find_original_send_element(TransportQueueElement* orig)
 {
   const TransportSendElement* ose =
-    dynamic_cast<const TransportSendElement*>(orig_);
+    dynamic_cast<const TransportSendElement*>(orig);
   if (!ose) {
     const TransportCustomizedElement* tce =
-      dynamic_cast<const TransportCustomizedElement*>(orig_);
+      dynamic_cast<const TransportCustomizedElement*>(orig);
     return tce ? tce->original_send_element() : 0;
   }
   return ose;
 }
+
+const TransportSendElement*
+TransportCustomizedElement::original_send_element() const
+{
+  return ose_;
+}
+
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
@@ -84,7 +84,7 @@ TransportCustomizedElement::find_original_send_element(TransportQueueElement* or
 const TransportSendElement*
 TransportCustomizedElement::original_send_element() const
 {
-  return ose_;
+  return original_send_element_;
 }
 
 

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.h
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.h
@@ -36,6 +36,8 @@ public:
   SequenceNumber sequence() const;
   void set_sequence(const SequenceNumber& value);
 
+  virtual ACE_Message_Block* duplicate_msg() const;
+
   virtual const ACE_Message_Block* msg() const;
   void set_msg(Message_Block_Ptr m);
 
@@ -55,8 +57,11 @@ protected:
 
   virtual ~TransportCustomizedElement();
 
+  static const TransportSendElement* find_original_send_element(TransportQueueElement* orig);
+
 private:
   TransportQueueElement* orig_;
+  const TransportSendElement* ose_;
   Message_Block_Ptr msg_;
   RepoId publication_id_;
   RepoId subscription_id_;

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.h
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.h
@@ -61,7 +61,7 @@ protected:
 
 private:
   TransportQueueElement* orig_;
-  const TransportSendElement* ose_;
+  const TransportSendElement* original_send_element_;
   Message_Block_Ptr msg_;
   RepoId publication_id_;
   RepoId subscription_id_;

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.inl
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.inl
@@ -18,6 +18,7 @@ TransportCustomizedElement::TransportCustomizedElement(
   TransportQueueElement* orig)
   : TransportQueueElement(1),
     orig_(orig),
+    ose_(find_original_send_element(orig)),
     publication_id_(orig ? orig->publication_id() : GUID_UNKNOWN),
     subscription_id_(GUID_UNKNOWN),
     sequence_(SequenceNumber::SEQUENCENUMBER_UNKNOWN()),

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.inl
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.inl
@@ -18,7 +18,7 @@ TransportCustomizedElement::TransportCustomizedElement(
   TransportQueueElement* orig)
   : TransportQueueElement(1),
     orig_(orig),
-    ose_(find_original_send_element(orig)),
+    original_send_element_(find_original_send_element(orig)),
     publication_id_(orig ? orig->publication_id() : GUID_UNKNOWN),
     subscription_id_(GUID_UNKNOWN),
     sequence_(SequenceNumber::SEQUENCENUMBER_UNKNOWN()),
@@ -65,7 +65,7 @@ TransportCustomizedElement::sequence() const
   if (sequence_ != SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
     return sequence_;
   }
-  return this->orig_ ? this->orig_->sequence()
+  return orig_ ? orig_->sequence()
     : SequenceNumber::SEQUENCENUMBER_UNKNOWN();
 }
 

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -120,6 +120,9 @@ public:
     return SequenceNumber::SEQUENCENUMBER_UNKNOWN();
   }
 
+  /// A reference-incremented duplicate of the marshalled sample (sample header + sample data)
+  virtual ACE_Message_Block* duplicate_msg() const = 0;
+
   /// The marshalled sample (sample header + sample data)
   virtual const ACE_Message_Block* msg() const = 0;
 

--- a/dds/DCPS/transport/framework/TransportReplacedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportReplacedElement.cpp
@@ -16,14 +16,14 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 OpenDDS::DCPS::TransportReplacedElement::~TransportReplacedElement()
 {
-  DBG_ENTRY_LVL("TransportReplacedElement","~TransportReplacedElement",6);
+  DBG_ENTRY_LVL("TransportReplacedElement", "~TransportReplacedElement", 6);
 }
 
 void
 OpenDDS::DCPS::TransportReplacedElement::release_element(bool dropped_by_transport)
 {
   ACE_UNUSED_ARG(dropped_by_transport);
-  DBG_ENTRY_LVL("TransportReplacedElement","release_element",6);
+  DBG_ENTRY_LVL("TransportReplacedElement", "release_element", 6);
 
 
   delete this;

--- a/dds/DCPS/transport/framework/TransportReplacedElement.h
+++ b/dds/DCPS/transport/framework/TransportReplacedElement.h
@@ -30,6 +30,8 @@ public:
   /// Accessor for the publisher id.
   virtual RepoId publication_id() const;
 
+  virtual ACE_Message_Block* duplicate_msg() const;
+
   /// Accessor for the ACE_Message_Block
   virtual const ACE_Message_Block* msg() const;
 

--- a/dds/DCPS/transport/framework/TransportReplacedElement.inl
+++ b/dds/DCPS/transport/framework/TransportReplacedElement.inl
@@ -21,11 +21,11 @@ OpenDDS::DCPS::TransportReplacedElement::TransportReplacedElement
   DBG_ENTRY_LVL("TransportReplacedElement", "TransportReplacedElement", 6);
 
   // Obtain the publisher id.
-  this->publisher_id_ = orig_elem->publication_id();
+  publisher_id_ = orig_elem->publication_id();
 
-  this->msg_.reset(TransportQueueElement::clone_mb(orig_elem->msg(),
-                                               this->mb_allocator_,
-                                               this->db_allocator_));
+  msg_.reset(TransportQueueElement::clone_mb(orig_elem->msg(),
+                                             mb_allocator_,
+                                             db_allocator_));
 }
 
 ACE_INLINE
@@ -33,7 +33,7 @@ OpenDDS::DCPS::RepoId
 OpenDDS::DCPS::TransportReplacedElement::publication_id() const
 {
   DBG_ENTRY_LVL("TransportReplacedElement", "publication_id", 6);
-  return this->publisher_id_;
+  return publisher_id_;
 }
 
 ACE_INLINE
@@ -41,7 +41,7 @@ ACE_Message_Block*
 OpenDDS::DCPS::TransportReplacedElement::duplicate_msg() const
 {
   DBG_ENTRY_LVL("TransportReplacedElement", "duplicate_msg", 6);
-  return this->msg_->duplicate();
+  return msg_->duplicate();
 }
 
 ACE_INLINE
@@ -49,7 +49,7 @@ const ACE_Message_Block*
 OpenDDS::DCPS::TransportReplacedElement::msg() const
 {
   DBG_ENTRY_LVL("TransportReplacedElement", "msg", 6);
-  return this->msg_.get();
+  return msg_.get();
 }
 
 ACE_INLINE
@@ -57,7 +57,7 @@ const ACE_Message_Block*
 OpenDDS::DCPS::TransportReplacedElement::msg_payload() const
 {
   DBG_ENTRY_LVL("TransportReplacedElement", "msg_payload", 6);
-  return this->msg_->cont();
+  return msg_->cont();
 }
 
 ACE_INLINE

--- a/dds/DCPS/transport/framework/TransportReplacedElement.inl
+++ b/dds/DCPS/transport/framework/TransportReplacedElement.inl
@@ -18,7 +18,7 @@ OpenDDS::DCPS::TransportReplacedElement::TransportReplacedElement
   , mb_allocator_ (mb_allocator)
   , db_allocator_ (db_allocator)
 {
-  DBG_ENTRY_LVL("TransportReplacedElement","TransportReplacedElement",6);
+  DBG_ENTRY_LVL("TransportReplacedElement", "TransportReplacedElement", 6);
 
   // Obtain the publisher id.
   this->publisher_id_ = orig_elem->publication_id();
@@ -32,15 +32,23 @@ ACE_INLINE
 OpenDDS::DCPS::RepoId
 OpenDDS::DCPS::TransportReplacedElement::publication_id() const
 {
-  DBG_ENTRY_LVL("TransportReplacedElement","publication_id",6);
+  DBG_ENTRY_LVL("TransportReplacedElement", "publication_id", 6);
   return this->publisher_id_;
+}
+
+ACE_INLINE
+ACE_Message_Block*
+OpenDDS::DCPS::TransportReplacedElement::duplicate_msg() const
+{
+  DBG_ENTRY_LVL("TransportReplacedElement", "duplicate_msg", 6);
+  return this->msg_->duplicate();
 }
 
 ACE_INLINE
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportReplacedElement::msg() const
 {
-  DBG_ENTRY_LVL("TransportReplacedElement","msg",6);
+  DBG_ENTRY_LVL("TransportReplacedElement", "msg", 6);
   return this->msg_.get();
 }
 

--- a/dds/DCPS/transport/framework/TransportRetainedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportRetainedElement.cpp
@@ -16,7 +16,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 OpenDDS::DCPS::TransportRetainedElement::~TransportRetainedElement()
 {
-  DBG_ENTRY_LVL("TransportRetainedElement","~TransportRetainedElement",6);
+  DBG_ENTRY_LVL("TransportRetainedElement", "~TransportRetainedElement", 6);
 }
 
 void
@@ -24,29 +24,36 @@ OpenDDS::DCPS::TransportRetainedElement::release_element(
   bool /* dropped_by_transport */
 )
 {
-  DBG_ENTRY_LVL("TransportRetainedElement","release_element",6);
+  DBG_ENTRY_LVL("TransportRetainedElement", "release_element", 6);
   delete this;
 }
 
 OpenDDS::DCPS::RepoId
 OpenDDS::DCPS::TransportRetainedElement::publication_id() const
 {
-  DBG_ENTRY_LVL("TransportRetainedElement","publication_id",6);
-  return this->publication_id_;
+  DBG_ENTRY_LVL("TransportRetainedElement", "publication_id", 6);
+  return publication_id_;
+}
+
+ACE_Message_Block*
+OpenDDS::DCPS::TransportRetainedElement::duplicate_msg() const
+{
+  DBG_ENTRY_LVL("TransportRetainedElement", "duplicate_msg", 6);
+  return msg_->duplicate();
 }
 
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportRetainedElement::msg() const
 {
-  DBG_ENTRY_LVL("TransportRetainedElement","msg",6);
-  return this->msg_.get();
+  DBG_ENTRY_LVL("TransportRetainedElement", "msg", 6);
+  return msg_.get();
 }
 
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportRetainedElement::msg_payload() const
 {
   DBG_ENTRY_LVL("TransportRetainedElement", "msg_payload", 6);
-  return this->msg_->cont();
+  return msg_->cont();
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportRetainedElement.h
+++ b/dds/DCPS/transport/framework/TransportRetainedElement.h
@@ -23,6 +23,13 @@ class TransportRetainedElement;
 class OpenDDS_Dcps_Export TransportRetainedElement
   : public TransportQueueElement {
 public:
+
+  /// Construct with message block chain and Id values.
+  TransportRetainedElement(
+    ACE_Message_Block*                 message,
+    const RepoId&                      pubId
+  );
+
   /// Construct with message block chain and Id values.
   TransportRetainedElement(
     const ACE_Message_Block*           message,
@@ -40,6 +47,7 @@ public:
 
   virtual RepoId publication_id() const;
 
+  virtual ACE_Message_Block* duplicate_msg() const;
   virtual const ACE_Message_Block* msg() const;
   virtual const ACE_Message_Block* msg_payload() const;
 
@@ -60,9 +68,11 @@ private:
   RepoId publication_id_;
 
   /// Cached allocator for DataSampleHeader message block
-  MessageBlockAllocator*             mb_allocator_;
+  MessageBlockAllocator* mb_allocator_;
   /// Cached allocator for DataSampleHeader data block
-  DataBlockAllocator*                db_allocator_;
+  DataBlockAllocator* db_allocator_;
+
+  bool is_duplicate_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/TransportRetainedElement.inl
+++ b/dds/DCPS/transport/framework/TransportRetainedElement.inl
@@ -14,14 +14,12 @@ OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
     ACE_Message_Block*                 message,
     const RepoId&                      pubId
 ) : TransportQueueElement(1),
+    msg_(message),
     publication_id_(pubId),
     mb_allocator_(0),
     db_allocator_(0),
     is_duplicate_(true)
 {
-  if (message != 0) {
-    msg_.reset(message->duplicate());
-  }
 }
 
 ACE_INLINE
@@ -31,29 +29,27 @@ OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
     MessageBlockAllocator*             mb_allocator,
     DataBlockAllocator*                db_allocator
 ) : TransportQueueElement(1),
+    msg_(message ? TransportQueueElement::clone_mb(message,
+                                                   mb_allocator,
+                                                   db_allocator) : 0),
     publication_id_(pubId),
     mb_allocator_(mb_allocator),
     db_allocator_(db_allocator),
     is_duplicate_(false)
 {
-  if (message != 0) {
-    msg_.reset(TransportQueueElement::clone_mb(message,
-                                               mb_allocator_,
-                                               db_allocator_));
-  }
 }
 
 ACE_INLINE
 OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
   const TransportRetainedElement& source
 ) : TransportQueueElement(1),
-    msg_(ACE_Message_Block::duplicate(source.msg())),
+    msg_(source.duplicate_msg()),
     publication_id_(source.publication_id()),
     mb_allocator_(source.mb_allocator_),
     db_allocator_(source.db_allocator_),
     is_duplicate_(source.is_duplicate_)
 {
-  DBG_ENTRY_LVL("TransportRetainedElement","TransportRetainedElement",6);
+  DBG_ENTRY_LVL("TransportRetainedElement", "TransportRetainedElement", 6);
 }
 
 

--- a/dds/DCPS/transport/framework/TransportRetainedElement.inl
+++ b/dds/DCPS/transport/framework/TransportRetainedElement.inl
@@ -11,19 +11,35 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_INLINE
 OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
+    ACE_Message_Block*                 message,
+    const RepoId&                      pubId
+) : TransportQueueElement(1),
+    publication_id_(pubId),
+    mb_allocator_(0),
+    db_allocator_(0),
+    is_duplicate_(true)
+{
+  if (message != 0) {
+    msg_.reset(message->duplicate());
+  }
+}
+
+ACE_INLINE
+OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
     const ACE_Message_Block*           message,
     const RepoId&                      pubId,
     MessageBlockAllocator*             mb_allocator,
     DataBlockAllocator*                db_allocator
 ) : TransportQueueElement(1),
-    publication_id_( pubId),
-    mb_allocator_( mb_allocator),
-    db_allocator_( db_allocator)
+    publication_id_(pubId),
+    mb_allocator_(mb_allocator),
+    db_allocator_(db_allocator),
+    is_duplicate_(false)
 {
   if (message != 0) {
     msg_.reset(TransportQueueElement::clone_mb(message,
-                                           this->mb_allocator_,
-                                           this->db_allocator_));
+                                               mb_allocator_,
+                                               db_allocator_));
   }
 }
 
@@ -31,10 +47,11 @@ ACE_INLINE
 OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
   const TransportRetainedElement& source
 ) : TransportQueueElement(1),
-    msg_( ACE_Message_Block::duplicate( source.msg())),
-    publication_id_( source.publication_id()),
-    mb_allocator_( source.mb_allocator_),
-    db_allocator_( source.db_allocator_)
+    msg_(ACE_Message_Block::duplicate(source.msg())),
+    publication_id_(source.publication_id()),
+    mb_allocator_(source.mb_allocator_),
+    db_allocator_(source.db_allocator_),
+    is_duplicate_(source.is_duplicate_)
 {
   DBG_ENTRY_LVL("TransportRetainedElement","TransportRetainedElement",6);
 }
@@ -42,16 +59,16 @@ OpenDDS::DCPS::TransportRetainedElement::TransportRetainedElement(
 
 ACE_INLINE
 bool
-OpenDDS::DCPS::TransportRetainedElement::owned_by_transport ()
+OpenDDS::DCPS::TransportRetainedElement::owned_by_transport()
 {
-  return true;
+  return !is_duplicate_;
 }
 
 ACE_INLINE
 bool
 OpenDDS::DCPS::TransportRetainedElement::is_retained_replaced() const
 {
-  return true;
+  return !is_duplicate_;
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -290,7 +290,8 @@ SingleSendBuffer::insert_buffer(BufferType& buffer,
 
   CopyChainVisitor visitor(*elems,
                            &retained_mb_allocator_,
-                           &retained_db_allocator_);
+                           &retained_db_allocator_,
+                           true);
   queue->accept_visitor(visitor);
 
   buffer.second = chain->duplicate();

--- a/dds/DCPS/transport/framework/TransportSendControlElement.cpp
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.cpp
@@ -35,7 +35,7 @@ TransportSendControlElement::TransportSendControlElement(int initial_count,
     msg_(msg_block.release()),
     dcps_elem_(0)
 {
-  DBG_ENTRY_LVL("TransportSendControlElement","TransportSendControlElement",6);
+  DBG_ENTRY_LVL("TransportSendControlElement", "TransportSendControlElement", 6);
 }
 
 
@@ -52,13 +52,13 @@ TransportSendControlElement::TransportSendControlElement(int initial_count,
 
 TransportSendControlElement::~TransportSendControlElement()
 {
-  DBG_ENTRY_LVL("TransportSendControlElement","~TransportSendControlElement",6);
+  DBG_ENTRY_LVL("TransportSendControlElement", "~TransportSendControlElement", 6);
 }
 
 bool
 TransportSendControlElement::requires_exclusive_packet() const
 {
-  DBG_ENTRY_LVL("TransportSendControlElement","requires_exclusive_packet",6);
+  DBG_ENTRY_LVL("TransportSendControlElement", "requires_exclusive_packet", 6);
   return true;
 }
 
@@ -94,14 +94,14 @@ TransportSendControlElement::release_element(bool dropped_by_transport)
 {
   ACE_UNUSED_ARG(dropped_by_transport);
 
-  DBG_ENTRY_LVL("TransportSendControlElement","release_element",6);
+  DBG_ENTRY_LVL("TransportSendControlElement", "release_element", 6);
 
   // store off local copies to use after "this" pointer deleted
-  const bool dropped = this->was_dropped();
+  const bool dropped = was_dropped();
 
-  Message_Block_Ptr msg(this->msg_.release());
+  Message_Block_Ptr msg(msg_.release());
 
-  TransportSendListener* const listener = this->listener_;
+  TransportSendListener* const listener = listener_;
   const DataSampleElement* dcps_elem = dcps_elem_;
 
 
@@ -119,30 +119,41 @@ TransportSendControlElement::release_element(bool dropped_by_transport)
 RepoId
 TransportSendControlElement::publication_id() const
 {
-  DBG_ENTRY_LVL("TransportSendControlElement","publication_id",6);
-  return this->publisher_id_;
+  DBG_ENTRY_LVL("TransportSendControlElement", "publication_id", 6);
+  return publisher_id_;
+}
+
+ACE_Message_Block*
+TransportSendControlElement::duplicate_msg() const
+{
+  DBG_ENTRY_LVL("TransportSendControlElement", "duplicate_msg", 6);
+  if (dcps_elem_) {
+    return const_cast<DataSampleElement*>(dcps_elem_)->get_sample()->duplicate();
+  }
+  return msg_->duplicate();
 }
 
 const ACE_Message_Block*
 TransportSendControlElement::msg() const
 {
-  DBG_ENTRY_LVL("TransportSendControlElement","msg",6);
-  if (dcps_elem_)
+  DBG_ENTRY_LVL("TransportSendControlElement", "msg", 6);
+  if (dcps_elem_) {
     return dcps_elem_->get_sample();
-  return this->msg_.get();
+  }
+  return msg_.get();
 }
 
 const ACE_Message_Block*
 TransportSendControlElement::msg_payload() const
 {
   DBG_ENTRY_LVL("TransportSendControlElement", "msg_payload", 6);
-  return this->msg()->cont();
+  return msg()->cont();
 }
 
 bool
 TransportSendControlElement::is_control(RepoId pub_id) const
 {
-  return (pub_id == this->publisher_id_);
+  return (pub_id == publisher_id_);
 }
 
 }

--- a/dds/DCPS/transport/framework/TransportSendControlElement.h
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.h
@@ -56,10 +56,10 @@ public:
   /// Accessor for the ACE_Message_Block
   virtual const ACE_Message_Block* msg() const;
 
-  const DataSampleHeader& header() const { return this->header_; }
+  const DataSampleHeader& header() const { return header_; }
   // Only allow const access to the header.  Modifying the header
   // would require remarshaling.
-  //DataSampleHeader& header() { return this->header_; }
+  //DataSampleHeader& header() { return header_; }
 
   const TransportSendListener* listener() const { return listener_; }
 

--- a/dds/DCPS/transport/framework/TransportSendControlElement.h
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.h
@@ -51,6 +51,8 @@ public:
   /// Accessor for the publisher id.
   virtual RepoId publication_id() const;
 
+  virtual ACE_Message_Block* duplicate_msg() const;
+
   /// Accessor for the ACE_Message_Block
   virtual const ACE_Message_Block* msg() const;
 

--- a/dds/DCPS/transport/framework/TransportSendControlElement.inl
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.inl
@@ -21,7 +21,7 @@ ACE_INLINE
 SequenceNumber
 TransportSendControlElement::sequence() const
 {
-  return this->header_.sequence_;
+  return header_.sequence_;
 }
 
 }

--- a/dds/DCPS/transport/framework/TransportSendElement.cpp
+++ b/dds/DCPS/transport/framework/TransportSendElement.cpp
@@ -17,13 +17,13 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 OpenDDS::DCPS::TransportSendElement::~TransportSendElement()
 {
-  DBG_ENTRY_LVL("TransportSendElement","~TransportSendElement",6);
+  DBG_ENTRY_LVL("TransportSendElement", "~TransportSendElement", 6);
 }
 
 void
 OpenDDS::DCPS::TransportSendElement::release_element(bool dropped_by_transport)
 {
-  DBG_ENTRY_LVL("TransportSendElement","release_element",6);
+  DBG_ENTRY_LVL("TransportSendElement", "release_element", 6);
 
   if (this->was_dropped()) {
     this->element_->get_send_listener()->data_dropped(this->element_,
@@ -40,7 +40,7 @@ OpenDDS::DCPS::TransportSendElement::release_element(bool dropped_by_transport)
 OpenDDS::DCPS::RepoId
 OpenDDS::DCPS::TransportSendElement::publication_id() const
 {
-  DBG_ENTRY_LVL("TransportSendElement","publication_id",6);
+  DBG_ENTRY_LVL("TransportSendElement", "publication_id", 6);
   return this->element_->get_pub_id();
 }
 
@@ -53,10 +53,17 @@ OpenDDS::DCPS::TransportSendElement::subscription_id() const
   return GUID_UNKNOWN;
 }
 
+ACE_Message_Block*
+OpenDDS::DCPS::TransportSendElement::duplicate_msg() const
+{
+  DBG_ENTRY_LVL("TransportSendElement", "duplicate_msg", 6);
+  return this->element_->get_sample()->duplicate();
+}
+
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportSendElement::msg() const
 {
-  DBG_ENTRY_LVL("TransportSendElement","msg",6);
+  DBG_ENTRY_LVL("TransportSendElement", "msg", 6);
   return this->element_->get_sample();
 }
 

--- a/dds/DCPS/transport/framework/TransportSendElement.cpp
+++ b/dds/DCPS/transport/framework/TransportSendElement.cpp
@@ -25,14 +25,13 @@ OpenDDS::DCPS::TransportSendElement::release_element(bool dropped_by_transport)
 {
   DBG_ENTRY_LVL("TransportSendElement", "release_element", 6);
 
-  if (this->was_dropped()) {
-    this->element_->get_send_listener()->data_dropped(this->element_,
-                                                 dropped_by_transport);
-
-  } else {
-    this->element_->get_send_listener()->data_delivered(this->element_);
+  if (element_->get_send_listener()) {
+    if (was_dropped()) {
+      element_->get_send_listener()->data_dropped(element_, dropped_by_transport);
+    } else {
+      element_->get_send_listener()->data_delivered(element_);
+    }
   }
-
 
   delete this;
 }
@@ -41,14 +40,14 @@ OpenDDS::DCPS::RepoId
 OpenDDS::DCPS::TransportSendElement::publication_id() const
 {
   DBG_ENTRY_LVL("TransportSendElement", "publication_id", 6);
-  return this->element_->get_pub_id();
+  return element_->get_pub_id();
 }
 
 OpenDDS::DCPS::RepoId
 OpenDDS::DCPS::TransportSendElement::subscription_id() const
 {
-  if (this->element_->get_num_subs() == 1) {
-    return this->element_->get_sub_id(0);
+  if (element_->get_num_subs() == 1) {
+    return element_->get_sub_id(0);
   }
   return GUID_UNKNOWN;
 }
@@ -57,21 +56,21 @@ ACE_Message_Block*
 OpenDDS::DCPS::TransportSendElement::duplicate_msg() const
 {
   DBG_ENTRY_LVL("TransportSendElement", "duplicate_msg", 6);
-  return this->element_->get_sample()->duplicate();
+  return element_->get_sample()->duplicate();
 }
 
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportSendElement::msg() const
 {
   DBG_ENTRY_LVL("TransportSendElement", "msg", 6);
-  return this->element_->get_sample();
+  return element_->get_sample();
 }
 
 const ACE_Message_Block*
 OpenDDS::DCPS::TransportSendElement::msg_payload() const
 {
   DBG_ENTRY_LVL("TransportSendElement", "msg_payload", 6);
-  return this->element_->get_sample() ? this->element_->get_sample()->cont() : 0;
+  return element_->get_sample() ? element_->get_sample()->cont() : 0;
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportSendElement.h
+++ b/dds/DCPS/transport/framework/TransportSendElement.h
@@ -30,6 +30,8 @@ public:
 
   virtual RepoId subscription_id() const;
 
+  virtual ACE_Message_Block* duplicate_msg() const;
+
   /// Accessor for the ACE_Message_Block
   virtual const ACE_Message_Block* msg() const;
 

--- a/dds/DCPS/transport/framework/TransportSendElement.inl
+++ b/dds/DCPS/transport/framework/TransportSendElement.inl
@@ -15,7 +15,7 @@ OpenDDS::DCPS::TransportSendElement::TransportSendElement(int initial_count,
   : TransportQueueElement(initial_count),
     element_(sample)
 {
-  DBG_ENTRY_LVL("TransportSendElement","TransportSendElement",6);
+  DBG_ENTRY_LVL("TransportSendElement", "TransportSendElement", 6);
 }
 
 
@@ -30,14 +30,14 @@ ACE_INLINE
 OpenDDS::DCPS::SequenceNumber
 OpenDDS::DCPS::TransportSendElement::sequence() const
 {
-  return this->element_->get_header().sequence_;
+  return element_->get_header().sequence_;
 }
 
 ACE_INLINE
 const OpenDDS::DCPS::DataSampleElement*
 OpenDDS::DCPS::TransportSendElement::sample() const
 {
-  return this->element_;
+  return element_;
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -87,7 +87,7 @@ TransportSendStrategy::TransportSendStrategy(
 
   // Create a ThreadSynch object just for us.
   DirectPriorityMapper mapper(priority);
-  this->synch_.reset(thread_sync_strategy->create_synch_object(
+  synch_.reset(thread_sync_strategy->create_synch_object(
                    synch_resource,
 #ifdef ACE_WIN32
                    ACE_DEFAULT_THREAD_PRIORITY,
@@ -100,7 +100,7 @@ TransportSendStrategy::TransportSendStrategy(
   // don't want to keep asking for it over and over.
   max_header_size_ = TransportHeader::get_max_serialized_size();
 
-  delayed_delivered_notification_queue_.reserve(this->max_samples_);
+  delayed_delivered_notification_queue_.reserve(max_samples_);
 }
 
 TransportSendStrategy::~TransportSendStrategy()
@@ -108,16 +108,16 @@ TransportSendStrategy::~TransportSendStrategy()
   DBG_ENTRY_LVL("TransportSendStrategy","~TransportSendStrategy",6);
 
 
-  this->delayed_delivered_notification_queue_.clear();
+  delayed_delivered_notification_queue_.clear();
 }
 
 void
 TransportSendStrategy::send_buffer(TransportSendBuffer* send_buffer)
 {
-  this->send_buffer_ = send_buffer;
+  send_buffer_ = send_buffer;
 
-  if (this->send_buffer_ != 0) {
-    this->send_buffer_->bind(this);
+  if (send_buffer_ != 0) {
+    send_buffer_->bind(this);
   }
 }
 
@@ -129,12 +129,12 @@ TransportSendStrategy::perform_work()
   SendPacketOutcome outcome;
   bool no_more_work = false;
 
-  { // scope for the guard(this->lock_);
-    GuardType guard(this->lock_);
+  { // scope for the guard(lock_);
+    GuardType guard(lock_);
 
-    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: perform_work mode: %C\n", mode_as_str(this->mode_)), 5);
+    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: perform_work mode: %C\n", mode_as_str(mode_)), 5);
 
-    if (this->mode_ == MODE_TERMINATED) {
+    if (mode_ == MODE_TERMINATED) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Entered perform_work() and mode_ is MODE_TERMINATED - "
                 "we lost connection and could not reconnect, just return "
@@ -158,10 +158,10 @@ TransportSendStrategy::perform_work()
     // WORK_OUTCOME_NO_MORE_TO_DO to tell our caller that we really don't
     // see a need for it to call our perform_work() again (at least not
     // right now).
-    if (this->mode_ != MODE_QUEUE && this->mode_ != MODE_SUSPEND) {
+    if (mode_ != MODE_QUEUE && mode_ != MODE_SUSPEND) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Entered perform_work() and mode_ is %C - just return "
-                "WORK_OUTCOME_NO_MORE_TO_DO.\n", mode_as_str(this->mode_)), 5);
+                "WORK_OUTCOME_NO_MORE_TO_DO.\n", mode_as_str(mode_)), 5);
       return WORK_OUTCOME_NO_MORE_TO_DO;
     }
 
@@ -173,7 +173,7 @@ TransportSendStrategy::perform_work()
     // packet.  When we find the current packet in the "partially sent" state,
     // we will not touch the queue_ - we will just try to send the unsent
     // bytes in the current (partially sent) packet.
-    const size_t header_length = this->header_.length_;
+    const size_t header_length = header_.length_;
 
     if (header_length == 0) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
@@ -186,7 +186,7 @@ TransportSendStrategy::perform_work()
 
       // Before we build the packet from the queue_, let's make sure that
       // there is actually something on the queue_ to build from.
-      if (this->queue_.size() == 0) {
+      if (queue_.size() == 0) {
         VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                   "But the queue is empty.  We have cleared the "
                   "backpressure situation.\n"),5);
@@ -200,7 +200,7 @@ TransportSendStrategy::perform_work()
                   "WORK_OUTCOME_NO_MORE_TO_DO.\n"), 5);
 
         // Flip the mode back to MODE_DIRECT.
-        this->mode_ = MODE_DIRECT;
+        mode_ = MODE_DIRECT;
 
         // And return WORK_OUTCOME_NO_MORE_TO_DO to tell our caller that
         // perform_work() doesn't need to be called again (at this time).
@@ -213,13 +213,13 @@ TransportSendStrategy::perform_work()
 
       // There is stuff in the queue_ if we get to this point in the logic.
       // Build-up the current packet using element(s) from the queue_.
-      this->get_packet_elems_from_queue();
+      get_packet_elems_from_queue();
 
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Prepare the packet from the packet elems_.\n"), 5);
 
       // Now we can prepare the new packet to be sent.
-      this->prepare_packet();
+      prepare_packet();
 
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Packet has been prepared from packet elems_.\n"), 5);
@@ -237,20 +237,20 @@ TransportSendStrategy::perform_work()
     // from the queue_ (and subsequently prepared for sending) - it doesn't
     // matter.  Just attempt to send as many of the "unsent" bytes in the
     // packet as possible.
-    outcome = this->send_packet();
+    outcome = send_packet();
 
     // If we sent the whole packet (eg, partial_send is false), and the queue_
     // is now empty, then we've cleared the backpressure situation.
-    if ((outcome == OUTCOME_COMPLETE_SEND) && (this->queue_.size() == 0)) {
+    if ((outcome == OUTCOME_COMPLETE_SEND) && (queue_.size() == 0)) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Flip the mode to MODE_DIRECT, and then return "
                 "WORK_OUTCOME_NO_MORE_TO_DO.\n"), 5);
 
       // Revert back to MODE_DIRECT mode.
-      this->mode_ = MODE_DIRECT;
+      mode_ = MODE_DIRECT;
       no_more_work = true;
     }
-  } // End of scope for guard(this->lock_);
+  } // End of scope for guard(lock_);
 
   VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
             "The outcome of the send_packet() was %d.\n", outcome), 5);
@@ -282,9 +282,9 @@ TransportSendStrategy::perform_work()
               "Now flip to MODE_SUSPEND before we try to reconnect.\n"), 5);
 
     bool do_suspend = true;
-    this->relink(do_suspend);
+    relink(do_suspend);
 
-    if (this->mode_ == MODE_SUSPEND) {
+    if (mode_ == MODE_SUSPEND) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "The reconnect has not done yet and we are still in MODE_SUSPEND. "
                 "Return WORK_OUTCOME_CLOGGED_RESOURCE.\n"), 5);
@@ -292,7 +292,7 @@ TransportSendStrategy::perform_work()
       // don't desire another call to this perform_work() method.
       return WORK_OUTCOME_NO_MORE_TO_DO;
 
-    } else if (this->mode_ == MODE_TERMINATED) {
+    } else if (mode_ == MODE_TERMINATED) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Reconnect failed, now we are in MODE_TERMINATED\n"), 5);
       return WORK_OUTCOME_BROKEN_RESOURCE;
@@ -304,7 +304,7 @@ TransportSendStrategy::perform_work()
       // If the datalink is re-established then notify the synch
       // thread to perform work.  We do not hold the object lock at
       // this point.
-      this->synch_->work_available();
+      synch_->work_available();
     }
   }
 
@@ -374,7 +374,7 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
         "Peek at the element at the front of the packet elems_.\n"));
 
   // This is the element currently at the front of elems_.
-  TransportQueueElement* element = this->elems_.peek();
+  TransportQueueElement* element = elems_.peek();
 
   if(!element){
     ACE_DEBUG((LM_INFO, "(%P|%t) WARNING: adjust_packet_after_send skipping due to NULL element\n"));
@@ -406,7 +406,7 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
             "At top of 'num bytes left' loop.  num_bytes_left == [%d].\n",
             num_bytes_left));
 
-      const int block_length = static_cast<int>(this->pkt_chain_->length());
+      const int block_length = static_cast<int>(pkt_chain_->length());
 
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "Length of block at front of pkt_chain_ is [%d].\n",
@@ -423,12 +423,12 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Extract the fully sent block from the pkt_chain_.\n"));
 
-        ACE_Message_Block* fully_sent_block = this->pkt_chain_;
+        ACE_Message_Block* fully_sent_block = pkt_chain_;
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Set pkt_chain_ to pkt_chain_->cont().\n"));
 
-        this->pkt_chain_ = this->pkt_chain_->cont();
+        pkt_chain_ = pkt_chain_->cont();
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Set the fully sent block's cont() to 0.\n"));
@@ -445,7 +445,7 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Now, num_bytes_left == [%d].\n", num_bytes_left));
 
-        if (!this->header_complete_) {
+        if (!header_complete_) {
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "Since the header_complete_ flag is false, it means "
                 "that the packet header block was still in the "
@@ -457,7 +457,7 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
 
           // That was the packet header block.  And now we know that it
           // has been completely sent.
-          this->header_complete_ = true;
+          header_complete_ = true;
 
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "Release the fully sent block.\n"));
@@ -513,21 +513,21 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
                   "the packet elems_ (we were just peeking).\n"));
 
             // Extract the element from the elems_ collection
-            element = this->elems_.get();
+            element = elems_.get();
 
             VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                   "Tell the element that a decision has been made "
                   "regarding its fate - data_delivered().\n"));
 
             // Inform the element that the data has been delivered.
-            this->add_delayed_notification(element);
+            add_delayed_notification(element);
 
             VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                   "Peek at the next element in the packet "
                   "elems_.\n"));
 
             // Set up for the next element in elems_ by peek()'ing.
-            element = this->elems_.peek();
+            element = elems_.peek();
 
             if (element != 0) {
               VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -586,9 +586,9 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
               "by the num_bytes_left (%d).\n", num_bytes_left));
 
         // Only part of the current block was sent.
-        this->pkt_chain_->rd_ptr(num_bytes_left);
+        pkt_chain_->rd_ptr(num_bytes_left);
 
-        if (this->header_complete_) {
+        if (header_complete_) {
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "And since the packet header block has already been "
                 "completely sent, add num_bytes_left to the "
@@ -625,18 +625,18 @@ TransportSendStrategy::adjust_packet_after_send(ssize_t num_bytes_sent)
         "num_non_header_bytes_sent.\n"));
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Before, header_.length_ == %d.\n",
-        this->header_.length_));
+        header_.length_));
 
   // Adjust the packet header_.length_ to indicate how many non header
   // bytes are left to send.
-  this->header_.length_ -= static_cast<ACE_UINT32>(num_non_header_bytes_sent);
+  header_.length_ -= static_cast<ACE_UINT32>(num_non_header_bytes_sent);
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "After, header_.length_ == %d.\n",
-        this->header_.length_));
+        header_.length_));
 
   // Returns 0 if the entire packet was sent, and returns 1 otherwise.
-  int rc = (this->header_.length_ == 0) ? 0 : 1;
+  int rc = (header_.length_ == 0) ? 0 : 1;
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Adjustments all done.  Returning [%d].  0 means entire packet "
@@ -696,7 +696,7 @@ TransportSendStrategy::send_delayed_notifications(const TransportQueueElement::M
   if (!found_element)
     return false;
 
-  bool transport_shutdown = this->transport_.is_shut_down();
+  bool transport_shutdown = transport_.is_shut_down();
 
   if (num_delayed_notifications == 1) {
     // optimization for the common case
@@ -735,13 +735,13 @@ TransportSendStrategy::terminate_send(bool graceful_disconnecting)
   bool reset_flag = true;
 
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
 
     // If the terminate_send call due to a non-graceful disconnection before
     // a datalink shutdown then we will not try to send the graceful disconnect
     // message.
-    if ((this->mode_ == MODE_TERMINATED || this->mode_ == MODE_SUSPEND)
-        && !this->graceful_disconnecting_) {
+    if ((mode_ == MODE_TERMINATED || mode_ == MODE_SUSPEND)
+        && !graceful_disconnecting_) {
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "It was already terminated non gracefully, will not set to graceful disconnecting\n"));
       reset_flag = false;
@@ -750,11 +750,11 @@ TransportSendStrategy::terminate_send(bool graceful_disconnecting)
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:  Now flip to MODE_TERMINATED\n"));
 
-  this->clear(MODE_TERMINATED);
+  clear(MODE_TERMINATED);
 
   if (reset_flag) {
-    GuardType guard(this->lock_);
-    this->graceful_disconnecting_ = graceful_disconnecting;
+    GuardType guard(lock_);
+    graceful_disconnecting_ = graceful_disconnecting;
   }
 }
 
@@ -772,16 +772,16 @@ TransportSendStrategy::clear(SendMode new_mode, SendMode old_mode)
   QueueType elems;
   QueueType queue;
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
 
-    if (old_mode != MODE_NOT_SET && this->mode_ != old_mode)
+    if (old_mode != MODE_NOT_SET && mode_ != old_mode)
       return;
 
-    if (this->header_.length_ > 0) {
+    if (header_.length_ > 0) {
       // Clear the messages in the pkt_chain_ that is partially sent.
       // We just reuse these functions for normal partial send except actual sending.
-      int num_bytes_left = static_cast<int>(this->pkt_chain_->total_length());
-      int result = this->adjust_packet_after_send(num_bytes_left);
+      int num_bytes_left = static_cast<int>(pkt_chain_->total_length());
+      int result = adjust_packet_after_send(num_bytes_left);
 
       if (result == 0) {
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -793,15 +793,15 @@ TransportSendStrategy::clear(SendMode new_mode, SendMode old_mode)
       }
     }
 
-    elems.swap(this->elems_);
-    queue.swap(this->queue_);
+    elems.swap(elems_);
+    queue.swap(queue_);
 
-    this->header_.length_ = 0;
-    this->pkt_chain_ = 0;
-    this->header_complete_ = false;
-    this->start_counter_ = 0;
-    this->mode_ = new_mode;
-    this->mode_before_suspend_ = MODE_NOT_SET;
+    header_.length_ = 0;
+    pkt_chain_ = 0;
+    header_complete_ = false;
+    start_counter_ = 0;
+    mode_ = new_mode;
+    mode_before_suspend_ = MODE_NOT_SET;
   }
 
   // We need remove the queued elements outside the lock,
@@ -821,9 +821,9 @@ TransportSendStrategy::start()
   DBG_ENTRY_LVL("TransportSendStrategy","start",6);
 
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
 
-    if (!this->start_i()) {
+    if (!start_i()) {
       return -1;
     }
   }
@@ -832,15 +832,15 @@ TransportSendStrategy::start()
 
   // If a secondary send buffer is bound, sent headers should
   // be cached to properly maintain the buffer:
-  if (this->send_buffer_ != 0) {
-    header_chunks += this->send_buffer_->capacity();
+  if (send_buffer_ != 0) {
+    header_chunks += send_buffer_->capacity();
 
   } else {
     header_chunks += 1;
   }
 
-  this->header_db_allocator_.reset( new TransportDataBlockAllocator(header_chunks));
-  this->header_mb_allocator_.reset( new TransportMessageBlockAllocator(header_chunks));
+  header_db_allocator_.reset( new TransportDataBlockAllocator(header_chunks));
+  header_mb_allocator_.reset( new TransportMessageBlockAllocator(header_chunks));
 
   // Since we (the TransportSendStrategy object) are a reference-counted
   // object, but the synch_ object doesn't necessarily know this, we need
@@ -848,7 +848,7 @@ TransportSendStrategy::start()
   // We will do the reverse when we unregister ourselves (as a worker) from
   // the synch_ object.
 
-  if (this->synch_->register_worker(*this) == -1) {
+  if (synch_->register_worker(*this) == -1) {
 
     ACE_ERROR_RETURN((LM_ERROR,
                       "(%P|%t) ERROR: TransportSendStrategy failed to register "
@@ -929,13 +929,13 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
   DBG_ENTRY_LVL("TransportSendStrategy", "send", 6);
 
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
 
-    if (this->link_released_) {
-      this->add_delayed_notification(element);
+    if (link_released_) {
+      add_delayed_notification(element);
 
     } else {
-      if (this->mode_ == MODE_TERMINATED && !this->graceful_disconnecting_) {
+      if (mode_ == MODE_TERMINATED && !graceful_disconnecting_) {
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "TransportSendStrategy::send: mode is MODE_TERMINATED and not in "
               "graceful disconnecting, so discard message.\n"));
@@ -950,22 +950,22 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
             element_length));
 
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
-            "this->max_header_size_ == [%d].\n",
-            this->max_header_size_));
+            "max_header_size_ == [%d].\n",
+            max_header_size_));
 
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
-            "this->max_size_ == [%d].\n",
-            this->max_size_));
+            "max_size_ == [%d].\n",
+            max_size_));
 
-      const size_t max_message_size = this->max_message_size();
+      const size_t max_msg_size = max_message_size();
 
       // Really an assert.  We can't accept any element that wouldn't fit into
       // a transport packet by itself (ie, it would be the only element in the
       // packet).  This max_size_ is the user-configurable maximum, not based
-      // on the transport's inherent maximum message size.  If max_message_size
+      // on the transport's inherent maximum message size.  If max_msg_size
       // is non-zero, we will fragment so max_size_ doesn't apply per-element.
-      if (max_message_size == 0 &&
-          this->max_header_size_ + element_length > this->max_size_) {
+      if (max_msg_size == 0 &&
+          max_header_size_ + element_length > max_size_) {
         ACE_ERROR((LM_ERROR,
                    "(%P|%t) ERROR: Element too large (%Q) "
                    "- won't fit into packet.\n", ACE_UINT64(element_length)));
@@ -973,22 +973,22 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
       }
 
       // Check the mode_ to see if we simply put the element on the queue.
-      if (this->mode_ == MODE_QUEUE || this->mode_ == MODE_SUSPEND) {
+      if (mode_ == MODE_QUEUE || mode_ == MODE_SUSPEND) {
         VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
-                  "this->mode_ == %C, so queue elem and leave.\n",
-                  mode_as_str(this->mode_)), 5);
+                  "mode_ == %C, so queue elem and leave.\n",
+                  mode_as_str(mode_)), 5);
 
-        this->queue_.put(element);
+        queue_.put(element);
 
-        if (this->mode_ != MODE_SUSPEND) {
-          this->synch_->work_available();
+        if (mode_ != MODE_SUSPEND) {
+          synch_->work_available();
         }
 
         return;
       }
 
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
-            "this->mode_ == MODE_DIRECT.\n"));
+            "mode_ == MODE_DIRECT.\n"));
 
       // We are in the MODE_DIRECT send mode.  When in this mode, the send()
       // calls will "build up" the transport packet to be sent directly when it
@@ -1020,11 +1020,11 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
           ));
 
       const size_t space_needed =
-        (max_message_size > 0)
+        (max_msg_size > 0)
         ? /* fragmenting */ DataSampleHeader::get_max_serialized_size() + MIN_FRAG
         : /* not fragmenting */ element_length;
 
-      if ((exclusive && (this->elems_.size() != 0))
+      if ((exclusive && (elems_.size() != 0))
           || (current_space_available() < space_needed)) {
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1033,22 +1033,22 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "max_header_size_: %d, header_.length_: %d, element_length: %d\n"
-              , this->max_header_size_, this->header_.length_, element_length));
+              , max_header_size_, header_.length_, element_length));
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Tot possible length: %d, max_len: %d\n"
-              , this->max_header_size_ + this->header_.length_ + element_length
-              , this->max_size_));
+              , max_header_size_ + header_.length_ + element_length
+              , max_size_));
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "current elem size: %d\n"
-              , this->elems_.size()));
+              , elems_.size()));
 
         // Send the current packet, and deal with the current element
         // afterwards.
         // The invocation's relink status should dictate the direct_send's
-        // relink. We don't want a (relink == false) invocation to end up
+        // do_relink. We don't want a (relink == false) invocation to end up
         // doing a relink. Think of (relink == false) as a non-blocking call.
-        this->direct_send(relink);
+        direct_send(relink);
 
         // Now check to see if we flipped into MODE_QUEUE, which would mean
         // that the direct_send() experienced backpressure, and the
@@ -1058,13 +1058,13 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
         // Otherwise, if the mode_ is still MODE_DIRECT, we can just
         // "drop" through to the next step in the logic where we append the
         // current element to the current packet.
-        if (this->mode_ == MODE_QUEUE) {
+        if (mode_ == MODE_QUEUE) {
           VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                     "We experienced backpressure on that direct send, as "
                     "the mode_ is now MODE_QUEUE or MODE_SUSPEND.  "
                     "Queue elem and leave.\n"), 5);
-          this->queue_.put(element);
-          this->synch_->work_available();
+          queue_.put(element);
+          synch_->work_available();
 
           return;
         }
@@ -1074,17 +1074,17 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
       bool first_pkt = true; // enter the loop 1st time through unconditionally
       for (TransportQueueElement* next_fragment = 0;
            (first_pkt || next_fragment)
-           && (this->mode_ == MODE_DIRECT || this->mode_ == MODE_TERMINATED);) {
+           && (mode_ == MODE_DIRECT || mode_ == MODE_TERMINATED);) {
            // We do need to send in MODE_TERMINATED (GRACEFUL_DISCONNECT msg)
 
         if (next_fragment) {
           element = next_fragment;
           element_length = next_fragment->msg()->total_length();
-          this->header_.first_fragment_ = false;
+          header_.first_fragment_ = false;
         }
 
-        this->header_.last_fragment_ = false;
-        if (max_message_size) { // fragmentation enabled
+        header_.last_fragment_ = false;
+        if (max_msg_size) { // fragmentation enabled
           const size_t avail = current_space_available();
           if (element_length > avail) {
             VDBG_LVL((LM_TRACE, "(%P|%t) DBG:   Fragmenting %B > %B\n", element_length, avail), 0);
@@ -1097,11 +1097,11 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
             element = ep.first;
             element_length = element->msg()->total_length();
             next_fragment = ep.second;
-            this->header_.first_fragment_ = first_pkt;
+            header_.first_fragment_ = first_pkt;
           } else if (next_fragment) {
             // We are sending the "tail" element of a previous fragment()
             // operation, and this element didn't itself require fragmentation
-            this->header_.last_fragment_ = true;
+            header_.last_fragment_ = true;
             next_fragment = 0;
           }
         }
@@ -1118,15 +1118,15 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
         // the current packet.
 
         // Add the current element to the collection of packet elements.
-        this->elems_.put(element);
+        elems_.put(element);
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Before, the header_.length_ == [%d].\n",
-              this->header_.length_));
+              header_.length_));
 
         // Adjust the header_.length_ to account for the length of the element.
-        this->header_.length_ += static_cast<ACE_UINT32>(element_length);
-        const size_t message_length = this->header_.length_;
+        header_.length_ += static_cast<ACE_UINT32>(element_length);
+        const size_t message_length = header_.length_;
 
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "After adding element's length, the header_.length_ == [%d].\n",
@@ -1146,25 +1146,25 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
         // - The current element (currently part of the packet elems_)
         //   requires an exclusive packet.
         //
-        if (next_fragment || (this->elems_.size() >= this->max_samples_)
-            || (this->max_header_size_ + message_length > this->optimum_size_)
+        if (next_fragment || (elems_.size() >= max_samples_)
+            || (max_header_size_ + message_length > optimum_size_)
             || exclusive) {
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "Now the current packet looks full - send it (directly).\n"));
 
-          this->direct_send(relink);
+          direct_send(relink);
 
-          if (next_fragment && this->mode_ != MODE_DIRECT) {
-            if (this->mode_ == MODE_QUEUE) {
-              this->queue_.put(next_fragment);
-              this->synch_->work_available();
+          if (next_fragment && mode_ != MODE_DIRECT) {
+            if (mode_ == MODE_QUEUE) {
+              queue_.put(next_fragment);
+              synch_->work_available();
 
             } else {
               next_fragment->data_dropped(true /* dropped by transport */);
             }
           } else if (mode_ == MODE_QUEUE) {
             // Background thread handles packets in progress
-            this->synch_->work_available();
+            synch_->work_available();
           }
 
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1172,7 +1172,7 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
 
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "And we %C as a result of the direct_send() call.\n",
-                ((this->mode_ == MODE_QUEUE) ? "flipped into MODE_QUEUE"
+                ((mode_ == MODE_QUEUE) ? "flipped into MODE_QUEUE"
                                              : "stayed in MODE_DIRECT")));
 
         } else {
@@ -1180,15 +1180,15 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
                 "Packet not sent. Send conditions weren't satisfied.\n"));
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "elems_.size(): %d, max_samples_: %d\n",
-                int(this->elems_.size()), int(this->max_samples_)));
+                int(elems_.size()), int(max_samples_)));
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "header_size_: %d, optimum_size_: %d\n",
-                int(this->max_header_size_ + message_length),
-                int(this->optimum_size_)));
+                int(max_header_size_ + message_length),
+                int(optimum_size_)));
           VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                 "element_requires_exclusive_packet: %d\n", int(exclusive)));
 
-          if (this->mode_ == MODE_QUEUE) {
+          if (mode_ == MODE_QUEUE) {
             VDBG((LM_DEBUG, "(%P|%t) DBG:   "
                   "We flipped into MODE_QUEUE.\n"));
 
@@ -1209,28 +1209,28 @@ TransportSendStrategy::send_stop(RepoId /*repoId*/)
 {
   DBG_ENTRY_LVL("TransportSendStrategy","send_stop",6);
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
 
-    if (this->link_released_)
+    if (link_released_)
       return;
 
-    if (this->start_counter_ == 0) {
+    if (start_counter_ == 0) {
       // This is an indication of a logic error.  This is more of an assert.
       VDBG_LVL((LM_ERROR,
                 "(%P|%t) ERROR: Received unexpected send_stop() call.\n"), 5);
       return;
     }
 
-    --this->start_counter_;
+    --start_counter_;
 
-    if (this->start_counter_ != 0) {
+    if (start_counter_ != 0) {
       // This wasn't the last send_stop() that we are expecting.  We only
       // really honor the first send_start() and the last send_stop().
       // We can return without doing anything else in this case.
       return;
     }
 
-    if (this->mode_ == MODE_TERMINATED && !this->graceful_disconnecting_) {
+    if (mode_ == MODE_TERMINATED && !graceful_disconnecting_) {
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "TransportSendStrategy::send_stop: dont try to send current packet "
             "since mode is MODE_TERMINATED and not in graceful disconnecting.\n"));
@@ -1253,16 +1253,16 @@ TransportSendStrategy::send_stop(RepoId /*repoId*/)
     // MODE_DIRECT.  It means that we may have some sample(s) in the
     // current packet that have never been sent.  This is our
     // opportunity to send the current packet directly if this is the case.
-    if (this->mode_ == MODE_QUEUE || this->mode_ == MODE_SUSPEND) {
+    if (mode_ == MODE_QUEUE || mode_ == MODE_SUSPEND) {
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "But since we are in %C, we don't have to do "
             "anything more in this important send_stop().\n",
-            mode_as_str(this->mode_)));
+            mode_as_str(mode_)));
       // We don't do anything if we are in MODE_QUEUE.  Just leave.
       return;
     }
 
-    size_t header_length = this->header_.length_;
+    size_t header_length = header_.length_;
     VDBG((LM_DEBUG, "(%P|%t) DBG:   "
           "We are in MODE_DIRECT in an important send_stop() - "
           "header_.length_ == [%d].\n", header_length));
@@ -1270,24 +1270,24 @@ TransportSendStrategy::send_stop(RepoId /*repoId*/)
     // Only attempt to send the current packet (directly) if the current
     // packet actually contains something (it could be empty).
     if ((header_length > 0) &&
-        //(this->elems_.size ()+this->not_yet_pac_q_->size() > 0))
-        (this->elems_.size() > 0)) {
+        //(elems_.size ()+not_yet_pac_q_->size() > 0))
+        (elems_.size() > 0)) {
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "There is something in the current packet - attempt to send "
             "it (directly) now.\n"));
       // If a relink needs to be done for this packet to be sent, do it.
-      this->direct_send(true);
+      direct_send(true);
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "Back from the attempt to send leftover packet directly.\n"));
 
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "But we %C as a result.\n",
-            ((this->mode_ == MODE_QUEUE)? "flipped into MODE_QUEUE":
+            ((mode_ == MODE_QUEUE)? "flipped into MODE_QUEUE":
                                           "stayed in MODE_DIRECT" )));
-      if (this->mode_ == MODE_QUEUE  && this->mode_ != MODE_SUSPEND) {
+      if (mode_ == MODE_QUEUE  && mode_ != MODE_SUSPEND) {
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
               "Notify Synch thread of work availability\n"));
-        this->synch_->work_available();
+        synch_->work_available();
       }
     }
   }
@@ -1303,12 +1303,12 @@ TransportSendStrategy::remove_all_msgs(const RepoId& pub_id)
   const TransportQueueElement::MatchOnPubId match(pub_id);
   send_delayed_notifications(&match);
 
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
 
-  if (this->send_buffer_ != 0) {
+  if (send_buffer_ != 0) {
     // If a secondary send buffer is bound, removed samples must
     // be retained in order to properly maintain the buffer:
-    this->send_buffer_->retain_all(pub_id);
+    send_buffer_->retain_all(pub_id);
   }
 
   do_remove_sample(pub_id, match, true);
@@ -1338,7 +1338,7 @@ TransportSendStrategy::remove_sample(const DataSampleElement* sample)
     return REMOVE_RELEASED;
   }
 
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
   return do_remove_sample(pub_id, modp);
 }
 
@@ -1349,12 +1349,12 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
   DBG_ENTRY_LVL("TransportSendStrategy", "do_remove_sample", 6);
 
   //ciju: Tim had the idea that we could do the following check
-  // if ((this->mode_ == MODE_DIRECT) ||
-  //     ((this->pkt_chain_ == 0) && (queue_ == empty)))
+  // if ((mode_ == MODE_DIRECT) ||
+  //     ((pkt_chain_ == 0) && (queue_ == empty)))
   // then we can assume that the sample can be safely removed (no need for
   // replacement) from the elems_ queue.
-  if ((this->mode_ == MODE_DIRECT)
-      || ((this->pkt_chain_ == 0) && (this->queue_.size() == 0))) {
+  if ((mode_ == MODE_DIRECT)
+      || ((pkt_chain_ == 0) && (queue_.size() == 0))) {
     //ciju: I believe this is the only mode where a safe
     // assumption can be made that the samples
     // in the elems_ queue aren't part of a packet.
@@ -1363,12 +1363,12 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
           "transport packet is in progress.\n"));
 
     QueueRemoveVisitor simple_rem_vis(criteria, remove_all);
-    this->elems_.accept_remove_visitor(simple_rem_vis);
+    elems_.accept_remove_visitor(simple_rem_vis);
 
     const RemoveResult status = simple_rem_vis.status();
 
     if (status == REMOVE_RELEASED || status == REMOVE_FOUND) {
-      this->header_.length_ -= simple_rem_vis.removed_bytes();
+      header_.length_ -= simple_rem_vis.removed_bytes();
 
     } else if (status == REMOVE_NOT_FOUND) {
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1382,7 +1382,7 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
         "Visit the queue_ with the RemoveElementVisitor.\n"));
 
   QueueRemoveVisitor simple_rem_vis(criteria, remove_all);
-  this->queue_.accept_remove_visitor(simple_rem_vis);
+  queue_.accept_remove_visitor(simple_rem_vis);
 
   RemoveResult status = simple_rem_vis.status();
 
@@ -1419,13 +1419,13 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
         "Visit our elems_ with the PacketRemoveVisitor.\n"));
 
   PacketRemoveVisitor pac_rem_vis(criteria,
-                                  this->pkt_chain_,
-                                  this->header_block_,
-                                  this->replaced_element_mb_allocator_,
-                                  this->replaced_element_db_allocator_,
+                                  pkt_chain_,
+                                  header_block_,
+                                  replaced_element_mb_allocator_,
+                                  replaced_element_db_allocator_,
                                   remove_all);
 
-  this->elems_.accept_replace_visitor(pac_rem_vis);
+  elems_.accept_replace_visitor(pac_rem_vis);
 
   status = pac_rem_vis.status();
 
@@ -1446,7 +1446,7 @@ TransportSendStrategy::do_remove_sample(const RepoId&,
 }
 
 void
-TransportSendStrategy::direct_send(bool relink)
+TransportSendStrategy::direct_send(bool do_relink)
 {
   DBG_ENTRY_LVL("TransportSendStrategy", "direct_send", 6);
 
@@ -1454,7 +1454,7 @@ TransportSendStrategy::direct_send(bool relink)
         "Prepare the current packet for a direct send attempt.\n"));
 
   // Prepare the packet for sending.
-  this->prepare_packet();
+  prepare_packet();
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Now attempt to send the packet.\n"));
@@ -1463,7 +1463,7 @@ TransportSendStrategy::direct_send(bool relink)
   // is re-established.  Only loops if the "continue" line is hit.
   while (true) {
     // Attempt to send the packet
-    const SendPacketOutcome outcome = this->send_packet();
+    const SendPacketOutcome outcome = send_packet();
 
     VDBG((LM_DEBUG, "(%P|%t) DBG:   "
           "The outcome of the send_packet() was %d.\n", outcome));
@@ -1478,7 +1478,7 @@ TransportSendStrategy::direct_send(bool relink)
                 "Flip into the MODE_QUEUE mode_.\n"), 5);
 
       // We encountered backpressure, or only sent part of the packet.
-      this->mode_ = MODE_QUEUE;
+      mode_ = MODE_QUEUE;
 
     } else if ((outcome == OUTCOME_PEER_LOST) ||
                (outcome == OUTCOME_SEND_ERROR)) {
@@ -1489,7 +1489,7 @@ TransportSendStrategy::direct_send(bool relink)
                    ACE_TEXT("send_bytes")));
 
         if (Transport_debug_level > 0) {
-          this->transport_.config().dump();
+          transport_.config().dump();
         }
       } else {
         VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1500,21 +1500,21 @@ TransportSendStrategy::direct_send(bool relink)
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Now flip to MODE_SUSPEND before we try to reconnect.\n"), 5);
 
-      if (this->mode_ != MODE_SUSPEND) {
-        this->mode_before_suspend_ = this->mode_;
-        this->mode_ = MODE_SUSPEND;
+      if (mode_ != MODE_SUSPEND) {
+        mode_before_suspend_ = mode_;
+        mode_ = MODE_SUSPEND;
       }
 
-      if (relink) {
+      if (do_relink) {
         bool do_suspend = false;
-        this->relink(do_suspend);
+        relink(do_suspend);
 
-        if (this->mode_ == MODE_SUSPEND) {
+        if (mode_ == MODE_SUSPEND) {
           VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                     "The reconnect has not done yet and we are "
                     "still in MODE_SUSPEND.\n"), 5);
 
-        } else if (this->mode_ == MODE_TERMINATED) {
+        } else if (mode_ == MODE_TERMINATED) {
           VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                     "Reconnect failed, we are in MODE_TERMINATED\n"), 5);
 
@@ -1547,8 +1547,8 @@ TransportSendStrategy::get_packet_elems_from_queue()
 {
   DBG_ENTRY_LVL("TransportSendStrategy", "get_packet_elems_from_queue", 6);
 
-  for (TransportQueueElement* element = this->queue_.peek(); element != 0;
-       element = this->queue_.peek()) {
+  for (TransportQueueElement* element = queue_.peek(); element != 0;
+       element = queue_.peek()) {
 
     // Total number of bytes in the current element's message block chain.
     size_t element_length = element->msg()->total_length();
@@ -1561,8 +1561,8 @@ TransportSendStrategy::get_packet_elems_from_queue()
     bool frag = false;
     if (element_length > avail) {
       // The current element won't fit into the current packet
-      if (this->max_message_size()) { // fragmentation enabled
-        this->header_.first_fragment_ = !element->is_fragment();
+      if (max_message_size()) { // fragmentation enabled
+        header_.first_fragment_ = !element->is_fragment();
         VDBG_LVL((LM_TRACE, "(%P|%t) DBG:   Fragmenting from queue\n"), 0);
         const TqePair ep = element->fragment(avail);
         if (ep == null_tqe_pair) {
@@ -1572,7 +1572,7 @@ TransportSendStrategy::get_packet_elems_from_queue()
         }
         element = ep.first;
         element_length = element->msg()->total_length();
-        this->queue_.replace_head(ep.second);
+        queue_.replace_head(ep.second);
         frag = true; // queue_ is already taken care of, don't get() later
       } else {
         break;
@@ -1582,16 +1582,16 @@ TransportSendStrategy::get_packet_elems_from_queue()
     // If exclusive and the current packet is empty, we won't violate the
     // exclusive_packet requirement by put()'ing the element
     // into the elems_ collection.
-    if ((exclusive_packet && this->elems_.size() == 0)
+    if ((exclusive_packet && elems_.size() == 0)
         || !exclusive_packet) {
       // At this point, we have passed all of the pre-conditions and we can
       // now extract the current element from the queue_, put it into the
       // packet elems_, and adjust the packet header_.length_.
-      this->elems_.put(frag ? element : this->queue_.get());
-      if (this->header_.length_ == 0) {
-        this->header_.last_fragment_ = !frag && element->is_fragment();
+      elems_.put(frag ? element : queue_.get());
+      if (header_.length_ == 0) {
+        header_.last_fragment_ = !frag && element->is_fragment();
       }
-      this->header_.length_ += static_cast<ACE_UINT32>(element_length);
+      header_.length_ += static_cast<ACE_UINT32>(element_length);
       VDBG_LVL((LM_TRACE, "(%P|%t) DBG:   Packetizing from queue\n"), 0);
     }
 
@@ -1605,10 +1605,10 @@ TransportSendStrategy::get_packet_elems_from_queue()
     if (exclusive_packet || frag
         // If the current number of packet elems_ has reached the maximum
         // number of samples per packet, then we are done.
-        || this->elems_.size() == this->max_samples_
+        || elems_.size() == max_samples_
         // If the current value of the header_.length_ exceeds (or equals)
         // the optimum_size_ for a packet, then we are done.
-        || this->header_.length_ >= this->optimum_size_) {
+        || header_.length_ >= optimum_size_) {
       break;
     }
   }
@@ -1620,11 +1620,11 @@ TransportSendStrategy::prepare_header()
   DBG_ENTRY_LVL("TransportSendStrategy", "prepare_header", 6);
 
   // Increment header sequence for packet:
-  this->header_.sequence_ = ++this->header_sequence_;
+  header_.sequence_ = ++header_sequence_;
 
   // Allow the specific implementation the opportunity to set
   // values in the packet header.
-  this->prepare_header_i();
+  prepare_header_i();
 }
 
 void
@@ -1641,18 +1641,18 @@ TransportSendStrategy::prepare_packet()
   DBG_ENTRY_LVL("TransportSendStrategy", "prepare_packet", 6);
 
   // Prepare the header for sending.
-  this->prepare_header();
+  prepare_header();
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Marshal the packet header.\n"));
 
-  if (this->header_block_ != 0) {
-    this->header_block_->release();
+  if (header_block_ != 0) {
+    header_block_->release();
   }
 
-  ACE_NEW_MALLOC(this->header_block_,
-    static_cast<ACE_Message_Block*>(this->header_mb_allocator_->malloc()),
-    ACE_Message_Block(this->max_header_size_,
+  ACE_NEW_MALLOC(header_block_,
+    static_cast<ACE_Message_Block*>(header_mb_allocator_->malloc()),
+    ACE_Message_Block(max_header_size_,
                       ACE_Message_Block::MB_DATA,
                       0,
                       0,
@@ -1661,12 +1661,12 @@ TransportSendStrategy::prepare_packet()
                       ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY,
                       ACE_Time_Value::zero,
                       ACE_Time_Value::max_time,
-                      this->header_db_allocator_.get(),
-                      this->header_mb_allocator_.get()));
+                      header_db_allocator_.get(),
+                      header_mb_allocator_.get()));
 
-  marshal_transport_header(this->header_block_);
+  marshal_transport_header(header_block_);
 
-  this->pkt_chain_ = this->header_block_->duplicate();
+  pkt_chain_ = header_block_->duplicate();
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Use a BuildChainVisitor to visit the packet elems_.\n"));
@@ -1675,21 +1675,21 @@ TransportSendStrategy::prepare_packet()
   // held by each element (in elems_), and then chaining the new duplicate
   // blocks together to form one long chain.
   BuildChainVisitor visitor;
-  this->elems_.accept_visitor(visitor);
+  elems_.accept_visitor(visitor);
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Attach the visitor's chain of blocks to the lone (packet "
         "header) block currently in the pkt_chain_.\n"));
 
   // Attach the visitor's chain of blocks to the packet header block.
-  this->pkt_chain_->cont(visitor.chain());
+  pkt_chain_->cont(visitor.chain());
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Increment header sequence for next packet.\n"));
 
   // Allow the specific implementation the opportunity to process the
   // newly prepared packet.
-  this->prepare_packet_i();
+  prepare_packet_i();
 
   VDBG((LM_DEBUG, "(%P|%t) DBG:   "
         "Set the header_complete_ flag to false.\n"));
@@ -1697,13 +1697,13 @@ TransportSendStrategy::prepare_packet()
   // Set the header_complete_ to false to indicate
   // that the first block in the pkt_chain_ is the packet header block
   // (actually a duplicate() of the packet header_block_).
-  this->header_complete_ = false;
+  header_complete_ = false;
 }
 
 bool
 TransportSendStrategy::marshal_transport_header(ACE_Message_Block* mb)
 {
-  return *mb << this->header_;
+  return *mb << header_;
 }
 
 void
@@ -1717,7 +1717,7 @@ TransportSendStrategy::prepare_packet_i()
 void
 TransportSendStrategy::set_graceful_disconnecting(bool flag)
 {
-  this->graceful_disconnecting_ = flag;
+  graceful_disconnecting_ = flag;
 }
 
 ssize_t
@@ -1759,7 +1759,7 @@ TransportSendStrategy::do_send_packet(const ACE_Message_Block* packet, int& bp)
   VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
             "Attempt to send_bytes() now.\n"), 5);
 
-  const ssize_t num_bytes_sent = this->send_bytes(iov, num_blocks, bp);
+  const ssize_t num_bytes_sent = send_bytes(iov, num_blocks, bp);
 
   VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
             "The send_bytes() said that num_bytes_sent == [%d].\n",
@@ -1785,7 +1785,7 @@ TransportSendStrategy::send_packet()
 
   int bp_flag = 0;
   const ssize_t num_bytes_sent =
-    this->do_send_packet(this->pkt_chain_, bp_flag);
+    do_send_packet(pkt_chain_, bp_flag);
 
   if (num_bytes_sent == 0) {
     VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1820,11 +1820,11 @@ TransportSendStrategy::send_packet()
     return OUTCOME_SEND_ERROR;
   }
 
-  if (this->send_buffer_ != 0) {
+  if (send_buffer_ != 0) {
     // If a secondary send buffer is bound, sent samples must
     // be inserted in order to properly maintain the buffer:
-    this->send_buffer_->insert(this->header_.sequence_,
-      &this->elems_, this->pkt_chain_);
+    send_buffer_->insert(header_.sequence_,
+      &elems_, pkt_chain_);
   }
 
   VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1834,7 +1834,7 @@ TransportSendStrategy::send_packet()
   // We sent some bytes - adjust the current packet (elems_ and pkt_chain_)
   // to account for the bytes that have been sent.
   const int result =
-    this->adjust_packet_after_send(num_bytes_sent);
+    adjust_packet_after_send(num_bytes_sent);
 
   if (result == 0) {
     VDBG((LM_DEBUG, "(%P|%t) DBG:   "
@@ -1854,7 +1854,7 @@ ssize_t
 TransportSendStrategy::non_blocking_send(const iovec iov[], int n, int& bp)
 {
   int val = 0;
-  ACE_HANDLE handle = this->get_handle();
+  ACE_HANDLE handle = get_handle();
 
   if (handle == ACE_INVALID_HANDLE)
     return -1;
@@ -1867,7 +1867,7 @@ TransportSendStrategy::non_blocking_send(const iovec iov[], int n, int& bp)
   // Clear errno
   errno = 0;
 
-  ssize_t result = this->send_bytes_i(iov, n);
+  ssize_t result = send_bytes_i(iov, n);
 
   if (result == -1) {
     if ((errno == EWOULDBLOCK) || (errno == ENOBUFS)) {
@@ -1901,20 +1901,20 @@ void
 TransportSendStrategy::add_delayed_notification(TransportQueueElement* element)
 {
   if (Transport_debug_level) {
-    size_t size = this->delayed_delivered_notification_queue_.size();
-    if ((size > 0) && (size % this->max_samples_ == 0)) {
+    size_t size = delayed_delivered_notification_queue_.size();
+    if ((size > 0) && (size % max_samples_ == 0)) {
       ACE_DEBUG((LM_DEBUG,
                  "(%P|%t) Transport send strategy notification queue threshold, size=%d\n",
                  size));
     }
   }
 
-  this->delayed_delivered_notification_queue_.push_back(std::make_pair(element, this->mode_));
+  delayed_delivered_notification_queue_.push_back(std::make_pair(element, mode_));
 }
 
 void TransportSendStrategy::deliver_ack_request(TransportQueueElement* element)
 {
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
   element->data_delivered();
 }
 

--- a/tests/unit-tests/dds/DCPS/transport/framework/CopyChainVisitor.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/framework/CopyChainVisitor.cpp
@@ -1,0 +1,113 @@
+#include <dds/DCPS/transport/framework/CopyChainVisitor.h>
+#include <dds/DCPS/transport/framework/RemoveAllVisitor.h>
+#include <dds/DCPS/transport/framework/TransportSendElement.h>
+
+#include <dds/DCPS/DataSampleElement.h>
+#include <dds/DCPS/PublicationInstance.h>
+
+#include <gtest/gtest.h>
+
+using namespace OpenDDS::DCPS;
+
+// Tests
+
+TEST(copy_chain_visitor, simple_copy)
+{
+  ACE_Log_Msg *lm = ACE_LOG_MSG;
+  lm->start_tracing();
+
+  OpenDDS::DCPS::Message_Block_Ptr amb(new ACE_Message_Block(5));
+  amb->cont(new ACE_Message_Block(8));
+  amb->cont()->cont(new ACE_Message_Block(16));
+
+  DataSampleElement* dse = new DataSampleElement(GUID_UNKNOWN, 0, PublicationInstance_rch());
+  dse->set_sample(move(amb));
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 1);
+
+  BasicQueue<TransportQueueElement> queue_in;
+  queue_in.put(new TransportSendElement(1, dse));
+
+  BasicQueue<TransportQueueElement> queue_out;
+  MessageBlockAllocator mba(1024);
+  DataBlockAllocator dba(1024);
+  CopyChainVisitor ccv(queue_out, &mba, &dba); // copy
+
+  queue_in.accept_visitor(ccv);
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 1);
+
+  ASSERT_EQ(queue_in.size(), queue_out.size());
+  ASSERT_EQ(queue_out.size(), 1u);
+
+  TransportRetainedElement* tse_out = dynamic_cast<TransportRetainedElement*>(queue_out.peek());
+  ASSERT_NE(tse_out, static_cast<TransportRetainedElement*>(0));
+  ASSERT_EQ(tse_out->msg()->capacity(), 5u);
+  ASSERT_EQ(tse_out->msg()->cont()->capacity(), 8u);
+  ASSERT_EQ(tse_out->msg()->cont()->cont()->capacity(), 16u);
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 1);
+  ASSERT_EQ(tse_out->msg()->reference_count(), 1);
+  ASSERT_NE(dse->get_sample(), tse_out->msg());
+
+  RemoveAllVisitor rav_out;
+  queue_out.accept_remove_visitor(rav_out);
+
+  RemoveAllVisitor rav_in;
+  queue_in.accept_remove_visitor(rav_in);
+
+  delete dse;
+  lm->stop_tracing();
+}
+
+TEST(copy_chain_visitor, simple_duplicate)
+{
+  ACE_Log_Msg *lm = ACE_LOG_MSG;
+  lm->start_tracing();
+
+  OpenDDS::DCPS::Message_Block_Ptr amb(new ACE_Message_Block(5));
+  amb->cont(new ACE_Message_Block(8));
+  amb->cont()->cont(new ACE_Message_Block(16));
+
+  DataSampleElement* dse = new DataSampleElement(GUID_UNKNOWN, 0, PublicationInstance_rch());
+  dse->set_sample(move(amb));
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 1);
+
+  BasicQueue<TransportQueueElement> queue_in;
+  queue_in.put(new TransportSendElement(1, dse));
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 1);
+
+  BasicQueue<TransportQueueElement> queue_out;
+  MessageBlockAllocator mba(1024);
+  DataBlockAllocator dba(1024);
+  CopyChainVisitor ccv(queue_out, &mba, &dba, true); // duplicate
+
+  queue_in.accept_visitor(ccv);
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 2);
+
+  ASSERT_EQ(queue_in.size(), queue_out.size());
+  ASSERT_EQ(queue_out.size(), 1u);
+
+  TransportRetainedElement* tse_out = dynamic_cast<TransportRetainedElement*>(queue_out.peek());
+  ASSERT_NE(tse_out, static_cast<TransportRetainedElement*>(0));
+  ASSERT_EQ(tse_out->msg()->capacity(), 5u);
+  ASSERT_EQ(tse_out->msg()->cont()->capacity(), 8u);
+  ASSERT_EQ(tse_out->msg()->cont()->cont()->capacity(), 16u);
+
+  ASSERT_EQ(dse->get_sample()->reference_count(), 2);
+  ASSERT_EQ(tse_out->msg()->reference_count(), 2);
+  ASSERT_NE(dse->get_sample(), tse_out->msg());
+  ASSERT_EQ(dse->get_sample()->data_block(), tse_out->msg()->data_block());
+
+  RemoveAllVisitor rav_out;
+  queue_out.accept_remove_visitor(rav_out);
+
+  RemoveAllVisitor rav_in;
+  queue_in.accept_remove_visitor(rav_in);
+
+  delete dse;
+  lm->stop_tracing();
+}

--- a/tests/unit-tests/dds/DCPS/transport/framework/CopyChainVisitor.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/framework/CopyChainVisitor.cpp
@@ -49,6 +49,7 @@ TEST(copy_chain_visitor, simple_copy)
   ASSERT_EQ(dse->get_sample()->reference_count(), 1);
   ASSERT_EQ(tse_out->msg()->reference_count(), 1);
   ASSERT_NE(dse->get_sample(), tse_out->msg());
+  ASSERT_NE(dse->get_sample()->data_block(), tse_out->msg()->data_block());
 
   RemoveAllVisitor rav_out;
   queue_out.accept_remove_visitor(rav_out);


### PR DESCRIPTION
Primary Improvements:
- [X] Avoid full copy of TransportQueueElement in TransportSendBuffer (SingleSendBuffer) by allowing calls to ACE_Message_Block::duplicate().
- [x] Avoid many unnecessary dynamic_casts inside TransportCustomizedElement::original_send_element() by caching result (which should not change over time).