### PR TITLE
Use TAO IDL Features Macros

### DIFF
--- a/dds/CorbaSeq/Int8Seq.idl
+++ b/dds/CorbaSeq/Int8Seq.idl
@@ -6,11 +6,18 @@
 #ifndef OPENDDS_CORBASEQ_INT8SEQ_IDL
 #define OPENDDS_CORBASEQ_INT8SEQ_IDL
 
-#pragma prefix "omg.org"
+#if defined __TAO_IDL_FEATURES
+#  include __TAO_IDL_FEATURES
+#endif
+
+#if defined TAO_IDL_HAS_EXPLICIT_INTS and TAO_IDL_HAS_EXPLICIT_INTS
+#  pragma prefix "omg.org"
 
 module CORBA
 {
   typedef sequence<int8> Int8Seq;
 };
+
+#endif
 
 #endif /* OPENDDS_CORBASEQ_INT8SEQ_IDL */

--- a/dds/CorbaSeq/Int8Seq.idl
+++ b/dds/CorbaSeq/Int8Seq.idl
@@ -10,7 +10,7 @@
 #  include __TAO_IDL_FEATURES
 #endif
 
-#if defined TAO_IDL_HAS_EXPLICIT_INTS and TAO_IDL_HAS_EXPLICIT_INTS
+#if defined TAO_IDL_HAS_EXPLICIT_INTS && TAO_IDL_HAS_EXPLICIT_INTS
 #  pragma prefix "omg.org"
 
 module CORBA

--- a/dds/CorbaSeq/UInt8Seq.idl
+++ b/dds/CorbaSeq/UInt8Seq.idl
@@ -6,11 +6,18 @@
 #ifndef OPENDDS_CORBASEQ_UINT8SEQ_IDL
 #define OPENDDS_CORBASEQ_UINT8SEQ_IDL
 
-#pragma prefix "omg.org"
+#if defined __TAO_IDL_FEATURES
+#  include __TAO_IDL_FEATURES
+#endif
+
+#if TAO_IDL_HAS_EXPLICIT_INTS
+#  pragma prefix "omg.org"
 
 module CORBA
 {
   typedef sequence<uint8> UInt8Seq;
 };
+
+#endif
 
 #endif /* OPENDDS_CORBASEQ_UINT8SEQ_IDL */

--- a/dds/CorbaSeq/UInt8Seq.idl
+++ b/dds/CorbaSeq/UInt8Seq.idl
@@ -10,7 +10,7 @@
 #  include __TAO_IDL_FEATURES
 #endif
 
-#if TAO_IDL_HAS_EXPLICIT_INTS
+#if defined TAO_IDL_HAS_EXPLICIT_INTS && TAO_IDL_HAS_EXPLICIT_INTS
 #  pragma prefix "omg.org"
 
 module CORBA

--- a/dds/DCPS/Definitions.h
+++ b/dds/DCPS/Definitions.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -9,9 +7,10 @@
 #define OPENDDS_DCPS_DEFINITIONS_H
 
 #include "Cached_Allocator_With_Overflow_T.h"
-#include "ace/Message_Block.h"
-#include "ace/Global_Macros.h"
-#include "ace/Null_Mutex.h"
+
+#include <ace/Message_Block.h>
+#include <ace/Global_Macros.h>
+#include <ace/Null_Mutex.h>
 
 #include <functional>
 #include <utility>
@@ -65,6 +64,14 @@
 #else
 #  include <cassert>
 #  define OPENDDS_ASSERT(C) assert(C)
+#endif
+
+#include <tao/orbconf.h>
+#if defined TAO_HAS_IDL_FEATURES && TAO_HAS_IDL_FEATURES
+#  include <tao/idl_features.h>
+#  define OPENDDS_HAS_EXPLICIT_INTS TAO_IDL_HAS_EXPLICIT_INTS
+#else
+#  define OPENDDS_HAS_EXPLICIT_INTS 0
 #endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/JsonValueReader.h
+++ b/dds/DCPS/JsonValueReader.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,13 +6,19 @@
 #ifndef OPENDDS_DCPS_JSON_VALUE_READER_H
 #define OPENDDS_DCPS_JSON_VALUE_READER_H
 
-#ifdef OPENDDS_RAPIDJSON
-#ifndef OPENDDS_SAFETY_PROFILE
+#if defined OPENDDS_RAPIDJSON && !defined OPENDDS_SAFETY_PROFILE
+#  define OPENDDS_HAS_JSON_VALUE_READER 1
+#else
+#  define OPENDDS_HAS_JSON_VALUE_READER 0
+#endif
+
+#if OPENDDS_HAS_JSON_VALUE_READER
 
 #include "dcps_export.h"
 #include "ValueReader.h"
 #include "RapidJsonWrapper.h"
 #include "TypeSupportImpl.h"
+#include "Definitions.h"
 
 #include <iosfwd>
 #include <sstream>
@@ -28,8 +32,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-// Convert values to JSON.
-// Currently, this class does not produce value JSON nor does it adhere to the DDS JSON spec.
+/// Convert values to JSON.
+/// Currently, this class does not produce value JSON nor does it adhere to the DDS JSON spec.
 template <typename InputStream = rapidjson::StringStream>
 class JsonValueReader
   : public ValueReader,
@@ -64,8 +68,10 @@ public:
 
   bool read_boolean(ACE_CDR::Boolean& value);
   bool read_byte(ACE_CDR::Octet& value);
+#if OPENDDS_HAS_EXPLICIT_INTS
   bool read_int8(ACE_CDR::Int8& value);
   bool read_uint8(ACE_CDR::UInt8& value);
+#endif
   bool read_int16(ACE_CDR::Short& value);
   bool read_uint16(ACE_CDR::UShort& value);
   bool read_int32(ACE_CDR::Long& value);
@@ -298,6 +304,7 @@ bool JsonValueReader<InputStream>::read_byte(ACE_CDR::Octet& value)
   return false;
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 template <typename InputStream>
 bool JsonValueReader<InputStream>::read_int8(ACE_CDR::Int8& value)
 {
@@ -322,6 +329,7 @@ bool JsonValueReader<InputStream>::read_uint8(ACE_CDR::UInt8& value)
   }
   return false;
 }
+#endif
 
 template <typename InputStream>
 bool JsonValueReader<InputStream>::read_int16(ACE_CDR::Short& value)
@@ -577,7 +585,6 @@ bool from_json(T& value, InputStream& sample)
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#endif
 #endif
 
 #endif  /* OPENDDS_DCPS_JSON_VALUE_READER_H */

--- a/dds/DCPS/JsonValueWriter.h
+++ b/dds/DCPS/JsonValueWriter.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,18 +6,21 @@
 #ifndef OPENDDS_DCPS_JSON_VALUE_WRITER_H
 #define OPENDDS_DCPS_JSON_VALUE_WRITER_H
 
-#ifdef OPENDDS_RAPIDJSON
-#ifndef OPENDDS_SAFETY_PROFILE
+#if defined OPENDDS_RAPIDJSON && !defined OPENDDS_SAFETY_PROFILE
+#  define OPENDDS_HAS_JSON_VALUE_WRITER 1
+#else
+#  define OPENDDS_HAS_JSON_VALUE_WRITER 0
+#endif
 
-#define OPENDDS_HAS_JSON_VALUE_WRITER 1
-
-#include "dcps_export.h"
+#if OPENDDS_HAS_JSON_VALUE_WRITER
 
 #include "ValueWriter.h"
 #include "RapidJsonWrapper.h"
+#include "dcps_export.h"
+#include "Definitions.h"
 
-#include "dds/DdsDcpsCoreTypeSupportImpl.h"
-#include "dds/DdsDcpsTopicC.h"
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
+#include <dds/DdsDcpsTopicC.h>
 
 #include <iosfwd>
 #include <sstream>
@@ -34,8 +35,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-// Convert values to JSON.
-// Currently, this class does not produce value JSON nor does it adhere to the DDS JSON spec.
+/// Convert values to JSON.
+/// Currently, this class does not produce value JSON nor does it adhere to the DDS JSON spec.
 template <typename Buffer = rapidjson::StringBuffer>
 class JsonValueWriter : public ValueWriter {
 public:
@@ -70,8 +71,10 @@ public:
 
   void write_boolean(ACE_CDR::Boolean value);
   void write_byte(ACE_CDR::Octet value);
+#if OPENDDS_HAS_EXPLICIT_INTS
   void write_int8(ACE_CDR::Int8 value);
   void write_uint8(ACE_CDR::UInt8 value);
+#endif
   void write_int16(ACE_CDR::Short value);
   void write_uint16(ACE_CDR::UShort value);
   void write_int32(ACE_CDR::Long value);
@@ -194,6 +197,7 @@ void JsonValueWriter<Buffer>::write_byte(ACE_CDR::Octet value)
   writer_.Uint(value);
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 template <typename Buffer>
 void JsonValueWriter<Buffer>::write_int8(ACE_CDR::Int8 value)
 {
@@ -205,6 +209,7 @@ void JsonValueWriter<Buffer>::write_uint8(ACE_CDR::UInt8 value)
 {
   writer_.Uint(value);
 }
+#endif
 
 template <typename Buffer>
 void JsonValueWriter<Buffer>::write_int16(ACE_CDR::Short value)
@@ -341,7 +346,6 @@ std::string to_json(const DDS::TopicDescription_ptr topic,
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#endif
 #endif
 
 #endif  /* OPENDDS_DCPS_JSON_VALUE_WRITER_H */

--- a/dds/DCPS/OpenDDS_Util.mpc
+++ b/dds/DCPS/OpenDDS_Util.mpc
@@ -2,7 +2,7 @@ project: acelib, dds_macros, install {
   requires += no_opendds_safety_profile
   sharedname = OpenDDS_Util
   dynamicflags = OPENDDS_DCPS_BUILD_DLL
-  includes += $(DDS_ROOT) $(DDS_ROOT)/dds
+  includes += $(DDS_ROOT) $(DDS_ROOT)/dds $(TAO_ROOT)
   libout = $(DDS_ROOT)/lib
   pch_header =
   pch_source =

--- a/dds/DCPS/RTPS/Logging.cpp
+++ b/dds/DCPS/RTPS/Logging.cpp
@@ -36,7 +36,7 @@ void log_message(const char* format,
                  bool send,
                  const Message& message)
 {
-#ifdef OPENDDS_HAS_JSON_VALUE_WRITER
+#if OPENDDS_HAS_JSON_VALUE_WRITER
   DCPS::JsonValueWriter<> jvw;
   jvw.begin_struct();
   jvw.begin_struct_member("guidPrefix");

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -454,8 +454,10 @@ public:
   bool read_char_array(ACE_CDR::Char* x, ACE_CDR::ULong length);
   bool read_wchar_array(ACE_CDR::WChar* x, ACE_CDR::ULong length);
   bool read_octet_array(ACE_CDR::Octet* x, ACE_CDR::ULong length);
+#if OPENDDS_HAS_EXPLICIT_INTS
   bool read_int8_array(ACE_CDR::Int8* x, ACE_CDR::ULong length);
   bool read_uint8_array(ACE_CDR::UInt8* x, ACE_CDR::ULong length);
+#endif
   bool read_short_array(ACE_CDR::Short* x, ACE_CDR::ULong length);
   bool read_ushort_array(ACE_CDR::UShort* x, ACE_CDR::ULong length);
   bool read_long_array(ACE_CDR::Long* x, ACE_CDR::ULong length);
@@ -476,8 +478,10 @@ public:
   bool write_char_array(const ACE_CDR::Char* x, ACE_CDR::ULong length);
   bool write_wchar_array(const ACE_CDR::WChar* x, ACE_CDR::ULong length);
   bool write_octet_array(const ACE_CDR::Octet* x, ACE_CDR::ULong length);
+#if OPENDDS_HAS_EXPLICIT_INTS
   bool write_int8_array(const ACE_CDR::Int8* x, ACE_CDR::ULong length);
   bool write_uint8_array(const ACE_CDR::UInt8* x, ACE_CDR::ULong length);
+#endif
   bool write_short_array(const ACE_CDR::Short* x, ACE_CDR::ULong length);
   bool write_ushort_array(const ACE_CDR::UShort* x, ACE_CDR::ULong length);
   bool write_long_array(const ACE_CDR::Long* x, ACE_CDR::ULong length);
@@ -532,10 +536,12 @@ public:
   bool operator<<(Serializer& s, ACE_OutputCDR::from_string x);
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, ACE_OutputCDR::from_wstring x);
+#if OPENDDS_HAS_EXPLICIT_INTS
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, ACE_OutputCDR::from_uint8 x);
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, ACE_OutputCDR::from_int8 x);
+#endif
 
   friend OpenDDS_Dcps_Export
   bool operator<<(Serializer& s, const String& x);
@@ -605,10 +611,12 @@ public:
   bool operator>>(Serializer& s, ACE_InputCDR::to_string x);
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, ACE_InputCDR::to_wstring x);
+#if OPENDDS_HAS_EXPLICIT_INTS
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, ACE_InputCDR::to_uint8 x);
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, ACE_InputCDR::to_int8 x);
+#endif
 
   friend OpenDDS_Dcps_Export
   bool operator>>(Serializer& s, String& x);
@@ -931,6 +939,7 @@ OpenDDS_Dcps_Export
 bool primitive_serialized_size(
   const Encoding& encoding, size_t& size,
   const ACE_OutputCDR::from_octet value, size_t count = 1);
+#if OPENDDS_HAS_EXPLICIT_INTS
 OpenDDS_Dcps_Export
 bool primitive_serialized_size(
   const Encoding& encoding, size_t& size,
@@ -939,6 +948,7 @@ OpenDDS_Dcps_Export
 bool primitive_serialized_size(
   const Encoding& encoding, size_t& size,
   const ACE_OutputCDR::from_int8 value, size_t count = 1);
+#endif
 
 // predefined type method explicit disambiguators.
 OpenDDS_Dcps_Export
@@ -956,12 +966,14 @@ void primitive_serialized_size_octet(const Encoding& encoding, size_t& size,
 OpenDDS_Dcps_Export
 void primitive_serialized_size_ulong(const Encoding& encoding, size_t& size,
   size_t count = 1);
+#if OPENDDS_HAS_EXPLICIT_INTS
 OpenDDS_Dcps_Export
 void primitive_serialized_size_uint8(const Encoding& encoding, size_t& size,
   size_t count = 1);
 OpenDDS_Dcps_Export
 void primitive_serialized_size_int8(const Encoding& encoding, size_t& size,
   size_t count = 1);
+#endif
 
 /// Add delimiter to the size of a serialized size if the encoding has them.
 OpenDDS_Dcps_Export

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -563,6 +563,7 @@ Serializer::read_octet_array(ACE_CDR::Octet* x, ACE_CDR::ULong length)
   return good_bit();
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 ACE_INLINE
 bool Serializer::read_int8_array(ACE_CDR::Int8* x, ACE_CDR::ULong length)
 {
@@ -576,6 +577,7 @@ bool Serializer::read_uint8_array(ACE_CDR::UInt8* x, ACE_CDR::ULong length)
   read_array(reinterpret_cast<char*>(x), uint8_cdr_size, length);
   return good_bit();
 }
+#endif
 
 ACE_INLINE bool
 Serializer::read_short_array(ACE_CDR::Short* x, ACE_CDR::ULong length)
@@ -700,6 +702,7 @@ Serializer::write_octet_array(const ACE_CDR::Octet* x, ACE_CDR::ULong length)
   return good_bit();
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 ACE_INLINE
 bool Serializer::write_int8_array(const ACE_CDR::Int8* x, ACE_CDR::ULong length)
 {
@@ -713,6 +716,7 @@ bool Serializer::write_uint8_array(const ACE_CDR::UInt8* x, ACE_CDR::ULong lengt
   write_array(reinterpret_cast<const char*>(x), uint8_cdr_size, length);
   return good_bit();
 }
+#endif
 
 ACE_INLINE bool
 Serializer::write_short_array(const ACE_CDR::Short* x, ACE_CDR::ULong length)
@@ -1188,6 +1192,7 @@ operator<<(Serializer& s, ACE_OutputCDR::from_wstring x)
   return s.good_bit() && ((x.bound_ == 0) || (stringlen <= x.bound_));
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 ACE_INLINE
 bool operator<<(Serializer& s, ACE_OutputCDR::from_uint8 x)
 {
@@ -1201,6 +1206,7 @@ bool operator<<(Serializer& s, ACE_OutputCDR::from_int8 x)
   s.buffer_write(reinterpret_cast<const char*>(&x.val_), int8_cdr_size, false);
   return s.good_bit();
 }
+#endif
 
 //
 // The following extraction operators are done in the style of the
@@ -1398,6 +1404,7 @@ operator>>(Serializer& s, ACE_InputCDR::to_wstring x)
   return s.good_bit();
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 ACE_INLINE
 bool operator>>(Serializer& s, ACE_InputCDR::to_uint8 x)
 {
@@ -1411,6 +1418,7 @@ bool operator>>(Serializer& s, ACE_InputCDR::to_int8 x)
   s.buffer_read(reinterpret_cast<char*>(&x.ref_), int8_cdr_size, false);
   return s.good_bit();
 }
+#endif
 
 ACE_INLINE bool
 operator>>(Serializer& s, String& x)
@@ -1591,6 +1599,7 @@ bool primitive_serialized_size(
   return true;
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 ACE_INLINE
 bool primitive_serialized_size(
   const Encoding& /*encoding*/, size_t& size,
@@ -1608,6 +1617,7 @@ bool primitive_serialized_size(
   size += int8_cdr_size * count;
   return true;
 }
+#endif
 
 // predefined type method explicit disambiguators.
 
@@ -1648,6 +1658,7 @@ void primitive_serialized_size_ulong(const Encoding& encoding, size_t& size,
   size += uint32_cdr_size * count;
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 ACE_INLINE
 void primitive_serialized_size_uint8(const Encoding& /*encoding*/, size_t& size,
   size_t count)
@@ -1661,6 +1672,7 @@ void primitive_serialized_size_int8(const Encoding& /*encoding*/, size_t& size,
 {
   size += int8_cdr_size * count;
 }
+#endif
 
 ACE_INLINE
 void serialized_size_delimiter(const Encoding& encoding, size_t& size)

--- a/dds/DCPS/ValueReader.h
+++ b/dds/DCPS/ValueReader.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,9 +6,10 @@
 #ifndef OPENDDS_DCPS_VALUE_READER_H
 #define OPENDDS_DCPS_VALUE_READER_H
 
-
-#include "FACE/Fixed.h"
+#include "Definitions.h"
 #include "XTypes/TypeObject.h"
+
+#include <FACE/Fixed.h>
 #include <dds/Versioned_Namespace.h>
 
 #include <ace/CDR_Base.h>
@@ -22,16 +21,15 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-// A ValueReader produces events and values for the recitation of a
-// value.  To use it, one manually or automatically, e.g., code
-// generation in the IDL compiler, defines a vread function for a
-// given type V.
-//
-//   bool vread(ValueReader& vw, V& value)
-//
-// The vread function should invoke the appropriate methods of the
-// ValueReader and dispatch to other vread functions.
-
+/// A ValueReader produces events and values for the recitation of a
+/// value.  To use it, one manually or automatically, e.g., code
+/// generation in the IDL compiler, defines a vread function for a
+/// given type V.
+///
+///   bool vread(ValueReader& vw, V& value)
+///
+/// The vread function should invoke the appropriate methods of the
+/// ValueReader and dispatch to other vread functions.
 class MemberHelper {
 public:
   virtual ~MemberHelper() {}
@@ -127,8 +125,10 @@ struct ValueReader {
 
   virtual bool read_boolean(ACE_CDR::Boolean& value) = 0;
   virtual bool read_byte(ACE_CDR::Octet& value) = 0;
+#if OPENDDS_HAS_EXPLICIT_INTS
   virtual bool read_int8(ACE_CDR::Int8& value) = 0;
   virtual bool read_uint8(ACE_CDR::UInt8& value) = 0;
+#endif
   virtual bool read_int16(ACE_CDR::Short& value) = 0;
   virtual bool read_uint16(ACE_CDR::UShort& value) = 0;
   virtual bool read_int32(ACE_CDR::Long& value) = 0;

--- a/dds/DCPS/ValueWriter.h
+++ b/dds/DCPS/ValueWriter.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,9 +6,10 @@
 #ifndef OPENDDS_DCPS_VALUE_WRITER_H
 #define OPENDDS_DCPS_VALUE_WRITER_H
 
-#include "dds/Versioned_Namespace.h"
+#include "Definitions.h"
 
-#include "FACE/Fixed.h"
+#include <dds/Versioned_Namespace.h>
+#include <FACE/Fixed.h>
 
 #include <ace/CDR_Base.h>
 
@@ -21,18 +20,17 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-// A ValueWriter receives events and values from the recitation of a
-// value.  Typical examples of value recitation are serializing an
-// object for transmission, formatting an object for printing, or
-// copying an object to another representation, e.g., C++ to v8.  To
-// use it, one manually or automatically, e.g., code generation in the
-// IDL compiler, defines a vwrite function for a given type V.
-//
-//   void vwrite(ValueWriter& vw, const V& value)
-//
-// The vwrite function should invoke the appropriate methods of the
-// ValueWriter and dispatch for other vwrite functions.
-
+/// A ValueWriter receives events and values from the recitation of a
+/// value.  Typical examples of value recitation are serializing an
+/// object for transmission, formatting an object for printing, or
+/// copying an object to another representation, e.g., C++ to v8.  To
+/// use it, one manually or automatically, e.g., code generation in the
+/// IDL compiler, defines a vwrite function for a given type V.
+///
+///   void vwrite(ValueWriter& vw, const V& value)
+///
+/// The vwrite function should invoke the appropriate methods of the
+/// ValueWriter and dispatch for other vwrite functions.
 struct ValueWriter {
   virtual ~ValueWriter() {}
 
@@ -57,8 +55,10 @@ struct ValueWriter {
 
   virtual void write_boolean(ACE_CDR::Boolean /*value*/) = 0;
   virtual void write_byte(ACE_CDR::Octet /*value*/) = 0;
+#if OPENDDS_HAS_EXPLICIT_INTS
   virtual void write_int8(ACE_CDR::Int8 /*value*/) = 0;
   virtual void write_uint8(ACE_CDR::UInt8 /*value*/) = 0;
+#endif
   virtual void write_int16(ACE_CDR::Short /*value*/) = 0;
   virtual void write_uint16(ACE_CDR::UShort /*value*/) = 0;
   virtual void write_int32(ACE_CDR::Long /*value*/) = 0;

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -10,7 +8,9 @@
 
 #include "be_extern.h"
 #include "be_util.h"
-#include "../DCPS/RestoreOutputStreamState.h"
+
+#include <dds/DCPS/RestoreOutputStreamState.h>
+#include <dds/DCPS/Definitions.h>
 
 #include <utl_scoped_name.h>
 #include <utl_identifier.h>
@@ -460,12 +460,14 @@ std::string wrapPrefix(AST_Type* type, WrapDirection wd)
     case AST_PredefinedType::PT_boolean:
       return (wd == WD_OUTPUT)
         ? "ACE_OutputCDR::from_boolean(" : "ACE_InputCDR::to_boolean(";
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_uint8:
       return (wd == WD_OUTPUT)
         ? "ACE_OutputCDR::from_uint8(" : "ACE_InputCDR::to_uint8(";
     case AST_PredefinedType::PT_int8:
       return (wd == WD_OUTPUT)
         ? "ACE_OutputCDR::from_int8(" : "ACE_InputCDR::to_int8(";
+#endif
     default:
       return "";
     }
@@ -520,12 +522,14 @@ inline std::string to_cxx_type(AST_Type* type, std::size_t& size)
     case AST_PredefinedType::PT_ushort:
       size = 2;
       return "ACE_CDR::UShort";
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_int8:
       size = 1;
       return "ACE_CDR::Int8";
     case AST_PredefinedType::PT_uint8:
       size = 1;
       return "ACE_CDR::UInt8";
+#endif
     case AST_PredefinedType::PT_float:
       size = 4;
       return "ACE_CDR::Float";
@@ -676,10 +680,12 @@ std::ostream& operator<<(std::ostream& o,
   switch (ev.et) {
   case AST_Expression::EV_octet:
     return hex_value(o << "0x", static_cast<int>(ev.u.oval), 1);
+#if OPENDDS_HAS_EXPLICIT_INTS
   case AST_Expression::EV_int8:
     return o << static_cast<short>(ev.u.int8val);
   case AST_Expression::EV_uint8:
     return o << static_cast<unsigned short>(ev.u.uint8val);
+#endif
   case AST_Expression::EV_short:
     return o << ev.u.sval;
   case AST_Expression::EV_ushort:
@@ -775,8 +781,10 @@ inline bool needSyntheticDefault(AST_Type* disc, size_t n_labels)
   switch (pdt->pt()) {
   case AST_PredefinedType::PT_boolean:
     return n_labels < 2;
+#if OPENDDS_HAS_EXPLICIT_INTS
   case AST_PredefinedType::PT_int8:
   case AST_PredefinedType::PT_uint8:
+#endif
   case AST_PredefinedType::PT_char:
   case AST_PredefinedType::PT_octet:
     return n_labels < ACE_OCTET_MAX;

--- a/dds/idl/itl_generator.cpp
+++ b/dds/idl/itl_generator.cpp
@@ -1,17 +1,17 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
 #include "itl_generator.h"
+
 #include "be_extern.h"
 #include "global_extern.h"
 
-#include "utl_identifier.h"
-#include "utl_labellist.h"
+#include <dds/DCPS/Definitions.h>
 
+#include <utl_identifier.h>
+#include <utl_labellist.h>
 #include <ast_fixed.h>
 
 using namespace AstTypeClassification;
@@ -110,12 +110,14 @@ operator<<(std::ostream& out,
       be_global->itl_ << "{ \"kind\" : \"int\", \"bits\" : 8, \"unsigned\" : true, "
         "\"note\" : { \"presentation\" : { \"type\" : \"byte\" } }  }";
       break;
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_uint8:
       be_global->itl_ << "{ \"kind\" : \"int\", \"bits\" : 8, \"unsigned\" : true }";
       break;
     case AST_PredefinedType::PT_int8:
       be_global->itl_ << "{ \"kind\" : \"int\", \"bits\" : 8 }";
       break;
+#endif
     case AST_PredefinedType::PT_any:
     case AST_PredefinedType::PT_object:
     case AST_PredefinedType::PT_value:

--- a/dds/idl/langmap_generator.cpp
+++ b/dds/idl/langmap_generator.cpp
@@ -8,6 +8,8 @@
 #include "field_info.h"
 #include "be_extern.h"
 
+#include <dds/DCPS/Definitions.h>
+
 #ifdef ACE_HAS_CDR_FIXED
 #  include <ast_fixed.h>
 #endif
@@ -133,8 +135,10 @@ struct GeneratorBase
   {
     AST_PredefinedType::PredefinedType pt = AST_PredefinedType::PT_void;
     switch (type) {
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_Expression::EV_int8: pt = AST_PredefinedType::PT_int8; break;
     case AST_Expression::EV_uint8: pt = AST_PredefinedType::PT_uint8; break;
+#endif
     case AST_Expression::EV_short: pt = AST_PredefinedType::PT_short; break;
     case AST_Expression::EV_ushort: pt = AST_PredefinedType::PT_ushort; break;
     case AST_Expression::EV_long: pt = AST_PredefinedType::PT_long; break;
@@ -210,12 +214,14 @@ struct GeneratorBase
 
     switch (the_union->udisc_type ())
       {
+#if OPENDDS_HAS_EXPLICIT_INTS
       case AST_Expression::EV_int8:
         first_label << signed(dv.u.char_val);
         break;
       case AST_Expression::EV_uint8:
         first_label << unsigned(dv.u.char_val);
         break;
+#endif
       case AST_Expression::EV_short:
         first_label << dv.u.short_val;
         break;
@@ -1117,8 +1123,10 @@ struct SafetyProfileGenerator : GeneratorBase
     primtype_[AST_PredefinedType::PT_ulonglong] = "CORBA::UnsignedLongLong";
     primtype_[AST_PredefinedType::PT_short] = "CORBA::Short";
     primtype_[AST_PredefinedType::PT_ushort] = "CORBA::UShort";
+#if OPENDDS_HAS_EXPLICIT_INTS
     primtype_[AST_PredefinedType::PT_int8] = "CORBA::Int8";
     primtype_[AST_PredefinedType::PT_uint8] = "CORBA::UInt8";
+#endif
     primtype_[AST_PredefinedType::PT_float] = "CORBA::Float";
     primtype_[AST_PredefinedType::PT_double] = "CORBA::Double";
     primtype_[AST_PredefinedType::PT_longdouble] = "CORBA::LongDouble";
@@ -1350,8 +1358,10 @@ struct Cxx11Generator : GeneratorBase
     primtype_[AST_PredefinedType::PT_ulonglong] = "uint64_t";
     primtype_[AST_PredefinedType::PT_short] = "int16_t";
     primtype_[AST_PredefinedType::PT_ushort] = "uint16_t";
+#if OPENDDS_HAS_EXPLICIT_INTS
     primtype_[AST_PredefinedType::PT_int8] = "int8_t";
     primtype_[AST_PredefinedType::PT_uint8] = "uint8_t";
+#endif
     primtype_[AST_PredefinedType::PT_float] = "float";
     primtype_[AST_PredefinedType::PT_double] = "double";
     primtype_[AST_PredefinedType::PT_longdouble] = "long double";

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -11,7 +9,9 @@
 #include "field_info.h"
 #include "topic_keys.h"
 #include "be_util.h"
-#include "dds/DCPS/SafetyProfileStreams.h"
+
+#include <dds/DCPS/SafetyProfileStreams.h>
+#include <dds/DCPS/Definitions.h>
 
 #include <utl_identifier.h>
 
@@ -510,10 +510,12 @@ namespace {
       return "primitive_serialized_size_wchar(" + first_args + ", " + count_expr + ")";
     case AST_PredefinedType::PT_boolean:
       return "primitive_serialized_size_boolean(" + first_args + ", " + count_expr + ")";
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_uint8:
       return "primitive_serialized_size_uint8(" + first_args + ", " + count_expr + ")";
     case AST_PredefinedType::PT_int8:
       return "primitive_serialized_size_int8(" + first_args + ", " + count_expr + ")";
+#endif
     default:
       return "primitive_serialized_size(" + first_args + ", " +
         scoped(type->name()) + "(), " + count_expr + ")";
@@ -531,10 +533,12 @@ namespace {
       return "short";
     case AST_PredefinedType::PT_ushort:
       return "ushort";
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_int8:
       return "int8";
     case AST_PredefinedType::PT_uint8:
       return "uint8";
+#endif
     case AST_PredefinedType::PT_octet:
       return "octet";
     case AST_PredefinedType::PT_char:
@@ -1750,8 +1754,10 @@ namespace {
       case AST_PredefinedType::PT_char:
       case AST_PredefinedType::PT_boolean:
       case AST_PredefinedType::PT_octet:
+#if OPENDDS_HAS_EXPLICIT_INTS
       case AST_PredefinedType::PT_uint8:
       case AST_PredefinedType::PT_int8:
+#endif
         size += 1;
         break;
       case AST_PredefinedType::PT_short:
@@ -3875,8 +3881,10 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
         if (ul->label_kind() != AST_UnionLabel::UL_default) {
           AST_Expression::AST_ExprValue* ev = branch->label(i)->label_val()->ev();
           if ((ev->et == AST_Expression::EV_enum && ev->u.eval == default_enum_val) ||
+#if OPENDDS_HAS_EXPLICIT_INTS
               (ev->et == AST_Expression::EV_uint8 && ev->u.uint8val == 0) ||
               (ev->et == AST_Expression::EV_int8 && ev->u.int8val == 0) ||
+#endif
               (ev->et == AST_Expression::EV_short && ev->u.sval == 0) ||
               (ev->et == AST_Expression::EV_ushort && ev->u.usval == 0) ||
               (ev->et == AST_Expression::EV_long && ev->u.lval == 0) ||

--- a/dds/idl/rapidjson_generator.cpp
+++ b/dds/idl/rapidjson_generator.cpp
@@ -7,6 +7,8 @@
 
 #include "be_extern.h"
 
+#include <dds/DCPS/Definitions.h>
+
 #include <utl_identifier.h>
 
 using namespace AstTypeClassification;
@@ -42,12 +44,16 @@ namespace {
         return "String";
       case AST_PredefinedType::PT_boolean:
         return "Bool";
+#if OPENDDS_HAS_EXPLICIT_INTS
       case AST_PredefinedType::PT_int8:
+#endif
       case AST_PredefinedType::PT_short:
       case AST_PredefinedType::PT_long:
         return "Int";
       case AST_PredefinedType::PT_octet:
+#if OPENDDS_HAS_EXPLICIT_INTS
       case AST_PredefinedType::PT_uint8:
+#endif
       case AST_PredefinedType::PT_ushort:
       case AST_PredefinedType::PT_ulong:
         return "Uint";
@@ -155,14 +161,18 @@ namespace {
           // prefix and suffix not needed
           break;
 
+#if OPENDDS_HAS_EXPLICIT_INTS
         case AST_PredefinedType::PT_int8:
+#endif
         case AST_PredefinedType::PT_short:
           prefix = "static_cast<int>(";
           suffix = ")";
           break;
 
         case AST_PredefinedType::PT_octet:
+#if OPENDDS_HAS_EXPLICIT_INTS
         case AST_PredefinedType::PT_uint8:
+#endif
         case AST_PredefinedType::PT_ushort:
           prefix = "static_cast<unsigned int>(";
           suffix = ")";
@@ -311,8 +321,10 @@ namespace {
         case AST_PredefinedType::PT_longlong:
         case AST_PredefinedType::PT_ulonglong:
         case AST_PredefinedType::PT_octet:
+#if OPENDDS_HAS_EXPLICIT_INTS
         case AST_PredefinedType::PT_uint8:
         case AST_PredefinedType::PT_int8:
+#endif
         case AST_PredefinedType::PT_ushort:
         case AST_PredefinedType::PT_short:
         case AST_PredefinedType::PT_ulong:

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -1,21 +1,20 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
 #include "typeobject_generator.h"
 
-#include "utl_identifier.h"
 #include "topic_keys.h"
 #include "dds_visitor.h"
-
 #include "be_extern.h"
 #include "be_util.h"
 
 #include <dds/DCPS/Hash.h>
 #include <dds/DCPS/SafetyProfileStreams.h>
+#include <dds/DCPS/Definitions.h>
+
+#include <utl_identifier.h>
 
 using std::string;
 using namespace AstTypeClassification;
@@ -58,10 +57,12 @@ to_long(const AST_Expression::AST_ExprValue& ev)
   switch (ev.et) {
   case AST_Expression::EV_octet:
     return ev.u.oval;
+#if OPENDDS_HAS_EXPLICIT_INTS
   case AST_Expression::EV_uint8:
     return ev.u.uint8val;
   case AST_Expression::EV_int8:
     return ev.u.int8val;
+#endif
   case AST_Expression::EV_short:
     return ev.u.sval;
   case AST_Expression::EV_ushort:
@@ -1616,12 +1617,14 @@ typeobject_generator::generate_minimal_type_identifier(AST_Type* type, bool forc
       case AST_PredefinedType::PT_ushort:
         minimal_type_identifier_map_[type] = OpenDDS::XTypes::TypeIdentifier(OpenDDS::XTypes::TK_UINT16);
         break;
+#if OPENDDS_HAS_EXPLICIT_INTS
       case AST_PredefinedType::PT_int8:
         minimal_type_identifier_map_[type] = OpenDDS::XTypes::TypeIdentifier(OpenDDS::XTypes::TK_INT8);
         break;
       case AST_PredefinedType::PT_uint8:
         minimal_type_identifier_map_[type] = OpenDDS::XTypes::TypeIdentifier(OpenDDS::XTypes::TK_UINT8);
         break;
+#endif
       case AST_PredefinedType::PT_float:
         minimal_type_identifier_map_[type] = OpenDDS::XTypes::TypeIdentifier(OpenDDS::XTypes::TK_FLOAT32);
         break;

--- a/dds/idl/v8_generator.cpp
+++ b/dds/idl/v8_generator.cpp
@@ -1,14 +1,15 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
 #include "v8_generator.h"
+
 #include "be_extern.h"
 
-#include "utl_identifier.h"
+#include <dds/DCPS/Definitions.h>
+
+#include <utl_identifier.h>
 
 using namespace AstTypeClassification;
 
@@ -47,8 +48,10 @@ namespace {
       case AST_PredefinedType::PT_boolean:
         return "Boolean";
       case AST_PredefinedType::PT_octet:
+#if OPENDDS_HAS_EXPLICIT_INTS
       case AST_PredefinedType::PT_uint8:
       case AST_PredefinedType::PT_int8:
+#endif
       case AST_PredefinedType::PT_ushort:
       case AST_PredefinedType::PT_short:
       case AST_PredefinedType::PT_ulong:

--- a/dds/idl/value_reader_generator.cpp
+++ b/dds/idl/value_reader_generator.cpp
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -9,6 +7,8 @@
 
 #include "be_extern.h"
 #include "be_util.h"
+
+#include <dds/DCPS/Definitions.h>
 
 #include <global_extern.h>
 #include <utl_identifier.h>
@@ -59,10 +59,12 @@ namespace {
       return "int16";
     case AST_PredefinedType::PT_ushort:
       return "uint16";
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_int8:
       return "int8";
     case AST_PredefinedType::PT_uint8:
       return "uint8";
+#endif
     case AST_PredefinedType::PT_float:
       return "float32";
     case AST_PredefinedType::PT_double:

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -1,17 +1,17 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
 #include "value_writer_generator.h"
+
 #include "be_extern.h"
 #include "global_extern.h"
 
-#include "utl_identifier.h"
-#include "utl_labellist.h"
+#include <dds/DCPS/Definitions.h>
 
+#include <utl_identifier.h>
+#include <utl_labellist.h>
 #include <ast_fixed.h>
 
 using namespace AstTypeClassification;
@@ -57,10 +57,12 @@ namespace {
       return "int16";
     case AST_PredefinedType::PT_ushort:
       return "uint16";
+#if OPENDDS_HAS_EXPLICIT_INTS
     case AST_PredefinedType::PT_int8:
       return "int8";
     case AST_PredefinedType::PT_uint8:
       return "uint8";
+#endif
     case AST_PredefinedType::PT_float:
       return "float32";
     case AST_PredefinedType::PT_double:

--- a/tests/DCPS/Compiler/char_literals/test.idl
+++ b/tests/DCPS/Compiler/char_literals/test.idl
@@ -1,3 +1,10 @@
+#if defined __TAO_IDL_FEATURES
+#  include __TAO_IDL_FEATURES
+#  define WCHAR_DISC TAO_IDL_HAS_OCTET_AND_WCHAR_UNION_DISCS
+#else
+#  define WCHAR_DISC 0
+#endif
+
 const char c_a = 'a';
 const char c_newline = '\n';
 const char c_tab = '\t';
@@ -79,7 +86,7 @@ const wchar wc_hex_254 = L'\xfe';
 const wchar wc_u_escape = L'\u203C'; // (Double Exclamation Mark: ‼)
 #endif
 
-/* TODO(iguessthislldo): Support for 7.4.13.4.2 in TAO_IDL
+#if WCHAR_DISC
 @topic
 union WcharUnion switch (@key wchar) {
 case L'a':
@@ -119,7 +126,7 @@ case L'\u203C':
 default:
   long defualt_member;
 }
-*/
+#endif
 
 /* TODO(iguessthislldo): config-linux.h doesn't seem to have ACE_HAS_WCHAR
  * defined, which makes WChar typedef to ACE_UINT16, which doesn't seem to

--- a/tests/DCPS/Compiler/explicit_ints/main.cpp
+++ b/tests/DCPS/Compiler/explicit_ints/main.cpp
@@ -1,7 +1,10 @@
 #include <testTypeSupportImpl.h>
 
+#include <dds/DCPS/Definitions.h>
+
 #include <gtest/gtest.h>
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 TEST(ExplicitInts, min_max)
 {
   EXPECT_EQ(u8_max, 255);
@@ -17,6 +20,7 @@ TEST(ExplicitInts, min_max)
   EXPECT_EQ(i64_min, -9223372036854775807 - 1);
   EXPECT_EQ(i64_max, 9223372036854775807);
 }
+#endif
 
 int main(int argc, char* argv[])
 {

--- a/tests/DCPS/Compiler/explicit_ints/test.idl
+++ b/tests/DCPS/Compiler/explicit_ints/test.idl
@@ -1,9 +1,11 @@
-#include <tao/Int8Seq.pidl>
-#include <tao/UInt8Seq.pidl>
-#include <tao/OctetSeq.pidl>
-#include <tao/CharSeq.pidl>
+#if defined __TAO_IDL_FEATURES
+#  include __TAO_IDL_FEATURES
+#  if TAO_IDL_HAS_EXPLICIT_INTS
+#    include <tao/Int8Seq.pidl>
+#    include <tao/UInt8Seq.pidl>
+#    include <tao/OctetSeq.pidl>
+#    include <tao/CharSeq.pidl>
 
-const uint8 u8_min = 0;
 const uint8 u8_max = 255;
 const int8 i8_min = -128;
 const int8 i8_max = 127;
@@ -40,6 +42,7 @@ struct StructWithInts {
   // Make sure there's no conflict between uint8, int8, octet, and char.
   @key uint8 u8_arr[3];
   @key int8 i8_arr[3];
+  // TODO(iguessthislldo): Support key sequences
   sequence<uint8> u8_seq;
   sequence<int8> i8_seq;
   sequence<octet> o_seq;
@@ -104,3 +107,6 @@ case 8:
 case 9:
   I8seq td_i8seq;
 };
+
+#  endif
+#endif

--- a/tests/DCPS/Compiler/rapidjson_generator/RapidJsonTest.cpp
+++ b/tests/DCPS/Compiler/rapidjson_generator/RapidJsonTest.cpp
@@ -4,6 +4,7 @@
 #include "RapidJsonTestTypeSupportImpl.h"
 
 #include <dds/DCPS/RapidJsonWrapper.h>
+#include <dds/DCPS/Definitions.h>
 
 #include <fstream>
 
@@ -27,8 +28,10 @@ TEST(RapidJsonTest, ParseTest)
   ASSERT_EQ(sample.enu, Mod::three);
   ASSERT_EQ(sample.enu2, Mod::two);
   ASSERT_EQ(sample.bt.o, 129);
+#if OPENDDS_HAS_EXPLICIT_INTS
   ASSERT_EQ(sample.bt.u8, 130);
   ASSERT_EQ(sample.bt.i8, -50);
+#endif
   ASSERT_EQ(sample.bt.us, 32777);
   ASSERT_EQ(sample.bt.s, -32765);
   ASSERT_EQ(sample.bt.ul, 2147483690);
@@ -104,8 +107,10 @@ TEST(RapidJsonTest, SerializeTest)
   sample.enu = Mod::three;
   sample.enu2 = Mod::two;
   sample.bt.o = 129;
+#if OPENDDS_HAS_EXPLICIT_INTS
   sample.bt.u8 = 130;
   sample.bt.i8 = -50;
+#endif
   sample.bt.us = 32777u;
   sample.bt.s = -32765;
   sample.bt.ul = 2147483690u;
@@ -164,8 +169,10 @@ TEST(RapidJsonTest, SerializeTest)
   ASSERT_EQ(val["enu"], "three");
   ASSERT_EQ(val["enu2"], "two");
   ASSERT_EQ(val["bt"]["o"], 129);
+#if OPENDDS_HAS_EXPLICIT_INTS
   ASSERT_EQ(val["bt"]["u8"], 130);
   ASSERT_EQ(val["bt"]["i8"], -50);
+#endif
   ASSERT_EQ(val["bt"]["us"], 32777u);
   ASSERT_EQ(val["bt"]["s"], -32765);
   ASSERT_EQ(val["bt"]["ul"], 2147483690u);

--- a/tests/DCPS/Compiler/rapidjson_generator/RapidJsonTest.idl
+++ b/tests/DCPS/Compiler/rapidjson_generator/RapidJsonTest.idl
@@ -1,3 +1,10 @@
+#if defined __TAO_IDL_FEATURES
+#  include __TAO_IDL_FEATURES
+#  if TAO_IDL_HAS_EXPLICIT_INTS
+#    define EXPLICIT_INTS
+#  endif
+#endif
+
 #include <tao/LongSeq.pidl>
 #include <tao/ShortSeq.pidl>
 #include <tao/StringSeq.pidl>
@@ -8,8 +15,10 @@ module Mod {
 
   struct BasicTypes {
     octet o;
+#ifdef EXPLICIT_INTS
     uint8 u8;
     int8 i8;
+#endif
     unsigned short us;
     short s;
     unsigned long ul;

--- a/tests/DCPS/Serializer/SerializerTest.cpp
+++ b/tests/DCPS/Serializer/SerializerTest.cpp
@@ -1,5 +1,7 @@
 #include "common.h"
 
+#include <dds/DCPS/Definitions.h>
+
 #include <ace/ACE.h>
 #include <ace/Message_Block.h>
 #include <ace/OS_NS_string.h>
@@ -16,11 +18,15 @@ bool failed = false;
 
 struct Values {
   ACE_CDR::Octet octetValue;
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::Int8 int8Value;
+#endif
   ACE_CDR::Short shortValue;
   ACE_CDR::Long longValue;
   ACE_CDR::LongLong longlongValue;
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::UInt8 uint8Value;
+#endif
   ACE_CDR::UShort ushortValue;
   ACE_CDR::ULong ulongValue;
   ACE_CDR::ULongLong ulonglongValue;
@@ -43,11 +49,15 @@ struct Values {
 
 struct ArrayValues {
   ACE_CDR::Octet octetValue[ARRAYSIZE];
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::Int8 int8Value[ARRAYSIZE];
+#endif
   ACE_CDR::Short shortValue[ARRAYSIZE];
   ACE_CDR::Long longValue[ARRAYSIZE];
   ACE_CDR::LongLong longlongValue[ARRAYSIZE];
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::UInt8 uint8Value[ARRAYSIZE];
+#endif
   ACE_CDR::UShort ushortValue[ARRAYSIZE];
   ACE_CDR::ULong ulongValue[ARRAYSIZE];
   ACE_CDR::ULongLong ulonglongValue[ARRAYSIZE];
@@ -64,11 +74,15 @@ void insertions(ACE_Message_Block* chain, const Values& values,
   Serializer serializer(chain, encoding);
 
   serializer << ACE_OutputCDR::from_octet(values.octetValue);
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer << ACE_OutputCDR::from_int8(values.int8Value);
+#endif
   serializer << values.shortValue;
   serializer << values.longValue;
   serializer << values.longlongValue;
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer << ACE_OutputCDR::from_uint8(values.uint8Value);
+#endif
   serializer << values.ushortValue;
   serializer << values.ulongValue;
   serializer << values.ulonglongValue;
@@ -96,11 +110,15 @@ void array_insertions(
   Serializer serializer(chain, encoding);
 
   serializer.write_octet_array(values.octetValue, length);
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer.write_int8_array(values.int8Value, length);
+#endif
   serializer.write_short_array(values.shortValue, length);
   serializer.write_long_array(values.longValue, length);
   serializer.write_longlong_array(values.longlongValue, length);
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer.write_uint8_array(values.uint8Value, length);
+#endif
   serializer.write_ushort_array(values.ushortValue, length);
   serializer.write_ulong_array(values.ulongValue, length);
   serializer.write_ulonglong_array(values.ulonglongValue, length);
@@ -150,12 +168,14 @@ bool extractions(Serializer& serializer, Values& values,
     print(pos, expectedPos, prevPos, readPosOk, "octet");
   }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer >> ACE_InputCDR::to_int8(values.int8Value);
   if (checkPos) {
     expectedPos += OpenDDS::DCPS::int8_cdr_size;
     pos = serializer.rpos();
     print(pos, expectedPos, prevPos, readPosOk, "int8");
   }
+#endif
 
   serializer >> values.shortValue;
   if (checkPos) {
@@ -181,12 +201,14 @@ bool extractions(Serializer& serializer, Values& values,
     print(pos, expectedPos, prevPos, readPosOk, "long long");
   }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer >> ACE_InputCDR::to_uint8(values.uint8Value);
   if (checkPos) {
     expectedPos += OpenDDS::DCPS::uint8_cdr_size;
     pos = serializer.rpos();
     print(pos, expectedPos, prevPos, readPosOk, "uint8");
   }
+#endif
 
   serializer >> values.ushortValue;
   if (checkPos) {
@@ -297,11 +319,15 @@ void array_extractions(ACE_Message_Block* chain, ArrayValues& values,
   Serializer serializer(chain, encoding);
 
   serializer.read_octet_array(values.octetValue, length);
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer.read_int8_array(values.int8Value, length);
+#endif
   serializer.read_short_array(values.shortValue, length);
   serializer.read_long_array(values.longValue, length);
   serializer.read_longlong_array(values.longlongValue, length);
+#if OPENDDS_HAS_EXPLICIT_INTS
   serializer.read_uint8_array(values.uint8Value, length);
+#endif
   serializer.read_ushort_array(values.ushortValue, length);
   serializer.read_ulong_array(values.ulongValue, length);
   serializer.read_ulonglong_array(values.ulonglongValue, length);
@@ -387,12 +413,14 @@ checkValues(const Values& expected, const Values& observed)
     std::cout << "(expected: " << expected.octetValue << ", observed: " << observed.octetValue << ")." << std::endl;
     failed = true;
   }
+#if OPENDDS_HAS_EXPLICIT_INTS
   if (expected.int8Value != observed.int8Value) {
     std::cout << "int8 values not correct after insertion and extraction." << std::endl
       << "(expected: " << expected.int8Value << ", observed: " << observed.int8Value
       << ")." << std::endl;
     failed = true;
   }
+#endif
   if (expected.shortValue != observed.shortValue) {
     std::cout << "short values not correct after insertion and extraction." << std::endl;
     std::cout << "(expected: " << expected.shortValue << ", observed: " << observed.shortValue << ")." << std::endl;
@@ -408,12 +436,14 @@ checkValues(const Values& expected, const Values& observed)
     std::cout << "(expected: " << expected.ulongValue << ", observed: " << observed.ulongValue << ")." << std::endl;
     failed = true;
   }
+#if OPENDDS_HAS_EXPLICIT_INTS
   if (expected.uint8Value != observed.uint8Value) {
     std::cout << "uint8 values not correct after insertion and extraction." << std::endl
       << "(expected: " << expected.uint8Value << ", observed: " << observed.uint8Value
       << ")." << std::endl;
     failed = true;
   }
+#endif
   if (expected.ushortValue != observed.ushortValue) {
     std::cout << "ushort values not correct after insertion and extraction." << std::endl;
     std::cout << "(expected: " << expected.ushortValue << ", observed: " << observed.ushortValue << ")." << std::endl;
@@ -586,6 +616,7 @@ checkArrayValues(const ArrayValues& expected, const ArrayValues& observed)
       std::cout << ")." << std::endl;
       failed = true;
     }
+#if OPENDDS_HAS_EXPLICIT_INTS
     if (expected.uint8Value[i] != observed.uint8Value[i]) {
       ACE::format_hexdump((char*)&(expected.uint8Value[i]), sizeof(ACE_CDR::UInt8),
         ebuffer, sizeof(ebuffer));
@@ -610,6 +641,7 @@ checkArrayValues(const ArrayValues& expected, const ArrayValues& observed)
         << ")." << std::endl;
       failed = true;
     }
+#endif
   }
 }
 
@@ -627,7 +659,15 @@ void runTest(const Values& expected, const ArrayValues& expectedArray,
   displayChain(testchain);
   std::cout << "EXTRACTING SINGLE VALUES WITH" << out << " SWAPPING" << std::endl;
   Values observed = {
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,
+#if OPENDDS_HAS_EXPLICIT_INTS
+    0,
+#endif
+    0, 0, 0,
+#if OPENDDS_HAS_EXPLICIT_INTS
+    0,
+#endif
+    0, 0, 0, 0, 0,
     ACE_CDR_LONG_DOUBLE_INITIALIZER, 0, 0, 0
 #ifndef OPENDDS_SAFETY_PROFILE
     , ""
@@ -818,11 +858,15 @@ ACE_TMAIN(int, ACE_TCHAR*[])
 
   Values expected = {
     0x01,
+#if OPENDDS_HAS_EXPLICIT_INTS
     0x11,
+#endif
     0x2345,
     0x67abcdef,
     ACE_INT64_LITERAL(0x0123456789abcdef),
+#if OPENDDS_HAS_EXPLICIT_INTS
     0x22,
+#endif
     0x0123,
     0x456789ab,
     ACE_UINT64_LITERAL(0xcdef0123456789ab),
@@ -852,11 +896,15 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   // Initialize the array
   for (size_t i = 0; i < ARRAYSIZE; ++i) {
     expectedArray.octetValue[i] = (0xff&i);
+#if OPENDDS_HAS_EXPLICIT_INTS
     expectedArray.int8Value[i] = (0xdd&i);
+#endif
     expectedArray.shortValue[i] = (0xffff&i);
     expectedArray.longValue[i] = ACE_CDR::Long(0x0f0f0f0f|i);
     expectedArray.longlongValue[i] = ACE_INT64_LITERAL(0x0123456789abcdef);
+#if OPENDDS_HAS_EXPLICIT_INTS
     expectedArray.uint8Value[i] = (0xdd|i);
+#endif
     expectedArray.ushortValue[i] = ACE_CDR::UShort(0xffff|i);
     expectedArray.ulongValue[i] = ACE_CDR::ULong(0xf0f0f0f0|i);
     expectedArray.ulonglongValue[i] = ACE_UINT64_LITERAL(0xcdef0123456789ab);

--- a/tests/unit-tests/dds/DCPS/JsonValueReader.cpp
+++ b/tests/unit-tests/dds/DCPS/JsonValueReader.cpp
@@ -7,8 +7,7 @@
 
 #include <gtest/gtest.h>
 
-#ifdef OPENDDS_RAPIDJSON
-#ifndef OPENDDS_SAFETY_PROFILE
+#if OPENDDS_HAS_JSON_VALUE_READER
 
 using namespace rapidjson;
 using namespace OpenDDS::DCPS;
@@ -104,8 +103,10 @@ TEST(JsonValueReader, struct_max)
     "{"
     "\"bool\":true,"
     "\"byte\":255,"
+#if OPENDDS_HAS_EXPLICIT_INTS
     "\"int8\":127,"
     "\"uint8\":255,"
+#endif
     "\"int16\":32767,"
     "\"uint16\":65535,"
     "\"int32\":2147483647,"
@@ -125,8 +126,10 @@ TEST(JsonValueReader, struct_max)
   MemberId member_id;
   ACE_CDR::Boolean bool_value;
   ACE_CDR::Octet byte_value;
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::Int8 int8_value;
   ACE_CDR::UInt8 uint8_value;
+#endif
   ACE_CDR::Short int16_value;
   ACE_CDR::UShort uint16_value;
   ACE_CDR::Long int32_value;
@@ -155,6 +158,7 @@ TEST(JsonValueReader, struct_max)
   EXPECT_EQ(byte_value, 255);
   EXPECT_TRUE(jvr.end_struct_member());
 
+#if OPENDDS_HAS_EXPLICIT_INTS
   EXPECT_TRUE(jvr.begin_struct_member(member_id, member_helper));
   EXPECT_EQ(member_id, INT8_MEMBER_ID);
   EXPECT_TRUE(jvr.read_int8(int8_value));
@@ -166,6 +170,7 @@ TEST(JsonValueReader, struct_max)
   EXPECT_TRUE(jvr.read_uint8(uint8_value));
   EXPECT_EQ(uint8_value, 255);
   EXPECT_TRUE(jvr.end_struct_member());
+#endif
 
   EXPECT_TRUE(jvr.begin_struct_member(member_id, member_helper));
   EXPECT_EQ(member_id, INT16_MEMBER_ID);
@@ -270,13 +275,19 @@ TEST(JsonValueReader, a_union)
 
 TEST(JsonValueReader, array_min)
 {
-  const char json[] = "[false,0,-128,0,-32768,0,-2147483648,0,-9223372036854775808,0,-1.25,-1.25,-1.25,97,97,\"a string\",\"kValue2\"]";
+  const char json[] = "[false,0,"
+#if OPENDDS_HAS_EXPLICIT_INTS
+    "-128,0,"
+#endif
+    "-32768,0,-2147483648,0,-9223372036854775808,0,-1.25,-1.25,-1.25,97,97,\"a string\",\"kValue2\"]";
   StringStream ss(json);
   JsonValueReader<> jvr(ss);
   ACE_CDR::Boolean bool_value;
   ACE_CDR::Octet byte_value;
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::Int8 int8_value;
   ACE_CDR::UInt8 uint8_value;
+#endif
   ACE_CDR::Short int16_value;
   ACE_CDR::UShort uint16_value;
   ACE_CDR::Long int32_value;
@@ -303,6 +314,7 @@ TEST(JsonValueReader, array_min)
   EXPECT_EQ(byte_value, 0);
   EXPECT_TRUE(jvr.end_element());
 
+#if OPENDDS_HAS_EXPLICIT_INTS
   EXPECT_TRUE(jvr.begin_element());
   EXPECT_TRUE(jvr.read_int8(int8_value));
   EXPECT_EQ(int8_value, -128);
@@ -312,6 +324,7 @@ TEST(JsonValueReader, array_min)
   EXPECT_TRUE(jvr.read_uint8(uint8_value));
   EXPECT_EQ(uint8_value, 0);
   EXPECT_TRUE(jvr.end_element());
+#endif
 
   EXPECT_TRUE(jvr.begin_element());
   EXPECT_TRUE(jvr.read_int16(int16_value));
@@ -383,13 +396,19 @@ TEST(JsonValueReader, array_min)
 
 TEST(JsonValueReader, sequence_zero)
 {
-  const char json[] = "[false,0,0,0,0,0,0,0,0,0,0,0,0,0,0,\"\",\"kValue1\"]";
+  const char json[] = "[false,0,"
+#if OPENDDS_HAS_EXPLICIT_INTS
+    "0,0,"
+#endif
+    "0,0,0,0,0,0,0,0,0,0,0,\"\",\"kValue1\"]";
   StringStream ss(json);
   JsonValueReader<> jvr(ss);
   ACE_CDR::Boolean bool_value;
   ACE_CDR::Octet byte_value;
+#if OPENDDS_HAS_EXPLICIT_INTS
   ACE_CDR::Int8 int8_value;
   ACE_CDR::UInt8 uint8_value;
+#endif
   ACE_CDR::Short int16_value;
   ACE_CDR::UShort uint16_value;
   ACE_CDR::Long int32_value;
@@ -418,6 +437,7 @@ TEST(JsonValueReader, sequence_zero)
   EXPECT_EQ(byte_value, 0);
   EXPECT_TRUE(jvr.end_element());
 
+#if OPENDDS_HAS_EXPLICIT_INTS
   EXPECT_TRUE(jvr.elements_remaining());
   EXPECT_TRUE(jvr.begin_element());
   EXPECT_TRUE(jvr.read_int8(int8_value));
@@ -429,6 +449,7 @@ TEST(JsonValueReader, sequence_zero)
   EXPECT_TRUE(jvr.read_uint8(uint8_value));
   EXPECT_EQ(uint8_value, 0);
   EXPECT_TRUE(jvr.end_element());
+#endif
 
   EXPECT_TRUE(jvr.elements_remaining());
   EXPECT_TRUE(jvr.begin_element());
@@ -551,5 +572,4 @@ TEST(JsonValueReader, from_json)
   EXPECT_TRUE(from_json(s, ss));
 }
 
-#endif
 #endif

--- a/tests/unit-tests/dds/DCPS/JsonValueWriter.cpp
+++ b/tests/unit-tests/dds/DCPS/JsonValueWriter.cpp
@@ -3,12 +3,11 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "dds/DCPS/JsonValueWriter.h"
+#include <dds/DCPS/JsonValueWriter.h>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
-#ifdef OPENDDS_RAPIDJSON
-#ifndef OPENDDS_SAFETY_PROFILE
+#if OPENDDS_HAS_JSON_VALUE_WRITER
 
 using namespace rapidjson;
 using namespace OpenDDS::DCPS;
@@ -41,7 +40,7 @@ TEST(JsonValueWriter, end_struct_member)
   JsonValueWriter<> jvw;
   jvw.begin_struct();
   jvw.begin_struct_member("aField");
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   jvw.end_struct_member();
   EXPECT_STREQ(jvw.buffer().GetString(), "{\"aField\":5");
 }
@@ -66,7 +65,7 @@ TEST(JsonValueWriter, begin_discriminator)
   JsonValueWriter<> jvw;
   jvw.begin_union();
   jvw.begin_discriminator();
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   EXPECT_STREQ(jvw.buffer().GetString(), "{\"$discriminator\":5");
 }
 
@@ -75,7 +74,7 @@ TEST(JsonValueWriter, end_discriminator)
   JsonValueWriter<> jvw;
   jvw.begin_union();
   jvw.begin_discriminator();
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   jvw.end_discriminator();
   EXPECT_STREQ(jvw.buffer().GetString(), "{\"$discriminator\":5");
 }
@@ -93,7 +92,7 @@ TEST(JsonValueWriter, end_union_member)
   JsonValueWriter<> jvw;
   jvw.begin_union();
   jvw.begin_union_member("aField");
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   jvw.end_union_member();
   EXPECT_STREQ(jvw.buffer().GetString(), "{\"aField\":5");
 }
@@ -103,10 +102,10 @@ TEST(JsonValueWriter, complete_struct)
   JsonValueWriter<> jvw;
   jvw.begin_struct();
   jvw.begin_struct_member("aField");
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   jvw.end_struct_member();
   jvw.begin_struct_member("bField");
-  jvw.write_int8(6);
+  jvw.write_int16(6);
   jvw.end_struct_member();
   jvw.end_struct();
   EXPECT_STREQ(jvw.buffer().GetString(), "{\"aField\":5,\"bField\":6}");
@@ -155,7 +154,7 @@ TEST(JsonValueWriter, end_element)
   JsonValueWriter<> jvw;
   jvw.begin_sequence();
   jvw.begin_element(0);
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   jvw.end_element();
   EXPECT_STREQ(jvw.buffer().GetString(), "[5");
 }
@@ -165,10 +164,10 @@ TEST(JsonValueWriter, complete_array)
   JsonValueWriter<> jvw;
   jvw.begin_array();
   jvw.begin_element(0);
-  jvw.write_int8(5);
+  jvw.write_int16(5);
   jvw.end_element();
   jvw.begin_element(1);
-  jvw.write_int8(6);
+  jvw.write_int16(6);
   jvw.end_element();
   jvw.end_array();
   EXPECT_STREQ(jvw.buffer().GetString(), "[5,6]");
@@ -202,6 +201,7 @@ TEST(JsonValueWriter, write_byte)
   }
 }
 
+#if OPENDDS_HAS_EXPLICIT_INTS
 TEST(JsonValueWriter, write_int8)
 {
   {
@@ -229,6 +229,7 @@ TEST(JsonValueWriter, write_uint8)
     EXPECT_STREQ(jvw.buffer().GetString(), "255");
   }
 }
+#endif
 
 TEST(JsonValueWriter, write_int16)
 {
@@ -382,5 +383,4 @@ TEST(JsonValueWriter, write_enum)
   EXPECT_STREQ(jvw.buffer().GetString(), "\"label\"");
 }
 
-#endif
 #endif


### PR DESCRIPTION
Use https://github.com/DOCGroup/ACE_TAO/pull/1621 if available to test for support for explicitly-named integer types added in https://github.com/objectcomputing/OpenDDS/pull/2814.

Also allow IDL files being processed by `opendds_idl` to include '.h' files since `tao_idl` doesn't seem to have a problem with it and it's needed for the `idl_features.h` file to work with both C++ and IDL.