### PR TITLE
fix unit test fails built with openssl 1.0.2

### DIFF
--- a/tests/unit-tests/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -307,6 +307,10 @@ public:
     TheServiceParticipant->shutdown();
   }
 
+  static void SetUpTestCase () {
+    openssl_init();
+  }
+
   ~AccessControlTest()
   {
   }

--- a/tests/unit-tests/dds/DCPS/security/SSL/Certificate.cpp
+++ b/tests/unit-tests/dds/DCPS/security/SSL/Certificate.cpp
@@ -72,6 +72,11 @@ public:
   {
   }
 
+  static void SetUpTestCase () 
+  {
+    openssl_init();
+  }
+
   Certificate ca_;
   Certificate ca_data_;
   Certificate signed_;

--- a/tests/unit-tests/dds/DCPS/security/SSL/Certificate.cpp
+++ b/tests/unit-tests/dds/DCPS/security/SSL/Certificate.cpp
@@ -72,7 +72,7 @@ public:
   {
   }
 
-  static void SetUpTestCase () 
+  static void SetUpTestCase()
   {
     openssl_init();
   }


### PR DESCRIPTION
The security unit tests for Certificates and AccessControl fail on platforms with the older OpenSSL libraries. This is the result of preceding tests causing the OpenSSL library to purge its cipher and digest collections that had been initialized at test startup. The solution is to run through the openssl_init again at the start of these test groups.