### PR TITLE
Disable fail-fast strategy for matrix builds

### DIFF
--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -52,7 +52,7 @@ jobs:
     needs: get_info
     runs-on: ubuntu-20.04
     strategy:
-      fast-fail: false
+      fail-fast: false
       matrix:
         info: ${{ fromJSON(needs.get_info.outputs.info) }}
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}

--- a/.github/workflows/check_test_results.yml
+++ b/.github/workflows/check_test_results.yml
@@ -52,6 +52,7 @@ jobs:
     needs: get_info
     runs-on: ubuntu-20.04
     strategy:
+      fast-fail: false
       matrix:
         info: ${{ fromJSON(needs.get_info.outputs.info) }}
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}


### PR DESCRIPTION
In the event that one of the check test result jobs matrix jobs fails (invalid input, job failure, etc), the other jobs should not get canceled.