### PR TITLE
RTPS Discovery: added a Lease Extension config option

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -50,6 +50,7 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , quick_resend_ratio_(0.1)
   , min_resend_delay_(TimeDuration::from_msec(100))
   , lease_duration_(300)
+  , lease_extension_(0)
   , pb_(7400) // see RTPS v2.1 9.6.1.3 for PB, DG, PG, D0, D1 defaults
   , dg_(250)
   , pg_(2)
@@ -191,6 +192,17 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
               value.c_str(), rtps_name.c_str()), -1);
           }
           config->lease_duration(TimeDuration(duration));
+        } else if (name == "LeaseExtension") {
+          const OPENDDS_STRING& value = it->second;
+          int extension;
+          if (!DCPS::convertToInteger(value, extension)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+              ACE_TEXT("Invalid entry (%C) for LeaseExtension in ")
+              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+              value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->lease_extension(TimeExtension(extension));
         } else if (name == "PB") {
           const OPENDDS_STRING& value = it->second;
           u_short pb;

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -202,7 +202,7 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
               ACE_TEXT("[rtps_discovery/%C] section.\n"),
               value.c_str(), rtps_name.c_str()), -1);
           }
-          config->lease_extension(TimeExtension(extension));
+          config->lease_extension(TimeDuration(extension));
         } else if (name == "PB") {
           const OPENDDS_STRING& value = it->second;
           u_short pb;

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -83,6 +83,17 @@ public:
     lease_duration_ = period;
   }
 
+  DCPS::TimeDuration lease_extension() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return lease_extension_;
+  }
+  void lease_extension(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    lease_extension_ = period;
+  }
+
   u_short pb() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, u_short());
@@ -607,6 +618,7 @@ private:
   double quick_resend_ratio_;
   DCPS::TimeDuration min_resend_delay_;
   DCPS::TimeDuration lease_duration_;
+  DCPS::TimeDuration lease_extension_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
   unsigned char ttl_;
   bool sedp_multicast_;
@@ -701,6 +713,9 @@ public:
 
   DCPS::TimeDuration lease_duration() const { return config_->lease_duration(); }
   void lease_duration(const DCPS::TimeDuration& period) { config_->lease_duration(period); }
+
+  DCPS::TimeDuration lease_extension() const { return config_->lease_extension(); }
+  void lease_extension(const DCPS::TimeDuration& period) { config_->lease_extension(period); }
 
   u_short pb() const { return config_->pb(); }
   void pb(u_short port_base) { config_->pb(port_base); }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3547,7 +3547,7 @@ Spdp::update_lease_expiration_i(DiscoveredParticipantIter iter,
                                    iter->second.pdata_.participantProxy.protocolVersion,
                                    iter->second.pdata_.participantProxy.vendorId);
 
-  iter->second.lease_expiration_ = now + d;
+  iter->second.lease_expiration_ = now + d + config_->lease_extension();
 
   // Insert.
   const bool cancel = !lease_expirations_.empty() && iter->second.lease_expiration_ < lease_expirations_.begin()->first;


### PR DESCRIPTION
Problem
-------

Participants that connect to the RtpsRelay over the public internet
will often have problems.  For example, a cable modem that is on the
fritz may be up for a minute and then down for 14 minutes.  This adds
load to the RtpsRelay as it has to discover the participant each time
if the participant's lease is small.

Solution
--------

Provide an option that allows a participant to extend the lease of
discovered participants.