### PR TITLE
Use bitwise alignment calculation

### DIFF
--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -18,12 +18,7 @@ namespace DCPS {
 ACE_INLINE
 void align(size_t& value, size_t by)
 {
-  // TODO(iguessthislldo): If this is always alignment by a power of two, it
-  // might benefit from a bitwise version.
-  const size_t offset_by = value % by;
-  if (offset_by) {
-    value += by - offset_by;
-  }
+  value = (value + by - 1) & ~(by - 1);
 }
 
 ACE_INLINE

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -94,8 +94,8 @@ TEST(serializer_test, align_value_add_offset)
 TEST(serializer_test, align_value_smaller_than_by)
 {
   size_t value = 4;
-  align(value, 9);
-  EXPECT_EQ(size_t(9), value);
+  align(value, 8);
+  EXPECT_EQ(size_t(8), value);
 }
 
 TEST(serializer_test, Encoding__is_encapsulated_this_XCDR1)


### PR DESCRIPTION
For any alignment of a power of two (the only kind we support), this calculation avoids modulus calculation and branch prediction. 