### PR TITLE
Avoid ACE_Message_Block duplication from pre_send_packet 

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -1732,15 +1732,17 @@ TransportSendStrategy::do_send_packet(const ACE_Message_Block* packet, int& bp)
   DBG_ENTRY_LVL("TransportSendStrategy", "do_send_packet", 6);
 
 #ifdef OPENDDS_SECURITY
-  const DDS::Security::CryptoTransform_var crypto = security_config()->get_crypto_transform();
-  // pre_send_packet may provide different data that takes the place of the
-  // original "packet" (used for security encryption/authentication)
   Message_Block_Ptr substitute;
-  if (crypto) {
-    substitute.reset(pre_send_packet(packet));
-    if (!substitute) {
-      VDBG((LM_DEBUG, "(%P|%t) DBG:   pre_send_packet returned NULL, dropping.\n"));
-      return packet->total_length();
+  if (security_config()) {
+    const DDS::Security::CryptoTransform_var crypto = security_config()->get_crypto_transform();
+    // pre_send_packet may provide different data that takes the place of the
+    // original "packet" (used for security encryption/authentication)
+    if (crypto) {
+      substitute.reset(pre_send_packet(packet));
+      if (!substitute) {
+        VDBG((LM_DEBUG, "(%P|%t) DBG:   pre_send_packet returned NULL, dropping.\n"));
+        return packet->total_length();
+      }
     }
   }
 #endif

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -1732,12 +1732,16 @@ TransportSendStrategy::do_send_packet(const ACE_Message_Block* packet, int& bp)
   DBG_ENTRY_LVL("TransportSendStrategy", "do_send_packet", 6);
 
 #ifdef OPENDDS_SECURITY
+  const DDS::Security::CryptoTransform_var crypto = security_config()->get_crypto_transform();
   // pre_send_packet may provide different data that takes the place of the
   // original "packet" (used for security encryption/authentication)
-  Message_Block_Ptr substitute(pre_send_packet(packet));
-  if (!substitute) {
-    VDBG((LM_DEBUG, "(%P|%t) DBG:   pre_send_packet returned NULL, dropping.\n"));
-    return packet->total_length();
+  Message_Block_Ptr substitute;
+  if (crypto) {
+    substitute.reset(pre_send_packet(packet));
+    if (!substitute) {
+      VDBG((LM_DEBUG, "(%P|%t) DBG:   pre_send_packet returned NULL, dropping.\n"));
+      return packet->total_length();
+    }
   }
 #endif
 
@@ -1747,7 +1751,7 @@ TransportSendStrategy::do_send_packet(const ACE_Message_Block* packet, int& bp)
   iovec iov[MAX_SEND_BLOCKS];
 
 #ifdef OPENDDS_SECURITY
-  const int num_blocks = mb_to_iov(*substitute, iov);
+  const int num_blocks = mb_to_iov(substitute ? *substitute : *packet, iov);
 #else
   const int num_blocks = mb_to_iov(*packet, iov);
 #endif
@@ -1766,7 +1770,7 @@ TransportSendStrategy::do_send_packet(const ACE_Message_Block* packet, int& bp)
             num_bytes_sent), 5);
 
 #ifdef OPENDDS_SECURITY
-  if (num_bytes_sent > 0 && packet->data_block() != substitute->data_block()) {
+  if (num_bytes_sent > 0 && substitute && packet->data_block() != substitute->data_block()) {
     // Although the "substitute" data took the place of "packet", the rest
     // of the framework needs to account for the bytes in "packet" being taken
     // care of, as if they were actually sent.

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -21,6 +21,12 @@
 #include "ThreadSynchStrategy_rch.h"
 #include "ace/Synch_Traits.h"
 
+#if defined(OPENDDS_SECURITY)
+#include "dds/DdsSecurityCoreC.h"
+#include "dds/DCPS/security/framework/SecurityConfig.h"
+#include "dds/DCPS/security/framework/SecurityConfig_rch.h"
+#endif
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -202,6 +208,10 @@ protected:
   /// either a certain individual packet or a publication id.
   /// Returns true if anything in the delayed notification list matched.
   bool send_delayed_notifications(const TransportQueueElement::MatchCriteria* match = 0);
+
+#ifdef OPENDDS_SECURITY
+  virtual Security::SecurityConfig_rch security_config() const { return Security::SecurityConfig_rch(); }
+#endif
 
 private:
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -181,14 +181,16 @@ RtpsUdpSendStrategy::send_rtps_control(RTPS::Message& message,
   const AMB_Continuation cont(rtps_header_mb_lock_, rtps_header_mb_, submessages);
 
 #ifdef OPENDDS_SECURITY
-  const DDS::Security::CryptoTransform_var crypto = link_->security_config()->get_crypto_transform();
   Message_Block_Ptr alternate;
-  if (crypto) {
-    alternate.reset(pre_send_packet(&rtps_header_mb_));
-    if (!alternate) {
-      VDBG((LM_DEBUG, "(%P|%t) RtpsUdpSendStrategy::send_rtps_control () - "
-            "pre_send_packet returned NULL, dropping.\n"));
-      return;
+  if (security_config()) {
+    const DDS::Security::CryptoTransform_var crypto = link_->security_config()->get_crypto_transform();
+    if (crypto) {
+      alternate.reset(pre_send_packet(&rtps_header_mb_));
+      if (!alternate) {
+        VDBG((LM_DEBUG, "(%P|%t) RtpsUdpSendStrategy::send_rtps_control () - "
+              "pre_send_packet returned NULL, dropping.\n"));
+        return;
+      }
     }
   }
   ACE_Message_Block& use_mb = alternate ? *alternate : rtps_header_mb_;
@@ -219,14 +221,16 @@ RtpsUdpSendStrategy::send_rtps_control(RTPS::Message& message,
   const AMB_Continuation cont(rtps_header_mb_lock_, rtps_header_mb_, submessages);
 
 #ifdef OPENDDS_SECURITY
-  const DDS::Security::CryptoTransform_var crypto = link_->security_config()->get_crypto_transform();
   Message_Block_Ptr alternate;
-  if (crypto) {
-    alternate.reset(pre_send_packet(&rtps_header_mb_));
-    if (!alternate) {
-      VDBG((LM_DEBUG, "(%P|%t) RtpsUdpSendStrategy::send_rtps_control () - "
-            "pre_send_packet returned NULL, dropping.\n"));
-      return;
+  if (security_config()) {
+    const DDS::Security::CryptoTransform_var crypto = link_->security_config()->get_crypto_transform();
+    if (crypto) {
+      alternate.reset(pre_send_packet(&rtps_header_mb_));
+      if (!alternate) {
+        VDBG((LM_DEBUG, "(%P|%t) RtpsUdpSendStrategy::send_rtps_control () - "
+              "pre_send_packet returned NULL, dropping.\n"));
+        return;
+      }
     }
   }
   ACE_Message_Block& use_mb = alternate ? *alternate : rtps_header_mb_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
@@ -79,6 +79,10 @@ public:
   static const size_t MaxSecureFullMessageAdditionalSize =
     MaxSecureFullMessageLeadingSize + MaxSubmessagePadding + MaxSecureFullMessageFollowingSize;
 
+#ifdef OPENDDS_SECURITY
+  virtual Security::SecurityConfig_rch security_config() const;
+#endif
+
 protected:
   virtual ssize_t send_bytes_i(const iovec iov[], int n);
   ssize_t send_bytes_i_helper(const iovec iov[], int n);


### PR DESCRIPTION
Specifically, when security is disabled, don't call pre_send_packet to avoid duplication and extra message block allocations (even if data blocks are merely reference-incremented).