### PR TITLE
Use C++11 unordered_map for Fragment Lookup When Possible

### DIFF
--- a/dds/DCPS/Hash.h
+++ b/dds/DCPS/Hash.h
@@ -59,4 +59,15 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
   }
 #endif
 
+#ifdef ACE_HAS_CPP11
+#define OPENDDS_OOAT_CUSTOM_HASH(Key, Export, Name) \
+  struct Export Name \
+  { \
+    std::size_t operator()(const Key& val) const noexcept \
+    { \
+      return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&val), sizeof (Key))); \
+    } \
+  };
+#endif
+
 #endif // OPENDDS_DCPS_HASH_H

--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -148,7 +148,11 @@ typedef std::basic_string<wchar_t, std::char_traits<wchar_t>, OPENDDS_ALLOCATOR(
 #ifdef ACE_HAS_CPP11
 #define OPENDDS_UNORDERED_MAP(K, V) std::unordered_map<K, V, std::hash<K >, std::equal_to<K >, \
           OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
+#define OPENDDS_UNORDERED_MAP_CHASH(K, V, C) std::unordered_map<K, V, C, std::equal_to<K >, \
+          OpenDDS::DCPS::PoolAllocator<std::pair<OpenDDS::DCPS::add_const<K >::type, V > > >
 #define OPENDDS_UNORDERED_MAP_T(K, V) std::unordered_map<K, V, std::hash<K >, std::equal_to<K >, \
+          OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
+#define OPENDDS_UNORDERED_MAP_CHASH_T(K, V, C) std::unordered_map<K, V, C, std::equal_to<K >, \
           OpenDDS::DCPS::PoolAllocator<std::pair<typename OpenDDS::DCPS::add_const<K >::type, V > > >
 #endif
 
@@ -173,7 +177,9 @@ typedef std::wstring WString;
 #define OPENDDS_QUEUE(T) std::queue<T >
 #ifdef ACE_HAS_CPP11
 #define OPENDDS_UNORDERED_MAP(K, V) std::unordered_map<K, V >
+#define OPENDDS_UNORDERED_MAP_CHASH(K, V, C) std::unordered_map<K, V, C >
 #define OPENDDS_UNORDERED_MAP_T OPENDDS_UNORDERED_MAP
+#define OPENDDS_UNORDERED_MAP_CHASH_T OPENDDS_UNORDERED_MAP_CHASH
 #endif
 
 #endif // OPENDDS_POOL_ALLOCATOR

--- a/dds/DCPS/transport/framework/TransportReassembly.h
+++ b/dds/DCPS/transport/framework/TransportReassembly.h
@@ -91,6 +91,10 @@ private:
     SequenceNumber data_sample_seq_;
   };
 
+#if defined ACE_HAS_CPP11
+  OPENDDS_OOAT_CUSTOM_HASH(FragKey, OpenDDS_Dcps_Export, FragKeyHash);
+#endif
+
   // A FragRange represents a chunk of a partially-reassembled message.
   // The transport_seq_ range is the range of transport sequence numbers
   // that were used to send the given chunk of data.
@@ -120,7 +124,11 @@ private:
     MonotonicTimePoint expiration_;
   };
 
+#ifdef ACE_HAS_CPP11
+  typedef OPENDDS_UNORDERED_MAP_CHASH(FragKey, FragInfo, FragKeyHash) FragInfoMap;
+#else
   typedef OPENDDS_MAP(FragKey, FragInfo) FragInfoMap;
+#endif
   FragInfoMap fragments_;
 
   typedef OPENDDS_MULTIMAP(MonotonicTimePoint, FragKey) ExpirationQueue;


### PR DESCRIPTION
Problem: Fragment lookup gets expensive as number of FragKeys grow in size. Time spend in std::map lookups for FragKeys starts to become prohibitive for large numbers of publication ids & sequence numbers.

Solution: For C++11, std::unordered_map greatly reduces the lookup time for large numbers of FragKeys.