### PR TITLE
Support INSTALL_LIB in CMake Module

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -349,6 +349,7 @@ jobs:
         set -e
         export DESTDIR=$(realpath install_temp)
         export INSTALL_PREFIX=$(realpath install_prefix)
+        export INSTALL_LIB=special-lib
         . setenv.sh
         cd $ACE_ROOT
         make install
@@ -366,7 +367,7 @@ jobs:
         export JAVA_PLATFORM=linux
         export PATH="\$OPENDDS_INSTALL_PREFIX/bin:\$PATH"
         export MPC_ROOT=$ACE_ROOT/MPC
-        export LD_LIBRARY_PATH="\$OPENDDS_INSTALL_PREFIX/lib:\$LD_LIBRARY_PATH"
+        export LD_LIBRARY_PATH="\$OPENDDS_INSTALL_PREFIX/\$INSTALL_LIB:\$LD_LIBRARY_PATH"
         export PERL5LIB=$(realpath bin):$(realpath $ACE_ROOT/bin)
         EOF
     - name: build make install messenger

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -367,7 +367,7 @@ jobs:
         export JAVA_PLATFORM=linux
         export PATH="\$OPENDDS_INSTALL_PREFIX/bin:\$PATH"
         export MPC_ROOT=$ACE_ROOT/MPC
-        export LD_LIBRARY_PATH="\$OPENDDS_INSTALL_PREFIX/\$INSTALL_LIB:\$LD_LIBRARY_PATH"
+        export LD_LIBRARY_PATH="\$OPENDDS_INSTALL_PREFIX/$INSTALL_LIB:\$LD_LIBRARY_PATH"
         export PERL5LIB=$(realpath bin):$(realpath $ACE_ROOT/bin)
         EOF
     - name: build make install messenger

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ OpenDDS 3.20.0 is currently in development, so this list might change.
     - To help facilitate this, a new function called `opendds_get_library_dependencies` has been added.
   - To help install generated files, `OPENDDS_TARGET_SOURCES` now adds lists of the files that where passed in and generated that are part of the `PUBLIC` and `INTERFACE` scopes as properties on the target (#3315)
   - Added an `OPENDDS_DEFAULT_SCOPE` option that allows changing the default scope of `OPENDDS_TARGET_SOURCES` (#3315)
+  - Support `INSTALL_LIB` being used with `make install` to change the name of the `lib` directory (#2879)
+    - NOTE: This required changing the CMake module installation destination from `lib` to `share`.
   - See `docs/cmake.md` for details on all of these new features
 
 ### Fixes:

--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -57,6 +57,10 @@ macro(_OPENDDS_RETURN_ERR msg)
   return()
 endmacro()
 
+if(NOT DEFINED OPENDDS_INSTALL_LIB)
+  set(OPENDDS_INSTALL_LIB "lib")
+endif()
+
 if(OPENDDS_USE_PREFIX_PATH)
   set(OPENDDS_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../..")
 else()
@@ -75,14 +79,14 @@ if(NOT DEFINED DDS_ROOT)
   endif()
 
   set(OPENDDS_BIN_DIR "${OPENDDS_ROOT}/bin")
-  set(OPENDDS_LIB_DIR "${OPENDDS_ROOT}/lib")
+  set(OPENDDS_LIB_DIR "${OPENDDS_ROOT}/${OPENDDS_INSTALL_LIB}")
 endif()
 
 if (NOT DEFINED ACE_ROOT)
   if(OPENDDS_USE_PREFIX_PATH)
     set(ACE_ROOT "${OPENDDS_ROOT}/share/ace")
     set(ACE_INCLUDE_DIRS "${OPENDDS_ROOT}/include")
-    set(ACE_LIB_DIR "${OPENDDS_ROOT}/lib")
+    set(ACE_LIB_DIR "${OPENDDS_ROOT}/${OPENDDS_INSTALL_LIB}")
 
   elseif(OPENDDS_ACE)
     set(ACE_ROOT ${OPENDDS_ACE})

--- a/dds/DdsDcps.mpc
+++ b/dds/DdsDcps.mpc
@@ -81,14 +81,22 @@ project(OpenDDS_Dcps): core, coverage_optional, \
     ../rules.dds.GNU
   }
 
+  verbatim (gnuace, top, 1) {
+    cmake_dir_install_dest=$(DESTDIR)$(INSTALL_PREFIX)/share/cmake/OpenDDS
+    cmake_config_install_dest=$(cmake_dir_install_dest)/config.cmake
+  }
+
   verbatim(gnuace, postinstall, 1) {
 "	echo export DDS_ROOT=$(INSTALL_PREFIX)/share/dds> $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds-devel.sh"
 "	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds"
 "	ln -sf ../../../include/dds/Version.h $(DESTDIR)$(INSTALL_PREFIX)/share/dds/dds"
 "	cp $(DDS_ROOT)/user_macros.GNU $(DESTDIR)$(INSTALL_PREFIX)/share/dds $(ACE_NUL_STDERR)"
-"	@$(MKDIR) $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)/cmake/OpenDDS"
-"	cp $(DDS_ROOT)/cmake/*.cmake $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)/cmake/OpenDDS"
-"	echo 'set(OPENDDS_USE_PREFIX_PATH ON) # from make install' >> $(DESTDIR)$(INSTALL_PREFIX)/$(INSTALL_LIB)/cmake/OpenDDS/config.cmake"
+"	@$(MKDIR) $(cmake_dir_install_dest)"
+"	cp $(DDS_ROOT)/cmake/*.cmake $(cmake_dir_install_dest)"
+"	echo '' >> $(cmake_config_install_dest)"
+"	echo '# From make install' >> $(cmake_config_install_dest)"
+"	echo 'set(OPENDDS_USE_PREFIX_PATH ON)' >> $(cmake_config_install_dest)"
+"	echo 'set(OPENDDS_INSTALL_LIB \"$(INSTALL_LIB)\")' >> $(cmake_config_install_dest)"
   }
 
 }


### PR DESCRIPTION
Follow up to https://github.com/objectcomputing/OpenDDS/pull/2740

Support `INSTALL_LIB` being used with `make install` to change the name of the `lib` directory. To make it possible for `find_package` to find the OpenDDS CMake module in this case, the installation destination for the CMake module was changed from `lib` to `share`.