### PR TITLE
Empty partitions degrade RtpsRelay performance

### DIFF
--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -15,6 +15,7 @@ public:
     , static_limit_(0)
     , max_pending_(0)
     , application_domain_(1)
+    , allow_empty_partition_(true)
     , log_warnings_(false)
     , log_entries_(false)
     , log_discovery_(false)
@@ -69,6 +70,16 @@ public:
   DDS::DomainId_t application_domain() const
   {
     return application_domain_;
+  }
+
+  void allow_empty_partition(bool flag)
+  {
+    allow_empty_partition_ = flag;
+  }
+
+  bool allow_empty_partition() const
+  {
+    return allow_empty_partition_;
   }
 
   void log_warnings(bool flag)
@@ -197,6 +208,7 @@ private:
   size_t static_limit_;
   size_t max_pending_;
   DDS::DomainId_t application_domain_;
+  bool allow_empty_partition_;
   bool log_warnings_;
   bool log_entries_;
   bool log_discovery_;

--- a/tools/rtpsrelay/GuidPartitionTable.cpp
+++ b/tools/rtpsrelay/GuidPartitionTable.cpp
@@ -57,7 +57,7 @@ void GuidPartitionTable::insert(const OpenDDS::DCPS::GUID_t& guid, const DDS::St
 
   add_new(globally_new);
 
-  if (spdp_replay_writer_->write(spdp_replay, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+  if (!spdp_replay.partitions().empty() && spdp_replay_writer_->write(spdp_replay, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to write Relay Partitions\n")));
   }
 }

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -121,6 +121,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-UserData"))) {
       user_data = arg;
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-AllowEmptyPartition"))) {
+      config.allow_empty_partition(ACE_OS::atoi(arg));
+      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-LogWarnings"))) {
       config.log_warnings(ACE_OS::atoi(arg));
       args.consume_arg();


### PR DESCRIPTION
Problem
-------

The RtpsRelay is most efficient when an application is divided into a
number of small partitions.  Participants that (inadvertently) don't
specify any partitions are effectively placed in the same partition.
This partition can become large which degrades the performance of the
RtpsRelay.

Solution
--------

Add a control that allows the empty partition "" to be filtered.