### PR TITLE
GitHub Actions: Increase timeout on Compiler_* jobs.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4042,7 +4042,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_stat_qt_ws_sec
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - name: install xerces
@@ -5018,15 +5018,9 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_p1_stat_js0
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
-    - name: install openssl & xerces-c
-      uses: lukka/run-vcpkg@v7
-      with:
-        vcpkgGitCommitId: d417ae59d6e9aa20d9f812b5deb966645c54687d
-        vcpkgArguments: --recurse openssl xerces-c
-        vcpkgTriplet: x64-windows
     - name: checkout MPC
       uses: actions/checkout@v2
       with:
@@ -5095,7 +5089,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Compiler
-        perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features ssl=1 -features no_cxx11=0
+        perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features no_cxx11=0
     - name: make compiler tests
       shell: cmd
       run: |
@@ -5745,15 +5739,9 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_p1_stat_FM-08
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
-    - name: install openssl & xerces-c
-      uses: lukka/run-vcpkg@v7
-      with:
-        vcpkgGitCommitId: d417ae59d6e9aa20d9f812b5deb966645c54687d
-        vcpkgArguments: --recurse openssl xerces-c
-        vcpkgTriplet: x64-windows
     - name: checkout MPC
       uses: actions/checkout@v2
       with:
@@ -5822,7 +5810,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Compiler
-        perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
+        perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features no_rapidjson=0 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
     - name: make compiler tests
       shell: cmd
       run: |
@@ -6483,7 +6471,7 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_o1p1_sec
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - name: install openssl & xerces-c
@@ -7291,7 +7279,7 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_j_ws_FM-1f
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - name: install xerces-c


### PR DESCRIPTION
This PR increases the timeout of Compiler_* jobs due to them occasionally timing out.

It also removes Xerces and SSL from the w19 static Compiler_* jobs due to them running out of disk space.