### PR TITLE
Fix for deadlocks brought out by the GroupPresentation test.

### DIFF
--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -592,7 +592,7 @@ SubscriberImpl::notify_datareaders()
   }
 
 #ifndef OPENDDS_NO_MULTI_TOPIC
-  MultiTopicReaderMap localmtr;
+  MultitopicReaderMap localmtr;
   {
     ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                     guard,

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -572,7 +572,6 @@ DDS::ReturnCode_t
 SubscriberImpl::notify_datareaders()
 {
   DataReaderMap localreadermap;
-  DataReaderMap::iterator it;
   {
     ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex,
                     guard,
@@ -580,8 +579,8 @@ SubscriberImpl::notify_datareaders()
                     DDS::RETCODE_ERROR);
     localreadermap = datareader_map_;
   }
-  for (it = localreadermap.begin(); it != localreadermap.end(); ++it) {
-    if ( it->second->have_sample_states(DDS::NOT_READ_SAMPLE_STATE)) {
+  for (DataReaderMap::iterator it = localreadermap.begin(); it != localreadermap.end(); ++it) {
+    if (it->second->have_sample_states(DDS::NOT_READ_SAMPLE_STATE)) {
       DDS::DataReaderListener_var listener = it->second->get_listener();
       if (listener) {
         listener->on_data_available(it->second.in());


### PR DESCRIPTION
This PR focuses on two potential deadlock scenarios, both in the subscriber impl code, the function to get a list of current data readers and a function to notify datareaders. The problem is that multiple threads are passing through these functions and must mediate the sharing of resources using locks. However there is a lock on the SubscriberImpl object that is grabbed a the start of these functions, then during processing a second lock on the DataReaderImpl object is repeatedly taken while evaluating individual data readers. This triggers a deadlock when a thread is holding the DataReaderImpl instance lock and waiting for the SubscriberImpl lock, but another thread is holding the SI lock and wants the particular DataReaderImpl instance lock currently held by the first thread.
This solution is to make a local copy of the data reader collection to be searched then release the SI lock before iterating the data reader collection. This avoids the deadlock condition. 