### PR TITLE
RtpsRelay discovery logging and statistics don't handle updates

### DIFF
--- a/tools/rtpsrelay/GuidPartitionTable.h
+++ b/tools/rtpsrelay/GuidPartitionTable.h
@@ -18,6 +18,12 @@ const size_t MAX_SLOT_SIZE = 64;
 
 class GuidPartitionTable {
 public:
+  enum Result {
+    ADDED,
+    UPDATED,
+    NO_CHANGE
+  };
+
   GuidPartitionTable(const Config& config,
                      RelayPartitionsDataWriter_var relay_partitions_writer,
                      SpdpReplayDataWriter_var spdp_replay_writer)
@@ -27,7 +33,7 @@ public:
   {}
 
   // Insert a reader/writer guid and its partitions.
-  void insert(const OpenDDS::DCPS::GUID_t& guid, const DDS::StringSeq& partitions);
+  Result insert(const OpenDDS::DCPS::GUID_t& guid, const DDS::StringSeq& partitions);
 
   void remove(const OpenDDS::DCPS::GUID_t& guid)
   {

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -50,11 +50,14 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
 
         guid_addr_set_.remove_pending(repoid);
 
-        if (config_.log_discovery()) {
-          ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::on_data_available add local participant %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
-        }
+        const auto p = guids_.insert(repoid);
+        if (p.second) {
+          if (config_.log_discovery()) {
+            ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::on_data_available add local participant %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
+          }
 
-        stats_reporter_.add_local_participant(OpenDDS::DCPS::MonotonicTimePoint::now());
+          stats_reporter_.add_local_participant(OpenDDS::DCPS::MonotonicTimePoint::now());
+        }
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:
@@ -69,6 +72,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
         }
 
         stats_reporter_.remove_local_participant(OpenDDS::DCPS::MonotonicTimePoint::now());
+        guids_.erase(repoid);
       }
       break;
     }

--- a/tools/rtpsrelay/ParticipantListener.h
+++ b/tools/rtpsrelay/ParticipantListener.h
@@ -23,6 +23,7 @@ private:
   GuidAddrSet& guid_addr_set_;
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   DomainStatisticsReporter& stats_reporter_;
+  std::unordered_set<OpenDDS::DCPS::GUID_t> guids_;
 };
 
 }


### PR DESCRIPTION
Problem
-------

It is expected that RtpsRelay clients will determine and update their
server-reflexive address.  These updates will appear as new samples in
the BITs read by the RtpsRelay.  The RtpsRelay will log these updates
as new participants, publications, and subscriptions which is
misleading.

Solution
--------

Distinguish between new participants, publications, and subscriptions
and updates to existing ones.