### PR TITLE
ThreadSanitizer Error / Warning Cleanup, Round 1

### DIFF
--- a/dds/DCPS/PeriodicTask.h
+++ b/dds/DCPS/PeriodicTask.h
@@ -138,7 +138,7 @@ class PmfPeriodicTask : public PeriodicTask {
 public:
   typedef void (Delegate::*PMF)(const MonotonicTimePoint&);
 
-  PmfPeriodicTask(RcHandle<ReactorInterceptor> interceptor, Delegate& delegate, PMF function)
+  PmfPeriodicTask(RcHandle<ReactorInterceptor> interceptor, const Delegate& delegate, PMF function)
     : PeriodicTask(interceptor)
     , delegate_(delegate)
     , function_(function) {}

--- a/dds/DCPS/PublisherImpl.h
+++ b/dds/DCPS/PublisherImpl.h
@@ -206,6 +206,7 @@ private:
   /// The recursive lock to protect datawriter map and suspend count.
   mutable lock_type                   pi_lock_;
   reverse_lock_type                   reverse_pi_lock_;
+  mutable lock_type                   pi_suspended_lock_;
 
   /// Monitor object for this entity
   unique_ptr<Monitor> monitor_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2056,6 +2056,7 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter& iter)
 void
 Spdp::init_bit(const DDS::Subscriber_var& bit_subscriber)
 {
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
   bit_subscriber_ = bit_subscriber;
 
   // This is here to make sure thread status gets a valid BIT Subscriber
@@ -2070,8 +2071,12 @@ public:
 void
 Spdp::fini_bit()
 {
-  bit_subscriber_ = 0;
-  DCPS::ReactorTask_rch reactor_task = sedp_->reactor_task();
+  DCPS::ReactorTask_rch reactor_task;
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    bit_subscriber_ = 0;
+    reactor_task = sedp_->reactor_task();
+  }
   if (!reactor_task->is_shut_down()) {
     DCPS::ReactorInterceptor::CommandPtr command = reactor_task->interceptor()->execute_or_enqueue(new Noop());
     command->wait();

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2056,8 +2056,10 @@ Spdp::remove_discovered_participant_i(DiscoveredParticipantIter& iter)
 void
 Spdp::init_bit(const DDS::Subscriber_var& bit_subscriber)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-  bit_subscriber_ = bit_subscriber;
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    bit_subscriber_ = bit_subscriber;
+  }
 
   // This is here to make sure thread status gets a valid BIT Subscriber
   tport_->enable_periodic_tasks();

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -177,7 +177,7 @@ class PmfSporadicTask : public SporadicTask {
 public:
   typedef void (Delegate::*PMF)(const MonotonicTimePoint&);
 
-  PmfSporadicTask(RcHandle<ReactorInterceptor> interceptor, Delegate& delegate, PMF function)
+  PmfSporadicTask(RcHandle<ReactorInterceptor> interceptor, const Delegate& delegate, PMF function)
     : SporadicTask(interceptor)
     , delegate_(delegate)
     , function_(function)

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -1034,7 +1034,7 @@ TransportClient::send_i(SendStateDataSampleList send_list, ACE_UINT64 transactio
     // The reason that the send_links_ set is cleared is because we continually
     // reuse the same send_links_ object over and over for each call to this
     // send method.
-    RepoId pub_id(repo_id_);
+    RepoId pub_id = repo_id();
     send_links.send_stop(pub_id);
     if (transaction_id != 0) {
       expected_transaction_id_ = max_transaction_id_seen_ + 1;

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -135,6 +135,11 @@ public:
   bool associated_with(const GUID_t& remote) const;
   bool pending_association_with(const GUID_t& remote) const;
 
+  RepoId repo_id() const {
+    ACE_Guard<ACE_Thread_Mutex> guard(lock_);
+    return repo_id_;
+  }
+
 private:
 
   // Implemented by derived classes (DataReaderImpl/DataWriterImpl)

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -135,7 +135,8 @@ public:
   bool associated_with(const GUID_t& remote) const;
   bool pending_association_with(const GUID_t& remote) const;
 
-  RepoId repo_id() const {
+  RepoId repo_id() const
+  {
     ACE_Guard<ACE_Thread_Mutex> guard(lock_);
     return repo_id_;
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -82,7 +82,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
   , reactor_task_(reactor_task)
   , job_queue_(make_rch<JobQueue>(reactor_task->get_reactor()))
   , multi_buff_(this, config.nak_depth_)
-  , flush_send_queue_task_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue)
+  , flush_send_queue_task_(new Sporadic(reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue), keep_count())
   , best_effort_heartbeat_count_(0)
   , heartbeat_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_heartbeats)
   , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
@@ -104,7 +104,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
 
 RtpsUdpDataLink::~RtpsUdpDataLink()
 {
-  flush_send_queue_task_.cancel_and_wait();
+  flush_send_queue_task_->cancel_and_wait();
 }
 
 RtpsUdpInst&
@@ -247,10 +247,10 @@ RtpsUdpDataLink::RtpsWriter::remove_all_msgs()
   send_buff_->retain_all(id_);
 
   {
+    ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
+    ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rg(rev_lock);
     GuardType guard(link->strategy_lock_);
     if (link->send_strategy_) {
-      ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
-      ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rg(rev_lock);
       link->send_strategy_->remove_all_msgs(id_);
     }
   }
@@ -893,8 +893,8 @@ RtpsUdpDataLink::RtpsWriter::pre_stop_helper(TqeVector& to_drop, bool true_stop)
   g.release();
 
   if (stopping_) {
-    heartbeat_.cancel_and_wait();
-    nack_response_.cancel_and_wait();
+    heartbeat_->cancel_and_wait();
+    nack_response_->cancel_and_wait();
   }
 }
 
@@ -904,33 +904,38 @@ RtpsUdpDataLink::pre_stop_i()
   DBG_ENTRY_LVL("RtpsUdpDataLink","pre_stop_i",6);
   DataLink::pre_stop_i();
   TqeVector to_drop;
+
+  RtpsWriterMap writers;
   {
     ACE_GUARD(ACE_Thread_Mutex, g, writers_lock_);
-
-    RtpsWriterMap::iterator iter = writers_.begin();
-    while (iter != writers_.end()) {
-      RtpsWriter_rch writer = iter->second;
-      writer->pre_stop_helper(to_drop, true);
-      RtpsWriterMap::iterator last = iter;
-      ++iter;
-      heartbeat_counts_.erase(last->first.entityId);
-      writers_.erase(last);
+    writers_.swap(writers);
+    for (RtpsWriterMap::const_iterator it = writers.begin(); it != writers.end(); ++it) {
+      heartbeat_counts_.erase(it->first.entityId);
     }
   }
+
+  RtpsWriterMap::iterator w_iter = writers.begin();
+  while (w_iter != writers.end()) {
+    w_iter->second->pre_stop_helper(to_drop, true);
+    writers.erase(w_iter++);
+  }
+
   TqeVector::iterator drop_it = to_drop.begin();
   while (drop_it != to_drop.end()) {
     (*drop_it)->data_dropped(true);
     ++drop_it;
   }
+
+  RtpsReaderMap readers;
   {
     ACE_GUARD(ACE_Thread_Mutex, g, readers_lock_);
+    readers = readers_;
+  }
 
-    RtpsReaderMap::iterator iter = readers_.begin();
-    while (iter != readers_.end()) {
-      RtpsReader_rch reader = iter->second;
-      reader->pre_stop_helper();
-      ++iter;
-    }
+  RtpsReaderMap::iterator r_iter = readers.begin();
+  while (r_iter != readers.end()) {
+    r_iter->second->pre_stop_helper();
+    ++r_iter;
   }
 }
 
@@ -1441,7 +1446,7 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const MonotonicTimePoint& /*now*/)
   gather_heartbeats_i(meta_submessages);
 
   if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
-    heartbeat_.schedule(link->config().heartbeat_period_);
+    heartbeat_->schedule(link->config().heartbeat_period_);
   }
 
   g.release();
@@ -1610,7 +1615,7 @@ RtpsUdpDataLink::RtpsReader::pre_stop_helper()
   guard.release();
   g.release();
 
-  preassociation_task_.cancel_and_wait();
+  preassociation_task_->cancel_and_wait();
 }
 
 RtpsUdpDataLink::RtpsReader::~RtpsReader()
@@ -2030,7 +2035,7 @@ RtpsUdpDataLink::RtpsWriter::add_reader(const ReaderInfo_rch& reader)
       return false;
     }
 
-    heartbeat_.schedule(link->config().heartbeat_period_);
+    heartbeat_->schedule(link->config().heartbeat_period_);
     if (link->config().responsive_mode_) {
       MetaSubmessageVec meta_submessages;
       MetaSubmessage meta_submessage(id_, GUID_UNKNOWN);
@@ -2107,7 +2112,7 @@ RtpsUdpDataLink::RtpsReader::add_writer(const WriterInfo_rch& writer)
       return false;
     }
 
-    preassociation_task_.schedule(link->config().heartbeat_period_);
+    preassociation_task_->schedule(link->config().heartbeat_period_);
     if (link->config().responsive_mode_) {
       MetaSubmessageVec meta_submessages;
       gather_preassociation_acknack_i(meta_submessages, writer);
@@ -2192,7 +2197,7 @@ RtpsUdpDataLink::RtpsReader::send_preassociation_acknacks(const MonotonicTimePoi
 
   link->queue_submessages(meta_submessages);
 
-  preassociation_task_.schedule(link->config().heartbeat_period_);
+  preassociation_task_->schedule(link->config().heartbeat_period_);
 }
 
 void
@@ -2626,7 +2631,7 @@ RtpsUdpDataLink::disable_response_queue()
   }
 
   if (schedule) {
-    flush_send_queue_task_.schedule(config().send_delay_);
+    flush_send_queue_task_->schedule(config().send_delay_);
   }
 }
 
@@ -2656,7 +2661,7 @@ RtpsUdpDataLink::queue_submessages(MetaSubmessageVec& in)
   }
 
   if (schedule) {
-    flush_send_queue_task_.schedule(config().send_delay_);
+    flush_send_queue_task_->schedule(config().send_delay_);
   }
 }
 
@@ -3119,7 +3124,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
       previous_acked_sn = acked_sn;
       check_leader_lagger();
-      heartbeat_.schedule(link->config().heartbeat_period_);
+      heartbeat_->schedule(link->config().heartbeat_period_);
 
       if (reader->durable_) {
         if (Transport_debug_level > 5) {
@@ -3233,7 +3238,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 #endif
 
   if (!dont_schedule_nack_response && schedule_nack_response) {
-    nack_response_.schedule(link->config().nak_response_delay_);
+    nack_response_->schedule(link->config().nak_response_delay_);
   }
 
   g.release();
@@ -3310,7 +3315,7 @@ void RtpsUdpDataLink::RtpsWriter::process_nackfrag(const RTPS::NackFragSubmessag
   if (link->config().responsive_mode_) {
     readers_expecting_heartbeat_.insert(reader);
   }
-  nack_response_.schedule(link->config().nak_response_delay_);
+  nack_response_->schedule(link->config().nak_response_delay_);
 }
 
 void
@@ -3634,7 +3639,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
             lagging_readers_[previous_max_sn] = leading_pos->second;
           }
           leading_readers_.erase(leading_pos);
-          heartbeat_.schedule(link->config().heartbeat_period_);
+          heartbeat_->schedule(link->config().heartbeat_period_);
         }
       }
 #ifdef OPENDDS_SECURITY
@@ -3657,7 +3662,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
       if (acked_sn == previous_max_sn && previous_max_sn != max_sn_) {
         snris_erase(leading_readers_, acked_sn, reader);
         snris_insert(lagging_readers_, reader);
-        heartbeat_.schedule(link->config().heartbeat_period_);
+        heartbeat_->schedule(link->config().heartbeat_period_);
       }
     }
 #endif
@@ -3685,7 +3690,7 @@ RtpsUdpDataLink::RtpsWriter::make_lagger_leader(const ReaderInfo_rch& reader,
   snris_erase(previous_acked_sn == previous_max_sn ? leading_readers_ : lagging_readers_, previous_acked_sn, reader);
   snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
   if (acked_sn != max_sn) {
-    heartbeat_.schedule(link->config().heartbeat_period_);
+    heartbeat_->schedule(link->config().heartbeat_period_);
   }
 }
 
@@ -4221,8 +4226,8 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
  , is_ps_writer_(id_.entityId == RTPS::ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER)
 #endif
- , heartbeat_(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats)
- , nack_response_(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses)
+ , heartbeat_(new RtpsWriter::Sporadic(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats), keep_count())
+ , nack_response_(new RtpsWriter::Sporadic(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses), keep_count())
 {
   send_buff_->bind(link->send_strategy());
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -82,7 +82,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
   , reactor_task_(reactor_task)
   , job_queue_(make_rch<JobQueue>(reactor_task->get_reactor()))
   , multi_buff_(this, config.nak_depth_)
-  , flush_send_queue_task_(new Sporadic(reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue), keep_count())
+  , flush_send_queue_task_(make_rch<Sporadic>(reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue))
   , best_effort_heartbeat_count_(0)
   , heartbeat_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_heartbeats)
   , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
@@ -4226,8 +4226,8 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
  , is_ps_writer_(id_.entityId == RTPS::ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER)
 #endif
- , heartbeat_(new RtpsWriter::Sporadic(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats), keep_count())
- , nack_response_(new RtpsWriter::Sporadic(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses), keep_count())
+ , heartbeat_(make_rch<RtpsWriter::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats))
+ , nack_response_(make_rch<RtpsWriter::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses))
 {
   send_buff_->bind(link->send_strategy());
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -434,8 +434,8 @@ private:
 
     typedef PmfSporadicTask<RtpsWriter> Sporadic;
 
-    Sporadic heartbeat_;
-    Sporadic nack_response_;
+    RcHandle<Sporadic> heartbeat_;
+    RcHandle<Sporadic> nack_response_;
 
     void send_heartbeats(const MonotonicTimePoint& now);
     void send_nack_responses(const MonotonicTimePoint& now);
@@ -570,7 +570,7 @@ private:
       , id_(id)
       , stopping_(false)
       , nackfrag_count_(0)
-      , preassociation_task_(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks)
+      , preassociation_task_(new RtpsReader::Sporadic(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks), keep_count())
     {}
 
     ~RtpsReader();
@@ -625,7 +625,7 @@ private:
     bool stopping_;
     CORBA::Long nackfrag_count_;
     typedef PmfSporadicTask<RtpsReader> Sporadic;
-    Sporadic preassociation_task_;
+    RcHandle<Sporadic> preassociation_task_;
   };
   typedef RcHandle<RtpsReader> RtpsReader_rch;
 
@@ -663,7 +663,7 @@ private:
   ThreadSendQueueMap thread_send_queues_;
   MetaSubmessageVecVecVec send_queue_;
   typedef PmfSporadicTask<RtpsUdpDataLink> Sporadic;
-  Sporadic flush_send_queue_task_;
+  RcHandle<Sporadic> flush_send_queue_task_;
   void flush_send_queue(const MonotonicTimePoint& now);
 
   RepoIdSet pending_reliable_readers_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -570,7 +570,7 @@ private:
       , id_(id)
       , stopping_(false)
       , nackfrag_count_(0)
-      , preassociation_task_(new RtpsReader::Sporadic(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks), keep_count())
+      , preassociation_task_(make_rch<RtpsReader::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks))
     {}
 
     ~RtpsReader();

--- a/tests/DCPS/EntityLifecycleStress/subscriber.cpp
+++ b/tests/DCPS/EntityLifecycleStress/subscriber.cpp
@@ -42,7 +42,7 @@ struct DataReaderListenerImpl : public virtual OpenDDS::DCPS::LocalObject<DDS::D
 #else
    , cv_(mutex_)
 #endif
-   , valid_data_seen(false) {}
+   , valid_data_seen_(false) {}
 
   virtual ~DataReaderListenerImpl() {}
 
@@ -83,7 +83,12 @@ struct DataReaderListenerImpl : public virtual OpenDDS::DCPS::LocalObject<DDS::D
         ss << " - From  : " << message.from << endl;
         ss << " - Count : " << message.count << endl;
         cout << ss.str() << flush;
-        valid_data_seen = true;
+#ifdef ACE_HAS_CPP11
+        std::unique_lock<std::mutex> lock(mutex_);
+#else
+        ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+#endif
+        valid_data_seen_ = true;
         cv_.notify_all();
       }
     }
@@ -97,9 +102,9 @@ struct DataReaderListenerImpl : public virtual OpenDDS::DCPS::LocalObject<DDS::D
     ACE_Guard<ACE_Thread_Mutex> g(mutex_);
 #endif
 #ifdef ACE_HAS_CPP11
-    while (!valid_data_seen && cv_.wait_for(lock, ms) != cv_status::timeout) {
+    while (!valid_data_seen_ && cv_.wait_for(lock, ms) != cv_status::timeout) {
 #else
-    while (!valid_data_seen && !(cv_.wait_until(deadline) == OpenDDS::DCPS::CvStatus_NoTimeout)) {
+    while (!valid_data_seen_ && !(cv_.wait_until(deadline) == OpenDDS::DCPS::CvStatus_NoTimeout)) {
 #endif
     }
   }
@@ -111,7 +116,7 @@ struct DataReaderListenerImpl : public virtual OpenDDS::DCPS::LocalObject<DDS::D
   ACE_Thread_Mutex mutex_;
   OpenDDS::DCPS::ConditionVariable<ACE_Thread_Mutex> cv_;
 #endif
-  bool valid_data_seen;
+  bool valid_data_seen_;
 };
 
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
@@ -207,7 +212,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
 
 #ifdef ACE_HAS_CPP11
-    bool still_cleaning = true;
+    std::atomic<bool> still_cleaning(true);
     thread t([&](){
       this_thread::sleep_for(chrono::seconds(3));
       while (still_cleaning) {


### PR DESCRIPTION
Running ThreadSanitizer against `tests/DCPS/Messenger/run_test.pl rtps_disc` and `tests/DCPS/EntityLifecycleStress/run_test.pl rtps_disc` revealed a number of data races and mutex lock order inversions (potential deadlocks).

These are some of the 'safer' / 'easier' changes that resulted in clean runs, but aren't enough on their own to fix all the reported issues or to allow a theoretical `tsan` build to catch these issues earlier.

In particular, the timer RCH changes in RtpsUdpDatalink are actually heap-use-after-free issues, resulting from the fact that the reactor believes it's holding a reference to the timer's RcEventHandler base class, when in reality these timers were simply deleted without regard for their reference count, since they were simple members of RtpsWriter/RtpsReader/RtpsUdpDatalink.

If the PR experiences too many errors, it may make sense to split this PR into several smaller ones for debugging.