### PR TITLE
Serializer Unit Test cleanup

### DIFF
--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -535,7 +535,7 @@ TEST(serializer_test, Serializer_align_context_2_buff_diff_walign_read)
   ASSERT_TRUE(ser << d);
 
   ACE_CDR::UShort c_out = 0;
-  ACE_CDR::ULongLong d_out = 0.0;
+  ACE_CDR::ULongLong d_out = 0;
 
   Serializer rser(amb.get(), enc);
 
@@ -581,7 +581,7 @@ TEST(serializer_test, Serializer_align_context_2_buff_diff_walign_read_with_min)
   ASSERT_TRUE(ser << d);
 
   ACE_CDR::UShort c_out = 0;
-  ACE_CDR::ULongLong d_out = 0.0;
+  ACE_CDR::ULongLong d_out = 0;
 
   Serializer rser(amb.get(), enc);
 

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -6,72 +6,72 @@
 
 using namespace OpenDDS::DCPS;
 
-TEST(serializer_test, Encoding__Encoding)
+TEST(serializer_test, Encoding_Encoding)
 {
   Encoding enc;
   EXPECT_EQ(0, enc.to_string().compare(0, 24, "CDR/XCDR1, little-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR1_ENDIAN_BIG)
+TEST(serializer_test, Encoding_Encoding_XCDR1_ENDIAN_BIG)
 {
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_BIG);
   EXPECT_EQ(0, enc.to_string().compare(0, 21, "CDR/XCDR1, big-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_UNALIGNED_CDR_ENDIAN_BIG)
+TEST(serializer_test, Encoding_Encoding_UNALIGNED_CDR_ENDIAN_BIG)
 {
   Encoding enc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_BIG);
   EXPECT_EQ(0, enc.to_string().compare(0, 25, "Unaligned CDR, big-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR2_ENDIAN_BIG)
+TEST(serializer_test, Encoding_Encoding_XCDR2_ENDIAN_BIG)
 {
   Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
   EXPECT_EQ(0, enc.to_string().compare(0, 17, "XCDR2, big-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR1_ENDIAN_LITTLE)
+TEST(serializer_test, Encoding_Encoding_XCDR1_ENDIAN_LITTLE)
 {
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_LITTLE);
 }
 
-TEST(serializer_test, Encoding__Encoding_UNALIGNED_CDR_ENDIAN_LITTLE)
+TEST(serializer_test, Encoding_Encoding_UNALIGNED_CDR_ENDIAN_LITTLE)
 {
   Encoding enc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_LITTLE);
   EXPECT_EQ(0, enc.to_string().compare(0, 28, "Unaligned CDR, little-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR2_ENDIAN_LITTLE)
+TEST(serializer_test, Encoding_Encoding_XCDR2_ENDIAN_LITTLE)
 {
   Encoding enc(Encoding::KIND_XCDR2, ENDIAN_LITTLE);
   EXPECT_EQ(0, enc.to_string().compare(0, 20, "XCDR2, little-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR2_Swap)
+TEST(serializer_test, Encoding_Encoding_XCDR2_Swap)
 {
   Encoding enc(Encoding::KIND_XCDR2, true);
   EXPECT_EQ(0, enc.to_string().compare(0, 17, "XCDR2, big-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR2_No_Swap)
+TEST(serializer_test, Encoding_Encoding_XCDR2_No_Swap)
 {
   Encoding enc(Encoding::KIND_XCDR2, false);
   EXPECT_EQ(0, enc.to_string().compare(0, 20, "XCDR2, little-endian"));
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR1_max_align)
+TEST(serializer_test, Encoding_Encoding_XCDR1_max_align)
 {
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_BIG);
   EXPECT_EQ(size_t(8), enc.max_align());
 }
 
-TEST(serializer_test, Encoding__Encoding_UNALIGNED_CDR_max_align)
+TEST(serializer_test, Encoding_Encoding_UNALIGNED_CDR_max_align)
 {
   Encoding enc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_BIG);
   EXPECT_EQ(size_t(0), enc.max_align());
 }
 
-TEST(serializer_test, Encoding__Encoding_XCDR2_max_align)
+TEST(serializer_test, Encoding_Encoding_XCDR2_max_align)
 {
   Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
   EXPECT_EQ(size_t(4), enc.max_align());
@@ -98,30 +98,30 @@ TEST(serializer_test, align_value_smaller_than_by)
   EXPECT_EQ(size_t(8), value);
 }
 
-TEST(serializer_test, Encoding__is_encapsulated_this_XCDR1)
+TEST(serializer_test, Encoding_is_encapsulated_this_XCDR1)
 {
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_BIG);
   EXPECT_TRUE(enc.is_encapsulated());
 }
 
-TEST(serializer_test, Encoding__is_encapsulated_this_UNALIGNED_CDR)
+TEST(serializer_test, Encoding_is_encapsulated_this_UNALIGNED_CDR)
 {
   Encoding enc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_LITTLE);
   EXPECT_FALSE(enc.is_encapsulated());
 }
 
-TEST(serializer_test, Encoding__Encoding_static_is_encacapsulatd_XCDR2)
+TEST(serializer_test, Encoding_Encoding_static_is_encacapsulatd_XCDR2)
 {
   EXPECT_TRUE(Encoding::is_encapsulated(Encoding::KIND_XCDR2));
 }
 
-TEST(serializer_test, EncapsulationHeader__EncapsulationHeader)
+TEST(serializer_test, EncapsulationHeader_EncapsulationHeader)
 {
   EncapsulationHeader eh;
   EXPECT_STREQ("CDR/XCDR1 Big Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__EncapsulationHeader_Encoding_Valid)
+TEST(serializer_test, EncapsulationHeader_EncapsulationHeader_Encoding_Valid)
 {
   Encoding initenc;
   EncapsulationHeader eh(initenc, FINAL);
@@ -129,7 +129,7 @@ TEST(serializer_test, EncapsulationHeader__EncapsulationHeader_Encoding_Valid)
   EXPECT_STREQ("CDR/XCDR1 Little Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__EncapsulationHeader_Encoding_Invalid)
+TEST(serializer_test, EncapsulationHeader_EncapsulationHeader_Encoding_Invalid)
 {
   Encoding initenc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_LITTLE);
   EncapsulationHeader eh(initenc, FINAL);
@@ -137,7 +137,7 @@ TEST(serializer_test, EncapsulationHeader__EncapsulationHeader_Encoding_Invalid)
   EXPECT_STREQ("Invalid", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR1_BIG_FINAL)
+TEST(serializer_test, EncapsulationHeader_from_encoding_XCDR1_BIG_FINAL)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_BIG);
@@ -145,7 +145,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR1_BIG_FINAL)
   EXPECT_STREQ("CDR/XCDR1 Big Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR1_LITTLE_FINAL)
+TEST(serializer_test, EncapsulationHeader_from_encoding_XCDR1_LITTLE_FINAL)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_LITTLE);
@@ -153,7 +153,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR1_LITTLE_FINAL)
   EXPECT_STREQ("CDR/XCDR1 Little Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR1_LITTLE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_from_encoding_XCDR1_LITTLE_MUTABLE)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_XCDR1, ENDIAN_LITTLE);
@@ -161,7 +161,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR1_LITTLE_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Little Endian Parameter List", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR2_LITTLE_FINAL)
+TEST(serializer_test, EncapsulationHeader_from_encoding_XCDR2_LITTLE_FINAL)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_XCDR2, ENDIAN_LITTLE);
@@ -169,7 +169,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR2_LITTLE_FINAL)
   EXPECT_STREQ("XCDR2 Little Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR2_LITTLE_APPENDABLE)
+TEST(serializer_test, EncapsulationHeader_from_encoding_XCDR2_LITTLE_APPENDABLE)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_XCDR2, ENDIAN_LITTLE);
@@ -177,7 +177,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR2_LITTLE_APPENDABLE
   EXPECT_STREQ("XCDR2 Little Endian Delimited", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR2_LITTLE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_from_encoding_XCDR2_LITTLE_MUTABLE)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_XCDR2, ENDIAN_LITTLE);
@@ -185,7 +185,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_XCDR2_LITTLE_MUTABLE)
   EXPECT_STREQ("XCDR2 Little Endian Parameter List", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__from_encoding_UNALIGNED_CDR_LITTLE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_from_encoding_UNALIGNED_CDR_LITTLE_MUTABLE)
 {
   EncapsulationHeader eh;
   Encoding enc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_LITTLE);
@@ -193,7 +193,7 @@ TEST(serializer_test, EncapsulationHeader__from_encoding_UNALIGNED_CDR_LITTLE_MU
   EXPECT_STREQ("CDR/XCDR1 Big Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_MUTABLE)
 {
   EncapsulationHeader eh;
   Encoding enc;
@@ -201,7 +201,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Big Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_NOT_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_NOT_MUTABLE)
 {
   EncapsulationHeader eh;
   Encoding enc;
@@ -209,7 +209,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_NOT_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Big Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_CDR_LE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_CDR_LE_MUTABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_CDR_LE);
@@ -218,7 +218,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_CDR_LE_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Little Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_CDR_LE_NOT_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_CDR_LE_NOT_MUTABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_CDR_LE);
@@ -227,7 +227,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_CDR_LE_NOT_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Little Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR_BE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_PL_CDR_BE_MUTABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_PL_CDR_BE);
@@ -236,7 +236,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR_BE_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Big Endian Parameter List", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR_LE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_PL_CDR_LE_MUTABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_PL_CDR_LE);
@@ -245,7 +245,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR_LE_MUTABLE)
   EXPECT_STREQ("CDR/XCDR1 Little Endian Parameter List", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_CDR2_BE_FINAL)
+TEST(serializer_test, EncapsulationHeader_to_encoding_CDR2_BE_FINAL)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_CDR2_BE);
@@ -254,7 +254,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_CDR2_BE_FINAL)
   EXPECT_STREQ("XCDR2 Big Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_CDR2_LE_FINAL)
+TEST(serializer_test, EncapsulationHeader_to_encoding_CDR2_LE_FINAL)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_CDR2_LE);
@@ -263,7 +263,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_CDR2_LE_FINAL)
   EXPECT_STREQ("XCDR2 Little Endian Plain", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_D_CDR2_BE_APPENDABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_D_CDR2_BE_APPENDABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_D_CDR2_BE);
@@ -272,7 +272,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_D_CDR2_BE_APPENDABLE)
   EXPECT_STREQ("XCDR2 Big Endian Delimited", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_D_CDR2_LE_APPENDABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_D_CDR2_LE_APPENDABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_D_CDR2_LE);
@@ -281,7 +281,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_D_CDR2_LE_APPENDABLE)
   EXPECT_STREQ("XCDR2 Little Endian Delimited", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR2_BE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_PL_CDR2_BE_MUTABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_PL_CDR2_BE);
@@ -290,7 +290,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR2_BE_MUTABLE)
   EXPECT_STREQ("XCDR2 Big Endian Parameter List", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR2_LE_MUTABLE)
+TEST(serializer_test, EncapsulationHeader_to_encoding_PL_CDR2_LE_MUTABLE)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_PL_CDR2_LE);
@@ -299,7 +299,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_PL_CDR2_LE_MUTABLE)
   EXPECT_STREQ("XCDR2 Little Endian Parameter List", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_XML)
+TEST(serializer_test, EncapsulationHeader_to_encoding_XML)
 {
   EncapsulationHeader eh;
   eh.kind(EncapsulationHeader::KIND_XML);
@@ -308,7 +308,7 @@ TEST(serializer_test, EncapsulationHeader__to_encoding_XML)
   EXPECT_STREQ("XML", eh.to_string().c_str());
 }
 
-TEST(serializer_test, EncapsulationHeader__to_encoding_INVALID)
+TEST(serializer_test, EncapsulationHeader_to_encoding_INVALID)
 {
   Encoding initenc(Encoding::KIND_UNALIGNED_CDR, ENDIAN_LITTLE);
   EncapsulationHeader eh(initenc, FINAL);


### PR DESCRIPTION
- fixed warnings
- avoid using identifiers that are reserved for the implementation