### PR TITLE
RtpsRelay is inefficient

### DIFF
--- a/tests/unit-tests/tools/OpenDDS_RtpsRelayLib/Name.cpp
+++ b/tests/unit-tests/tools/OpenDDS_RtpsRelayLib/Name.cpp
@@ -25,12 +25,12 @@ void test_invalid(const std::string& s)
 
 TEST(Name, maintest)
 {
-  std::set<char> digits;
+  std::unordered_set<char> digits;
   for (char c = '0'; c <= '9'; ++c) {
     digits.insert(c);
   }
 
-  std::set<char> abc;
+  std::unordered_set<char> abc;
   for (char c = 'a'; c <= 'c'; ++c) {
     abc.insert(c);
   }

--- a/tools/dds/rtpsrelaylib/Name.cpp
+++ b/tools/dds/rtpsrelaylib/Name.cpp
@@ -128,7 +128,7 @@ Atom Name::parse_character_class(Name& name, const std::string& buffer, size_t& 
     ++idx;
   }
 
-  std::set<char> characters;
+  std::unordered_set<char> characters;
 
   // One character is required.
   parse_character_or_range(name, buffer, idx, characters);
@@ -137,7 +137,7 @@ Atom Name::parse_character_class(Name& name, const std::string& buffer, size_t& 
   return Atom(negated, characters);
 }
 
-void Name::parse_character_class_tail(Name& name, const std::string& buffer, size_t& idx, std::set<char>& characters)
+void Name::parse_character_class_tail(Name& name, const std::string& buffer, size_t& idx, std::unordered_set<char>& characters)
 {
   if (idx == buffer.size()) {
     name.is_valid_ = false;
@@ -154,7 +154,7 @@ void Name::parse_character_class_tail(Name& name, const std::string& buffer, siz
   parse_character_class_tail(name, buffer, idx, characters);
 }
 
-void Name::parse_character_or_range(Name& name, const std::string& buffer, size_t& idx, std::set<char>& characters)
+void Name::parse_character_or_range(Name& name, const std::string& buffer, size_t& idx, std::unordered_set<char>& characters)
 {
   if (idx == buffer.size()) {
     name.is_valid_ = false;

--- a/tools/dds/rtpsrelaylib/Name.h
+++ b/tools/dds/rtpsrelaylib/Name.h
@@ -3,7 +3,7 @@
 
 #include "export.h"
 
-#include <set>
+#include <unordered_set>
 #include <string>
 #include <vector>
 
@@ -21,7 +21,7 @@ public:
 
   explicit Atom(Kind kind) : kind_(kind), character_(0) {}
   explicit Atom(char c) : kind_(CHARACTER), character_(c) {}
-  Atom(bool negated, const std::set<char>& characters)
+  Atom(bool negated, const std::unordered_set<char>& characters)
     : kind_(negated ? NEGATED_CHARACTER_CLASS : CHARACTER_CLASS)
     , character_(0)
     , characters_(characters) {}
@@ -30,23 +30,7 @@ public:
 
   char character() const { return character_; }
 
-  const std::set<char>& characters() const { return characters_; }
-
-  bool operator<(const Atom& other) const
-  {
-    if (kind_ != other.kind_) {
-      return kind_ < other.kind_;
-    }
-    switch (kind_) {
-    case CHARACTER:
-      return character_ < other.character_;
-    case CHARACTER_CLASS:
-    case NEGATED_CHARACTER_CLASS:
-      return characters_ < other.characters_;
-    default:
-      return false;
-    }
-  }
+  const std::unordered_set<char>& characters() const { return characters_; }
 
   bool operator==(const Atom& other) const
   {
@@ -85,7 +69,19 @@ public:
 private:
   Kind kind_;
   char character_;            // For CHARACTER.
-  std::set<char> characters_; // For CHARACTER_CLASS and NEGATED_CHARACTER_CLASS.
+  std::unordered_set<char> characters_; // For CHARACTER_CLASS and NEGATED_CHARACTER_CLASS.
+};
+
+struct AtomHash {
+  std::size_t operator() (const Atom& atom) const
+  {
+    std::size_t result = atom.kind();
+    result ^= (atom.character() << 8);
+    for (const auto c : atom.characters()) {
+      result ^= (c << 16);
+    }
+    return result;
+  }
 };
 
 OpenDDS_RtpsRelayLib_Export std::ostream& operator<<(std::ostream& out, const Atom& atom);
@@ -109,7 +105,7 @@ public:
   const_iterator begin() const { return atoms_.begin(); }
   const_iterator end() const { return atoms_.end(); }
 
-  bool operator<(const Name& other) const { return atoms_ < other.atoms_; }
+  //bool operator<(const Name& other) const { return atoms_ < other.atoms_; }
   bool operator==(const Name& other) const
   {
     return is_pattern_ == other.is_pattern_ &&
@@ -141,8 +137,8 @@ private:
   static Atom::Kind parse_pattern(Name& name, const std::string& buffer, size_t& idx, char expected, Atom::Kind kind);
   static char parse_character(Name& name, const std::string& buffer, size_t& idx);
   static Atom parse_character_class(Name& name, const std::string& buffer, size_t& idx);
-  static void parse_character_class_tail(Name& name, const std::string& buffer, size_t& idx, std::set<char>& characters);
-  static void parse_character_or_range(Name& name, const std::string& buffer, size_t& idx, std::set<char>& characters);
+  static void parse_character_class_tail(Name& name, const std::string& buffer, size_t& idx, std::unordered_set<char>& characters);
+  static void parse_character_or_range(Name& name, const std::string& buffer, size_t& idx, std::unordered_set<char>& characters);
 };
 
 OpenDDS_RtpsRelayLib_Export std::ostream& operator<<(std::ostream& out, const Name& name);

--- a/tools/dds/rtpsrelaylib/Name.h
+++ b/tools/dds/rtpsrelaylib/Name.h
@@ -105,7 +105,6 @@ public:
   const_iterator begin() const { return atoms_.begin(); }
   const_iterator end() const { return atoms_.end(); }
 
-  //bool operator<(const Name& other) const { return atoms_ < other.atoms_; }
   bool operator==(const Name& other) const
   {
     return is_pattern_ == other.is_pattern_ &&

--- a/tools/dds/rtpsrelaylib/PartitionIndex.h
+++ b/tools/dds/rtpsrelaylib/PartitionIndex.h
@@ -48,7 +48,7 @@ public:
   }
 
 private:
-  typedef std::map<Atom, NodePtr> ChildrenType;
+  typedef std::unordered_map<Atom, NodePtr, AtomHash> ChildrenType;
   ChildrenType children_;
   GuidSet guids_;
 

--- a/tools/dds/rtpsrelaylib/Utility.h
+++ b/tools/dds/rtpsrelaylib/Utility.h
@@ -15,7 +15,7 @@
 
 namespace RtpsRelay {
 
-typedef std::unordered_set<std::string> StringSet;
+typedef std::set<std::string> StringSet;
 
 inline std::string guid_to_string(const OpenDDS::DCPS::GUID_t& a_guid)
 {

--- a/tools/dds/rtpsrelaylib/Utility.h
+++ b/tools/dds/rtpsrelaylib/Utility.h
@@ -15,7 +15,7 @@
 
 namespace RtpsRelay {
 
-typedef std::set<std::string> StringSet;
+typedef std::unordered_set<std::string> StringSet;
 
 inline std::string guid_to_string(const OpenDDS::DCPS::GUID_t& a_guid)
 {
@@ -54,11 +54,11 @@ struct AddrPort {
 };
 
 struct GuidAddr {
-  OpenDDS::DCPS::RepoId guid;
+  OpenDDS::DCPS::GUID_t guid;
   AddrPort address;
 
   GuidAddr() : guid(OpenDDS::DCPS::GUID_UNKNOWN) {}
-  GuidAddr(const OpenDDS::DCPS::RepoId& a_guid, const AddrPort& a_address)
+  GuidAddr(const OpenDDS::DCPS::GUID_t& a_guid, const AddrPort& a_address)
     : guid(a_guid)
     , address(a_address)
   {}
@@ -89,7 +89,7 @@ inline void assign(EntityId_t& eid, const OpenDDS::DCPS::EntityId_t& a_eid)
   eid.entityKind(a_eid.entityKind);
 }
 
-inline void assign(GUID_t& guid, const OpenDDS::DCPS::RepoId& a_guid)
+inline void assign(GUID_t& guid, const OpenDDS::DCPS::GUID_t& a_guid)
 {
   std::memcpy(&guid._guidPrefix[0], a_guid.guidPrefix, sizeof(a_guid.guidPrefix));
   assign(guid.entityId(), a_guid.entityId);
@@ -112,14 +112,14 @@ inline bool operator<(const Duration_t& x, const Duration_t& y)
   return x.nanosec() < y.nanosec();
 }
 
-inline OpenDDS::DCPS::RepoId guid_to_repoid(const GUID_t& a_guid)
+inline OpenDDS::DCPS::GUID_t guid_to_repoid(const GUID_t& a_guid)
 {
-  OpenDDS::DCPS::RepoId retval;
-  std::memcpy(&retval, &a_guid, sizeof(OpenDDS::DCPS::RepoId));
+  OpenDDS::DCPS::GUID_t retval;
+  std::memcpy(&retval, &a_guid, sizeof(OpenDDS::DCPS::GUID_t));
   return retval;
 }
 
-inline GUID_t repoid_to_guid(const OpenDDS::DCPS::RepoId& a_guid)
+inline GUID_t repoid_to_guid(const OpenDDS::DCPS::GUID_t& a_guid)
 {
   GUID_t retval;
   std::memcpy(&retval.guidPrefix(), a_guid.guidPrefix, sizeof(a_guid.guidPrefix));
@@ -129,7 +129,7 @@ inline GUID_t repoid_to_guid(const OpenDDS::DCPS::RepoId& a_guid)
 }
 
 struct GuidHash {
-  std::size_t operator() (const OpenDDS::DCPS::RepoId& guid) const
+  std::size_t operator() (const OpenDDS::DCPS::GUID_t& guid) const
   {
     return
       (std::hash<::CORBA::Octet>{}(guid.guidPrefix[0]) << 15) ^
@@ -150,7 +150,7 @@ struct GuidHash {
       (std::hash<::CORBA::Octet>{}(guid.entityId.entityKind) << 0);
   }
 };
-typedef std::unordered_set<OpenDDS::DCPS::RepoId, GuidHash> GuidSet;
+typedef std::unordered_set<OpenDDS::DCPS::GUID_t, GuidHash> GuidSet;
 
 }
 

--- a/tools/dds/rtpsrelaylib/Utility.h
+++ b/tools/dds/rtpsrelaylib/Utility.h
@@ -112,14 +112,14 @@ inline bool operator<(const Duration_t& x, const Duration_t& y)
   return x.nanosec() < y.nanosec();
 }
 
-inline OpenDDS::DCPS::GUID_t guid_to_repoid(const GUID_t& a_guid)
+inline OpenDDS::DCPS::GUID_t relay_guid_to_rtps_guid(const GUID_t& a_guid)
 {
   OpenDDS::DCPS::GUID_t retval;
   std::memcpy(&retval, &a_guid, sizeof(OpenDDS::DCPS::GUID_t));
   return retval;
 }
 
-inline GUID_t repoid_to_guid(const OpenDDS::DCPS::GUID_t& a_guid)
+inline GUID_t rtps_guid_to_relay_guid(const OpenDDS::DCPS::GUID_t& a_guid)
 {
   GUID_t retval;
   std::memcpy(&retval.guidPrefix(), a_guid.guidPrefix, sizeof(a_guid.guidPrefix));

--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -23,12 +23,12 @@ public:
     , log_activity_(false)
   {}
 
-  void application_participant_guid(const OpenDDS::DCPS::RepoId& value)
+  void application_participant_guid(const OpenDDS::DCPS::GUID_t& value)
   {
     application_participant_guid_ = value;
   }
 
-  const OpenDDS::DCPS::RepoId& application_participant_guid() const
+  const OpenDDS::DCPS::GUID_t& application_participant_guid() const
   {
     return application_participant_guid_;
   }
@@ -214,7 +214,7 @@ public:
   }
 
 private:
-  OpenDDS::DCPS::RepoId application_participant_guid_;
+  OpenDDS::DCPS::GUID_t application_participant_guid_;
   OpenDDS::DCPS::TimeDuration lifespan_;
   size_t static_limit_;
   size_t max_pending_;

--- a/tools/rtpsrelay/DomainStatisticsReporter.h
+++ b/tools/rtpsrelay/DomainStatisticsReporter.h
@@ -21,8 +21,8 @@ public:
   {
     DDS::Topic_var topic = writer_->get_topic();
     topic_name_ = topic->get_name();
-    log_domain_statistics_.application_participant_guid(repoid_to_guid(config_.application_participant_guid()));
-    publish_domain_statistics_.application_participant_guid(repoid_to_guid(config_.application_participant_guid()));
+    log_domain_statistics_.application_participant_guid(rtps_guid_to_relay_guid(config_.application_participant_guid()));
+    publish_domain_statistics_.application_participant_guid(rtps_guid_to_relay_guid(config_.application_participant_guid()));
   }
 
   void add_local_participant(const OpenDDS::DCPS::MonotonicTimePoint& now)

--- a/tools/rtpsrelay/GuidPartitionTable.cpp
+++ b/tools/rtpsrelay/GuidPartitionTable.cpp
@@ -29,6 +29,8 @@ GuidPartitionTable::Result GuidPartitionTable::insert(const OpenDDS::DCPS::GUID_
     return NO_CHANGE;
   }
 
+  remove_from_cache(guid);
+
   SpdpReplay spdp_replay;
   populate_replay(spdp_replay, guid, to_add);
 

--- a/tools/rtpsrelay/GuidPartitionTable.h
+++ b/tools/rtpsrelay/GuidPartitionTable.h
@@ -165,7 +165,7 @@ private:
   void write_slots(const std::unordered_set<size_t>& slots_to_write)
   {
     RelayPartitions relay_partitions;
-    relay_partitions.application_participant_guid(repoid_to_guid(config_.application_participant_guid()));
+    relay_partitions.application_participant_guid(rtps_guid_to_relay_guid(config_.application_participant_guid()));
     for (const auto slot : slots_to_write) {
       relay_partitions.slot(static_cast<CORBA::ULong>(slot));
       relay_partitions.partitions().assign(slots_[slot].begin(), slots_[slot].end());

--- a/tools/rtpsrelay/HandlerStatisticsReporter.h
+++ b/tools/rtpsrelay/HandlerStatisticsReporter.h
@@ -25,9 +25,9 @@ public:
   {
     DDS::Topic_var topic = writer->get_topic();
     topic_name_ = topic->get_name();
-    log_handler_statistics_.application_participant_guid(repoid_to_guid(config.application_participant_guid()));
+    log_handler_statistics_.application_participant_guid(rtps_guid_to_relay_guid(config.application_participant_guid()));
     log_handler_statistics_.name(name);
-    publish_handler_statistics_.application_participant_guid(repoid_to_guid(config.application_participant_guid()));
+    publish_handler_statistics_.application_participant_guid(rtps_guid_to_relay_guid(config.application_participant_guid()));
     publish_handler_statistics_.name(name);
   }
 

--- a/tools/rtpsrelay/ParticipantStatisticsReporter.h
+++ b/tools/rtpsrelay/ParticipantStatisticsReporter.h
@@ -94,7 +94,7 @@ public:
 
     const auto ret = writer->write(publish_participant_statistics_, DDS::HANDLE_NIL);
     if (ret != DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: writing participant %C statistics\n"), guid_to_string(guid_to_repoid(publish_participant_statistics_.guid())).c_str()));
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: writing participant %C statistics\n"), guid_to_string(relay_guid_to_rtps_guid(publish_participant_statistics_.guid())).c_str()));
     }
 
     publish_last_report_ = now;

--- a/tools/rtpsrelay/RelayAddressListener.cpp
+++ b/tools/rtpsrelay/RelayAddressListener.cpp
@@ -38,14 +38,14 @@ void RelayAddressListener::on_data_available(DDS::DataReader_ptr reader)
     switch (info.instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       if (info.valid_data) {
-        relay_partition_table_.insert(guid_to_repoid(data.application_participant_guid()),
+        relay_partition_table_.insert(relay_guid_to_rtps_guid(data.application_participant_guid()),
                                       data.name(),
                                       ACE_INET_Addr(data.address().c_str()));
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:
     case DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE:
-      relay_partition_table_.remove(guid_to_repoid(data.application_participant_guid()),
+      relay_partition_table_.remove(relay_guid_to_rtps_guid(data.application_participant_guid()),
                                     data.name());
       break;
     }

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -227,7 +227,7 @@ void RelayHandler::enqueue_message(const ACE_INET_Addr& addr,
 ParticipantStatisticsReporter&
 GuidAddrSet::Proxy::record_activity(const AddrPort& remote_address,
                                     const OpenDDS::DCPS::MonotonicTimePoint& now,
-                                    const OpenDDS::DCPS::RepoId& src_guid,
+                                    const OpenDDS::DCPS::GUID_t& src_guid,
                                     const size_t& msg_len,
                                     RelayHandler& handler)
 {
@@ -237,7 +237,7 @@ GuidAddrSet::Proxy::record_activity(const AddrPort& remote_address,
 ParticipantStatisticsReporter&
 GuidAddrSet::record_activity(const AddrPort& remote_address,
                              const OpenDDS::DCPS::MonotonicTimePoint& now,
-                             const OpenDDS::DCPS::RepoId& src_guid,
+                             const OpenDDS::DCPS::GUID_t& src_guid,
                              const size_t& msg_len,
                              RelayHandler& handler)
 {
@@ -360,7 +360,7 @@ bool GuidAddrSet::ignore(const OpenDDS::DCPS::GUID_t& guid,
   return false;
 }
 
-void GuidAddrSet::remove(const OpenDDS::DCPS::RepoId& guid)
+void GuidAddrSet::remove(const OpenDDS::DCPS::GUID_t& guid)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -436,7 +436,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
   const auto msg_len = msg->length();
   if (msg_len >= 4 && ACE_OS::memcmp(msg->rd_ptr(), "RTPS", 4) == 0) {
     OpenDDS::RTPS::MessageParser mp(*msg);
-    OpenDDS::DCPS::RepoId src_guid;
+    OpenDDS::DCPS::GUID_t src_guid;
     GuidSet to;
 
     if (!parse_message(mp, msg, src_guid, to, true, now)) {
@@ -489,7 +489,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
     }
 
     bool has_guid = false;
-    OpenDDS::DCPS::RepoId src_guid;
+    OpenDDS::DCPS::GUID_t src_guid;
     if (message.get_guid_prefix(src_guid.guidPrefix)) {
       src_guid.entityId = OpenDDS::DCPS::ENTITYID_PARTICIPANT;
       has_guid = true;
@@ -547,7 +547,7 @@ ParticipantStatisticsReporter&
 VerticalHandler::record_activity(GuidAddrSet::Proxy& proxy,
                                  const AddrPort& remote_address,
                                  const OpenDDS::DCPS::MonotonicTimePoint& now,
-                                 const OpenDDS::DCPS::RepoId& src_guid,
+                                 const OpenDDS::DCPS::GUID_t& src_guid,
                                  const size_t& msg_len)
 {
   return proxy.record_activity(remote_address, now, src_guid, msg_len, *this);
@@ -555,7 +555,7 @@ VerticalHandler::record_activity(GuidAddrSet::Proxy& proxy,
 
 bool VerticalHandler::parse_message(OpenDDS::RTPS::MessageParser& message_parser,
                                     const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
-                                    OpenDDS::DCPS::RepoId& src_guid,
+                                    OpenDDS::DCPS::GUID_t& src_guid,
                                     GuidSet& to,
                                     bool check_submessages,
                                     const OpenDDS::DCPS::MonotonicTimePoint& now)
@@ -580,7 +580,7 @@ bool VerticalHandler::parse_message(OpenDDS::RTPS::MessageParser& message_parser
     // Check that every non-info submessage has a "valid" (not unknown) destination.
     switch (submessage_header.submessageId) {
     case OpenDDS::RTPS::INFO_DST: {
-      OpenDDS::DCPS::RepoId dest = OpenDDS::DCPS::GUID_UNKNOWN;
+      OpenDDS::DCPS::GUID_t dest = OpenDDS::DCPS::GUID_UNKNOWN;
       OpenDDS::DCPS::GuidPrefix_t_forany guidPrefix(dest.guidPrefix);
       if (!(message_parser >> guidPrefix)) {
         HANDLER_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: VerticalHandler::parse_message %C failed to deserialize INFO_DST from %C\n"), name_.c_str(), guid_to_string(src_guid).c_str()));
@@ -694,7 +694,7 @@ bool VerticalHandler::parse_message(OpenDDS::RTPS::MessageParser& message_parser
 }
 
 CORBA::ULong VerticalHandler::send(GuidAddrSet::Proxy& proxy,
-                                   const OpenDDS::DCPS::RepoId& src_guid,
+                                   const OpenDDS::DCPS::GUID_t& src_guid,
                                    const StringSet& to_partitions,
                                    const GuidSet& to_guids,
                                    bool send_to_application_participant,
@@ -888,7 +888,7 @@ SpdpHandler::SpdpHandler(const Config& config,
 
 bool SpdpHandler::do_normal_processing(GuidAddrSet::Proxy& proxy,
                                        const ACE_INET_Addr& remote,
-                                       const OpenDDS::DCPS::RepoId& src_guid,
+                                       const OpenDDS::DCPS::GUID_t& src_guid,
                                        const GuidSet& to,
                                        bool& send_to_application_participant,
                                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,
@@ -937,7 +937,7 @@ bool SpdpHandler::do_normal_processing(GuidAddrSet::Proxy& proxy,
   return true;
 }
 
-void SpdpHandler::purge(const OpenDDS::DCPS::RepoId& guid)
+void SpdpHandler::purge(const OpenDDS::DCPS::GUID_t& guid)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, spdp_messages_mutex_);
   const auto pos = spdp_messages_.find(guid);
@@ -998,7 +998,7 @@ SedpHandler::SedpHandler(const Config& config,
 
 bool SedpHandler::do_normal_processing(GuidAddrSet::Proxy& proxy,
                                        const ACE_INET_Addr& remote,
-                                       const OpenDDS::DCPS::RepoId& src_guid,
+                                       const OpenDDS::DCPS::GUID_t& src_guid,
                                        const GuidSet& to,
                                        bool& send_to_application_participant,
                                        const OpenDDS::DCPS::Message_Block_Shared_Ptr& msg,

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -254,7 +254,7 @@ GuidAddrSet::record_activity(const AddrPort& remote_address,
       const auto after = guid_addr_set_map_.size();
       if (before != after) {
         relay_stats_reporter_.local_active_participants(after, now);
-        *guid_addr_set_map_[src_guid].select_stats_reporter(remote_address.port) = ParticipantStatisticsReporter(repoid_to_guid(src_guid), handler.name());
+        *guid_addr_set_map_[src_guid].select_stats_reporter(remote_address.port) = ParticipantStatisticsReporter(rtps_guid_to_relay_guid(src_guid), handler.name());
       }
 
       const GuidAddr ga(src_guid, remote_address);
@@ -802,7 +802,7 @@ void HorizontalHandler::enqueue_message(const ACE_INET_Addr& addr,
   }
   auto& tg = relay_header.to_guids();
   for (const auto& g : to_guids) {
-    tg.push_back(repoid_to_guid(g));
+    tg.push_back(rtps_guid_to_relay_guid(g));
   }
 
   size_t size = 0;
@@ -847,7 +847,7 @@ CORBA::ULong HorizontalHandler::process_message(const ACE_INET_Addr& from,
 
   if (!relay_header.to_guids().empty()) {
     for (const auto& guid : relay_header.to_guids()) {
-      const auto p = proxy.find(guid_to_repoid(guid));
+      const auto p = proxy.find(relay_guid_to_rtps_guid(guid));
       if (p != proxy.end()) {
         for (const auto& addr : *p->second.select_addr_set(port())) {
           vertical_handler_->venqueue_message(addr.first.addr, *p->second.select_stats_reporter(port()), msg, now);

--- a/tools/rtpsrelay/RelayPartitionTable.h
+++ b/tools/rtpsrelay/RelayPartitionTable.h
@@ -13,6 +13,13 @@ namespace RtpsRelay {
 typedef std::set<ACE_INET_Addr> AddressSet;
 typedef std::pair<OpenDDS::DCPS::GUID_t, size_t> SlotKey;
 
+struct SlotKeyHash {
+  std::size_t operator() (const SlotKey& slot_key) const
+  {
+    return GuidHash()(slot_key.first) ^ slot_key.second;
+  }
+};
+
 class RelayPartitionTable {
 public:
   RelayPartitionTable()
@@ -58,8 +65,8 @@ public:
   }
 
 private:
-  typedef std::map<std::string, ACE_INET_Addr> NameToAddress;
-  typedef std::map<OpenDDS::DCPS::GUID_t, NameToAddress> RelayToAddress;
+  typedef std::unordered_map<std::string, ACE_INET_Addr> NameToAddress;
+  typedef std::unordered_map<OpenDDS::DCPS::GUID_t, NameToAddress, GuidHash> RelayToAddress;
   RelayToAddress relay_to_address_;
 
   struct Map {
@@ -122,7 +129,7 @@ private:
 
     PartitionIndex partition_index_;
 
-    typedef std::map<SlotKey, StringSet> RelayToPartitions;
+    typedef std::unordered_map<SlotKey, StringSet, SlotKeyHash> RelayToPartitions;
     RelayToPartitions relay_to_partitions_;
   };
 

--- a/tools/rtpsrelay/RelayPartitionsListener.cpp
+++ b/tools/rtpsrelay/RelayPartitionsListener.cpp
@@ -38,13 +38,13 @@ void RelayPartitionsListener::on_data_available(DDS::DataReader_ptr reader)
     switch (info.instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       if (info.valid_data) {
-        relay_partition_table_.complete_insert(std::make_pair(guid_to_repoid(data.application_participant_guid()), data.slot()),
+        relay_partition_table_.complete_insert(std::make_pair(relay_guid_to_rtps_guid(data.application_participant_guid()), data.slot()),
                                                data.partitions());
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:
     case DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE:
-      relay_partition_table_.complete_insert(std::make_pair(guid_to_repoid(data.application_participant_guid()), data.slot()),
+      relay_partition_table_.complete_insert(std::make_pair(relay_guid_to_rtps_guid(data.application_participant_guid()), data.slot()),
                                              RtpsRelay::StringSequence());
       break;
     }

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -21,8 +21,8 @@ public:
   {
     DDS::Topic_var topic = writer_->get_topic();
     topic_name_ = topic->get_name();
-    log_relay_statistics_.application_participant_guid(repoid_to_guid(config.application_participant_guid()));
-    publish_relay_statistics_.application_participant_guid(repoid_to_guid(config.application_participant_guid()));
+    log_relay_statistics_.application_participant_guid(rtps_guid_to_relay_guid(config.application_participant_guid()));
+    publish_relay_statistics_.application_participant_guid(rtps_guid_to_relay_guid(config.application_participant_guid()));
   }
 
   void input_message(size_t byte_count,

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -767,7 +767,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   RelayAddress relay_address;
-  relay_address.application_participant_guid(repoid_to_guid(config.application_participant_guid()));
+  relay_address.application_participant_guid(rtps_guid_to_relay_guid(config.application_participant_guid()));
   relay_address.name(HSPDP);
   relay_address.address(OpenDDS::DCPS::LogAddr(spdp_horizontal_addr).str());
   ret = relay_address_writer->write(relay_address, DDS::HANDLE_NIL);
@@ -803,7 +803,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   RelayInstance relay_instance;
-  relay_instance.application_participant_guid(repoid_to_guid(config.application_participant_guid()));
+  relay_instance.application_participant_guid(rtps_guid_to_relay_guid(config.application_participant_guid()));
   relay_instance.application_participant_user_data().value.length(static_cast<CORBA::ULong>(user_data.length()));
   std::memcpy(relay_instance.application_participant_user_data().value.get_buffer(), user_data.data(), user_data.length());
 


### PR DESCRIPTION
Problem
-------

The RtpsRelay uses std::set and std::map in various places where
std::unordered_set and std::unordered_map may provide superior
performance.

The lookup of guid to partitions iterates over all readers/writers
with the given prefix requiring a log(N) find and P O(1) operations to
iterate.

Solution
--------

Replace ordered sets and maps with unordered ones where possible.  A
hash function for ACE_INET_Addr is need to convert the remaining
cases.

Add a cache for the guid to partitions lookup.