### PR TITLE
Fix and Refactor XML Security File Parsing

### DIFF
--- a/dds/DCPS/ConfigUtils.h
+++ b/dds/DCPS/ConfigUtils.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,9 +6,11 @@
 #ifndef OPENDDS_DCPS_CONFIGUTILS_H
 #define OPENDDS_DCPS_CONFIGUTILS_H
 
-#include "ace/Configuration.h"
 #include "dcps_export.h"
 #include "PoolAllocator.h"
+#include "SafetyProfileStreams.h"
+
+#include <ace/Configuration.h>
 
 #include <sstream>
 #include <cstdlib>
@@ -24,48 +24,6 @@ namespace DCPS {
   typedef OPENDDS_MAP(OPENDDS_STRING, OPENDDS_STRING) ValueMap;
   typedef std::pair<OPENDDS_STRING, ACE_Configuration_Section_Key> SubsectionPair;
   typedef OPENDDS_LIST(SubsectionPair) KeyList;
-
-
-  /**
-   * Convert string s to value of integral type T.
-   *
-   * Returns true for success, false for error
-   */
-  template <typename T>
-  bool convertToInteger(const OPENDDS_STRING& s, T& value)
-  {
-#ifdef OPENDDS_SAFETY_PROFILE
-    char* end;
-    const long conv = std::strtol(s.c_str(), &end, 10);
-    if (end == s.c_str()) return false;
-    value = static_cast<T>(conv);
-#else
-    std::stringstream istr(s.c_str());
-    if (!(istr >> value) || (istr.peek() != EOF)) return false;
-#endif
-    return true;
-  }
-
-  /**
-   * Convert string s to value of double type T.
-   *
-   * Returns true for success, false for error
-   */
-  template <typename T>
-  bool convertToDouble(const OPENDDS_STRING& s, T& value)
-  {
-#ifdef OPENDDS_SAFETY_PROFILE
-    char* end;
-    const double conv = std::strtod(s.c_str(), &end);
-    if (end == s.c_str()) return false;
-    value = static_cast<T>(conv);
-#else
-    std::stringstream istr(s.c_str());
-    if (!(istr >> value) || (istr.peek() != EOF)) return false;
-#endif
-    return true;
-  }
-
 
   ///     Function that pulls all the values from the
   ///     specified ACE Configuration Section and places them in a

--- a/dds/DCPS/DisjointSequence.h
+++ b/dds/DCPS/DisjointSequence.h
@@ -168,8 +168,8 @@ public:
       for (typename Container::iterator i = lower_bound(lower - 1);
           i != ranges_.end() && (i->first <= above || i->second <= above);
           /* iterate in loop because of removal */) {
-        lower = std::min(lower, i->first);
-        upper = std::max(upper, i->second);
+        lower = (std::min)(lower, i->first);
+        upper = (std::max)(upper, i->second);
         ranges_.erase(i++);
       }
 

--- a/dds/DCPS/DisjointSequence.h
+++ b/dds/DCPS/DisjointSequence.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -11,7 +9,6 @@
 #include "dcps_export.h"
 #include "Definitions.h"
 #include "SequenceNumber.h"
-
 #include "PoolAllocator.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -160,37 +157,28 @@ public:
     size_type size() const { return ranges_.size(); }
     void clear() { ranges_.clear(); }
 
-    void add(T value)
+    void add(T lower, T upper)
     {
-      typedef typename Container::iterator iter_t; // underlying iterator type, not const_iterator
-      const iter_t iter = ranges_.lower_bound(TPair(T() /*ignored*/, value));
-      if (iter != ranges_.end() && !(value < iter->first)) {
+      OPENDDS_ASSERT(upper >= lower);
+      if (has(lower, upper)) {
         return;
       }
 
-      if (!empty() && iter == ranges_.end()) {
-        const iter_t last = --ranges_.end();
-        if (last->second + T(1) == value) {
-          const T first = last->first;
-          ranges_.erase(last);
-          ranges_.insert(TPair(first, value));
-          return;
-        }
-      } else if (!empty() && value + T(1) == iter->first) {
-        const T second = iter->second;
-        iter_t prev(iter);
-        const bool combine_left = iter != ranges_.begin() && (--prev)->second + T(1) == value;
-        ranges_.erase(iter);
-        if (combine_left) {
-          const TPair combined(prev->first, second);
-          ranges_.erase(prev);
-          ranges_.insert(combined);
-        } else {
-          ranges_.insert(TPair(value, second));
-        }
-        return;
+      const T above = upper + 1;
+      for (typename Container::iterator i = lower_bound(lower - 1);
+          i != ranges_.end() && (i->first <= above || i->second <= above);
+          /* iterate in loop because of removal */) {
+        lower = std::min(lower, i->first);
+        upper = std::max(upper, i->second);
+        ranges_.erase(i++);
       }
-      ranges_.insert(TPair(value, value));
+
+      ranges_.insert(TPair(lower, upper));
+    }
+
+    void add(T value)
+    {
+      add(value, value);
     }
 
     void remove(T value)
@@ -209,17 +197,35 @@ public:
       return value;
     }
 
+    bool has(T lower, T upper) const
+    {
+      const const_iterator iter = lower_bound(upper);
+      return iter != end() && !(lower < iter->first);
+    }
+
+    bool has(const TPair& range) const
+    {
+      return has(range.first, range.second);
+    }
+
     bool has(T value) const
     {
-      const const_iterator iter = lower_bound(value);
-      return iter != end() && !(value < iter->first);
+      return has(value, value);
+    }
+
+    bool has_any(T lower, T upper) const
+    {
+      const const_iterator iter = lower_bound(lower);
+      return iter != end() && !(upper < iter->first);
     }
 
     bool has_any(const TPair& range) const
     {
-      const const_iterator iter = lower_bound(range.first);
-      return iter != end() && !(range.second < iter->first);
+      return has_any(range.first, range.second);
     }
+
+    template <typename Type> friend
+    bool operator==(const OrderedRanges<Type>& a, const OrderedRanges<Type>& b);
 
   private:
     const_iterator lower_bound(const TPair& p) const { return ranges_.lower_bound(p); }
@@ -227,6 +233,13 @@ public:
     const_iterator lower_bound(T t) const
     {
       return ranges_.lower_bound(TPair(T() /*ignored*/, t));
+    }
+
+    const_iterator upper_bound(const TPair& p) const { return ranges_.upper_bound(p); }
+
+    const_iterator upper_bound(T t) const
+    {
+      return ranges_.upper_bound(TPair(T() /*ignored*/, t));
     }
 
     // 'iter' must be a valid iterator to a range that contains 'value'
@@ -271,6 +284,13 @@ public:
   /// sequence numbers between low and high, inclusive (maximum 8 longs).
   static ACE_CDR::ULong bitmap_num_longs(const SequenceNumber& low, const SequenceNumber& high);
 };
+
+template <typename T>
+bool operator==(
+  const DisjointSequence::OrderedRanges<T>& a, const DisjointSequence::OrderedRanges<T>& b)
+{
+  return a.ranges_ == b.ranges_;
+}
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/SafetyProfileStreams.cpp
+++ b/dds/DCPS/SafetyProfileStreams.cpp
@@ -1,45 +1,38 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
-#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+
+#include <DCPS/DdsDcps_pch.h> // Only the _pch include should start with DCPS/
 
 #include "SafetyProfileStreams.h"
 
 #include "Definitions.h"
-#ifdef OPENDDS_SECURITY
-#  include "../DdsSecurityCoreC.h"
-#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace DCPS {
 
-OPENDDS_STRING
-to_dds_string(unsigned short to_convert)
+String to_dds_string(unsigned short to_convert)
 {
   const char* fmt = "%hu";
   const int buff_size = 5 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
 }
 
-OPENDDS_STRING
-to_dds_string(int to_convert)
+String to_dds_string(int to_convert)
 {
   const char* fmt = "%d";
   const int buff_size = 20 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
 }
 
-OPENDDS_STRING
-to_dds_string(unsigned int to_convert, bool as_hex)
+String to_dds_string(unsigned int to_convert, bool as_hex)
 {
   const char* fmt;
   if (as_hex) {
@@ -47,38 +40,35 @@ to_dds_string(unsigned int to_convert, bool as_hex)
     const int buff_size = 3; // note +1 for null terminator
     char buf[buff_size];
     ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-    return OPENDDS_STRING(buf);
+    return String(buf);
   } else {
     fmt = "%u";
     const int buff_size = 20 + 1; // note +1 for null terminator
     char buf[buff_size];
     ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-    return OPENDDS_STRING(buf);
+    return String(buf);
   }
 }
 
-OPENDDS_STRING
-to_dds_string(long to_convert)
+String to_dds_string(long to_convert)
 {
   const char* fmt = "%ld";
   const int buff_size = 20 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
 }
 
-OPENDDS_STRING
-to_dds_string(long long to_convert)
+String to_dds_string(long long to_convert)
 {
   const char* fmt = "%lld";
   const int buff_size = 20 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
 }
 
-OPENDDS_STRING
-to_dds_string(unsigned long long to_convert, bool as_hex)
+String to_dds_string(unsigned long long to_convert, bool as_hex)
 {
   const char* fmt;
   if (as_hex) {
@@ -89,11 +79,10 @@ to_dds_string(unsigned long long to_convert, bool as_hex)
   const int buff_size = 20 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
 }
 
-OPENDDS_STRING
-to_dds_string(unsigned long to_convert, bool as_hex)
+String to_dds_string(unsigned long to_convert, bool as_hex)
 {
   const char* fmt;
   if (as_hex) {
@@ -104,10 +93,10 @@ to_dds_string(unsigned long to_convert, bool as_hex)
   const int buff_size = 20 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
 }
 
-OPENDDS_STRING to_hex_dds_string(
+String to_hex_dds_string(
   const unsigned char* data, const size_t size, const char delim, const size_t delim_every)
 {
   return to_hex_dds_string(reinterpret_cast<const char*>(data), size, delim, delim_every);
@@ -119,7 +108,7 @@ static inline char nibble_to_hex_char(char nibble)
   return ((nibble < 0xA) ? '0' : ('a' - 0xA)) + nibble;
 }
 
-OPENDDS_STRING to_hex_dds_string(
+String to_hex_dds_string(
   const char* data, size_t size, const char delim, const size_t delim_every)
 {
   const bool valid_delim = delim && delim_every;
@@ -131,7 +120,7 @@ OPENDDS_STRING to_hex_dds_string(
     }
   }
 
-  OPENDDS_STRING rv;
+  String rv;
   rv.reserve(l);
   for (size_t i = 0; i < size; i++) {
     if (valid_delim && i && !(i % delim_every)) {

--- a/dds/DCPS/SafetyProfileStreams.h
+++ b/dds/DCPS/SafetyProfileStreams.h
@@ -19,38 +19,78 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(unsigned short to_convert);
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(int to_convert);
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(unsigned int to_convert, bool as_hex = false);
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(long to_convert);
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(long long to_convert);
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(unsigned long long to_convert, bool as_hex = false);
-OpenDDS_Dcps_Export OPENDDS_STRING to_dds_string(unsigned long to_convert, bool as_hex = false);
+OpenDDS_Dcps_Export String to_dds_string(unsigned short to_convert);
+OpenDDS_Dcps_Export String to_dds_string(int to_convert);
+OpenDDS_Dcps_Export String to_dds_string(unsigned int to_convert, bool as_hex = false);
+OpenDDS_Dcps_Export String to_dds_string(long to_convert);
+OpenDDS_Dcps_Export String to_dds_string(long long to_convert);
+OpenDDS_Dcps_Export String to_dds_string(unsigned long long to_convert, bool as_hex = false);
+OpenDDS_Dcps_Export String to_dds_string(unsigned long to_convert, bool as_hex = false);
 
 //@{
 /**
- * Converts a series of bytes at data to a optionally delimited OPENDDS_STRING
+ * Converts a series of bytes at data to a optionally delimited String
  * of hexadecimal numbers.
  *
  * If delim is '\0' (the default) or delim_every is 0, then the output will not
  * be delimited.
  */
-OpenDDS_Dcps_Export OPENDDS_STRING to_hex_dds_string(
+OpenDDS_Dcps_Export String to_hex_dds_string(
   const unsigned char* data, size_t size, char delim = '\0', size_t delim_every = 1);
-OpenDDS_Dcps_Export OPENDDS_STRING to_hex_dds_string(
+OpenDDS_Dcps_Export String to_hex_dds_string(
   const char* data, size_t size, char delim = '\0', size_t delim_every = 1);
 //@}
 
-/// Convert Pointer to OPENDDS_STRING
+/// Convert Pointer to String
 template <typename T>
-inline OPENDDS_STRING
-to_dds_string(const T* to_convert)
+inline
+String to_dds_string(const T* to_convert)
 {
   const char* fmt = "%p";
   const int buff_size = 20 + 1; // note +1 for null terminator
   char buf[buff_size];
   ACE_OS::snprintf(&buf[0], buff_size, fmt, to_convert);
-  return OPENDDS_STRING(buf);
+  return String(buf);
+}
+
+/**
+ * Convert string s to value of integral type T.
+ *
+ * Returns true for success, false for error
+ */
+template <typename T>
+bool convertToInteger(const String& s, T& value)
+{
+#ifdef OPENDDS_SAFETY_PROFILE
+  char* end;
+  const long conv = std::strtol(s.c_str(), &end, 10);
+  if (end == s.c_str()) return false;
+  value = static_cast<T>(conv);
+#else
+  std::stringstream istr(s.c_str());
+  if (!(istr >> value) || (istr.peek() != EOF)) return false;
+#endif
+  return true;
+}
+
+/**
+ * Convert string s to value of double type T.
+ *
+ * Returns true for success, false for error
+ */
+template <typename T>
+bool convertToDouble(const String& s, T& value)
+{
+#ifdef OPENDDS_SAFETY_PROFILE
+  char* end;
+  const double conv = std::strtod(s.c_str(), &end);
+  if (end == s.c_str()) return false;
+  value = static_cast<T>(conv);
+#else
+  std::stringstream istr(s.c_str());
+  if (!(istr >> value) || (istr.peek() != EOF)) return false;
+#endif
+  return true;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/debug.cpp
+++ b/dds/DCPS/debug.cpp
@@ -1,11 +1,9 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
-#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+#include <DCPS/DdsDcps_pch.h> // Only the _pch include should start with DCPS/
 
 #include "debug.h"
 
@@ -47,6 +45,7 @@ SecurityDebug::set_all_flags_to(bool value)
   new_entity_error = value;
   new_entity_warn = value;
   cleanup_error = value;
+  access_error = value;
   access_warn = value;
   bookkeeping = value;
   showkeys = value;
@@ -56,11 +55,11 @@ SecurityDebug::set_all_flags_to(bool value)
 void
 SecurityDebug::parse_flags(const ACE_TCHAR* flags)
 {
-  OPENDDS_STRING s(ACE_TEXT_ALWAYS_CHAR(flags));
-  const OPENDDS_STRING delim(",");
+  String s(ACE_TEXT_ALWAYS_CHAR(flags));
+  const String delim(",");
   while (true) {
     const size_t pos = s.find(delim);
-    const OPENDDS_STRING flag = s.substr(0, pos);
+    const String flag = s.substr(0, pos);
     if (flag.length()) {
       if (flag == "all") {
         set_all_flags_to(true);
@@ -80,6 +79,8 @@ SecurityDebug::parse_flags(const ACE_TCHAR* flags)
         new_entity_warn = true;
       } else if (flag == "cleanup_error") {
         cleanup_error = true;
+      } else if (flag == "access_error") {
+        access_error = true;
       } else if (flag == "access_warn") {
         access_warn = true;
       } else if (flag == "bookkeeping") {
@@ -89,11 +90,11 @@ SecurityDebug::parse_flags(const ACE_TCHAR* flags)
       } else if (flag == "chlookup") {
         chlookup = true;
       } else {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) SecurityDebug::parse_flags: ")
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: SecurityDebug::parse_flags: ")
           ACE_TEXT("Unknown Security Debug Category: \"%C\"\n"), flag.c_str()));
       }
     }
-    if (pos == OPENDDS_STRING::npos) {
+    if (pos == String::npos) {
       break;
     }
     s.erase(0, pos + delim.length());
@@ -103,7 +104,8 @@ SecurityDebug::parse_flags(const ACE_TCHAR* flags)
 void
 SecurityDebug::set_debug_level(unsigned level)
 {
-  access_warn = new_entity_error = cleanup_error = level >= 1;
+  access_error = new_entity_error = cleanup_error = level >= 1;
+  access_warn = level >= 2;
   auth_warn = encdec_error = level >= 3;
   new_entity_warn = level >= 3;
   auth_debug = encdec_warn = bookkeeping = level >= 4;

--- a/dds/DCPS/debug.h
+++ b/dds/DCPS/debug.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -9,11 +7,12 @@
 #define OPENDDS_DCPS_DEBUG_H
 
 #include "dcps_export.h"
-#include "ace/ace_wchar.h"
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-#pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#include <ace/ace_wchar.h>
+
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -79,6 +78,7 @@ public:
   bool cleanup_error;
 
   /// Permissions and Governance
+  bool access_error;
   bool access_warn;
 
   /// Generation and Tracking of Crypto Handles and Keys
@@ -106,6 +106,31 @@ public:
 };
 extern OpenDDS_Dcps_Export SecurityDebug security_debug;
 #endif
+
+class DebugRestore {
+public:
+  DebugRestore()
+    : orig_dcps_debug_level_(DCPS_debug_level)
+#ifdef OPENDDS_SECURITY
+    , orig_security_debug_(security_debug)
+#endif
+  {
+  }
+
+  ~DebugRestore()
+  {
+    DCPS_debug_level = orig_dcps_debug_level_;
+#ifdef OPENDDS_SECURITY
+    security_debug = orig_security_debug_;
+#endif
+  }
+
+private:
+  unsigned orig_dcps_debug_level_;
+#ifdef OPENDDS_SECURITY
+  SecurityDebug orig_security_debug_;
+#endif
+};
 
 } // namespace OpenDDS
 } // namespace DCPS

--- a/dds/DCPS/security/AccessControl/DomainIdSet.h
+++ b/dds/DCPS/security/AccessControl/DomainIdSet.h
@@ -1,0 +1,29 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.OpenDDS.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_SECURITY_ACCESS_CONTROL_DOMAIN_ID_SET_H
+#define OPENDDS_DCPS_SECURITY_ACCESS_CONTROL_DOMAIN_ID_SET_H
+
+#include <dds/DCPS/DisjointSequence.h>
+#include <dds/DCPS/security/OpenDDS_Security_Export.h>
+#include <dds/Versioned_Namespace.h>
+
+#include <dds/DdsSecurityCoreC.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Security {
+
+typedef DCPS::DisjointSequence::OrderedRanges<DDS::Security::DomainId_t> DomainIdSet;
+const DDS::Security::DomainId_t domain_id_min = 0;
+const DDS::Security::DomainId_t domain_id_max = ACE_INT32_MAX;
+
+} // namespace Security
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif

--- a/dds/DCPS/security/AccessControl/Governance.cpp
+++ b/dds/DCPS/security/AccessControl/Governance.cpp
@@ -18,6 +18,7 @@ namespace Security {
 using XML::XStr;
 using namespace XmlUtils;
 using namespace DDS::Security;
+using OpenDDS::DCPS::security_debug;
 
 Governance::TopicAccessRule::TopicAccessRule()
 {
@@ -36,9 +37,11 @@ namespace {
     const ACE_TCHAR* name, bool& value)
   {
     if (!parse_bool(node, value)) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
-        "\"%s\" value, \"%C\", in \"%C\" is not a valid boolean value\n",
-        name, to_string(node).c_str(), doc.filename().c_str()));
+      if (security_debug.access_error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} Governance::load: "
+          "\"%s\" value, \"%C\", in \"%C\" is not a valid boolean value\n",
+          name, to_string(node).c_str(), doc.filename().c_str()));
+      }
       return false;
     }
 
@@ -50,9 +53,11 @@ namespace {
   {
     const xercesc::DOMNodeList* const nodes = parent->getElementsByTagName(XStr(name));
     if (nodes->getLength() != 1) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
-        "expected 1 boolean value \"%s\" in parent element in \"%C\", found %B\n",
-        name, doc.filename().c_str(), nodes->getLength()));
+      if (security_debug.access_error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} Governance::load: "
+          "expected 1 boolean value \"%s\" in parent element in \"%C\", found %B\n",
+          name, doc.filename().c_str(), nodes->getLength()));
+      }
       return false;
     }
 
@@ -65,9 +70,11 @@ namespace {
   {
     const xercesc::DOMNodeList* const nodes = parent->getElementsByTagName(XStr(name));
     if (nodes->getLength() != 1) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
-        "expected 1 proctection kind value named \"%s\" in parent element in \"%C\", found %B\n",
-        name, doc.filename().c_str(), nodes->getLength()));
+      if (security_debug.access_error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} Governance::load: "
+          "expected 1 proctection kind value named \"%s\" in parent element in \"%C\", found %B\n",
+          name, doc.filename().c_str(), nodes->getLength()));
+      }
       return false;
     }
 
@@ -88,8 +95,11 @@ namespace {
       attributes |= enc_attr;
       attributes |= oa_attr;
     } else {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: invalid %s, \"%C\", in \"%s\"\n",
-        name, value.c_str(), doc.filename().c_str()));
+      if (security_debug.access_error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} Governance::load: "
+          "invalid %s, \"%C\", in \"%s\"\n",
+          name, value.c_str(), doc.filename().c_str()));
+      }
       return false;
     }
 
@@ -103,7 +113,10 @@ int Governance::load(const SSL::SignedDocument& doc)
   doc.get_original_minus_smime(xml);
   ParserPtr parser(get_parser(doc.filename(), xml));
   if (!parser) {
-    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: get_parser failed\n"));
+    if (security_debug.access_error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} Governance::load: "
+        "get_parser failed\n"));
+    }
     return -1;
   }
 
@@ -123,9 +136,11 @@ int Governance::load(const SSL::SignedDocument& doc)
       const XStr dn_tag = ruleNode->getNodeName();
       if (ACE_TEXT("domains") == dn_tag) {
         if (!parse_domain_id_set(ruleNode, domain_rule.domains)) {
-          ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
-            "failed to process domain ids in \"%C\"\n",
-            doc.filename().c_str()));
+          if (security_debug.access_error) {
+            ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} Governance::load: "
+              "failed to process domain ids in \"%C\"\n",
+              doc.filename().c_str()));
+          }
           return -1;
         }
       }

--- a/dds/DCPS/security/AccessControl/Governance.cpp
+++ b/dds/DCPS/security/AccessControl/Governance.cpp
@@ -5,21 +5,19 @@
 
 #include "Governance.h"
 
-#include "xercesc/parsers/XercesDOMParser.hpp"
-#include "xercesc/dom/DOM.hpp"
-#include "xercesc/sax/HandlerBase.hpp"
-#include "xercesc/framework/MemBufInputSource.hpp"
-#include "xercesc/util/PlatformUtils.hpp"
+#include "XmlUtils.h"
 
-#include "ace/OS_NS_strings.h"
-#include "ace/XML_Utils/XercesString.h"
-
-#include <stdexcept>
+#include <ace/OS_NS_strings.h>
+#include <ace/XML_Utils/XercesString.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace Security {
+
+using XML::XStr;
+using namespace XmlUtils;
+using namespace DDS::Security;
 
 Governance::TopicAccessRule::TopicAccessRule()
 {
@@ -33,250 +31,185 @@ Governance::Governance()
 {
 }
 
+namespace {
+  bool get_bool_tag_value(const SSL::SignedDocument& doc, const xercesc::DOMNode* node,
+    const ACE_TCHAR* name, bool& value)
+  {
+    if (!to_bool(node, value)) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
+        "\"%s\" value, \"%C\", in \"%C\" is not a valid boolean value\n",
+        name, to_string(node).c_str(), doc.filename()));
+      return false;
+    }
+
+    return true;
+  }
+
+  bool get_bool_tag(const SSL::SignedDocument& doc, const xercesc::DOMElement* parent,
+    const ACE_TCHAR* name, bool& value)
+  {
+    const xercesc::DOMNodeList* const nodes = parent->getElementsByTagName(XStr(name));
+    if (nodes->getLength() != 1) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
+        "expected 1 boolean value \"%s\" in parent element in \"%C\", found %b\n",
+        name, doc.filename(), nodes->getLength()));
+      return false;
+    }
+
+    return get_bool_tag_value(doc, nodes->item(0), name, value);
+  }
+
+  bool get_protection_kind(const SSL::SignedDocument& doc, const xercesc::DOMElement* parent,
+    const ACE_TCHAR* name, bool& is_protected, CORBA::ULong& attributes,
+    CORBA::ULong enc_attr, CORBA::ULong oa_attr)
+  {
+    const xercesc::DOMNodeList* const nodes = parent->getElementsByTagName(XStr(name));
+    if (nodes->getLength() != 1) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
+        "expected 1 proctection kind value named \"%s\" in parent element in \"%C\", found %b\n",
+        name, doc.filename(), nodes->getLength()));
+      return false;
+    }
+
+    const xercesc::DOMNode* const node = nodes->item(0);
+    const std::string value = to_string(node);
+    if (ACE_OS::strcasecmp(value.c_str(), "NONE") == 0) {
+      is_protected = false;
+    } else if (ACE_OS::strcasecmp(value.c_str(), "SIGN") == 0) {
+      is_protected = true;
+    } else if (ACE_OS::strcasecmp(value.c_str(), "ENCRYPT") == 0) {
+      is_protected = true;
+      attributes |= enc_attr;
+    } else if (ACE_OS::strcasecmp(value.c_str(), "SIGN_WITH_ORIGIN_AUTHENTICATION") == 0) {
+      is_protected = true;
+      attributes |= oa_attr;
+    } else if (ACE_OS::strcasecmp(value.c_str(), "ENCRYPT_WITH_ORIGIN_AUTHENTICATION") == 0) {
+      is_protected = true;
+      attributes |= enc_attr;
+      attributes |= oa_attr;
+    } else {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: invalid %s, \"%C\", in \"%s\"\n",
+        name, value.c_str(), doc.filename()));
+      return false;
+    }
+
+    return true;
+  }
+}
+
 int Governance::load(const SSL::SignedDocument& doc)
 {
-  using XML::XStr;
-  static const char* gMemBufId = "gov buffer id";
-
-  xercesc::XMLPlatformUtils::Initialize();
-  DCPS::unique_ptr<xercesc::XercesDOMParser> parser(new xercesc::XercesDOMParser());
-
+  std::string xml;
+  doc.get_original_minus_smime(xml);
+  ParserPtr parser(get_parser(xml, doc.filename()));
   if (!parser) {
-    ACE_DEBUG((LM_ERROR, ACE_TEXT(
-      "(%P|%t) AccessControlBuiltInImpl::load_governance_file: Governance XML DOMParser Exception.\n")));
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: get_parser failed\n"));
     return -1;
-  }
-
-  parser->setValidationScheme(xercesc::XercesDOMParser::Val_Always);
-  parser->setDoNamespaces(true);    // optional
-  parser->setCreateCommentNodes(false);
-
-  DCPS::unique_ptr<xercesc::ErrorHandler> errHandler((xercesc::ErrorHandler*) new xercesc::HandlerBase());
-  parser->setErrorHandler(errHandler.get());
-
-  // buffer for parsing
-
-  std::string cleaned;
-  doc.get_original_minus_smime(cleaned);
-
-  xercesc::MemBufInputSource contentbuf((const XMLByte*) cleaned.c_str(),
-                                        cleaned.size(),
-                                        gMemBufId);
-
-  try {
-    parser->parse(contentbuf);
-
-  } catch (const xercesc::XMLException& toCatch) {
-    char* message = xercesc::XMLString::transcode(toCatch.getMessage());
-    ACE_DEBUG((LM_ERROR, ACE_TEXT(
-        "(%P|%t) AccessControlBuiltInImpl::load_governance_file: Exception message is %C.\n"), message));
-    xercesc::XMLString::release(&message);
-    return -1;
-
-  } catch (const xercesc::DOMException& toCatch) {
-    char* message = xercesc::XMLString::transcode(toCatch.msg);
-    ACE_DEBUG((LM_ERROR, ACE_TEXT(
-        "(%P|%t) AccessControlBuiltInImpl::load_governance_file: Exception message is %C.\n"), message));
-    xercesc::XMLString::release(&message);
-    return -1;
-
-  } catch (...) {
-    ACE_DEBUG((LM_ERROR, ACE_TEXT(
-        "(%P|%t) AccessControlBuiltInImpl::load_governance_file: Unexpected Governance XML Parser Exception.\n")));
-    return -1;
-  }
-
-  // Successfully parsed the governance file
-
-  const xercesc::DOMDocument* xmlDoc = parser->getDocument();
-
-  const xercesc::DOMElement* elementRoot = xmlDoc->getDocumentElement();
-  if (!elementRoot) {
-    throw std::runtime_error("empty XML document");
   }
 
   // Find the domain rules
-  const xercesc::DOMNodeList* domainRules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("domain_rule")));
-
+  const xercesc::DOMNodeList* const domainRules = parser->getDocument()->getDocumentElement()->
+    getElementsByTagName(XStr(ACE_TEXT("domain_rule")));
   for (XMLSize_t r = 0, dr_len = domainRules->getLength(); r < dr_len; ++r) {
-    Governance::DomainRule rule_holder_;
-    rule_holder_.domain_attrs.plugin_participant_attributes = 0;
+    Governance::DomainRule domain_rule;
+    domain_rule.domain_attrs.plugin_participant_attributes = 0;
+    const xercesc::DOMElement* const domain_rule_el =
+      dynamic_cast<const xercesc::DOMElement*>(domainRules->item(r));
 
-    const xercesc::DOMNode* domainRule = domainRules->item(r);
-
-    // Pull out domain ids used in the rule. We are NOT supporting ranges at this time
-    const xercesc::DOMNodeList* ruleNodes = domainRule->getChildNodes();
-
+    // Process domain ids this domain rule applies to
+    const xercesc::DOMNodeList* const ruleNodes = domain_rule_el->getChildNodes();
     for (XMLSize_t rn = 0, rn_len = ruleNodes->getLength(); rn < rn_len; rn++) {
-
-      const xercesc::DOMNode* ruleNode = ruleNodes->item(rn);
-
+      const xercesc::DOMNode* const ruleNode = ruleNodes->item(rn);
       const XStr dn_tag = ruleNode->getNodeName();
-
       if (ACE_TEXT("domains") == dn_tag) {
-        const xercesc::DOMNodeList* domainIdNodes = ruleNode->getChildNodes();
-
-        for (XMLSize_t did = 0, did_len = domainIdNodes->getLength(); did < did_len; did++) {
-
-          const xercesc::DOMNode* domainIdNode = domainIdNodes->item(did);
-
-          if (ACE_TEXT("id") == XStr(domainIdNode->getNodeName())) {
-            const XMLCh* t = domainIdNode->getTextContent();
-            unsigned int i;
-            if (xercesc::XMLString::textToBin(t, i)) {
-              rule_holder_.domain_list.insert(i);
-            }
-          } else if (ACE_TEXT("id_range") == XStr(domainIdNode->getNodeName())) {
-            int min_value = 0;
-            int max_value = 0;
-
-            const xercesc::DOMNodeList* domRangeIdNodes = domainIdNode->getChildNodes();
-
-            for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; drid++) {
-
-              const xercesc::DOMNode* domRangeIdNode = domRangeIdNodes->item(drid);
-
-              if (ACE_OS::strcmp("min", xercesc::XMLString::transcode(domRangeIdNode->getNodeName())) == 0) {
-                min_value = atoi(xercesc::XMLString::transcode(domRangeIdNode->getTextContent()));
-              } else if (strcmp("max", xercesc::XMLString::transcode(domRangeIdNode->getNodeName())) == 0) {
-                max_value = atoi(xercesc::XMLString::transcode(domRangeIdNode->getTextContent()));
-
-                if (min_value > max_value) {
-                  ACE_DEBUG((LM_ERROR, ACE_TEXT(
-                      "(%P|%t) AccessControlBuiltInImpl::load_governance_file: Governance XML Domain Range invalid.\n")));
-                  return -1;
-                }
-
-                for (int i = min_value; i <= max_value; ++i) {
-                  rule_holder_.domain_list.insert(i);
-                }
-              }
-            }
-          }
+        if (!to_domain_id_set(ruleNode, domain_rule.domain_list)) {
+          ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
+            "failed to process domain ids in \"%C\"\n",
+            doc.filename().c_str()));
+          return -1;
         }
-
       }
     }
 
     // Process allow_unauthenticated_participants
-    const xercesc::DOMNodeList* allow_unauthenticated_participants_ =
-              xmlDoc->getElementsByTagName(XStr(ACE_TEXT("allow_unauthenticated_participants")));
-    char* attr_aup = xercesc::XMLString::transcode(allow_unauthenticated_participants_->item(0)->getTextContent());
-    rule_holder_.domain_attrs.allow_unauthenticated_participants = (ACE_OS::strcasecmp(attr_aup,"false") == 0 ? false : true);
-    xercesc::XMLString::release(&attr_aup);
+    if (!get_bool_tag(doc, domain_rule_el, ACE_TEXT("allow_unauthenticated_participants"),
+        domain_rule.domain_attrs.allow_unauthenticated_participants)) {
+      return -1;
+    }
 
     // Process enable_join_access_control
-    const xercesc::DOMNodeList* enable_join_access_control_ =
-             xmlDoc->getElementsByTagName(XStr(ACE_TEXT("enable_join_access_control")));
-    char* attr_ejac = xercesc::XMLString::transcode(enable_join_access_control_->item(0)->getTextContent());
-    rule_holder_.domain_attrs.is_access_protected = ACE_OS::strcasecmp(attr_ejac, "false") == 0 ? false : true;
-    xercesc::XMLString::release(&attr_ejac);
+    if (!get_bool_tag(doc, domain_rule_el, ACE_TEXT("enable_join_access_control"),
+        domain_rule.domain_attrs.is_access_protected)) {
+      return -1;
+    }
 
     // Process discovery_protection_kind
-    const xercesc::DOMNodeList* discovery_protection_kind_ =
-             xmlDoc->getElementsByTagName(XStr(ACE_TEXT("discovery_protection_kind")));
-    char* attr_dpk = xercesc::XMLString::transcode(discovery_protection_kind_->item(0)->getTextContent());
-    if (ACE_OS::strcasecmp(attr_dpk, "NONE") == 0) {
-      rule_holder_.domain_attrs.is_discovery_protected = false;
-    } else if (ACE_OS::strcasecmp(attr_dpk, "SIGN") == 0) {
-      rule_holder_.domain_attrs.is_discovery_protected = true;
-    } else if (ACE_OS::strcasecmp(attr_dpk, "ENCRYPT") == 0) {
-      rule_holder_.domain_attrs.is_discovery_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_BUILTIN_IS_DISCOVERY_ENCRYPTED;
-    } else if (ACE_OS::strcasecmp(attr_dpk, "SIGN_WITH_ORIGIN_AUTHENTICATION") == 0) {
-      rule_holder_.domain_attrs.is_discovery_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_ORIGIN_AUTHENTICATED;
-    } else if (ACE_OS::strcasecmp(attr_dpk, "ENCRYPT_WITH_ORIGIN_AUTHENTICATION") == 0) {
-      rule_holder_.domain_attrs.is_discovery_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_BUILTIN_IS_DISCOVERY_ENCRYPTED;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_ORIGIN_AUTHENTICATED;
+    if (!get_protection_kind(doc, domain_rule_el, ACE_TEXT("discovery_protection_kind"),
+        domain_rule.domain_attrs.is_discovery_protected,
+        domain_rule.domain_attrs.plugin_participant_attributes,
+        PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_BUILTIN_IS_DISCOVERY_ENCRYPTED,
+        PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_ORIGIN_AUTHENTICATED)) {
+      return -1;
     }
-    xercesc::XMLString::release(&attr_dpk);
 
     // Process liveliness_protection_kind
-    const xercesc::DOMNodeList* liveliness_protection_kind_ =
-             xmlDoc->getElementsByTagName(XStr(ACE_TEXT("liveliness_protection_kind")));
-    char* attr_lpk = xercesc::XMLString::transcode(liveliness_protection_kind_->item(0)->getTextContent());
-    if (ACE_OS::strcasecmp(attr_lpk, "NONE") == 0) {
-      rule_holder_.domain_attrs.is_liveliness_protected = false;
-    } else if (ACE_OS::strcasecmp(attr_lpk, "SIGN") == 0) {
-      rule_holder_.domain_attrs.is_liveliness_protected = true;
-    } else if (ACE_OS::strcasecmp(attr_lpk, "ENCRYPT") == 0) {
-      rule_holder_.domain_attrs.is_liveliness_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ENCRYPTED;
-    } else if (ACE_OS::strcasecmp(attr_lpk, "SIGN_WITH_ORIGIN_AUTHENTICATION") == 0) {
-      rule_holder_.domain_attrs.is_liveliness_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ORIGIN_AUTHENTICATED;
-    } else if (ACE_OS::strcasecmp(attr_lpk, "ENCRYPT_WITH_ORIGIN_AUTHENTICATION") == 0) {
-      rule_holder_.domain_attrs.is_liveliness_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ENCRYPTED;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ORIGIN_AUTHENTICATED;
+    if (!get_protection_kind(doc, domain_rule_el, ACE_TEXT("liveliness_protection_kind"),
+        domain_rule.domain_attrs.is_liveliness_protected,
+        domain_rule.domain_attrs.plugin_participant_attributes,
+        PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ENCRYPTED,
+        PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ORIGIN_AUTHENTICATED)) {
+      return -1;
     }
-    xercesc::XMLString::release(&attr_lpk);
 
     // Process rtps_protection_kind
-    const xercesc::DOMNodeList* rtps_protection_kind_ =
-             xmlDoc->getElementsByTagName(XStr(ACE_TEXT("rtps_protection_kind")));
-    char* attr_rpk = xercesc::XMLString::transcode(rtps_protection_kind_->item(0)->getTextContent());
-
-    if (ACE_OS::strcasecmp(attr_rpk, "NONE") == 0) {
-      rule_holder_.domain_attrs.is_rtps_protected = false;
-    } else if (ACE_OS::strcasecmp(attr_rpk, "SIGN") == 0) {
-      rule_holder_.domain_attrs.is_rtps_protected = true;
-    } else if (ACE_OS::strcasecmp(attr_rpk, "ENCRYPT") == 0) {
-      rule_holder_.domain_attrs.is_rtps_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED;
-    } else if (ACE_OS::strcasecmp(attr_rpk, "SIGN_WITH_ORIGIN_AUTHENTICATION") == 0) {
-      rule_holder_.domain_attrs.is_rtps_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED;
-    } else if (ACE_OS::strcasecmp(attr_rpk, "ENCRYPT_WITH_ORIGIN_AUTHENTICATION") == 0) {
-      rule_holder_.domain_attrs.is_rtps_protected = true;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED;
-      rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED;
+    if (!get_protection_kind(doc, domain_rule_el, ACE_TEXT("rtps_protection_kind"),
+        domain_rule.domain_attrs.is_rtps_protected,
+        domain_rule.domain_attrs.plugin_participant_attributes,
+        PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ENCRYPTED,
+        PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED)) {
+      return -1;
     }
-    xercesc::XMLString::release(&attr_rpk);
 
-    rule_holder_.domain_attrs.plugin_participant_attributes |= ::DDS::Security::PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
+    domain_rule.domain_attrs.plugin_participant_attributes |=
+      PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_VALID;
 
     // Process topic rules
-
-    const xercesc::DOMNodeList* topic_rules = xmlDoc->getElementsByTagName(XStr(ACE_TEXT("topic_rule")));
-
+    const xercesc::DOMNodeList* topic_rules =
+      domain_rule_el->getElementsByTagName(XStr(ACE_TEXT("topic_rule")));
     for (XMLSize_t tr = 0, tr_len = topic_rules->getLength(); tr < tr_len; tr++) {
-
       const xercesc::DOMNode* topic_rule = topic_rules->item(tr);
-
       const xercesc::DOMNodeList* topic_rule_nodes = topic_rule->getChildNodes();
       Governance::TopicAccessRule t_rules;
-
       for (XMLSize_t trn = 0, trn_len = topic_rule_nodes->getLength(); trn < trn_len; trn++) {
-
         const xercesc::DOMNode* topic_rule_node = topic_rule_nodes->item(trn);
+        const std::string name = to_string(topic_rule_node->getNodeName());
 
-        const XStr tr_tag = topic_rule_node->getNodeName();
-        char* tr_val = xercesc::XMLString::transcode(topic_rule_node->getTextContent());
-
-        if (tr_tag == ACE_TEXT("topic_expression")) {
-          t_rules.topic_expression = tr_val;
-        } else if (tr_tag == ACE_TEXT("enable_discovery_protection")) {
-          t_rules.topic_attrs.is_discovery_protected = ACE_OS::strcasecmp(tr_val, "false") == 0 ? false : true;
-        } else if (tr_tag == ACE_TEXT("enable_liveliness_protection")) {
-          t_rules.topic_attrs.is_liveliness_protected = ACE_OS::strcasecmp(tr_val, "false") == 0 ? false : true;
-        } else if (tr_tag == ACE_TEXT("enable_read_access_control")) {
-          t_rules.topic_attrs.is_read_protected = ACE_OS::strcasecmp(tr_val, "false") == 0 ? false : true;
-        } else if (tr_tag == ACE_TEXT("enable_write_access_control")) {
-          t_rules.topic_attrs.is_write_protected = ACE_OS::strcasecmp(tr_val, "false") == 0 ? false : true;
-        } else if (tr_tag == ACE_TEXT("metadata_protection_kind")) {
-          t_rules.metadata_protection_kind.assign(tr_val);
-        } else if (tr_tag == ACE_TEXT("data_protection_kind")) {
-          t_rules.data_protection_kind.assign(tr_val);
+        bool* bool_value = 0;
+        if (name == "topic_expression") {
+          t_rules.topic_expression = to_string(topic_rule_node);
+        } else if (name == "enable_discovery_protection") {
+          bool_value = &t_rules.topic_attrs.is_discovery_protected;
+        } else if (name == "enable_liveliness_protection") {
+          bool_value = &t_rules.topic_attrs.is_liveliness_protected;
+        } else if (name == "enable_read_access_control") {
+          bool_value = &t_rules.topic_attrs.is_read_protected;
+        } else if (name == "enable_write_access_control") {
+          bool_value = &t_rules.topic_attrs.is_write_protected;
+        } else if (name == "metadata_protection_kind") {
+          t_rules.metadata_protection_kind = to_string(topic_rule_node);
+        } else if (name == "data_protection_kind") {
+          t_rules.data_protection_kind = to_string(topic_rule_node);
         }
-        xercesc::XMLString::release(&tr_val);
+
+        if (bool_value && !get_bool_tag_value(doc, topic_rule_node,
+            ACE_TEXT_CHAR_TO_TCHAR(name.c_str()), *bool_value)) {
+          return -1;
+        }
       }
-      rule_holder_.topic_rules.push_back(t_rules);
+      domain_rule.topic_rules.push_back(t_rules);
     }
 
-    access_rules_.push_back(rule_holder_);
+    access_rules_.push_back(domain_rule);
   } // domain_rule
 
   return 0;

--- a/dds/DCPS/security/AccessControl/Governance.cpp
+++ b/dds/DCPS/security/AccessControl/Governance.cpp
@@ -35,10 +35,10 @@ namespace {
   bool get_bool_tag_value(const SSL::SignedDocument& doc, const xercesc::DOMNode* node,
     const ACE_TCHAR* name, bool& value)
   {
-    if (!to_bool(node, value)) {
+    if (!parse_bool(node, value)) {
       ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
         "\"%s\" value, \"%C\", in \"%C\" is not a valid boolean value\n",
-        name, to_string(node).c_str(), doc.filename()));
+        name, to_string(node).c_str(), doc.filename().c_str()));
       return false;
     }
 
@@ -51,8 +51,8 @@ namespace {
     const xercesc::DOMNodeList* const nodes = parent->getElementsByTagName(XStr(name));
     if (nodes->getLength() != 1) {
       ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
-        "expected 1 boolean value \"%s\" in parent element in \"%C\", found %b\n",
-        name, doc.filename(), nodes->getLength()));
+        "expected 1 boolean value \"%s\" in parent element in \"%C\", found %B\n",
+        name, doc.filename().c_str(), nodes->getLength()));
       return false;
     }
 
@@ -66,8 +66,8 @@ namespace {
     const xercesc::DOMNodeList* const nodes = parent->getElementsByTagName(XStr(name));
     if (nodes->getLength() != 1) {
       ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
-        "expected 1 proctection kind value named \"%s\" in parent element in \"%C\", found %b\n",
-        name, doc.filename(), nodes->getLength()));
+        "expected 1 proctection kind value named \"%s\" in parent element in \"%C\", found %B\n",
+        name, doc.filename().c_str(), nodes->getLength()));
       return false;
     }
 
@@ -89,7 +89,7 @@ namespace {
       attributes |= oa_attr;
     } else {
       ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: invalid %s, \"%C\", in \"%s\"\n",
-        name, value.c_str(), doc.filename()));
+        name, value.c_str(), doc.filename().c_str()));
       return false;
     }
 
@@ -101,7 +101,7 @@ int Governance::load(const SSL::SignedDocument& doc)
 {
   std::string xml;
   doc.get_original_minus_smime(xml);
-  ParserPtr parser(get_parser(xml, doc.filename()));
+  ParserPtr parser(get_parser(doc.filename(), xml));
   if (!parser) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: get_parser failed\n"));
     return -1;
@@ -122,7 +122,7 @@ int Governance::load(const SSL::SignedDocument& doc)
       const xercesc::DOMNode* const ruleNode = ruleNodes->item(rn);
       const XStr dn_tag = ruleNode->getNodeName();
       if (ACE_TEXT("domains") == dn_tag) {
-        if (!to_domain_id_set(ruleNode, domain_rule.domain_list)) {
+        if (!parse_domain_id_set(ruleNode, domain_rule.domains)) {
           ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Governance::load: "
             "failed to process domain ids in \"%C\"\n",
             doc.filename().c_str()));

--- a/dds/DCPS/security/AccessControl/Governance.h
+++ b/dds/DCPS/security/AccessControl/Governance.h
@@ -6,12 +6,15 @@
 #ifndef OPENDDS_DCPS_SECURITY_ACCESSCONTROL_GOVERNANCE_H
 #define OPENDDS_DCPS_SECURITY_ACCESSCONTROL_GOVERNANCE_H
 
-#include "dds/DCPS/security/SSL/SignedDocument.h"
-#include "dds/DdsSecurityCoreC.h"
-#include "dds/DCPS/RcObject.h"
+#include "DomainIdSet.h"
+
+#include <dds/DCPS/security/SSL/SignedDocument.h>
+#include <dds/DCPS/RcObject.h>
+
+#include <dds/DdsSecurityCoreC.h>
+
 #include <string>
 #include <vector>
-#include <set>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -20,7 +23,6 @@ namespace Security {
 
 class Governance : public DCPS::RcObject {
 public:
-
   typedef DCPS::RcHandle<Governance> shared_ptr;
 
   struct TopicAccessRule {
@@ -34,7 +36,7 @@ public:
   typedef std::vector<TopicAccessRule> TopicAccessRules;
 
   struct DomainRule {
-    std::set<DDS::Security::DomainId_t> domain_list;
+    DomainIdSet domains;
     DDS::Security::ParticipantSecurityAttributes domain_attrs;
     TopicAccessRules topic_rules;
   };
@@ -51,9 +53,7 @@ public:
   }
 
 private:
-
   GovernanceAccessRules access_rules_;
-
 };
 
 }

--- a/dds/DCPS/security/AccessControl/LocalAccessCredentialData.cpp
+++ b/dds/DCPS/security/AccessControl/LocalAccessCredentialData.cpp
@@ -20,7 +20,6 @@ LocalAccessCredentialData::LocalAccessCredentialData()
 
 LocalAccessCredentialData::~LocalAccessCredentialData()
 {
-
 }
 
 bool LocalAccessCredentialData::load(const DDS::PropertySeq& props,

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -21,7 +21,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
 
   std::string xml;
   doc.get_original_minus_smime(xml);
-  ParserPtr parser(get_parser(xml, doc.filename()));
+  ParserPtr parser(get_parser(doc.filename(), xml));
   if (!parser) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Permissions::load: get_parser failed\n"));
     return -1;
@@ -58,13 +58,13 @@ int Permissions::load(const SSL::SignedDocument& doc)
           const xercesc::DOMNode* validityNode = validityNodes->item(vn);
           const XStr v_tag = validityNode->getNodeName();
           if (v_tag == ACE_TEXT("not_before")) {
-            if (!to_time(validityNode->getTextContent(), grant->validity.not_before)) {
+            if (!parse_time(validityNode->getTextContent(), grant->validity.not_before)) {
               ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Permissions::load: "
                 "invalid datetime in not_before\n"));
               return -1;
             }
           } else if (v_tag == ACE_TEXT("not_after")) {
-            if (!to_time(validityNode->getTextContent(), grant->validity.not_after)) {
+            if (!parse_time(validityNode->getTextContent(), grant->validity.not_after)) {
               ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Permissions::load: "
                 "invalid datetime in not_after\n"));
               return -1;
@@ -113,13 +113,13 @@ int Permissions::load(const SSL::SignedDocument& doc)
           const xercesc::DOMNode* const adNodeChild = adNodeChildren->item(anc);
           const XStr anc_tag = adNodeChild->getNodeName();
           if (anc_tag == ACE_TEXT("domains")) {
-            if (!to_domain_id_set(adNodeChild, rule.domains)) {
+            if (!parse_domain_id_set(adNodeChild, rule.domains)) {
               ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Permissions::load: "
-                "failed to load domain set\n"));
+                "failed to parse domain set\n"));
               return -1;
             }
 
-          } else if (anc_tag == ACE_TEXT("publish") || anc_tag == ACE_TEXT("subscribe")) {   // pub sub nodes
+          } else if (anc_tag == ACE_TEXT("publish") || anc_tag == ACE_TEXT("subscribe")) {
             Action action;
 
             action.ps_type = (anc_tag == ACE_TEXT("publish")) ? PUBLISH : SUBSCRIBE;

--- a/dds/DCPS/security/AccessControl/Permissions.h
+++ b/dds/DCPS/security/AccessControl/Permissions.h
@@ -6,19 +6,19 @@
 #ifndef OPENDDS_DCPS_SECURITY_ACCESSCONTROL_PERMISSIONS_H
 #define OPENDDS_DCPS_SECURITY_ACCESSCONTROL_PERMISSIONS_H
 
-#include "dds/DCPS/security/SSL/SignedDocument.h"
-#include "dds/DCPS/security/SSL/SubjectName.h"
+#include <dds/DCPS/security/SSL/SignedDocument.h>
+#include <dds/DCPS/security/SSL/SubjectName.h>
+#include <dds/DCPS/RcHandle_T.h>
+#include <dds/DCPS/RcObject.h>
 
-#include "dds/DdsDcpsCoreC.h"
-#include "dds/DdsSecurityCoreC.h"
-#include "dds/DdsSecurityParamsC.h"
-
-#include "dds/DCPS/RcHandle_T.h"
-#include "dds/DCPS/RcObject.h"
+#include <dds/DdsDcpsCoreC.h>
+#include <dds/DdsSecurityCoreC.h>
+#include <dds/DdsSecurityParamsC.h>
 
 #include <set>
 #include <string>
 #include <vector>
+#include <ctime>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -40,8 +40,8 @@ struct Permissions : DCPS::RcObject {
   };
 
   struct Validity_t {
-    std::string not_before;
-    std::string not_after;
+    time_t not_before;
+    time_t not_after;
   };
 
   struct Action {

--- a/dds/DCPS/security/AccessControl/Permissions.h
+++ b/dds/DCPS/security/AccessControl/Permissions.h
@@ -6,6 +6,8 @@
 #ifndef OPENDDS_DCPS_SECURITY_ACCESSCONTROL_PERMISSIONS_H
 #define OPENDDS_DCPS_SECURITY_ACCESSCONTROL_PERMISSIONS_H
 
+#include "DomainIdSet.h"
+
 #include <dds/DCPS/security/SSL/SignedDocument.h>
 #include <dds/DCPS/security/SSL/SubjectName.h>
 #include <dds/DCPS/RcHandle_T.h>
@@ -15,7 +17,6 @@
 #include <dds/DdsSecurityCoreC.h>
 #include <dds/DdsSecurityParamsC.h>
 
-#include <set>
 #include <string>
 #include <vector>
 #include <ctime>
@@ -26,7 +27,6 @@ namespace OpenDDS {
 namespace Security {
 
 struct Permissions : DCPS::RcObject {
-
   typedef DCPS::RcHandle<Permissions> shared_ptr;
 
   enum AllowDeny_t {
@@ -57,7 +57,7 @@ struct Permissions : DCPS::RcObject {
 
   struct Rule {
     AllowDeny_t ad_type;
-    std::set<DDS::Security::DomainId_t> domains;
+    DomainIdSet domains;
     Actions actions;
   };
 

--- a/dds/DCPS/security/AccessControl/XmlUtils.cpp
+++ b/dds/DCPS/security/AccessControl/XmlUtils.cpp
@@ -41,7 +41,7 @@ namespace {
   public:
     void warning(const xercesc::SAXParseException& ex)
     {
-      if (security_debug.access_error) {
+      if (security_debug.access_warn) {
         ACE_ERROR((LM_ERROR, "(%P|%t) WARNING: {access_warn} "
           "XmlUtils::ErrorHandler: %C\n",
           to_string(ex).c_str()));
@@ -50,7 +50,7 @@ namespace {
 
     void error(const xercesc::SAXParseException& ex)
     {
-      if (security_debug.access_warn) {
+      if (security_debug.access_error) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: {access_error} "
           "XmlUtils::ErrorHandler: %C\n",
           to_string(ex).c_str()));

--- a/dds/DCPS/security/AccessControl/XmlUtils.cpp
+++ b/dds/DCPS/security/AccessControl/XmlUtils.cpp
@@ -1,0 +1,204 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.OpenDDS.org/license.html
+ */
+
+#include "XmlUtils.h"
+
+#include <ace/OS_NS_strings.h>
+
+#include <xercesc/util/XMLDateTime.hpp>
+#include <xercesc/framework/MemBufInputSource.hpp>
+#include <xercesc/util/PlatformUtils.hpp>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Security {
+namespace XmlUtils {
+
+using DDS::Security::DomainId_t;
+
+ParserPtr get_parser(const std::string& xml, const std::string& filename)
+{
+  try {
+    xercesc::XMLPlatformUtils::Initialize();
+
+  } catch (const xercesc::XMLException& ex) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: get_parser: "
+      "XMLPlatformUtils::Initialize XMLException: %C\n",
+      to_string(ex).c_str()));
+    return ParserPtr();
+  }
+
+  ParserPtr parser(new xercesc::XercesDOMParser());
+  parser->setValidationScheme(xercesc::XercesDOMParser::Val_Always);
+  parser->setDoNamespaces(true);
+  parser->setCreateCommentNodes(false);
+  parser->setIncludeIgnorableWhitespace(false);
+  xercesc::MemBufInputSource contentbuf(
+    reinterpret_cast<const XMLByte*>(xml.c_str()), xml.size(), filename.c_str());
+
+  try {
+    parser->parse(contentbuf);
+
+  } catch (const xercesc::XMLException& ex) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: get_parser: "
+      "XMLException while parsing \"%C\": %C\n",
+      filename.c_str(), to_string(ex).c_str()));
+    return ParserPtr();
+
+  } catch (const xercesc::DOMException& ex) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: get_parser: "
+      "DOMException while parsing \"%C\": %C\n",
+      filename.c_str(), to_string(ex).c_str()));
+    return ParserPtr();
+
+  } catch (...) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: get_parser: "
+      "Unexpected exception while parsing \"%C\"",
+      filename.c_str()));
+    return ParserPtr();
+  }
+
+  if (!parser->getDocument()->getDocumentElement()) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: get_parser: "
+      "XML document \"%C\" is empty\n",
+      filename.c_str()));
+    return ParserPtr();
+  }
+
+  return parser;
+}
+
+std::string to_string(const XMLCh* in)
+{
+  char* c = xercesc::XMLString::transcode(in);
+  const std::string s(c);
+  xercesc::XMLString::release(&c);
+  return s;
+}
+
+bool to_bool(const XMLCh* in, bool& value)
+{
+  /*
+   * The security spec specifies the XML schema spec's boolean type, but the
+   * XML schema spec doesn't specify that true and false can be capitalized
+   * like the security spec uses.
+   */
+  const std::string s = to_string(in);
+  if (!ACE_OS::strcasecmp(s.c_str(), "true") || s == "1") {
+    value = true;
+  } else if (!ACE_OS::strcasecmp(s.c_str(), "false") || s == "0") {
+    value = false;
+  } else {
+    return false;
+  }
+  return true;
+}
+
+bool to_time(const XMLCh* in, time_t& value)
+{
+  try {
+    xercesc::XMLDateTime xdt(in);
+    xdt.parseDateTime();
+    value = xdt.getEpoch();
+  } catch (const xercesc::XMLException& ex) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: to_time: failed to parse date/time: %C\n",
+      to_string(ex).c_str()));
+    return false;
+  }
+  return true;
+}
+
+namespace {
+  bool to_domain_id(const xercesc::DOMNode* node, DomainId_t& value)
+  {
+    // NOTE: DomainId_t is a signed type, but a domain id actually can't be a negative value.
+    unsigned int i = 0;
+    const bool success = xercesc::XMLString::textToBin(node->getTextContent(), i);
+    if (success) {
+      value = static_cast<DomainId_t>(i);
+    }
+    return success;
+  }
+}
+
+bool to_domain_id_set(const xercesc::DOMNode* node, DomainIdSet& domain_id_set)
+{
+  const xercesc::DOMNodeList* const domainIdNodes = node->getChildNodes();
+  for (XMLSize_t did = 0, did_len = domainIdNodes->getLength(); did < did_len; ++did) {
+    const xercesc::DOMNode* const domainIdNode = domainIdNodes->item(did);
+    if (!is_element(domainIdNode)) {
+      continue;
+    }
+    const std::string domainIdNodeName = to_string(domainIdNode->getNodeName());
+    if (domainIdNodeName == "id") {
+      DomainId_t domain_id;
+      if (!to_domain_id(domainIdNode, domain_id)) {
+        ACE_ERROR((LM_ERROR,
+          "(%P|%t) ERROR: to_domain_id_set: Invalid domain ID \"%C\" in id\n",
+          to_string(domainIdNode).c_str()));
+        return false;
+      }
+      domain_id_set.insert(domain_id);
+
+    } else if (domainIdNodeName == "id_range") {
+      DomainId_t min_value = 0;
+      DomainId_t max_value = 0;
+      const xercesc::DOMNodeList* const domRangeIdNodes = domainIdNode->getChildNodes();
+      for (XMLSize_t drid = 0, drid_len = domRangeIdNodes->getLength(); drid < drid_len; ++drid) {
+        const xercesc::DOMNode* const domRangeIdNode = domRangeIdNodes->item(drid);
+        if (!is_element(domRangeIdNode)) {
+          continue;
+        }
+        const std::string domRangeIdNodeName = to_string(domainIdNode->getNodeName());
+        if ("min" == domRangeIdNodeName) {
+          if (!to_domain_id(domRangeIdNode, min_value)) {
+            ACE_ERROR((LM_ERROR,
+              "(%P|%t) ERROR: to_domain_id_set: Invalid domain ID \"%C\" in min_value\n",
+              to_string(domainIdNode).c_str()));
+            return false;
+          }
+
+        } else if ("max" == domRangeIdNodeName) {
+          if (!to_domain_id(domRangeIdNode, max_value)) {
+            ACE_ERROR((LM_ERROR,
+              "(%P|%t) ERROR: to_domain_id_set: Invalid domain ID \"%C\" in max_value\n",
+              to_string(domainIdNode).c_str()));
+            return false;
+          }
+
+          if (min_value > max_value || min_value == 0) {
+            ACE_ERROR((LM_ERROR,
+              "(%P|%t) ERROR: to_domain_id_set: Permission XML Domain Range invalid.\n"));
+            return false;
+          }
+
+          for (DomainId_t i = min_value; i <= max_value; ++i) {
+            domain_id_set.insert(i);
+          }
+        }
+      }
+
+    } else {
+      ACE_ERROR((LM_ERROR,
+        "(%P|%t) ERROR: to_domain_id_set: Invalid tag \"%C\" in domain ID set: \"%C\"\n",
+        domainIdNodeName.c_str(), to_string(domainIdNode).c_str()));
+      return false;
+    }
+  }
+
+  if (domain_id_set.empty()) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: to_domain_id_set: empty domain ID set\n"));
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace XmlUtils
+} // namespace Security
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/security/AccessControl/XmlUtils.h
+++ b/dds/DCPS/security/AccessControl/XmlUtils.h
@@ -18,6 +18,7 @@
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/util/XMLDateTime.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
 
 #include <string>
 #include <ctime>
@@ -41,6 +42,9 @@ bool parse_bool(const XMLCh* in, bool& value);
 
 OpenDDS_Security_Export
 bool parse_time(const XMLCh* in, time_t& value);
+
+OpenDDS_Security_Export
+std::string to_string(const xercesc::SAXParseException& ex);
 
 inline std::string to_string(const xercesc::XMLException& ex)
 {

--- a/dds/DCPS/security/AccessControl/XmlUtils.h
+++ b/dds/DCPS/security/AccessControl/XmlUtils.h
@@ -44,12 +44,7 @@ bool parse_time(const XMLCh* in, time_t& value);
 
 inline std::string to_string(const xercesc::XMLException& ex)
 {
-  std::string msg = to_string(ex.getMessage());
-  const std::string filename = ex.getSrcFile();
-  if (filename.size()) {
-    msg = filename + ":" + DCPS::to_dds_string(ex.getSrcLine()) + ": " + msg;
-  }
-  return msg;
+  return to_string(ex.getMessage());
 }
 
 inline std::string to_string(const xercesc::DOMException& ex)

--- a/dds/DCPS/security/AccessControl/XmlUtils.h
+++ b/dds/DCPS/security/AccessControl/XmlUtils.h
@@ -1,0 +1,95 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.OpenDDS.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_SECURITY_ACCESS_CONTROL_XML_UTILS_H
+#define OPENDDS_DCPS_SECURITY_ACCESS_CONTROL_XML_UTILS_H
+
+#include <dds/Versioned_Namespace.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
+#include <dds/DCPS/unique_ptr.h>
+#include <dds/DCPS/security/OpenDDS_Security_Export.h>
+
+#include <dds/DdsSecurityCoreC.h>
+
+#include <ace/XML_Utils/XercesString.h>
+
+#include <xercesc/dom/DOM.hpp>
+#include <xercesc/util/XMLDateTime.hpp>
+#include <xercesc/parsers/XercesDOMParser.hpp>
+
+#include <string>
+#include <set>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Security {
+namespace XmlUtils {
+
+typedef DCPS::unique_ptr<xercesc::XercesDOMParser> ParserPtr;
+
+OpenDDS_Security_Export
+ParserPtr get_parser(const std::string& xml, const std::string& filename);
+
+OpenDDS_Security_Export
+std::string to_string(const XMLCh* in);
+
+OpenDDS_Security_Export
+bool to_bool(const XMLCh* in, bool& value);
+
+OpenDDS_Security_Export
+bool to_time(const XMLCh* in, time_t& value);
+
+inline std::string to_string(const xercesc::XMLException& ex)
+{
+  std::string msg = to_string(ex.getMessage());
+  const std::string filename = ex.getSrcFile();
+  if (filename.size()) {
+    msg = filename + ":" + DCPS::to_dds_string(ex.getSrcLine());
+  }
+  return msg;
+}
+
+inline std::string to_string(const xercesc::DOMException& ex)
+{
+  return to_string(ex.getMessage());
+}
+
+inline std::string to_string(const xercesc::DOMNode* node)
+{
+  return to_string(node->getTextContent());
+}
+
+inline bool to_bool(const xercesc::DOMNode* node, bool& value)
+{
+  return to_bool(node->getTextContent(), value);
+}
+
+inline bool to_time(const xercesc::DOMNode* node, time_t& value)
+{
+  return to_time(node->getTextContent(), value);
+}
+
+typedef std::set<DDS::Security::DomainId_t> DomainIdSet;
+
+/**
+ * Convert a node that's a DomainIdSet in the permissions and governance XML
+ * Schema in the security spec to a std::set of domain ids.
+ */
+OpenDDS_Security_Export
+bool to_domain_id_set(const xercesc::DOMNode* node, DomainIdSet& domain_id_set);
+
+inline bool is_element(const xercesc::DOMNode* node)
+{
+  return node->getNodeType() == xercesc::DOMNode::ELEMENT_NODE;
+}
+
+} // namespace XMLUtils
+} // namespace Security
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif

--- a/dds/DCPS/security/AccessControl/XmlUtils.h
+++ b/dds/DCPS/security/AccessControl/XmlUtils.h
@@ -6,12 +6,12 @@
 #ifndef OPENDDS_DCPS_SECURITY_ACCESS_CONTROL_XML_UTILS_H
 #define OPENDDS_DCPS_SECURITY_ACCESS_CONTROL_XML_UTILS_H
 
+#include "DomainIdSet.h"
+
 #include <dds/Versioned_Namespace.h>
 #include <dds/DCPS/SafetyProfileStreams.h>
 #include <dds/DCPS/unique_ptr.h>
 #include <dds/DCPS/security/OpenDDS_Security_Export.h>
-
-#include <dds/DdsSecurityCoreC.h>
 
 #include <ace/XML_Utils/XercesString.h>
 
@@ -20,7 +20,7 @@
 #include <xercesc/parsers/XercesDOMParser.hpp>
 
 #include <string>
-#include <set>
+#include <ctime>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -31,23 +31,23 @@ namespace XmlUtils {
 typedef DCPS::unique_ptr<xercesc::XercesDOMParser> ParserPtr;
 
 OpenDDS_Security_Export
-ParserPtr get_parser(const std::string& xml, const std::string& filename);
+ParserPtr get_parser(const std::string& filename, const std::string& xml);
 
 OpenDDS_Security_Export
 std::string to_string(const XMLCh* in);
 
 OpenDDS_Security_Export
-bool to_bool(const XMLCh* in, bool& value);
+bool parse_bool(const XMLCh* in, bool& value);
 
 OpenDDS_Security_Export
-bool to_time(const XMLCh* in, time_t& value);
+bool parse_time(const XMLCh* in, time_t& value);
 
 inline std::string to_string(const xercesc::XMLException& ex)
 {
   std::string msg = to_string(ex.getMessage());
   const std::string filename = ex.getSrcFile();
   if (filename.size()) {
-    msg = filename + ":" + DCPS::to_dds_string(ex.getSrcLine());
+    msg = filename + ":" + DCPS::to_dds_string(ex.getSrcLine()) + ": " + msg;
   }
   return msg;
 }
@@ -62,24 +62,22 @@ inline std::string to_string(const xercesc::DOMNode* node)
   return to_string(node->getTextContent());
 }
 
-inline bool to_bool(const xercesc::DOMNode* node, bool& value)
+inline bool parse_bool(const xercesc::DOMNode* node, bool& value)
 {
-  return to_bool(node->getTextContent(), value);
+  return parse_bool(node->getTextContent(), value);
 }
 
-inline bool to_time(const xercesc::DOMNode* node, time_t& value)
+inline bool parse_time(const xercesc::DOMNode* node, time_t& value)
 {
-  return to_time(node->getTextContent(), value);
+  return parse_time(node->getTextContent(), value);
 }
-
-typedef std::set<DDS::Security::DomainId_t> DomainIdSet;
 
 /**
  * Convert a node that's a DomainIdSet in the permissions and governance XML
  * Schema in the security spec to a std::set of domain ids.
  */
 OpenDDS_Security_Export
-bool to_domain_id_set(const xercesc::DOMNode* node, DomainIdSet& domain_id_set);
+bool parse_domain_id_set(const xercesc::DOMNode* node, Security::DomainIdSet& domain_id_set);
 
 inline bool is_element(const xercesc::DOMNode* node)
 {

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -343,7 +343,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_id)) {
+    if (giter->domains.has(domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -392,7 +392,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_id)) {
+    if (giter->domains.has(domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -455,7 +455,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_id)) {
+    if (giter->domains.has(domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -523,7 +523,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_to_find)) {
+    if (giter->domains.has(domain_to_find)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -550,7 +550,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   // Iterate over allow / deny rules
   for (perm_topic_rules_iter ptr_iter = grant->rules.begin(); ptr_iter != grant->rules.end(); ++ptr_iter) {
 
-    if (ptr_iter->domains.count(domain_to_find)) {
+    if (ptr_iter->domains.has(domain_to_find)) {
 
       perm_topic_actions_iter tpsr_iter;
       for (tpsr_iter = ptr_iter->actions.begin(); tpsr_iter != ptr_iter->actions.end(); ++tpsr_iter) {
@@ -642,7 +642,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   gov_iter end = ac_iter->second.gov->access_rules().end();
 
   for (gov_iter giter = begin; giter != end; ++giter) {
-    if (giter->domain_list.count(domain_id) && !giter->domain_attrs.is_access_protected) {
+    if (giter->domains.has(domain_id) && !giter->domain_attrs.is_access_protected) {
       return true;
     }
   }
@@ -690,7 +690,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   }
 
   for (perm_topic_rules_iter ptr_iter = grant->rules.begin(); ptr_iter != grant->rules.end(); ++ptr_iter) {
-    if (ptr_iter->domains.count(domain_id) && ptr_iter->ad_type == Permissions::ALLOW) {
+    if (ptr_iter->domains.has(domain_id) && ptr_iter->ad_type == Permissions::ALLOW) {
       return true;
     }
   }
@@ -729,7 +729,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_id)) {
+    if (giter->domains.has(domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -789,7 +789,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_id)) {
+    if (giter->domains.has(domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -890,7 +890,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(domain_id)) {
+    if (giter->domains.has(domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -916,7 +916,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   bool found_deny = false;
   for (perm_topic_rules_iter ptr_iter = grant->rules.begin(); ptr_iter != grant->rules.end(); ++ptr_iter) {
 
-    if (ptr_iter->domains.count(domain_id)) {
+    if (ptr_iter->domains.has(domain_id)) {
 
       // Iterate over pub / sub rules
       perm_topic_actions_iter tpsr_iter;
@@ -1164,7 +1164,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(ac_iter->second.domain_id)) {
+    if (giter->domains.has(ac_iter->second.domain_id)) {
       attributes = giter->domain_attrs;
       return true;
     }
@@ -1205,7 +1205,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   for (gov_iter giter = begin; giter != end; ++giter) {
 
-    if (giter->domain_list.count(piter->second.domain_id)) {
+    if (giter->domains.has(piter->second.domain_id)) {
       Governance::TopicAccessRules::iterator tr_iter;
 
       for (tr_iter = giter->topic_rules.begin(); tr_iter != giter->topic_rules.end(); ++tr_iter) {
@@ -1362,24 +1362,18 @@ CORBA::Boolean AccessControlBuiltInImpl::get_sec_attributes(::DDS::Security::Per
                                                             ::DDS::Security::EndpointSecurityAttributes & attributes,
                                                             ::DDS::Security::SecurityException & ex)
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_mutex_, 1);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_mutex_, false);
 
-  ACPermsMap::iterator ac_iter = local_ac_perms_.find(permissions_handle);
-
+  const ACPermsMap::iterator ac_iter = local_ac_perms_.find(permissions_handle);
   if (ac_iter == local_ac_perms_.end()) {
     CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::get_datawriter_sec_attributes: No matching permissions handle present");
     return false;
   }
 
-  ::DDS::Security::DomainId_t domain_to_find = ac_iter->second.domain_id;
-
-  gov_iter begin = ac_iter->second.gov->access_rules().begin();
-  gov_iter end = ac_iter->second.gov->access_rules().end();
-
+  const gov_iter begin = ac_iter->second.gov->access_rules().begin();
+  const gov_iter end = ac_iter->second.gov->access_rules().end();
   for (gov_iter giter = begin; giter != end; ++giter) {
-    size_t d = giter->domain_list.count(domain_to_find);
-
-    if (d > 0) {
+    if (giter->domains.has(ac_iter->second.domain_id)) {
       if (std::strcmp(topic_name, "DCPSParticipantVolatileMessageSecure") == 0) {
         attributes.base.is_write_protected = false;
         attributes.base.is_read_protected = false;
@@ -1510,7 +1504,7 @@ bool AccessControlBuiltInImpl::search_permissions(
   DDS::Security::SecurityException& ex)
 {
   for (Permissions::Rules::const_iterator rit = grant.rules.begin(); rit != grant.rules.end(); ++rit) {
-    if (rit->domains.count(domain_id)) {
+    if (rit->domains.has(domain_id)) {
       for (Permissions::Actions::const_iterator ait = rit->actions.begin(); ait != rit->actions.end(); ++ait) {
         if (ait->ps_type == pub_or_sub &&
             ait->topic_matches(topic_name) &&

--- a/dds/DCPS/security/AccessControlBuiltInImpl.h
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.h
@@ -237,8 +237,6 @@ public:
 
   static bool pattern_match(const char* string, const char* pattern);
 
-  static time_t convert_permissions_time(const std::string& timeString);
-
 private:
 
   AccessControlBuiltInImpl(const AccessControlBuiltInImpl&);
@@ -296,7 +294,6 @@ private:
   RevokePermissionsTask_rch& make_task(RevokePermissionsTask_rch& task);
 
   bool validate_date_time(const Permissions::Validity_t& validity,
-                          time_t& expiration,
                           DDS::Security::SecurityException& ex);
 
   bool get_sec_attributes(DDS::Security::PermissionsHandle permissions_handle,

--- a/dds/DCPS/security/SSL/SignedDocument.cpp
+++ b/dds/DCPS/security/SSL/SignedDocument.cpp
@@ -178,7 +178,7 @@ public:
     if (!store_ctx_) {
       OPENDDS_SSL_LOG_ERR("X509_STORE_CTX_new failed");
     }
-    if (reader_) {
+    if (!reader_) {
       OPENDDS_SSL_LOG_ERR("BIO_new failed");
     }
   }

--- a/dds/DCPS/security/SSL/SignedDocument.cpp
+++ b/dds/DCPS/security/SSL/SignedDocument.cpp
@@ -4,9 +4,13 @@
  */
 
 #include "SignedDocument.h"
-#include "dds/DCPS/security/CommonUtilities.h"
+
 #include "Err.h"
+
+#include <dds/DCPS/security/CommonUtilities.h>
+
 #include <openssl/pem.h>
+
 #include <cstring>
 #include <sstream>
 #include <iterator>
@@ -19,8 +23,16 @@ namespace OpenDDS {
 namespace Security {
 namespace SSL {
 
+namespace {
+  const char* const default_filename = "<no filename: not loaded>";
+  const char* const data_filename = "<no filename: data uri>";
+}
+
 SignedDocument::SignedDocument(const std::string& uri)
-  : doc_(NULL), original_(), verifiable_("")
+  : doc_(0)
+  , original_()
+  , verifiable_("")
+  , filename_(default_filename)
 {
   DDS::Security::SecurityException ex;
   if (!load(uri, ex)) {
@@ -29,18 +41,27 @@ SignedDocument::SignedDocument(const std::string& uri)
 }
 
 SignedDocument::SignedDocument()
-  : doc_(NULL), original_(), verifiable_("")
+  : doc_(0)
+  , original_()
+  , verifiable_("")
+  , filename_(default_filename)
 {
 }
 
 SignedDocument::SignedDocument(const DDS::OctetSeq& src)
-  : doc_(NULL), original_(), verifiable_("")
+  : doc_(0)
+  , original_()
+  , verifiable_("")
+  , filename_(data_filename)
 {
   deserialize(src);
 }
 
 SignedDocument::SignedDocument(const SignedDocument& rhs)
-  : doc_(NULL), original_(), verifiable_("")
+  : doc_(0)
+  , original_()
+  , verifiable_("")
+  , filename_(rhs.filename_)
 {
   if (0 < rhs.original_.length()) {
     deserialize(rhs.original_);
@@ -60,6 +81,7 @@ SignedDocument& SignedDocument::operator=(const SignedDocument& rhs)
     if (0 < rhs.original_.length()) {
       deserialize(rhs.original_);
     }
+    filename_ = rhs.filename_;
   }
   return *this;
 }
@@ -78,10 +100,12 @@ bool SignedDocument::load(const std::string& uri, DDS::Security::SecurityExcepti
   switch (uri_info.scheme) {
   case URI::URI_FILE:
     PKCS7_from_SMIME_file(uri_info.everything_else);
+    filename_ = uri_info.everything_else;
     break;
 
   case URI::URI_DATA:
     deserialize(uri_info.everything_else);
+    filename_ = data_filename;
     break;
 
   case URI::URI_PKCS11:
@@ -142,19 +166,19 @@ class verify_signature_impl
 {
 public:
   verify_signature_impl(PKCS7* doc, const std::string& content)
-    : doc_(doc),
-      content_(content),
-      store_(NULL),
-      store_ctx_(NULL),
-      reader_(NULL)
+    : doc_(doc)
+    , content_(content)
+    , store_(X509_STORE_new())
+    , store_ctx_(X509_STORE_CTX_new())
+    , reader_(BIO_new(BIO_s_mem()))
   {
-    if (NULL == (store_ = X509_STORE_new())) {
+    if (!store_) {
       OPENDDS_SSL_LOG_ERR("X509_STORE_new failed");
     }
-    if (NULL == (store_ctx_ = X509_STORE_CTX_new())) {
+    if (!store_ctx_) {
       OPENDDS_SSL_LOG_ERR("X509_STORE_CTX_new failed");
     }
-    if (NULL == (reader_ = BIO_new(BIO_s_mem()))) {
+    if (reader_) {
       OPENDDS_SSL_LOG_ERR("BIO_new failed");
     }
   }
@@ -300,7 +324,7 @@ PKCS7* SignedDocument::PKCS7_from_SMIME_file(const std::string& path)
                "(%P|%t) SignedDocument::PKCS7_from_SMIME_file:"
                "WARNING: Failed to load file '%C'; '%m'\n",
                path.c_str()));
-    return NULL;
+    return 0;
   }
 
   const std::ifstream::pos_type begin = in.tellg();
@@ -316,7 +340,7 @@ PKCS7* SignedDocument::PKCS7_from_SMIME_file(const std::string& path)
                "(%P|%t) SignedDocument::PKCS7_from_SMIME_file:"
                "WARNING: Failed to load file '%C'; '%m'\n",
                path.c_str()));
-    return NULL;
+    return 0;
   }
 
   // To appease the other DDS security implementations
@@ -332,7 +356,7 @@ PKCS7* SignedDocument::PKCS7_from_data(const DDS::OctetSeq& s_mime_data)
     ACE_ERROR((LM_WARNING,
                "(%P|%t) SignedDocument::PKCS7_from_data: "
                "WARNING: document has already been constructed\n"));
-    return NULL;
+    return 0;
   }
 
   BIO* filebuf = BIO_new(BIO_s_mem());
@@ -343,7 +367,7 @@ PKCS7* SignedDocument::PKCS7_from_data(const DDS::OctetSeq& s_mime_data)
       OPENDDS_SSL_LOG_ERR("BIO_write failed");
     }
 
-    BIO* cache_this = NULL;
+    BIO* cache_this = 0;
 
     doc_ = SMIME_read_PKCS7(filebuf, &cache_this);
 

--- a/dds/DCPS/security/SSL/SignedDocument.h
+++ b/dds/DCPS/security/SSL/SignedDocument.h
@@ -26,8 +26,8 @@ class OpenDDS_Security_Export SignedDocument {
 public:
   typedef DCPS::unique_ptr<SignedDocument> unique_ptr;
 
-  friend OpenDDS_Security_Export bool operator==(const SignedDocument& lhs,
-                                            const SignedDocument& rhs);
+  friend OpenDDS_Security_Export bool operator==(
+    const SignedDocument& lhs, const SignedDocument& rhs);
 
   explicit SignedDocument(const std::string& uri);
 
@@ -77,13 +77,16 @@ public:
    */
   int deserialize(const std::string& src);
 
- private:
+  const std::string filename() const
+  {
+    return filename_;
+  }
+
+private:
 
   bool loaded()
   {
-    return (doc_ != NULL) &&
-      (0 < original_.length()) &&
-      (0 < verifiable_.length());
+    return doc_ && original_.length() && verifiable_.length();
   }
 
   /**
@@ -100,10 +103,11 @@ public:
   PKCS7* doc_;
   DDS::OctetSeq original_;
   std::string verifiable_;
+  std::string filename_;
 };
 
-OpenDDS_Security_Export bool operator==(const SignedDocument& lhs,
-                                   const SignedDocument& rhs);
+OpenDDS_Security_Export bool operator==(
+  const SignedDocument& lhs, const SignedDocument& rhs);
 
 }  // namespace SSL
 }  // namespace Security

--- a/tests/DCPS/LargeSample/run_test.pl
+++ b/tests/DCPS/LargeSample/run_test.pl
@@ -36,7 +36,10 @@ elsif ($test->flag('multicast_async')) {
 }
 elsif ($test->flag('rtps_disc_sec')) {
   $is_rtps = 1;
-  push(@common_opts, "-DCPSConfigFile", "rtps_disc_sec.ini");
+  push(@common_opts,
+    "-DCPSConfigFile", "rtps_disc_sec.ini",
+    "-DCPSSecurityDebugLevel", "1",
+  );
 }
 push(@common_opts, "-r $reliable -w $writers_per_process -s $samples_per_writer -o $data_length_offset");
 

--- a/tests/security/permissions/generate_generic_permissions.pl
+++ b/tests/security/permissions/generate_generic_permissions.pl
@@ -30,6 +30,7 @@ my $template_after_subject = << "EOF";
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/generate_generic_permissions.pl
+++ b/tests/security/permissions/generate_generic_permissions.pl
@@ -15,6 +15,7 @@ my $permissions_ca_path = "$output_path/../certs/permissions";
 
 my $template_before_subject = << "EOF";
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -30,7 +31,9 @@ my $template_after_subject = << "EOF";
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_01.xml
+++ b/tests/security/permissions/permissions_test_participant_01.xml
@@ -10,6 +10,7 @@
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_01.xml
+++ b/tests/security/permissions/permissions_test_participant_01.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -10,7 +11,9 @@
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_01_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_01_signed.p7s
@@ -1,12 +1,13 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----D7435B11F9D47187C510A20F25B54282"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----D604FE35B79F179DDDE718F3700492B6"
 
 This is an S/MIME signed message
 
-------D7435B11F9D47187C510A20F25B54282
+------D604FE35B79F179DDDE718F3700492B6
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -18,7 +19,9 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>
@@ -36,7 +39,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------D7435B11F9D47187C510A20F25B54282
+------D604FE35B79F179DDDE718F3700492B6
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -69,16 +72,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCAK6VdMep0tHMMB
-y5bdbUjK2ZzEyjOEhShrRCfp726jijB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTIyMTIzMDNaMC8GCSqGSIb3DQEJBDEiBCBxIVob26xB4n2V
+oGTuR152XNauZXZcXrI3QJ2gmMaLgTB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQASNdttDT286XjC8QCRgk2kCBdBM70mdE3fTLtW
-NNPaYYfj3d416H/z8c7Ytx1PJaRBzd+eNc9h/mCIPTeZ/X35intw/q5arlSDHdI5
-scrlL0MVZwMsNdbqE1JdUux90o5fx1DRwEudFeVU++F+gO1SF3LJCmW94Rbm0gtv
-OidltlEXpUw7LpSB2OJWMVtpC8jPu2Iifpq35yXc2I9k8SP9LnguRm+aL9D/RKWv
-U2aLsrjywm8QC6D/Hjzk6/vJQnJhRvF69cj1jkaUheHcY5ycfy0qDm03UJ2mRAQV
-fzssk3GtegcVml9bsHthCqsPdxxv8y7o0dsbGIbkvToGw+iI
+KDANBgkqhkiG9w0BAQEFAASCAQAci5CHmXeGNHBojFDNSu2hgx7mZBYzgFukyn1W
+yWvabl4GK3l7ci9J6QuprccmLoB+4c2cdSEiceqDqz4GZlxalSBjrH5nSIU6hy6K
+LF2IoIcpX9kAP+15irJAgjH/P2zA2HQTGRLiSLeWMXTeUZwIxyHsOU0EfpJE9v7A
+TDiTwMEo/dXl6VZ4nCR8IfINhw/ShJPB0CtbvgJXGyqDFP2ZRLRcEpezBuzGIS6J
+1zT9IHawMG12htngIdFE0MPw73GbB3bFAZI3uthw0GtJd1lCvdJwxqwo1LVldma/
+6VdopGCJdMIF1O7EVcsIPFq5tjJ5K6M6DxcLeHdp70Sxt4eq
 
-------D7435B11F9D47187C510A20F25B54282--
+------D604FE35B79F179DDDE718F3700492B6--
 

--- a/tests/security/permissions/permissions_test_participant_01_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_01_signed.p7s
@@ -1,9 +1,9 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----4DBEE4FDA12E04CF3FBD9EBBB7261357"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----D7435B11F9D47187C510A20F25B54282"
 
 This is an S/MIME signed message
 
-------4DBEE4FDA12E04CF3FBD9EBBB7261357
+------D7435B11F9D47187C510A20F25B54282
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
@@ -18,6 +18,7 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>
@@ -35,7 +36,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------4DBEE4FDA12E04CF3FBD9EBBB7261357
+------D7435B11F9D47187C510A20F25B54282
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -68,16 +69,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMDA3MjIyMjM5MTRaMC8GCSqGSIb3DQEJBDEiBCArFX3REOYMM7zw
-lfjRGg5ORmDfhL6RUTXkFBuSLWXKpTB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCAK6VdMep0tHMMB
+y5bdbUjK2ZzEyjOEhShrRCfp726jijB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQBYEpKll3iSQfD8WGhV2dWGh6hOYcJ0Zwc8QZ+z
-udSRxDgJEJWBXG5bT97Qzo3yqEZwZlKT35AIVWY6DO1HgIBOxBizNAJq1vu/86vp
-6eDOvgSwvjqb7tq1NpHleW8t2krrg0Qd+0IvBmSEASZzpDYGQjURDbMStOWzjrJL
-YHqLR7VdOd8xfB6Jq0CARRJex19nkr07jvHWxLZZTChmgf9GyzJWaFtTUO4QlVs4
-IiSY/nwglFpc2X6hNP08bb/abUGRVgcSo2iNL+bkXgqCLpx3XxHWWIhwoHIuLZyz
-oD/lvdu06K3lpM8h7kcDZZVVtzKPFozEIgEhO9YEYDaCfWz1
+KDANBgkqhkiG9w0BAQEFAASCAQASNdttDT286XjC8QCRgk2kCBdBM70mdE3fTLtW
+NNPaYYfj3d416H/z8c7Ytx1PJaRBzd+eNc9h/mCIPTeZ/X35intw/q5arlSDHdI5
+scrlL0MVZwMsNdbqE1JdUux90o5fx1DRwEudFeVU++F+gO1SF3LJCmW94Rbm0gtv
+OidltlEXpUw7LpSB2OJWMVtpC8jPu2Iifpq35yXc2I9k8SP9LnguRm+aL9D/RKWv
+U2aLsrjywm8QC6D/Hjzk6/vJQnJhRvF69cj1jkaUheHcY5ycfy0qDm03UJ2mRAQV
+fzssk3GtegcVml9bsHthCqsPdxxv8y7o0dsbGIbkvToGw+iI
 
-------4DBEE4FDA12E04CF3FBD9EBBB7261357--
+------D7435B11F9D47187C510A20F25B54282--
 

--- a/tests/security/permissions/permissions_test_participant_02.xml
+++ b/tests/security/permissions/permissions_test_participant_02.xml
@@ -10,6 +10,7 @@
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_02.xml
+++ b/tests/security/permissions/permissions_test_participant_02.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -10,7 +11,9 @@
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_02_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_02_signed.p7s
@@ -1,12 +1,13 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----6799E31F7F0A9CAC79FA80B90DAA3653"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----ECA1775B3CB86020E56A7DAA139BC203"
 
 This is an S/MIME signed message
 
-------6799E31F7F0A9CAC79FA80B90DAA3653
+------ECA1775B3CB86020E56A7DAA139BC203
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -18,7 +19,9 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>
@@ -36,7 +39,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------6799E31F7F0A9CAC79FA80B90DAA3653
+------ECA1775B3CB86020E56A7DAA139BC203
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -69,16 +72,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCAjUH4MZy6nXNMW
-BNC1tF22Km1Lds5JDNIhxS0YsEfclzB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTIyMTIzMDNaMC8GCSqGSIb3DQEJBDEiBCAsrxykZ3pc2zVH
+y2M/e42W1ENP/4A3hLDrXq4ltGQhYjB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQA1qdzwErIEIhSig0eVdXyrlatVTU7HrgapVplc
-DcjqT9+nSlS72dyK9vRpbPwMcu2vvf+lUQow9C9LLNv7JHav6KCCrLLjHrNzKMnG
-+gc7d5f2ejydVvDiCO00j/vSFBP9Q5lqtuxXJXswUWV3JCpaNNX9ID0acgHGQuUD
-n/73HxgJqyNhgMoXlMPUUgIDm9vb2FLD357Ho3z2dQLNmfi0HTs33JOaK9to3J5b
-gq76nonCJ8/QGFRZqgN0fa+V/K88YNQ2cU7usWTesPQ2KpE3AHxPB0JiotALe4J6
-ghTFqn1dJxjRaNGACOBlWD09s/6D/UIF+wLD2N5MrguRG5b/
+KDANBgkqhkiG9w0BAQEFAASCAQCOmkRa4pespGd41xYIk50eKi9AlKWZ35ie8y7V
+TBRaBHFogNM+ijicSuyfcDolrsb33g5AU0fCu+pFuHkKXpX6QchTftfIMwcRvuRh
+i1wTSkPzfV+mLbR6bY/Zi+29VzYx0q90zX0IB6XMsZGJxxSlBFNF5Z9FpukC9/2e
+QsXA7VBnmriajnUbLtccdTQd6l83a57I8l812yFem34JO1TsiDTej0QC5IfLMykB
+foz8PXxsiQRGS2hLLaO16UWx6s4KWK3+h0UFJ+yrO/0mIacezPtPODXYxF46BOre
+ywwa9WfiVuyHX9e7ya6hvXkV+c+OEgQSo6TOIK/CaoulxNpu
 
-------6799E31F7F0A9CAC79FA80B90DAA3653--
+------ECA1775B3CB86020E56A7DAA139BC203--
 

--- a/tests/security/permissions/permissions_test_participant_02_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_02_signed.p7s
@@ -1,9 +1,9 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----54A0A843B7050EA907741FA33F299BFF"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----6799E31F7F0A9CAC79FA80B90DAA3653"
 
 This is an S/MIME signed message
 
-------54A0A843B7050EA907741FA33F299BFF
+------6799E31F7F0A9CAC79FA80B90DAA3653
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
@@ -18,6 +18,7 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>
@@ -35,7 +36,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------54A0A843B7050EA907741FA33F299BFF
+------6799E31F7F0A9CAC79FA80B90DAA3653
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -68,16 +69,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMDA3MjIyMjM5MTRaMC8GCSqGSIb3DQEJBDEiBCACDIK60uRVxd/Z
-UBFs8tNJpdFLza0H8W9TqihV10YamjB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCAjUH4MZy6nXNMW
+BNC1tF22Km1Lds5JDNIhxS0YsEfclzB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQBY2ONOeMmOAAxu+vK9lbKmPc/i55no4ADx8eHt
-hwOdMld0Geh+N/9yKroo+XFiqBk6FmHwswez/vKY69dmyL/wRN6IKWHCUuqY0mbz
-38K+pnLaC1VFh3vj/nHH40V10IFavuaNtIKTPTsScliB8Zr1+2YDcJB9RrZApPkm
-ZR/hmfhtM5f3j+dT+gPmUH3GJ5mUwLUoPoXqEQGwpMUaZVgeIU1ehl4R5u2qm4Xp
-k+3OjtUDomtx22lIyPg+y6v1SSFy99+NMzEG3Q5MO9Ng+HDhg0lfhk5IRUYHtF8k
-OD1cn/GLY+/SlmRT4DgLqZtE8Xmm7zACrnToRDi6/QNYME9u
+KDANBgkqhkiG9w0BAQEFAASCAQA1qdzwErIEIhSig0eVdXyrlatVTU7HrgapVplc
+DcjqT9+nSlS72dyK9vRpbPwMcu2vvf+lUQow9C9LLNv7JHav6KCCrLLjHrNzKMnG
++gc7d5f2ejydVvDiCO00j/vSFBP9Q5lqtuxXJXswUWV3JCpaNNX9ID0acgHGQuUD
+n/73HxgJqyNhgMoXlMPUUgIDm9vb2FLD357Ho3z2dQLNmfi0HTs33JOaK9to3J5b
+gq76nonCJ8/QGFRZqgN0fa+V/K88YNQ2cU7usWTesPQ2KpE3AHxPB0JiotALe4J6
+ghTFqn1dJxjRaNGACOBlWD09s/6D/UIF+wLD2N5MrguRG5b/
 
-------54A0A843B7050EA907741FA33F299BFF--
+------6799E31F7F0A9CAC79FA80B90DAA3653--
 

--- a/tests/security/permissions/permissions_test_participant_03.xml
+++ b/tests/security/permissions/permissions_test_participant_03.xml
@@ -10,6 +10,7 @@
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_03.xml
+++ b/tests/security/permissions/permissions_test_participant_03.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -10,7 +11,9 @@
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_03_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_03_signed.p7s
@@ -1,9 +1,9 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----6F4BAE1BB8BEF9773EDB689344D28ACF"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----863F7298F0AB3DE997C4F4A93EBDAF55"
 
 This is an S/MIME signed message
 
-------6F4BAE1BB8BEF9773EDB689344D28ACF
+------863F7298F0AB3DE997C4F4A93EBDAF55
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
@@ -18,6 +18,7 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>
@@ -35,7 +36,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------6F4BAE1BB8BEF9773EDB689344D28ACF
+------863F7298F0AB3DE997C4F4A93EBDAF55
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -68,16 +69,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMDA3MjIyMjM5MTRaMC8GCSqGSIb3DQEJBDEiBCD00ZPcGLmDlH9e
-lIEuFPQ2mxlHUjAknWNnV84z7YMlczB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCAh0jzLKDkuTznB
+zDdQqwDMeyernN/OXBFPWBOFaJd91zB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQCG49qG4QdjH8YSpfEeRRtA7TFuEyaDeO/5mV16
-vBhNC5mqp5Obu30o/gDhIba/Q7I0LioympNexcTQ1Fymilh2GlEOpA0pAHtM297s
-dULdXWwqy1mqN1equ+Rb5YrpuB+IHiLAspLQoHWpTcKG6SajpVy7Oq/+BKvduoU/
-zqoihLhRiQH0Q+6Apf8Y+oHXBK9EWnXHPdu1+rP6g9IlnHej0c1pyMSm0XePozL6
-ru/Y8vo8kdp87tgxyHE4Qi8k4lxr1UC5xfliq3iPufIMLfao1y3nGZ/sjfYgUpDu
-YQwIq+Et7wrO1D6FfBpq9QGsfRCEl+hqdHx3/g7CrfnwafDH
+KDANBgkqhkiG9w0BAQEFAASCAQCP7ZFpsg2Ohu9iJmSfb6IHsnnx7z+iMTLbUZHx
+9DFHwRykqnZvtzAxzV/f5EiA50bETRemB7WNRy2mM9873k0RR2bT/TJKY8ppX7br
+U5CXMhL3esy1td1rgWmJToFTCiK9nsehvazzP++bdzN2HHN+2TGI1MNNUomx/Uar
+3TVpAuZTDNsblGJkeJv6lynIakcmjgbtRRcy483Qx+XCsw7YxK9u/a+gQDnfbioa
+evZfOsFSLd7Pt/+kxeFe3se1vrGVRKJLV9cdu1AGyWZcofQhZmdBxBd9o8zyNTt/
+/1WDl/2KIUGInlShVduNM0GiZR7176ROzLL1X5C576ycaUND
 
-------6F4BAE1BB8BEF9773EDB689344D28ACF--
+------863F7298F0AB3DE997C4F4A93EBDAF55--
 

--- a/tests/security/permissions/permissions_test_participant_03_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_03_signed.p7s
@@ -1,12 +1,13 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----863F7298F0AB3DE997C4F4A93EBDAF55"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----BB16FD54D98323BA0C88E65FBC7C2FEA"
 
 This is an S/MIME signed message
 
-------863F7298F0AB3DE997C4F4A93EBDAF55
+------BB16FD54D98323BA0C88E65FBC7C2FEA
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -18,7 +19,9 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>
@@ -36,7 +39,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------863F7298F0AB3DE997C4F4A93EBDAF55
+------BB16FD54D98323BA0C88E65FBC7C2FEA
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -69,16 +72,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCAh0jzLKDkuTznB
-zDdQqwDMeyernN/OXBFPWBOFaJd91zB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTIyMTIzMDNaMC8GCSqGSIb3DQEJBDEiBCCgeYj1SCmv72dw
+axBtGjxvbZIlw1BLWsB2uPBhUWnuAzB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQCP7ZFpsg2Ohu9iJmSfb6IHsnnx7z+iMTLbUZHx
-9DFHwRykqnZvtzAxzV/f5EiA50bETRemB7WNRy2mM9873k0RR2bT/TJKY8ppX7br
-U5CXMhL3esy1td1rgWmJToFTCiK9nsehvazzP++bdzN2HHN+2TGI1MNNUomx/Uar
-3TVpAuZTDNsblGJkeJv6lynIakcmjgbtRRcy483Qx+XCsw7YxK9u/a+gQDnfbioa
-evZfOsFSLd7Pt/+kxeFe3se1vrGVRKJLV9cdu1AGyWZcofQhZmdBxBd9o8zyNTt/
-/1WDl/2KIUGInlShVduNM0GiZR7176ROzLL1X5C576ycaUND
+KDANBgkqhkiG9w0BAQEFAASCAQBvATXp6qJ7WO55pRpyh6juLxOL5p+eE7n2S6W5
+lL4Qq4UxLQkQ+5YknY2UwciZX2gbY6ShA7StVCrASkPtYPeixYGHGNE7W+sqE7KY
+JN5aZ05fefdj9js0RQr3ST/oJ/SJBbHFSt2SUSlBSWmCKlHQiI/CHMcTh/xgO0Gz
+aPeKMkwerm3LaNBQQWiwjfHH4Ltu3PDEjBM5bKRGZ+FtDiRbV6yo7NszjPOy1TCL
+bqcB7kYjVig5ohTay6yWIkS138ZdTioajsVFcvRlMT76jAa5dIz1XlOUP1yxhYq2
+5/i0yxkgop22sP/e/y/a/w5pwA7fNrSzxIrqnqCdoBKzhElw
 
-------863F7298F0AB3DE997C4F4A93EBDAF55--
+------BB16FD54D98323BA0C88E65FBC7C2FEA--
 

--- a/tests/security/permissions/permissions_test_participant_04.xml
+++ b/tests/security/permissions/permissions_test_participant_04.xml
@@ -10,6 +10,7 @@
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_04.xml
+++ b/tests/security/permissions/permissions_test_participant_04.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -10,7 +11,9 @@
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>

--- a/tests/security/permissions/permissions_test_participant_04_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_04_signed.p7s
@@ -1,9 +1,9 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----FA1BA4E020EDAD4066F5D05FDAE043E1"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----7ACCE4FB48EFF283DAC6CD56873784FA"
 
 This is an S/MIME signed message
 
-------FA1BA4E020EDAD4066F5D05FDAE043E1
+------7ACCE4FB48EFF283DAC6CD56873784FA
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
@@ -18,6 +18,7 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
+          <min>0</min>
         </domains>
         <publish>
           <topics>
@@ -35,7 +36,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------FA1BA4E020EDAD4066F5D05FDAE043E1
+------7ACCE4FB48EFF283DAC6CD56873784FA
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -68,16 +69,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMDA3MjIyMjM5MTRaMC8GCSqGSIb3DQEJBDEiBCCaUnBmNkpk5GaI
-e5/EIeB/ds+cYJ53sfJJdNuQaFn88TB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCC3mKbguqsllSLl
+bywmxh5Adc1lR+U2t0KdBxpzQaotHDB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQAxYmXSeKx9Cbw2Xbu5p1YMzvjZvVELIrR0N5tE
-dKVZQyFn/IPLH9ImfBEWWD2ZNxFSeHNYJZWLbBzNPMAFZX0VOkK/fWcPma9Lc5yv
-+4rXdUUMxGRVvC81k1TlYsBr+8WIS6J7na6vxO5y1x6+j+t8X2keAlml12Rzhl4A
-5jDPXoTj2qiHrn3w1UVrO0oBuRtU04sX4MGkXM66uAJ3UAi2DG2U52OU3eI8n61i
-RiDgTEKX6WqRE9Eo/C4BZ0VmE1dN6vs42OosojwCeb84T+rPidUkwAO/93Och21o
-5zPzmhwN7902z3RXZBrphcRcOmDJ4d7MR26Q40E4/L4nGvm4
+KDANBgkqhkiG9w0BAQEFAASCAQCGUlV11nWLFAsVQXt4Fg3R3Ox/8xwSZbOMzzHQ
+6h4ydsFXOfDeUg7ZGezcMWz2NsRlBdtKijTSqIEtOqKr/OzTVIsnUWKxjiuynMpM
+mluC7SYZIjpZl24Jh41h+8xVjo6SkujxlB31cpjeIHo+RC7LKwcpBXEuz/PWOi2p
+rL7IJ2jGUNa+cdQIbt1Jyl6B3FNTY4xcs8RloIJ+0s5gKsHphqVfdDMQWUx8UWGx
+sPLpk4c9S6MDkZHBZXxhehTXDrTruGvcgzjgqEVQpwsfWrWa9rO0F10rHdS9GYEE
+eDm8nLhyc30fFKlCv6y6mvtGVMoo2+84+a5ffxHB9+6yZ3/G
 
-------FA1BA4E020EDAD4066F5D05FDAE043E1--
+------7ACCE4FB48EFF283DAC6CD56873784FA--
 

--- a/tests/security/permissions/permissions_test_participant_04_signed.p7s
+++ b/tests/security/permissions/permissions_test_participant_04_signed.p7s
@@ -1,12 +1,13 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----7ACCE4FB48EFF283DAC6CD56873784FA"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----51A0F92D74DC85CBD52BA03C779020F4"
 
 This is an S/MIME signed message
 
-------7ACCE4FB48EFF283DAC6CD56873784FA
+------51A0F92D74DC85CBD52BA03C779020F4
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Don't edit and sign these by hand, edit and run generate_generic_permissions.pl! -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20160303/omg_shared_ca_permissions.xsd">
   <permissions>
     <grant name="TheGrant">
@@ -18,7 +19,9 @@ Content-Type: text/plain
       </validity>
       <allow_rule>
         <domains>
-          <min>0</min>
+          <id_range>
+            <min>0</min>
+          </id_range>
         </domains>
         <publish>
           <topics>
@@ -36,7 +39,7 @@ Content-Type: text/plain
   </permissions>
 </dds>
 
-------7ACCE4FB48EFF283DAC6CD56873784FA
+------51A0F92D74DC85CBD52BA03C779020F4
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
@@ -69,16 +72,16 @@ T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
 Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
 hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
 hkgBZQMEAgEFAKCB5DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcNAQcBMBwGCSqGSIb3
-DQEJBTEPFw0yMTA4MTAxODQyNThaMC8GCSqGSIb3DQEJBDEiBCC3mKbguqsllSLl
-bywmxh5Adc1lR+U2t0KdBxpzQaotHDB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
+DQEJBTEPFw0yMTA4MTIyMTIzMDNaMC8GCSqGSIb3DQEJBDEiBCCS4fmwkszdnB98
+0DGlbLxWTFgSfuwVX4EQq+ZxWND97jB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
 AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
 SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASCAQCGUlV11nWLFAsVQXt4Fg3R3Ox/8xwSZbOMzzHQ
-6h4ydsFXOfDeUg7ZGezcMWz2NsRlBdtKijTSqIEtOqKr/OzTVIsnUWKxjiuynMpM
-mluC7SYZIjpZl24Jh41h+8xVjo6SkujxlB31cpjeIHo+RC7LKwcpBXEuz/PWOi2p
-rL7IJ2jGUNa+cdQIbt1Jyl6B3FNTY4xcs8RloIJ+0s5gKsHphqVfdDMQWUx8UWGx
-sPLpk4c9S6MDkZHBZXxhehTXDrTruGvcgzjgqEVQpwsfWrWa9rO0F10rHdS9GYEE
-eDm8nLhyc30fFKlCv6y6mvtGVMoo2+84+a5ffxHB9+6yZ3/G
+KDANBgkqhkiG9w0BAQEFAASCAQAdbEB/x3rDV1aHDe7UdfmOWexAJXrCDSgD5klZ
+GaiHwmQoOUTCh/F0oYOfBls5U3NlyIM4RC5yqlNaXy5KxKwzkjc4MU0kT3JP0pJp
+hWrpyexI27oxDSBIeGis6HfMdZdgAOayK0ObrENujDz3JcVUKn+gxarl08x9KE+c
+rdoX7m2scKII4fqazuOSjBsNOprjVfmoPZ9RXGgCIsT5XqLo3smEjRQ7apBELAkS
+DZ/p8bCyOhcavgDzF9qWUCHrej/xTZICVd2zc/ynfU2EBxTMPnHF7dyWX5UWhpfu
+8xSV5OfCXE3GYKbUWgkw+rdj4cULC13PLrE/4HNjm8fWKbgZ
 
-------7ACCE4FB48EFF283DAC6CD56873784FA--
+------51A0F92D74DC85CBD52BA03C779020F4--
 

--- a/tests/security/schema/omg_shared_ca_governance.xsd
+++ b/tests/security/schema/omg_shared_ca_governance.xsd
@@ -1,0 +1,120 @@
+<!-- This is a modified version of the schema from the spec. See BooleanKind for details. -->
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <xs:element name="dds" type="DomainAccessRulesNode" />
+
+    <xs:complexType name="DomainAccessRulesNode">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="domain_access_rules" type="DomainAccessRules" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DomainAccessRules">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="domain_rule" type="DomainRule" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DomainRule">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <!-- DDSSEC-75 -->
+            <xs:element name="domains" type="DomainIdSet" />
+            <xs:element name="allow_unauthenticated_participants" type="BooleanKind" />
+            <xs:element name="enable_join_access_control" type="BooleanKind" />
+            <xs:element name="discovery_protection_kind" type="ProtectionKind" />
+            <xs:element name="liveliness_protection_kind" type="ProtectionKind" />
+            <xs:element name="rtps_protection_kind" type="ProtectionKind" />
+            <xs:element name="topic_access_rules" type="TopicAccessRules" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- DDSSEC-75 -->
+    <xs:complexType name="DomainIdSet">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="id" type="DomainId" />
+            <xs:element name="id_range" type="DomainIdRange" />
+        </xs:choice>
+    </xs:complexType>
+
+    <!-- DDSSEC-75 -->
+    <xs:simpleType name="DomainId">
+        <xs:restriction base="xs:nonNegativeInteger" />
+    </xs:simpleType>
+
+    <!-- DDSSEC-75 -->
+    <xs:complexType name="DomainIdRange">
+      <!-- DDSSEC-130 -->
+      <xs:choice>
+          <xs:sequence>
+              <xs:element name="min" type="DomainId" />
+              <xs:element name="max" type="DomainId" minOccurs="0" />
+          </xs:sequence>
+          <xs:element name="max" type="DomainId" />
+      </xs:choice>
+    </xs:complexType>
+
+    <!-- DDSSEC11-11 -->
+    <xs:simpleType name="ProtectionKind">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ENCRYPT_WITH_ORIGIN_AUTHENTICATION" />
+            <xs:enumeration value="SIGN_WITH_ORIGIN_AUTHENTICATION" />
+            <xs:enumeration value="ENCRYPT" />
+            <xs:enumeration value="SIGN" />
+            <xs:enumeration value="NONE" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- DDSSEC11-11 -->
+    <xs:simpleType name="BasicProtectionKind">
+        <xs:restriction base="ProtectionKind">
+            <xs:enumeration value="ENCRYPT" />
+            <xs:enumeration value="SIGN" />
+            <xs:enumeration value="NONE" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--
+      Orignally the spec just had BooleanKind with TRUE and FALSE, but this was
+      latter replaced with xs:boolean. However we still have to accept those
+      values, so this is the original type that includes the possible values
+      from xs:boolean.
+    -->
+    <xs:simpleType name="BooleanKind">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="TRUE" />
+            <xs:enumeration value="FALSE" />
+            <xs:enumeration value="true" />
+            <xs:enumeration value="false" />
+            <xs:enumeration value="1" />
+            <xs:enumeration value="0" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="TopicAccessRules">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="topic_rule" type="TopicRule" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TopicRule">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="topic_expression" type="TopicExpression" />
+            <xs:element name="enable_discovery_protection" type="BooleanKind" />
+            <!-- DDSSEC11-85 -->
+            <xs:element name="enable_liveliness_protection" type="BooleanKind" />
+            <xs:element name="enable_read_access_control" type="BooleanKind" />
+            <xs:element name="enable_write_access_control" type="BooleanKind" />
+            <xs:element name="metadata_protection_kind" type="ProtectionKind" />
+            <!-- DDSSEC11-11 -->
+            <xs:element name="data_protection_kind" type="BasicProtectionKind" />
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <xs:simpleType name="TopicExpression">
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+
+</xs:schema>

--- a/tests/security/schema/omg_shared_ca_permissions.xsd
+++ b/tests/security/schema/omg_shared_ca_permissions.xsd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <xs:element name="dds" type="PermissionsNode" />
+    <xs:complexType name="PermissionsNode">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="permissions" type="Permissions" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Permissions">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="grant" type="Grant" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Grant">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="subject_name" type="xs:string" />
+            <xs:element name="validity" type="Validity" />
+            <xs:sequence minOccurs="1" maxOccurs="unbounded">
+                <xs:choice minOccurs="1" maxOccurs="1">
+                    <xs:element name="allow_rule" minOccurs="0" type="Rule" />
+                    <xs:element name="deny_rule" minOccurs="0" type="Rule" />
+                </xs:choice>
+            </xs:sequence>
+            <xs:element name="default" type="DefaultAction" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="Validity">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="not_before" type="xs:dateTime" />
+            <xs:element name="not_after" type="xs:dateTime" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Rule">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="domains" type="DomainIdSet" />
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="publish" type="Criteria" />
+            </xs:sequence>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="subscribe" type="Criteria" />
+            </xs:sequence>
+             <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="relay" type="Criteria" />
+            </xs:sequence>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DomainIdSet">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="id" type="DomainId" />
+            <xs:element name="id_range" type="DomainIdRange" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:simpleType name="DomainId">
+        <xs:restriction base="xs:nonNegativeInteger" />
+    </xs:simpleType>
+
+    <xs:complexType name="DomainIdRange">
+        <xs:choice> <!-- DDSSEC-134 -->
+            <xs:sequence>
+                <xs:element name="min" type="DomainId" />
+                <xs:element name="max" type="DomainId" minOccurs="0" />
+            </xs:sequence>
+            <xs:element name="max" type="DomainId" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="Criteria">
+        <xs:all minOccurs="1">
+            <!-- DDSSEC11-56 -->
+            <xs:element name="topics" minOccurs="1" type="TopicExpressionList" />
+            <xs:element name="partitions" minOccurs="0" type="PartitionExpressionList" />
+            <xs:element name="data_tags" minOccurs="0" type="DataTags" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="TopicExpressionList">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="topic" type="TopicExpression" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PartitionExpressionList">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="partition" type="PartitionExpression" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="TopicExpression">
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+
+    <xs:simpleType name="PartitionExpression">
+        <xs:restriction base="xs:string" />
+    </xs:simpleType>
+
+    <xs:complexType name="DataTags">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="tag" type="TagNameValuePair" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="TagNameValuePair">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="name" type="xs:string" />
+            <xs:element name="value" type="xs:string" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="DefaultAction">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ALLOW" />
+            <xs:enumeration value="DENY" />
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/tests/security/security_tests.lst
+++ b/tests/security/security_tests.lst
@@ -62,5 +62,5 @@ tests/DCPS/ParticipantLocationTopic/run_test.pl noice:      !DCPS_MIN CXX11 RTPS
 tests/DCPS/ParticipantLocationTopic/run_test.pl noice ipv6: !DCPS_MIN CXX11 RTPS !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE IPV6 RAPIDJSON !GH_ACTIONS
 
 tests/DCPS/Restart/run_test.pl --secure: !GH_ACTIONS
-tests/DCPS/LargeSample/run_test.pl rtps_disc_sec: !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/LargeSample/run_test.pl rtps_disc_sec: !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/XTypes/run_test.pl --secure

--- a/tests/unit-tests/dds/DCPS/DisjointSequence.cpp
+++ b/tests/unit-tests/dds/DCPS/DisjointSequence.cpp
@@ -993,3 +993,34 @@ TEST(DisjointSequence, maintest)
     EXPECT_TRUE(ir.has(8));
   }
 }
+
+TEST(DisjointSequence_OrderedRanges, insert_out_of_order)
+{
+  typedef DisjointSequence::OrderedRanges<int> IntRanges;
+
+  IntRanges ir;
+  ir.add(1);
+  ir.add(4);
+  ir.add(2);
+  EXPECT_TRUE(ir.has(1, 2));
+  EXPECT_TRUE(!ir.has(3));
+  EXPECT_TRUE(ir.has(4));
+  EXPECT_EQ(ir.size(), 2UL);
+}
+
+TEST(DisjointSequence_OrderedRanges, insert_ranges)
+{
+  typedef DisjointSequence::OrderedRanges<int> IntRanges;
+
+  IntRanges ir;
+  ir.add(1, 2);
+  ir.add(4);
+  ir.add(6, 9);
+  ir.add(13);
+  ir.add(3, 8);
+  ir.add(11, 12);
+  EXPECT_TRUE(ir.has(1, 9));
+  EXPECT_TRUE(!ir.has(10));
+  EXPECT_TRUE(ir.has(11, 13));
+  EXPECT_EQ(ir.size(), 2UL);
+}

--- a/tests/unit-tests/dds/DCPS/DisjointSequence.cpp
+++ b/tests/unit-tests/dds/DCPS/DisjointSequence.cpp
@@ -21,7 +21,7 @@ TEST(DisjointSequence, maintest)
     EXPECT_TRUE(sequence.empty());
 
     // ASSERT sequence is not disjoint:
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
   }
 
   // Insert single value
@@ -37,10 +37,10 @@ TEST(DisjointSequence, maintest)
     EXPECT_TRUE(sequence.low() == sequence.high());
 
     // ASSERT sequence is not disjoint:
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
 
     // ASSERT sequence is not empty:
-    EXPECT_TRUE(!sequence.empty());
+    EXPECT_FALSE(sequence.empty());
   }
 
   // Skipping values
@@ -61,7 +61,7 @@ TEST(DisjointSequence, maintest)
     EXPECT_TRUE(sequence.low() == sequence.high());
 
     // ASSERT sequence is not disjoint:
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
   }
 
   // Updating values
@@ -74,7 +74,7 @@ TEST(DisjointSequence, maintest)
 
     EXPECT_TRUE(sequence.cumulative_ack() == SequenceNumber(2));
     EXPECT_TRUE(sequence.cumulative_ack() == sequence.high());
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
 
     // ASSERT insert of value > low + 1 creates discontiguity:
     sequence.reset();
@@ -102,18 +102,18 @@ TEST(DisjointSequence, maintest)
     EXPECT_TRUE(sequence.last_ack() == SequenceNumber(3));
     EXPECT_TRUE(sequence.disjoint());
     EXPECT_TRUE(sequence.contains(1));
-    EXPECT_TRUE(!sequence.contains(2));
+    EXPECT_FALSE(sequence.contains(2));
     EXPECT_TRUE(sequence.contains(3));
     EXPECT_TRUE(sequence.contains(4));
     EXPECT_TRUE(sequence.contains(5));
     EXPECT_TRUE(sequence.contains(6));
-    EXPECT_TRUE(!sequence.contains(7));
+    EXPECT_FALSE(sequence.contains(7));
 
     sequence.insert(2);
 
     EXPECT_TRUE(sequence.cumulative_ack() == SequenceNumber(6));
     EXPECT_TRUE(sequence.high() == SequenceNumber(6));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
 
     // ASSERT insert of low + 1 updates the cumulative_ack
     //        and preserves existing discontiguities:
@@ -246,7 +246,7 @@ TEST(DisjointSequence, maintest)
     DisjointSequence sequence;
     sequence.insert(SequenceRange(3, 5));
     sequence.insert(SequenceRange(2, 4));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 2);
     EXPECT_TRUE(sequence.high() == 5);
   }
@@ -254,7 +254,7 @@ TEST(DisjointSequence, maintest)
     DisjointSequence sequence;
     SequenceNumber zero = SequenceNumber::ZERO();
     sequence.insert(SequenceRange(zero, zero));
-    EXPECT_TRUE(!sequence.empty() && !sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && !sequence.disjoint());
     EXPECT_TRUE(zero == sequence.low() && zero == sequence.high());
     sequence.insert(2);
     OPENDDS_VECTOR(SequenceRange) ranges = sequence.missing_sequence_ranges();
@@ -263,11 +263,11 @@ TEST(DisjointSequence, maintest)
     sequence.reset();
     sequence.insert(SequenceRange(zero, zero));
     sequence.insert(SequenceRange(1, 2));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     sequence.reset();
     sequence.insert(SequenceRange(1, 2));
     sequence.insert(SequenceRange(zero, zero));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
   }
   {
     DisjointSequence sequence;
@@ -306,7 +306,7 @@ TEST(DisjointSequence, maintest)
 
     OPENDDS_VECTOR(SequenceRange) dropped;
     EXPECT_TRUE(sequence.insert(SequenceRange(sequence.low(), 12), dropped));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     EXPECT_TRUE(dropped.size() == 3);
     EXPECT_TRUE(dropped[0] == SequenceRange(3, 4));
     EXPECT_TRUE(dropped[1] == SequenceRange(7, 8));
@@ -377,21 +377,21 @@ TEST(DisjointSequence, maintest)
     DisjointSequence sequence;
     ACE_CDR::Long bits[] = { 3 << 30 }; // high bit is logical index '0'
     EXPECT_TRUE(sequence.insert(0, 2 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.empty() && !sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && !sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 0 && sequence.high() == 1);
   }
   {
     DisjointSequence sequence;
     ACE_CDR::Long bits[] = { 3 << 29 }; // high bit is logical index '0'
     EXPECT_TRUE(sequence.insert(0, 3 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.empty() && !sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && !sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 1 && sequence.high() == 2);
   }
   {
     DisjointSequence sequence;
     ACE_CDR::Long bits[] = { 1 << 31 }; // high bit is logical index '0'
     EXPECT_TRUE(sequence.insert(5, 1 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.empty() && !sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && !sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 5 && sequence.high() == 5);
   }
   {
@@ -399,7 +399,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(3);
     ACE_CDR::Long bits[] = { 1 << 31 }; // high bit is logical index '0'
     EXPECT_TRUE(sequence.insert(5, 1 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.empty() && sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 3 && sequence.high() == 5);
 
     ACE_CDR::Long bitmap; // 4:2/01 = (5,5)
@@ -414,7 +414,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(7);
     ACE_CDR::Long bits[] = { 1 << 31 }; // high bit is logical index '0'
     EXPECT_TRUE(sequence.insert(5, 1 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.empty() && sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 3 && sequence.high() == 7);
     EXPECT_TRUE(sequence.present_sequence_ranges()[1] == SequenceRange(5, 5));
 
@@ -435,7 +435,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(3);
     ACE_CDR::Long bits[] = { (1 << 31) | (1 << 29) };
     EXPECT_TRUE(sequence.insert(5, 12 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.empty() && sequence.disjoint());
+    EXPECT_FALSE(sequence.empty() && sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 3 && sequence.high() == 7);
     EXPECT_TRUE(sequence.present_sequence_ranges()[1] == SequenceRange(5, 5));
   }
@@ -444,7 +444,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(4);
     ACE_CDR::Long bits[] = { (1 << 31) | (1 << 30) };
     EXPECT_TRUE(sequence.insert(5, 12 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 4 && sequence.high() == 6);
   }
   {
@@ -454,7 +454,7 @@ TEST(DisjointSequence, maintest)
     ACE_CDR::Long bits[] = { (1 << 30) | (1 << 29) | (1 << 28) |
                              (1 << 27) | (1 << 26) }; // 1/6:011111 = (2,6)
     EXPECT_TRUE(sequence.insert(1, 6 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 2 && sequence.high() == 6);
   }
   {
@@ -488,7 +488,7 @@ TEST(DisjointSequence, maintest)
     ACE_CDR::Long bits[] = { (1 << 30) | (1 << 29) | (1 << 28) |
                              (1 << 27) | (1 << 26) }; // 4/6:011111 = (5,9)
     EXPECT_TRUE(sequence.insert(4, 6 /*num_bits*/, bits));
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 3 && sequence.high() == 10);
   }
   {
@@ -497,7 +497,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(SequenceRange(8, 10));
     ACE_CDR::Long bits[] = { (1 << 30) | (1 << 29) | (1 << 28) };
     EXPECT_TRUE(sequence.insert(4, 4 /*num_bits*/, bits)); // 4/4:0111 = (5,7)
-    EXPECT_TRUE(!sequence.disjoint());
+    EXPECT_FALSE(sequence.disjoint());
     EXPECT_TRUE(sequence.low() == 3 && sequence.high() == 10);
   }
   {
@@ -515,7 +515,7 @@ TEST(DisjointSequence, maintest)
     ACE_CDR::ULong num_bits;
     EXPECT_TRUE(sequence.to_bitmap(bitmap, 2, num_bits));
     EXPECT_TRUE(num_bits == 37);
-    EXPECT_TRUE(!bitmap[0] && ((bitmap[1] & 0xF8000000) == 0xF8000000));
+    EXPECT_FALSE(bitmap[0] && ((bitmap[1] & 0xF8000000) == 0xF8000000));
 
     ACE_CDR::Long anti_bitmap; // 4:32/{32x1} = (4,35)
     ACE_CDR::ULong anti_num_bits;
@@ -555,7 +555,7 @@ TEST(DisjointSequence, maintest)
     ACE_CDR::Long anti_bitmap[] = { 0x55555555, 0x55555555 }; // 2:61/101010...
     ACE_CDR::ULong anti_num_bits;
     // doesn't fit in 1 Long, verify that it returns false
-    EXPECT_TRUE(!sequence.to_bitmap(anti_bitmap, 1, anti_num_bits, true));
+    EXPECT_FALSE(sequence.to_bitmap(anti_bitmap, 1, anti_num_bits, true));
     EXPECT_TRUE(sequence.to_bitmap(anti_bitmap, 2, anti_num_bits, true));
     EXPECT_TRUE(anti_num_bits == 61);
     EXPECT_TRUE(static_cast<unsigned int>(anti_bitmap[0]) == 0xAAAAAAAA);
@@ -716,7 +716,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(SequenceRange(32 + 63, 32 + 66));
     ACE_CDR::Long bitmap[2];
     ACE_CDR::ULong num_bits;
-    EXPECT_TRUE(!sequence.to_bitmap(bitmap, 2, num_bits));
+    EXPECT_FALSE(sequence.to_bitmap(bitmap, 2, num_bits));
     EXPECT_TRUE(num_bits == 64);
     EXPECT_TRUE(bitmap[0] == 0x003FF000);
     EXPECT_TRUE(bitmap[1] == 0x00000001);
@@ -877,7 +877,7 @@ TEST(DisjointSequence, maintest)
     sequence.insert(SequenceRange(2001, 2580));
     ACE_CDR::Long bitmap[8];
     ACE_CDR::ULong num_bits = 0;
-    EXPECT_TRUE(!sequence.to_bitmap(bitmap, 8, num_bits));
+    EXPECT_FALSE(sequence.to_bitmap(bitmap, 8, num_bits));
     EXPECT_TRUE(num_bits == 256);
     EXPECT_TRUE(bitmap[0] == 0x555557FF);
     EXPECT_TRUE(bitmap[1] == (int) 0xFFFFFFFF);
@@ -917,101 +917,110 @@ TEST(DisjointSequence, maintest)
       plain_set.erase(values[remove_idx]);
       ds_set.erase(values[remove_idx]);
       // Check.
-      EXPECT_TRUE(!ds_set.contains(values[remove_idx]));
+      EXPECT_FALSE(ds_set.contains(values[remove_idx]));
       for (std::set<SequenceNumber>::const_iterator pos = plain_set.begin(), limit = plain_set.end();
            pos != limit; ++pos) {
         EXPECT_TRUE(ds_set.contains(*pos));
       }
     }
   }
-  typedef DisjointSequence::OrderedRanges<int> IntRanges;
-  {
-    IntRanges ir;
-    ir.add(1);
-    EXPECT_TRUE(ir.has(1));
-    EXPECT_TRUE(!ir.has(2));
-
-    EXPECT_TRUE(ir.pop_front() == 1);
-    EXPECT_TRUE(ir.empty());
-
-    ir.add(3);
-    EXPECT_TRUE(ir.has(3));
-    ir.remove(3);
-    EXPECT_TRUE(ir.empty());
-
-    ir.add(3);
-    ir.add(5);
-    EXPECT_TRUE(ir.has(3));
-    EXPECT_TRUE(ir.has(5));
-    EXPECT_TRUE(ir.size() == 2);
-    ir.add(4);
-    EXPECT_TRUE(ir.has(4));
-    EXPECT_TRUE(ir.size() == 1);
-    ir.clear();
-    EXPECT_TRUE(ir.size() == 0);
-
-    ir.add(1);
-    ir.add(2);
-    EXPECT_TRUE(ir.has(1));
-    EXPECT_TRUE(ir.has(2));
-    EXPECT_TRUE(ir.size() == 1);
-    ir.clear();
-    EXPECT_TRUE(ir.size() == 0);
-
-    ir.add(2);
-    ir.add(1);
-    EXPECT_TRUE(ir.has(1));
-    EXPECT_TRUE(ir.has(2));
-    EXPECT_TRUE(ir.size() == 1);
-    ir.add(3);
-    EXPECT_TRUE(ir.has(1));
-    EXPECT_TRUE(ir.has(2));
-    EXPECT_TRUE(ir.has(3));
-    EXPECT_TRUE(ir.size() == 1);
-    ir.add(4);
-    EXPECT_TRUE(ir.has(1));
-    EXPECT_TRUE(ir.has(2));
-    EXPECT_TRUE(ir.has(3));
-    EXPECT_TRUE(ir.has(4));
-    EXPECT_TRUE(ir.size() == 1);
-    ir.add(7);
-    ir.add(8);
-    EXPECT_TRUE(ir.has(1));
-    EXPECT_TRUE(ir.has(2));
-    EXPECT_TRUE(ir.has(3));
-    EXPECT_TRUE(ir.has(4));
-    EXPECT_TRUE(ir.has(7));
-    EXPECT_TRUE(ir.has(8));
-    EXPECT_TRUE(ir.size() == 2);
-    EXPECT_TRUE(ir.pop_front() == 1);
-    EXPECT_TRUE(ir.size() == 2);
-    EXPECT_TRUE(!ir.has(1));
-    EXPECT_TRUE(ir.has(2));
-    EXPECT_TRUE(ir.has(3));
-    EXPECT_TRUE(ir.has(4));
-    EXPECT_TRUE(ir.has(7));
-    EXPECT_TRUE(ir.has(8));
-  }
 }
 
-TEST(DisjointSequence_OrderedRanges, insert_out_of_order)
-{
-  typedef DisjointSequence::OrderedRanges<int> IntRanges;
+typedef DisjointSequence::OrderedRanges<int> IntRanges;
 
+TEST(dds_DCPS_DisjointSequence, OrderedRanges_main_test)
+{
+  IntRanges ir;
+  ir.add(1);
+  EXPECT_TRUE(ir.has(1));
+  EXPECT_FALSE(ir.has(2));
+  EXPECT_FALSE(ir.empty());
+
+  EXPECT_EQ(ir.pop_front(), 1);
+  EXPECT_TRUE(ir.empty());
+
+  ir.add(3);
+  EXPECT_TRUE(ir.has(3));
+  ir.remove(3);
+  EXPECT_TRUE(ir.empty());
+
+  ir.add(3);
+  ir.add(5);
+  EXPECT_TRUE(ir.has(3));
+  EXPECT_TRUE(ir.has(5));
+  EXPECT_EQ(ir.size(), 2UL);
+  EXPECT_FALSE(ir.empty());
+  ir.add(4);
+  EXPECT_TRUE(ir.has(4));
+  EXPECT_EQ(ir.size(), 1UL);
+  EXPECT_FALSE(ir.empty());
+  ir.clear();
+  EXPECT_EQ(ir.size(), 0UL);
+  EXPECT_TRUE(ir.empty());
+
+  ir.add(1);
+  ir.add(2);
+  EXPECT_TRUE(ir.has(1));
+  EXPECT_TRUE(ir.has(2));
+  EXPECT_EQ(ir.size(), 1UL);
+  ir.clear();
+  EXPECT_EQ(ir.size(), 0UL);
+  EXPECT_TRUE(ir.empty());
+
+  ir.add(2);
+  ir.add(1);
+  EXPECT_TRUE(ir.has(1));
+  EXPECT_TRUE(ir.has(2));
+  EXPECT_EQ(ir.size(), 1UL);
+  EXPECT_FALSE(ir.empty());
+  ir.add(3);
+  EXPECT_TRUE(ir.has(1));
+  EXPECT_TRUE(ir.has(2));
+  EXPECT_TRUE(ir.has(3));
+  EXPECT_EQ(ir.size(), 1UL);
+  EXPECT_FALSE(ir.empty());
+  ir.add(4);
+  EXPECT_TRUE(ir.has(1));
+  EXPECT_TRUE(ir.has(2));
+  EXPECT_TRUE(ir.has(3));
+  EXPECT_TRUE(ir.has(4));
+  EXPECT_EQ(ir.size(), 1UL);
+  EXPECT_FALSE(ir.empty());
+  ir.add(7);
+  ir.add(8);
+  EXPECT_TRUE(ir.has(1));
+  EXPECT_TRUE(ir.has(2));
+  EXPECT_TRUE(ir.has(3));
+  EXPECT_TRUE(ir.has(4));
+  EXPECT_TRUE(ir.has(7));
+  EXPECT_TRUE(ir.has(8));
+  EXPECT_EQ(ir.size(), 2UL);
+  EXPECT_FALSE(ir.empty());
+  EXPECT_EQ(ir.pop_front(), 1);
+  EXPECT_EQ(ir.size(), 2UL);
+  EXPECT_FALSE(ir.empty());
+  EXPECT_FALSE(ir.has(1));
+  EXPECT_TRUE(ir.has(2));
+  EXPECT_TRUE(ir.has(3));
+  EXPECT_TRUE(ir.has(4));
+  EXPECT_TRUE(ir.has(7));
+  EXPECT_TRUE(ir.has(8));
+}
+
+TEST(dds_DCPS_DisjointSequence, OrderedRanges_insert_out_of_order)
+{
   IntRanges ir;
   ir.add(1);
   ir.add(4);
   ir.add(2);
   EXPECT_TRUE(ir.has(1, 2));
-  EXPECT_TRUE(!ir.has(3));
+  EXPECT_FALSE(ir.has(3));
   EXPECT_TRUE(ir.has(4));
   EXPECT_EQ(ir.size(), 2UL);
 }
 
-TEST(DisjointSequence_OrderedRanges, insert_ranges)
+TEST(dds_DCPS_DisjointSequence, OrderedRanges_insert_ranges)
 {
-  typedef DisjointSequence::OrderedRanges<int> IntRanges;
-
   IntRanges ir;
   ir.add(1, 2);
   ir.add(4);
@@ -1020,7 +1029,7 @@ TEST(DisjointSequence_OrderedRanges, insert_ranges)
   ir.add(3, 8);
   ir.add(11, 12);
   EXPECT_TRUE(ir.has(1, 9));
-  EXPECT_TRUE(!ir.has(10));
+  EXPECT_FALSE(ir.has(10));
   EXPECT_TRUE(ir.has(11, 13));
   EXPECT_EQ(ir.size(), 2UL);
 }

--- a/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
+++ b/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
@@ -1,0 +1,293 @@
+#include <dds/DCPS/security/AccessControl/XmlUtils.h>
+#include <dds/DCPS/debug.h>
+
+#include <gtest/gtest.h>
+
+using namespace OpenDDS::Security::XmlUtils;
+using XML::XStr;
+using OpenDDS::DCPS::security_debug;
+using OpenDDS::Security::DomainIdSet;
+using OpenDDS::Security::domain_id_max;
+
+TEST(XmlUtils, get_parser)
+{
+  EXPECT_FALSE(get_parser("empty string", ""));
+  EXPECT_FALSE(get_parser("invalid xml", ">What I'm writing isn't valid XML<"));
+  EXPECT_TRUE(get_parser("valid xml",
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<root>\n"
+    "  <content>Hello!</content>"
+    "</root>\n"));
+}
+
+namespace {
+  void parse_bool_checker(ParserPtr& parser, const ACE_TCHAR* tag,
+    bool expected_valid, bool expected_value = false)
+  {
+    const xercesc::DOMNodeList* const nodes =
+      parser->getDocument()->getElementsByTagName(XStr(tag));
+    const XMLSize_t count = nodes->getLength();
+    ASSERT_EQ(count, 3UL) << "node tag name is " << ACE_TEXT_ALWAYS_CHAR(tag);
+    for (XMLSize_t i = 0; i < count; ++i) {
+      const xercesc::DOMNode* const node = nodes->item(i);
+      bool value;
+      const bool valid = parse_bool(node, value);
+      EXPECT_EQ(valid, expected_valid)
+        << "node contains: \"" << to_string(node) << "\"";
+      if (expected_valid && valid) {
+        EXPECT_EQ(value, expected_value)
+          << "node contains: \"" << to_string(node) << "\"";
+      }
+    }
+  }
+}
+
+TEST(XmlUtils, parse_bool)
+{
+  ParserPtr parser = get_parser("parse_bool",
+    "<root>\n"
+    "  <invalid></invalid>\n"
+    "  <invalid>YES</invalid>\n"
+    "  <invalid>invalid</invalid>\n"
+
+    "  <true>TRUE</true>\n"
+    "  <true>true</true>\n"
+    "  <true>1</true>\n"
+
+    "  <false>FALSE</false>\n"
+    "  <false>false</false>\n"
+    "  <false>0</false>\n"
+    "</root>\n");
+  ASSERT_TRUE(parser);
+
+  parse_bool_checker(parser, ACE_TEXT("invalid"), false);
+  parse_bool_checker(parser, ACE_TEXT("true"), true, true);
+  parse_bool_checker(parser, ACE_TEXT("false"), true, false);
+}
+
+namespace {
+  void parse_time_checker(ParserPtr& parser, const ACE_TCHAR* tag,
+    bool expected_valid, time_t expected_value = 0)
+  {
+    const xercesc::DOMNodeList* const nodes =
+      parser->getDocument()->getElementsByTagName(XStr(tag));
+    const XMLSize_t count = nodes->getLength();
+    ASSERT_EQ(count, 1UL) << "node tag name is " << ACE_TEXT_ALWAYS_CHAR(tag);
+    const xercesc::DOMNode* const node = nodes->item(0);
+    time_t value;
+    const bool valid = parse_time(node, value);
+    EXPECT_EQ(valid, expected_valid)
+      << "node contains: \"" << to_string(node) << "\"";
+    if (expected_valid && valid) {
+      EXPECT_EQ(value, expected_value)
+        << "node contains: \"" << to_string(node) << "\"";
+    }
+  }
+}
+
+TEST(XmlUtils, parse_time)
+{
+  ParserPtr parser = get_parser("parse_time",
+    "<root>\n"
+    "  <invalid1></invalid1>\n"
+    "  <invalid2>2001/9/9</invalid2>\n"
+    "  <invalid3>2001-09-09T01:46:40Z+00:00</invalid3>\n"
+
+    "  <valid>2001-09-09T01:46:40</valid>\n"
+    "  <valid_z>2001-09-09T01:46:40Z</valid_z>\n"
+    "  <valid_0>2001-09-09T01:46:40+00:00</valid_0>\n"
+    "  <valid_frac_sec>2001-09-09T01:46:40.999</valid_frac_sec>\n"
+    "  <valid_frac_sec_z>2001-09-09T01:46:40.999Z</valid_frac_sec_z>\n"
+    "  <valid_frac_sec_0>2001-09-09T01:46:40.999+00:00</valid_frac_sec_0>\n"
+
+    "  <valid_plus_1min>2001-09-09T01:46:40+00:01</valid_plus_1min>\n"
+    "  <valid_minus_1min>2001-09-09T01:46:40-00:01</valid_minus_1min>\n"
+    "</root>\n");
+  ASSERT_TRUE(parser);
+
+  parse_time_checker(parser, ACE_TEXT("invalid1"), false);
+  parse_time_checker(parser, ACE_TEXT("invalid2"), false);
+  parse_time_checker(parser, ACE_TEXT("invalid3"), false);
+
+  parse_time_checker(parser, ACE_TEXT("valid"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("valid_z"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("valid_0"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("valid_frac_sec"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("valid_frac_sec_z"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("valid_frac_sec_0"), true, 1000000000);
+
+  parse_time_checker(parser, ACE_TEXT("valid_plus_1min"), true, 999999940);
+  parse_time_checker(parser, ACE_TEXT("valid_minus_1min"), true, 1000000060);
+}
+
+namespace {
+  void parse_domain_id_set_checker(ParserPtr& parser, const ACE_TCHAR* tag,
+    bool expected_valid, const DomainIdSet& expected_value, DomainIdSet& value)
+  {
+    const xercesc::DOMNodeList* const nodes =
+      parser->getDocument()->getElementsByTagName(XStr(tag));
+    const XMLSize_t count = nodes->getLength();
+    ASSERT_EQ(count, 1UL) << "node tag name is " << ACE_TEXT_ALWAYS_CHAR(tag);
+    const xercesc::DOMNode* const node = nodes->item(0);
+    const bool valid = parse_domain_id_set(node, value);
+    EXPECT_EQ(valid, expected_valid)
+      << "node tag name is " << ACE_TEXT_ALWAYS_CHAR(tag);
+    if (expected_valid && valid) {
+      EXPECT_EQ(value, expected_value)
+        << "node tag name is " << ACE_TEXT_ALWAYS_CHAR(tag);
+    }
+  }
+
+  void parse_domain_id_set_checker(ParserPtr& parser, const ACE_TCHAR* tag)
+  {
+    const DomainIdSet nilset;
+    DomainIdSet value;
+    parse_domain_id_set_checker(parser, tag, false, nilset, value);
+  }
+}
+
+TEST(XmlUtils, parse_domain_id_set)
+{
+  ParserPtr parser = get_parser("parse_time",
+    "<root>\n"
+    "  <empty></empty>\n"
+
+    "  <negative>\n"
+    "    <id>-1</id>\n"
+    "  </negative>\n"
+
+    "  <invalid_tag>\n"
+    "    <id>1</id>\n"
+    "    <invalidtag>1</invalidtag>\n"
+    "  </invalid_tag>\n"
+
+    "  <invalid_tag_in_range>\n"
+    "    <id>1</id>\n"
+    "    <id_range>\n"
+    "      <invalidtag>1</invalidtag>\n"
+    "    </id_range>\n"
+    "  </invalid_tag_in_range>\n"
+
+    "  <invalid_range>\n"
+    "    <id>1</id>\n"
+    "    <id_range>\n"
+    "      <min>6</min>\n"
+    "      <max>3</max>\n"
+    "    </id_range>\n"
+    "  </invalid_range>\n"
+
+    "  <has_1>\n"
+    "    <id>1</id>\n"
+    "  </has_1>\n"
+
+    "  <has_1_3>\n"
+    "    <id>1</id>\n"
+    "    <id>3</id>\n"
+    "  </has_1_3>\n"
+
+    "  <has_1_3_to_6>\n"
+    "    <id>1</id>\n"
+    "    <id_range>\n"
+    "      <min>3</min>\n"
+    "      <max>6</max>\n"
+    "    </id_range>\n"
+    "  </has_1_3_to_6>\n"
+
+    "  <has_1_to_3_5_to_6>\n"
+    "    <id_range>\n"
+    "      <min>1</min>\n"
+    "      <max>3</max>\n"
+    "    </id_range>\n"
+    "    <id_range>\n"
+    "      <min>5</min>\n"
+    "      <max>6</max>\n"
+    "    </id_range>\n"
+    "  </has_1_to_3_5_to_6>\n"
+
+    "  <has_2_to_4_6_to_all>\n"
+    "    <id_range>\n"
+    "      <min>2</min>\n"
+    "      <max>4</max>\n"
+    "    </id_range>\n"
+    "    <id_range>\n"
+    "      <min>6</min>\n"
+    "    </id_range>\n"
+    "  </has_2_to_4_6_to_all>\n"
+
+    "  <has_to_7>\n"
+    "    <id_range>\n"
+    "      <max>7</max>\n"
+    "    </id_range>\n"
+    "  </has_to_7>\n"
+
+    "  <has_all>\n"
+    "    <id_range>\n"
+    "      <min>0</min>\n"
+    "    </id_range>\n"
+    "  </has_all>\n"
+    "</root>\n");
+  ASSERT_TRUE(parser);
+
+  parse_domain_id_set_checker(parser, ACE_TEXT("empty"));
+  parse_domain_id_set_checker(parser, ACE_TEXT("negative"));
+  parse_domain_id_set_checker(parser, ACE_TEXT("invalid_tag"));
+  parse_domain_id_set_checker(parser, ACE_TEXT("invalid_tag_in_range"));
+  parse_domain_id_set_checker(parser, ACE_TEXT("invalid_range"));
+
+  OpenDDS::DCPS::DebugRestore debug_restore;
+  security_debug.access_warn = true;
+  security_debug.access_error = true;
+
+  {
+    DomainIdSet expected, value;
+    expected.add(1);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_1"), true, expected, value);
+    EXPECT_TRUE(value.has(1));
+    EXPECT_FALSE(value.has(2));
+  }
+
+  {
+    DomainIdSet expected, value;
+    expected.add(1);
+    expected.add(3);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_1_3"), true, expected, value);
+  }
+
+  {
+    DomainIdSet expected, value;
+    expected.add(1);
+    expected.add(3, 6);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_1_3_to_6"), true, expected, value);
+    EXPECT_FALSE(value.has(2));
+  }
+
+  {
+    DomainIdSet expected, value;
+    expected.add(1, 3);
+    expected.add(5, 6);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_1_to_3_5_to_6"), true, expected, value);
+  }
+
+  {
+    DomainIdSet expected, value;
+    expected.add(2, 4);
+    expected.add(6, domain_id_max);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_2_to_4_6_to_all"), true, expected, value);
+    EXPECT_FALSE(value.has(5));
+    EXPECT_TRUE(value.has(12345));
+  }
+
+  {
+    DomainIdSet expected, value;
+    expected.add(0, 7);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_to_7"), true, expected, value);
+  }
+
+  {
+    DomainIdSet expected, value;
+    expected.add(0, domain_id_max);
+    parse_domain_id_set_checker(parser, ACE_TEXT("has_all"), true, expected, value);
+    EXPECT_TRUE(value.has(1));
+    EXPECT_TRUE(value.has(99999));
+  }
+}

--- a/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
+++ b/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
@@ -11,7 +11,7 @@ using OpenDDS::DCPS::security_debug;
 using OpenDDS::Security::DomainIdSet;
 using OpenDDS::Security::domain_id_max;
 
-TEST(XmlUtils, get_parser)
+TEST(dds_DCPS_security_AccessControl_XmlUtils, get_parser)
 {
   EXPECT_FALSE(get_parser("empty string", ""));
   EXPECT_FALSE(get_parser("invalid xml", ">What I'm writing isn't valid XML<"));
@@ -44,7 +44,7 @@ namespace {
   }
 }
 
-TEST(XmlUtils, parse_bool)
+TEST(dds_DCPS_security_AccessControl_XmlUtils, parse_bool)
 {
   ParserPtr parser = get_parser("parse_bool",
     "<root>\n"
@@ -87,7 +87,7 @@ namespace {
   }
 }
 
-TEST(XmlUtils, parse_time)
+TEST(dds_DCPS_security_AccessControl_XmlUtils, parse_time)
 {
   ParserPtr parser = get_parser("parse_time",
     "<root>\n"
@@ -160,7 +160,7 @@ namespace {
   }
 }
 
-TEST(XmlUtils, parse_domain_id_set)
+TEST(dds_DCPS_security_AccessControl_XmlUtils, parse_domain_id_set)
 {
   ParserPtr parser = get_parser("parse_time",
     "<root>\n"

--- a/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
+++ b/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
@@ -1,3 +1,5 @@
+#ifdef OPENDDS_SECURITY
+
 #include <dds/DCPS/security/AccessControl/XmlUtils.h>
 #include <dds/DCPS/debug.h>
 
@@ -291,3 +293,5 @@ TEST(XmlUtils, parse_domain_id_set)
     EXPECT_TRUE(value.has(99999));
   }
 }
+
+#endif // OPENDDS_SECURITY

--- a/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
+++ b/tests/unit-tests/dds/DCPS/security/AccessControl/XmlUtils.cpp
@@ -94,6 +94,7 @@ TEST(XmlUtils, parse_time)
     "  <invalid1></invalid1>\n"
     "  <invalid2>2001/9/9</invalid2>\n"
     "  <invalid3>2001-09-09T01:46:40Z+00:00</invalid3>\n"
+    "  <leftover>2001-09-09T01:46:40.000+00:00123hello</leftover>\n"
 
     "  <valid>2001-09-09T01:46:40</valid>\n"
     "  <valid_z>2001-09-09T01:46:40Z</valid_z>\n"
@@ -102,6 +103,9 @@ TEST(XmlUtils, parse_time)
     "  <valid_frac_sec_z>2001-09-09T01:46:40.999Z</valid_frac_sec_z>\n"
     "  <valid_frac_sec_0>2001-09-09T01:46:40.999+00:00</valid_frac_sec_0>\n"
 
+    "  <tz_plus_one>2001-09-09T02:46:40+01:00</tz_plus_one>\n"
+    "  <tz_minus_one>2001-09-09T00:46:40-01:00</tz_minus_one>\n"
+    "  <tz_carry>1999-12-31T23:00:00-01:00</tz_carry>\n"
     "  <valid_plus_1min>2001-09-09T01:46:40+00:01</valid_plus_1min>\n"
     "  <valid_minus_1min>2001-09-09T01:46:40-00:01</valid_minus_1min>\n"
     "</root>\n");
@@ -110,6 +114,11 @@ TEST(XmlUtils, parse_time)
   parse_time_checker(parser, ACE_TEXT("invalid1"), false);
   parse_time_checker(parser, ACE_TEXT("invalid2"), false);
   parse_time_checker(parser, ACE_TEXT("invalid3"), false);
+  parse_time_checker(parser, ACE_TEXT("leftover"), false);
+
+  OpenDDS::DCPS::DebugRestore debug_restore;
+  security_debug.access_warn = true;
+  security_debug.access_error = true;
 
   parse_time_checker(parser, ACE_TEXT("valid"), true, 1000000000);
   parse_time_checker(parser, ACE_TEXT("valid_z"), true, 1000000000);
@@ -118,6 +127,9 @@ TEST(XmlUtils, parse_time)
   parse_time_checker(parser, ACE_TEXT("valid_frac_sec_z"), true, 1000000000);
   parse_time_checker(parser, ACE_TEXT("valid_frac_sec_0"), true, 1000000000);
 
+  parse_time_checker(parser, ACE_TEXT("tz_plus_one"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("tz_minus_one"), true, 1000000000);
+  parse_time_checker(parser, ACE_TEXT("tz_carry"), true, 946684800);
   parse_time_checker(parser, ACE_TEXT("valid_plus_1min"), true, 999999940);
   parse_time_checker(parser, ACE_TEXT("valid_minus_1min"), true, 1000000060);
 }


### PR DESCRIPTION
- Fix the following issues with the XML files:
  - The custom date/time parsing for the grant validity time range interpreted the time without timezone as local system time, not UTC, and did not parse time zone offsets correctly. Replaced custom code with functionality provided by Xerces if available, else fallback to new custom code.
  - If there are multiple domain rules in governance, then it use only uses the settings from the first domain rule for the rest.
  - Allow for using "1" and "0" in addition to "true" and "false" for XML boolean values in compliance in the XML schema spec.
  - Added missing support for `id_range`s with no `max` in the security XML domain id sets. As part of that tweaked and made use of `OrderedRanges` from `DisjointSequence`.
- Make some the XML parsing more strict and improve error reporting.
- Try to deduplicate code within governance and between governance and permissions.
- Added the `access_error` security debug category at level 1. Moved `access_warn` to level 2.
- Added the `DebugRestore` helper class in `debug.h` to save and restore debug state.