### PR TITLE
Make use of ACE's cached allocators for RtpsUdpDataLink's ACE_Message_Blocks

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -226,9 +226,18 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
 
   finish_message();
 
-  if (cur_rb->data_block()->reference_count() > 1) {
+  // Attempt to quickly switch to unreferenced buffer for next read
+  size_t index_count = 0;
+  size_t new_buffer_index = buffer_index_;
+  while (receive_buffers_[new_buffer_index]->data_block()->reference_count() > 1 && index_count++ <= RECEIVE_BUFFERS) {
+    new_buffer_index = (new_buffer_index + 1) % RECEIVE_BUFFERS;
+  }
+  buffer_index_ = new_buffer_index;
+
+  // If newly selected buffer index still has a reference count, we'll need to allocate a new one for the read
+  if (receive_buffers_[buffer_index_]->data_block()->reference_count() > 1) {
     ACE_DES_FREE(
-      cur_rb,
+      receive_buffers_[buffer_index_],
       mb_allocator_.free,
       ACE_Message_Block);
 

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -24,7 +24,7 @@ TransportReceiveStrategy<TH, DSH>::TransportReceiveStrategy()
     receive_sample_remaining_(0),
     mb_allocator_(MESSAGE_BLOCKS),
     db_allocator_(DATA_BLOCKS),
-    data_allocator_(DATA_BLOCKS),
+    data_allocator_(RECEIVE_BUFFERS * 2),
     buffer_index_(0),
     payload_(0),
     good_pdu_(true),

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -81,6 +81,10 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
              false)     // is_active
   , reactor_task_(reactor_task)
   , job_queue_(make_rch<JobQueue>(reactor_task->get_reactor()))
+  , mb_allocator_(TheServiceParticipant->association_chunk_multiplier())
+  , db_allocator_(TheServiceParticipant->association_chunk_multiplier())
+  , custom_allocator_(TheServiceParticipant->association_chunk_multiplier(), config.max_message_size_)
+  , bundle_allocator_(TheServiceParticipant->association_chunk_multiplier(), config.max_message_size_)
   , multi_buff_(this, config.nak_depth_)
   , flush_send_queue_task_(make_rch<Sporadic>(reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue))
   , best_effort_heartbeat_count_(0)
@@ -1078,27 +1082,46 @@ RtpsUdpDataLink::MultiSendBuffer::insert(SequenceNumber /*transport_seq*/,
   }
 }
 
-// Support for the send() data handling path
-namespace {
-  ACE_Message_Block* submsgs_to_msgblock(const RTPS::SubmessageSeq& subm)
-  {
-    // byte swapping is handled in the operator<<() implementation
-    const Encoding encoding(Encoding::KIND_XCDR1);
-    size_t size = 0;
-    for (CORBA::ULong i = 0; i < subm.length(); ++i) {
-      encoding.align(size, RTPS::SMHDR_SZ);
-      serialized_size(encoding, size, subm[i]);
-    }
+ACE_Message_Block*
+RtpsUdpDataLink::alloc_msgblock(size_t size, ACE_Allocator* data_allocator) {
+  ACE_Message_Block* result;
+  ACE_NEW_MALLOC_RETURN(result,
+    static_cast<ACE_Message_Block*>(
+      mb_allocator_.malloc(sizeof(ACE_Message_Block))),
+    ACE_Message_Block(size,
+                      ACE_Message_Block::MB_DATA,
+                      0, // cont
+                      0, // data
+                      data_allocator,
+                      0, // locking_strategy
+                      ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY,
+                      ACE_Time_Value::zero,
+                      ACE_Time_Value::max_time,
+                      &db_allocator_,
+                      &mb_allocator_),
+    0);
+  return result;
+}
 
-    ACE_Message_Block* hdr = new ACE_Message_Block(size);
-
-    for (CORBA::ULong i = 0; i < subm.length(); ++i) {
-      Serializer ser(hdr, encoding);
-      ser << subm[i];
-      ser.align_w(RTPS::SMHDR_SZ);
-    }
-    return hdr;
+ACE_Message_Block*
+RtpsUdpDataLink::submsgs_to_msgblock(const RTPS::SubmessageSeq& subm)
+{
+  // byte swapping is handled in the operator<<() implementation
+  const Encoding encoding(Encoding::KIND_XCDR1);
+  size_t size = 0;
+  for (CORBA::ULong i = 0; i < subm.length(); ++i) {
+    encoding.align(size, RTPS::SMHDR_SZ);
+    serialized_size(encoding, size, subm[i]);
   }
+
+  ACE_Message_Block* hdr = alloc_msgblock(size, &custom_allocator_);
+
+  for (CORBA::ULong i = 0; i < subm.length(); ++i) {
+    Serializer ser(hdr, encoding);
+    ser << subm[i];
+    ser.align_w(RTPS::SMHDR_SZ);
+  }
+  return hdr;
 }
 
 TransportQueueElement*
@@ -1211,7 +1234,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     link->send_strategy()->append_submessages(subm);
   }
 
-  Message_Block_Ptr hdr(submsgs_to_msgblock(subm));
+  Message_Block_Ptr hdr(link->submsgs_to_msgblock(subm));
   hdr->cont(data.release());
   RtpsCustomizedElement* rtps =
     new RtpsCustomizedElement(element, move(hdr));
@@ -2700,8 +2723,8 @@ RtpsUdpDataLink::bundle_and_send_submessages(MetaSubmessageVecVecVec& meta_subme
   for (size_t i = 0; i < meta_submessage_bundles.size(); ++i) {
     RTPS::Message rtps_message;
     prev_dst = GUID_UNKNOWN;
-    ACE_Message_Block mb_bundle(meta_submessage_bundle_sizes[i]); //FUTURE: allocators?
-    Serializer ser(&mb_bundle, encoding);
+    Message_Block_Ptr mb_bundle(alloc_msgblock(meta_submessage_bundle_sizes[i], &bundle_allocator_));
+    Serializer ser(mb_bundle.get(), encoding);
     for (MetaSubmessageIterVec::const_iterator it = meta_submessage_bundles[i].begin();
         it != meta_submessage_bundles[i].end(); ++it) {
       MetaSubmessage& res = **it;
@@ -2738,7 +2761,7 @@ RtpsUdpDataLink::bundle_and_send_submessages(MetaSubmessageVecVecVec& meta_subme
       }
       prev_dst = dst;
     }
-    send_strategy()->send_rtps_control(rtps_message, mb_bundle, meta_submessage_bundle_addrs[i].entry_->addrs_);
+    send_strategy()->send_rtps_control(rtps_message, *(mb_bundle.get()), meta_submessage_bundle_addrs[i].entry_->addrs_);
     if (transport_debug.log_messages) {
       RTPS::log_message("(%P|%t) {transport_debug.log_messages} %C\n", rtps_message.hdr.guidPrefix, true, rtps_message);
     }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -286,6 +286,14 @@ private:
   OPENDDS_SET(OPENDDS_STRING) ipv6_joined_interfaces_;
 #endif
 
+  MessageBlockAllocator mb_allocator_;
+  DataBlockAllocator db_allocator_;
+  Dynamic_Cached_Allocator_With_Overflow<ACE_Thread_Mutex> custom_allocator_;
+  Dynamic_Cached_Allocator_With_Overflow<ACE_Thread_Mutex> bundle_allocator_;
+
+  ACE_Message_Block* alloc_msgblock(size_t size, ACE_Allocator* data_allocator);
+  ACE_Message_Block* submsgs_to_msgblock(const RTPS::SubmessageSeq& subm);
+
   RcHandle<SingleSendBuffer> get_writer_send_buffer(const RepoId& pub_id);
 
   struct MultiSendBuffer : TransportSendBuffer {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -34,6 +34,7 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name)
 #endif
   , use_multicast_(true)
   , ttl_(1)
+  , anticipated_fragments_(RtpsUdpSendStrategy::UDP_MAX_MESSAGE_SIZE / RtpsSampleHeader::FRAG_SIZE)
   , max_message_size_(RtpsUdpSendStrategy::UDP_MAX_MESSAGE_SIZE)
   , nak_depth_(0)
   , nak_response_delay_(0, 200*1000 /*microseconds*/) // default from RTPS
@@ -121,6 +122,8 @@ RtpsUdpInst::load(ACE_Configuration_Heap& cf,
   GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("multicast_interface"),
                           multicast_interface_);
 
+  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("anticipated_fragments"), anticipated_fragments_, size_t);
+
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("max_message_size"), max_message_size_, size_t);
 
   GET_CONFIG_VALUE(cf, sect, ACE_TEXT("nak_depth"), nak_depth_, size_t);
@@ -176,6 +179,7 @@ RtpsUdpInst::dump_to_str() const
   ret += formatNameForDump("multicast_group_address") + LogAddr(multicast_group_address_).str() + '\n';
   ret += formatNameForDump("multicast_interface") + multicast_interface_ + '\n';
   ret += formatNameForDump("nak_depth") + to_dds_string(unsigned(nak_depth_)) + '\n';
+  ret += formatNameForDump("anticipated_fragments") + to_dds_string(unsigned(anticipated_fragments_)) + '\n';
   ret += formatNameForDump("max_message_size") + to_dds_string(unsigned(max_message_size_)) + '\n';
   ret += formatNameForDump("nak_response_delay") + to_dds_string(nak_response_delay_.value().msec()) + '\n';
   ret += formatNameForDump("heartbeat_period") + to_dds_string(heartbeat_period_.value().msec()) + '\n';

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -36,6 +36,7 @@ public:
   unsigned char ttl_;
   OPENDDS_STRING multicast_interface_;
 
+  size_t anticipated_fragments_;
   size_t max_message_size_;
   size_t nak_depth_;
   TimeDuration nak_response_delay_;


### PR DESCRIPTION
Problem: We're currently relying on `new` for the allocation of all ACE_Message_Blocks, which can be slow

Solution: Create appropriate allocators for message blocks, data blocks, and data buffers (for both customized blocks & fragments, as well as "bundled" responses).