### PR TITLE
more deadlock risk mitigation when using Topic presentation QOS

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1535,7 +1535,6 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
       it->second->set_group_info (control);
     }
 
-    guard.release();
     if (this->verify_coherent_changes_completion(writer.in())) {
       this->notify_read_conditions();
     }

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -491,8 +491,7 @@ DataReaderImpl::remove_associations(const WriterIdSeq& writers,
         statistics_.erase(writer_id);
 
         WriterMapType::iterator it = this->writers_.find(writer_id);
-        if (it != this->writers_.end() &&
-            it->second->active()) {
+        if (it != this->writers_.end()) {
           remove_association_sweeper_->schedule_timer(it->second, notify_lost);
         } else {
           push_back(non_active_writers, writer_id);

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -219,7 +219,8 @@ public:
   friend class SubscriberImpl;
 
   typedef OPENDDS_MAP(DDS::InstanceHandle_t, SubscriptionInstance_rch) SubscriptionInstanceMapType;
-
+  typedef OPENDDS_SET(DDS::InstanceHandle_t) InstanceSet;
+  typedef OPENDDS_SET(SubscriptionInstance_rch) SubscriptionInstanceSet;
   /// Type of collection of statistics for writers to this reader.
   typedef OPENDDS_MAP_CMP(PublicationId, WriterStats, GUID_tKeyLessThan) StatsMapType;
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -253,9 +253,10 @@ namespace OpenDDS {
 
     const Observer_rch observer = get_observer(Observer::e_SAMPLE_READ);
 
-    const typename InstanceMap::iterator the_end = instance_map_.end();
-    for (typename InstanceMap::iterator it = instance_map_.begin(); it != the_end; ++it) {
-      const SubscriptionInstance_rch ptr = get_handle_instance(it->second);
+    for (SubscriptionInstanceMapType::iterator iter = instances_.begin();
+        iter != instances_.end();
+        ++iter) {
+      SubscriptionInstance_rch ptr = iter->second;
 
       bool most_recent_generation = false;
 
@@ -311,10 +312,10 @@ namespace OpenDDS {
 
     const Observer_rch observer = get_observer(Observer::e_SAMPLE_TAKEN);
 
-    const typename InstanceMap::iterator the_end = instance_map_.end();
-    for (typename InstanceMap::iterator it = instance_map_.begin(); it != the_end; ++it) {
-      DDS::InstanceHandle_t handle = it->second;
-      OpenDDS::DCPS::SubscriptionInstance_rch ptr = get_handle_instance(handle);
+    for (SubscriptionInstanceMapType::iterator iter = instances_.begin();
+         iter != instances_.end();
+         ++iter) {
+      SubscriptionInstance_rch ptr = iter->second;
 
       bool most_recent_generation = false;
 
@@ -1386,10 +1387,11 @@ DDS::ReturnCode_t take_i(MessageSequenceType& received_data,
   if (!group_coherent_ordered) {
 #endif
 
-    for (typename InstanceMap::iterator it = instance_map_.begin(), the_end = instance_map_.end(); it != the_end; ++it) {
-
-      const DDS::InstanceHandle_t handle = it->second;
-      const SubscriptionInstance_rch inst = get_handle_instance(handle);
+    for (SubscriptionInstanceMapType::iterator iter = instances_.begin();
+         iter != instances_.end();
+         ++iter) {
+      DDS::InstanceHandle_t handle = iter->first;
+      SubscriptionInstance_rch inst = iter->second;
 
       if (inst->instance_state_->match(view_states, instance_states)) {
         size_t i(0);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -256,7 +256,7 @@ namespace OpenDDS {
     for (SubscriptionInstanceMapType::iterator iter = instances_.begin();
         iter != instances_.end();
         ++iter) {
-      SubscriptionInstance_rch ptr = iter->second;
+      const SubscriptionInstance_rch ptr = iter->second;
 
       bool most_recent_generation = false;
 
@@ -1390,8 +1390,8 @@ DDS::ReturnCode_t take_i(MessageSequenceType& received_data,
     for (SubscriptionInstanceMapType::iterator iter = instances_.begin();
          iter != instances_.end();
          ++iter) {
-      DDS::InstanceHandle_t handle = iter->first;
-      SubscriptionInstance_rch inst = iter->second;
+      const DDS::InstanceHandle_t handle = iter->first;
+      const SubscriptionInstance_rch inst = iter->second;
 
       if (inst->instance_state_->match(view_states, instance_states)) {
         size_t i(0);

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -537,7 +537,6 @@ SubscriberImpl::get_datareaders(
     if (this->access_depth_ == 0 && this->qos_.presentation.coherent_access) {
       return ::DDS::RETCODE_PRECONDITION_NOT_MET;
     }
-
     if (this->qos_.presentation.ordered_access) {
 
       GroupRakeData data;

--- a/tests/DCPS/GroupPresentation/SubscriberListener.cpp
+++ b/tests/DCPS/GroupPresentation/SubscriberListener.cpp
@@ -37,10 +37,10 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
   if (ret != ::DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-    ACE_TEXT(" ERROR: begin_access failed!\n")));
+               ACE_TEXT(" ERROR: begin_access failed!\n")));
     ACE_OS::exit(-1);
   }
-  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, listener_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, guard, listener_lock_);
   DDS::SubscriberQos qos;
   ret = subs->get_qos (qos);
   if (ret != ::DDS::RETCODE_OK) {
@@ -139,12 +139,12 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
                              ::DDS::ANY_INSTANCE_STATE);
       if (ret != DDS::RETCODE_OK) {
         if (ret == DDS::RETCODE_NO_DATA) {
-          ACE_ERROR((LM_ERROR,ACE_TEXT("%N:%l:%t: data reader[%d] has no data\n"),readers[i]->get_instance_handle()));
+          ACE_ERROR((LM_ERROR,ACE_TEXT("%N:%l:%t: data reader[%d] has no data\n"), readers[i]->get_instance_handle()));
           continue;
         }
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%N:%l:%t: SubscriberListenerImpl::on_data_on_readers()")
-          ACE_TEXT(" ERROR: reader[%d] failed with %C\n"),
+                   ACE_TEXT(" ERROR: reader[%d] failed with %C\n"),
                      readers[i]->get_instance_handle(), OpenDDS::DCPS::retcode_to_string(ret)));
           ACE_OS::exit(-1);
       }
@@ -153,7 +153,7 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
       if (num_samples > 1 && (msg.length() != num_samples || num_samples < num_messages * 2)) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-        ACE_TEXT(" ERROR: MessageSeq %d SampleInfoSeq %d != %d\n"),
+                   ACE_TEXT(" ERROR: MessageSeq %d SampleInfoSeq %d != %d\n"),
                    msg.length(), si.length(), num_messages));
         this->verify_result_ = false;
       }
@@ -170,7 +170,7 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
   if (ret != ::DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-    ACE_TEXT(" ERROR: end_access failed!\n")));
+               ACE_TEXT(" ERROR: end_access failed!\n")));
     ACE_OS::exit(-1);
   }
 }

--- a/tests/DCPS/GroupPresentation/SubscriberListener.cpp
+++ b/tests/DCPS/GroupPresentation/SubscriberListener.cpp
@@ -8,6 +8,7 @@
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_stdlib.h>
 
+#include <dds/DCPS/DCPS_Utils.h>
 #include <dds/DdsDcpsSubscriptionC.h>
 #include <dds/DCPS/Service_Participant.h>
 
@@ -21,6 +22,7 @@ extern unsigned int num_messages;
 
 SubscriberListenerImpl::SubscriberListenerImpl()
   : verify_result_ (true)
+  , listener_lock_()
 {
 }
 
@@ -31,8 +33,16 @@ SubscriberListenerImpl::~SubscriberListenerImpl()
 void
 SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
 {
+  ::DDS::ReturnCode_t ret = subs->begin_access ();
+  if (ret != ::DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
+    ACE_TEXT(" ERROR: begin_access failed!\n")));
+    ACE_OS::exit(-1);
+  }
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, listener_lock_);
   DDS::SubscriberQos qos;
-  ::DDS::ReturnCode_t ret = subs->get_qos (qos);
+  ret = subs->get_qos (qos);
   if (ret != ::DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR,
                   ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
@@ -56,13 +66,6 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
   CORBA::ULong len = readers->length ();
 
   if (qos.presentation.access_scope == ::DDS::GROUP_PRESENTATION_QOS) {
-    ret = subs->begin_access ();
-    if (ret != ::DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-      ACE_TEXT(" ERROR: begin_access failed!\n")));
-      ACE_OS::exit(-1);
-    }
     ACE_DEBUG((LM_DEBUG,
                 ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers() ")
                 ACE_TEXT("GROUP_PRESENTATION_QOS get_datareaders returned %d readers!\n"),
@@ -117,13 +120,6 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
 
       this->verify (msg[0], si[0], qos, false);
     }
-    ret = subs->end_access ();
-    if (ret != ::DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-      ACE_TEXT(" ERROR: end_access failed!\n")));
-      ACE_OS::exit(-1);
-    }
   }
   else if (qos.presentation.access_scope == ::DDS::TOPIC_PRESENTATION_QOS) {
     ACE_DEBUG((LM_DEBUG,
@@ -131,51 +127,51 @@ SubscriberListenerImpl::on_data_on_readers(DDS::Subscriber_ptr subs)
                 ACE_TEXT("TOPIC_PRESENTATION_QOS get_datareaders returned %d readers!\n"),
                   len));
 
-    // redirect datareader listener to receive DISPOSE and UNREGISTER notifications.
-    if (len != 2) {
-      if (subs->notify_datareaders () != ::DDS::RETCODE_OK) {
-        ACE_ERROR((LM_ERROR,
-                    ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-                    ACE_TEXT(" ERROR: notify_datareaders failed!\n")));
-        this->verify_result_ = false;
-      }
-    }
-    else {
-      for (CORBA::ULong i = 0; i < len; ++i) {
-        Messenger::MessageDataReader_var message_dr =
-          Messenger::MessageDataReader::_narrow(readers[i]);
+    for (CORBA::ULong i = 0; i < len; ++i) {
+      Messenger::MessageDataReader_var message_dr =
+        Messenger::MessageDataReader::_narrow(readers[i]);
 
-        Messenger::MessageSeq msg;
-        ::DDS::SampleInfoSeq si;
-        ret = message_dr->take(msg, si, DDS::LENGTH_UNLIMITED,
-                               ::DDS::NOT_READ_SAMPLE_STATE,
-                               ::DDS::ANY_VIEW_STATE,
-                               ::DDS::ANY_INSTANCE_STATE);
-        if (ret != DDS::RETCODE_OK) {
-          ACE_ERROR((LM_ERROR,
-                     ACE_TEXT("%N:%l:%t: SubscriberListenerImpl::on_data_on_readers()")
-          ACE_TEXT(" ERROR: read failed!\n")));
+      Messenger::MessageSeq msg;
+      ::DDS::SampleInfoSeq si;
+      ret = message_dr->take(msg, si, DDS::LENGTH_UNLIMITED,
+                             ::DDS::NOT_READ_SAMPLE_STATE,
+                             ::DDS::ANY_VIEW_STATE,
+                             ::DDS::ANY_INSTANCE_STATE);
+      if (ret != DDS::RETCODE_OK) {
+        if (ret == DDS::RETCODE_NO_DATA) {
+          ACE_ERROR((LM_ERROR,ACE_TEXT("%N:%l:%t: data reader[%d] has no data\n"),readers[i]->get_instance_handle()));
           continue;
         }
-        ACE_DEBUG((LM_DEBUG,"%N:%l:%t: message_dr->take returned\n"));
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%N:%l:%t: SubscriberListenerImpl::on_data_on_readers()")
+          ACE_TEXT(" ERROR: reader[%d] failed with %C\n"),
+                     readers[i]->get_instance_handle(), OpenDDS::DCPS::retcode_to_string(ret)));
+          ACE_OS::exit(-1);
+      }
 
-        CORBA::ULong num_samples = si.length();
-        if (num_samples > 1 && (msg.length() != num_samples || num_samples != num_messages * 2)) {
-          ACE_ERROR((LM_ERROR,
-                     ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
-          ACE_TEXT(" ERROR: MessageSeq %d SampleInfoSeq %d != %d\n"),
-                     msg.length(), si.length(), num_messages));
-          this->verify_result_ = false;
-        }
+      CORBA::ULong num_samples = si.length();
+      if (num_samples > 1 && (msg.length() != num_samples || num_samples < num_messages * 2)) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
+        ACE_TEXT(" ERROR: MessageSeq %d SampleInfoSeq %d != %d\n"),
+                   msg.length(), si.length(), num_messages));
+        this->verify_result_ = false;
+      }
 
-        for (CORBA::ULong i = 0; i < num_samples; ++i) {
-          this->verify (msg[i], si[i], qos, i == (num_samples - 1));
-        }
+      for (CORBA::ULong i = 0; i < num_samples; ++i) {
+        this->verify (msg[i], si[i], qos, i == (num_samples - 1));
       }
     }
   }
   else { //::DDS::INSTANCE_PRESENTATION_QOS
     subs->notify_datareaders ();
+  }
+  ret = subs->end_access ();
+  if (ret != ::DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("%N:%l: SubscriberListenerImpl::on_data_on_readers()")
+    ACE_TEXT(" ERROR: end_access failed!\n")));
+    ACE_OS::exit(-1);
   }
 }
 

--- a/tests/DCPS/GroupPresentation/SubscriberListener.h
+++ b/tests/DCPS/GroupPresentation/SubscriberListener.h
@@ -10,7 +10,7 @@
 
 #include <dds/DdsDcpsSubscriptionC.h>
 #include "MessengerC.h"
-
+#include <ace/Recursive_Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -67,6 +67,7 @@ private:
 
   DDS::Subscriber_var subscriber_;
   bool  verify_result_;
+  ACE_Recursive_Thread_Mutex listener_lock_;
 };
 
 #endif /* SUBSCRIBER_LISTENER_IMPL  */

--- a/tests/DCPS/GroupPresentation/SubscriberListener.h
+++ b/tests/DCPS/GroupPresentation/SubscriberListener.h
@@ -10,7 +10,7 @@
 
 #include <dds/DdsDcpsSubscriptionC.h>
 #include "MessengerC.h"
-#include <ace/Recursive_Thread_Mutex.h>
+#include <ace/Thread_Mutex.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -67,7 +67,7 @@ private:
 
   DDS::Subscriber_var subscriber_;
   bool  verify_result_;
-  ACE_Recursive_Thread_Mutex listener_lock_;
+  ACE_Thread_Mutex listener_lock_;
 };
 
 #endif /* SUBSCRIBER_LISTENER_IMPL  */

--- a/tests/DCPS/GroupPresentation/Writer.cpp
+++ b/tests/DCPS/GroupPresentation/Writer.cpp
@@ -143,7 +143,7 @@ Writer::svc()
   }
 
   finished_instances_ ++;
-
+  ACE_OS::sleep (1);
   return 0;
 }
 

--- a/tests/DCPS/GroupPresentation/Writer.cpp
+++ b/tests/DCPS/GroupPresentation/Writer.cpp
@@ -143,7 +143,6 @@ Writer::svc()
   }
 
   finished_instances_ ++;
-  ACE_OS::sleep (1);
   return 0;
 }
 


### PR DESCRIPTION
This PR adds a couple more uses of local copies of otherwise locked data to avoid conflicts across function calls. This PR also aaddresses some peculiar code specific to the GroupPresentation test case.