### PR TITLE
Disable NTP for macos virtual environment runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8740,6 +8740,11 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - name: disable ntp
+      shell: bash
+      run: |
+        sudo systemsetup -setusingnetworktime off
+        sudo rm -rf /etc/ntp.conf
     - name: run OpenDDS tests
       shell: bash
       run: |
@@ -9018,6 +9023,11 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - name: disable ntp
+      shell: bash
+      run: |
+        sudo systemsetup -setusingnetworktime off
+        sudo rm -rf /etc/ntp.conf
     - name: run OpenDDS tests
       shell: bash
       run: |


### PR DESCRIPTION
In order to reduce strange timing behaviors for MacOS Virtual Environment Runner Agents, disable NTP per the workaround listed on [https://github.com/actions/virtual-environments/issues/820](https://github.com/actions/virtual-environments/issues/820).