### PR TITLE
Liveliness Test: Automatic Reader receives incorrect liveliness change count

### DIFF
--- a/tests/DCPS/LivelinessTest/DataReaderListener.cpp
+++ b/tests/DCPS/LivelinessTest/DataReaderListener.cpp
@@ -18,6 +18,7 @@ DataReaderListenerImpl::DataReaderListenerImpl(DistributedConditionSet_rch dcs,
   , liveliness_lost_count_(0)
   , liveliness_gained_count_(0)
   , liveliness_changed_count_(0)
+  , samples_handled_(0)
   {
     last_status_.alive_count = 0;
     last_status_.not_alive_count = 0;
@@ -195,6 +196,7 @@ void DataReaderListenerImpl::on_subscription_matched(
           use_take ? "took": "read", i, foo[i].x, foo[i].y, foo[i].key));
         PrintSampleInfo(si[i]) ;
         last_si_ = si[i] ;
+        ++samples_handled_;
       }
     } else if (status == ::DDS::RETCODE_NO_DATA) {
       ACE_OS::fprintf (stderr, "read returned ::DDS::RETCODE_NO_DATA\n") ;

--- a/tests/DCPS/LivelinessTest/DataReaderListener.h
+++ b/tests/DCPS/LivelinessTest/DataReaderListener.h
@@ -82,6 +82,11 @@ public:
     return last_status_.alive_count == 0 && last_status_.not_alive_count == 0;
   }
 
+  int samples_handled() const
+  {
+    return samples_handled_;
+  }
+
 private:
   DistributedConditionSet_rch dcs_;
   const OPENDDS_STRING actor_;
@@ -90,6 +95,7 @@ private:
   int liveliness_gained_count_;
 
   int liveliness_changed_count_;
+  int samples_handled_;
   ::DDS::SampleInfo last_si_;
   ::DDS::LivelinessChangedStatus last_status_;
 };

--- a/tests/DCPS/LivelinessTest/LivelinessTest.cpp
+++ b/tests/DCPS/LivelinessTest/LivelinessTest.cpp
@@ -283,9 +283,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     dcs->wait_for("driver", LOCAL_MANUAL_DATAREADER, "LIVELINESS_LOST_" + OpenDDS::DCPS::to_dds_string(i));
   }
 
-
   while (automatic_drl_servant->samples_handled() < 1) {
-    ACE_OS::sleep(0.25);
+    ACE_OS::sleep(ACE_Time_Value(0, 200000));
   }
 
   delete writer;

--- a/tests/DCPS/LivelinessTest/LivelinessTest.cpp
+++ b/tests/DCPS/LivelinessTest/LivelinessTest.cpp
@@ -283,6 +283,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     dcs->wait_for("driver", LOCAL_MANUAL_DATAREADER, "LIVELINESS_LOST_" + OpenDDS::DCPS::to_dds_string(i));
   }
 
+
+  while (automatic_drl_servant->samples_handled() < 1) {
+    ACE_OS::sleep(0.25);
+  }
+
   delete writer;
   pub->delete_contained_entities();
   dp->delete_publisher(pub);


### PR DESCRIPTION
Problem: The Automatic reader was in rare cases getting interrupted while it was still handling the message that was received.  If the writer was shut down before the read/take was completed, an incorrect liveliness changed value would occur.

Solution: I introduced a way of tracking where the message has been read by the automatic data reader listener, and block the deletion of writer/publisher until the message has been handled.