### PR TITLE
Allow fallback for unanswered heartbeats

### DIFF
--- a/dds/DCPS/FibonacciSequence.h
+++ b/dds/DCPS/FibonacciSequence.h
@@ -1,0 +1,55 @@
+#ifndef OPENDDS_DCPS_FIBONACCI_SEQUENCE_H
+#define OPENDDS_DCPS_FIBONACCI_SEQUENCE_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#  pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+template <typename T>
+class FibonacciSequence
+{
+public:
+  FibonacciSequence(const T& f1) : f1_(f1), f_n_minus_1_(0), f_n_minus_2_(0)
+  {
+  }
+
+  T get() const
+  {
+    if (f_n_minus_1_ == T(0)) {
+      return f1_;
+    } else {
+      T f = f_n_minus_1_ + f_n_minus_2_;
+      return f;
+    }
+  }
+
+  void advance()
+  {
+    T f = f_n_minus_1_ == T(0) ? f1_ : f_n_minus_1_ + f_n_minus_2_;
+    f_n_minus_2_ = f_n_minus_1_;
+    f_n_minus_1_ = f;
+  }
+
+  void reset()
+  {
+    f_n_minus_1_ = f1_;
+    f_n_minus_2_ = f1_ + f1_;
+  }
+
+private:
+  const T f1_;
+  T f_n_minus_1_;
+  T f_n_minus_2_;
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif

--- a/dds/DCPS/FibonacciSequence.h
+++ b/dds/DCPS/FibonacciSequence.h
@@ -23,22 +23,22 @@ public:
     if (f_n_minus_1_ == T(0)) {
       return f1_;
     } else {
-      T f = f_n_minus_1_ + f_n_minus_2_;
-      return f;
+      T f_n = f_n_minus_1_ + f_n_minus_2_;
+      return f_n;
     }
   }
 
   void advance()
   {
-    T f = f_n_minus_1_ == T(0) ? f1_ : f_n_minus_1_ + f_n_minus_2_;
+    T f_n = f_n_minus_1_ == T(0) ? f1_ : f_n_minus_1_ + f_n_minus_2_;
     f_n_minus_2_ = f_n_minus_1_;
-    f_n_minus_1_ = f;
+    f_n_minus_1_ = f_n;
   }
 
   void reset()
   {
-    f_n_minus_1_ = f1_;
-    f_n_minus_2_ = f1_ + f1_;
+    f_n_minus_1_ = T(0);
+    f_n_minus_2_ = T(0);
   }
 
 private:

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1469,12 +1469,13 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const MonotonicTimePoint& /*now*/)
   gather_heartbeats_i(meta_submessages);
 
   if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
-    heartbeat_->schedule(link->config().heartbeat_period_);
+    heartbeat_->schedule(fallback_.get());
   }
 
   g.release();
 
   link->queue_submessages(meta_submessages);
+  fallback_.advance();
 }
 
 void
@@ -2058,7 +2059,7 @@ RtpsUdpDataLink::RtpsWriter::add_reader(const ReaderInfo_rch& reader)
       return false;
     }
 
-    heartbeat_->schedule(link->config().heartbeat_period_);
+    heartbeat_->schedule(fallback_.get());
     if (link->config().responsive_mode_) {
       MetaSubmessageVec meta_submessages;
       MetaSubmessage meta_submessage(id_, GUID_UNKNOWN);
@@ -3096,6 +3097,8 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
     }
   }
 
+  fallback_.reset();
+
   const bool is_final = acknack.smHeader.flags & RTPS::FLAG_F;
   const bool is_postassociation = count_is_not_zero && (is_final || bitmapNonEmpty(acknack.readerSNState) || ack != 1);
 
@@ -3147,7 +3150,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
       previous_acked_sn = acked_sn;
       check_leader_lagger();
-      heartbeat_->schedule(link->config().heartbeat_period_);
+      heartbeat_->schedule(fallback_.get());
 
       if (reader->durable_) {
         if (Transport_debug_level > 5) {
@@ -3662,7 +3665,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
             lagging_readers_[previous_max_sn] = leading_pos->second;
           }
           leading_readers_.erase(leading_pos);
-          heartbeat_->schedule(link->config().heartbeat_period_);
+          heartbeat_->schedule(fallback_.get());
         }
       }
 #ifdef OPENDDS_SECURITY
@@ -3685,7 +3688,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const RepoId& reader_id,
       if (acked_sn == previous_max_sn && previous_max_sn != max_sn_) {
         snris_erase(leading_readers_, acked_sn, reader);
         snris_insert(lagging_readers_, reader);
-        heartbeat_->schedule(link->config().heartbeat_period_);
+        heartbeat_->schedule(fallback_.get());
       }
     }
 #endif
@@ -3713,7 +3716,7 @@ RtpsUdpDataLink::RtpsWriter::make_lagger_leader(const ReaderInfo_rch& reader,
   snris_erase(previous_acked_sn == previous_max_sn ? leading_readers_ : lagging_readers_, previous_acked_sn, reader);
   snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
   if (acked_sn != max_sn) {
-    heartbeat_->schedule(link->config().heartbeat_period_);
+    heartbeat_->schedule(fallback_.get());
   }
 }
 
@@ -4251,6 +4254,7 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(RcHandle<RtpsUdpDataLink> link, const Re
 #endif
  , heartbeat_(make_rch<RtpsWriter::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats))
  , nack_response_(make_rch<RtpsWriter::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses))
+ , fallback_(link->config().heartbeat_period_)
 {
   send_buff_->bind(link->send_strategy());
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -41,6 +41,7 @@
 #include "dds/DCPS/SequenceNumber.h"
 #include "dds/DCPS/AddressCache.h"
 #include "dds/DCPS/Hash.h"
+#include "dds/DCPS/FibonacciSequence.h"
 
 #ifdef OPENDDS_SECURITY
 #include "dds/DdsSecurityCoreC.h"
@@ -444,6 +445,8 @@ private:
 
     RcHandle<Sporadic> heartbeat_;
     RcHandle<Sporadic> nack_response_;
+
+    FibonacciSequence<TimeDuration> fallback_;
 
     void send_heartbeats(const MonotonicTimePoint& now);
     void send_nack_responses(const MonotonicTimePoint& now);

--- a/tests/unit-tests/dds/DCPS/FibonacciSequence.cpp
+++ b/tests/unit-tests/dds/DCPS/FibonacciSequence.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <gtest/gtest.h>
+
+#include "dds/DCPS/Definitions.h"
+#include "dds/DCPS/FibonacciSequence.h"
+#include "dds/DCPS/TimeDuration.h"
+
+using namespace OpenDDS::DCPS;
+
+TEST(FibonacciSequence, size_t_test)
+{
+  FibonacciSequence<size_t> fs(1u);
+
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 2u);
+  EXPECT_EQ(fs.get(), 2u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 3u);
+  EXPECT_EQ(fs.get(), 3u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 5u);
+  EXPECT_EQ(fs.get(), 5u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 8u);
+  EXPECT_EQ(fs.get(), 8u);
+}
+
+TEST(FibonacciSequence, TimeDuration_test)
+{
+  FibonacciSequence<TimeDuration> fs(TimeDuration(0, 500000));
+
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(1, 0));
+  EXPECT_EQ(fs.get(), TimeDuration(1, 0));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(1, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(1, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(2, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(2, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(4, 0));
+  EXPECT_EQ(fs.get(), TimeDuration(4, 0));
+}

--- a/tests/unit-tests/dds/DCPS/FibonacciSequence.cpp
+++ b/tests/unit-tests/dds/DCPS/FibonacciSequence.cpp
@@ -41,11 +41,65 @@ TEST(FibonacciSequence, size_t_test)
   fs.advance();
   EXPECT_EQ(fs.get(), 8u);
   EXPECT_EQ(fs.get(), 8u);
+
+  fs.reset();
+
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+  EXPECT_EQ(fs.get(), 1u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 2u);
+  EXPECT_EQ(fs.get(), 2u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 3u);
+  EXPECT_EQ(fs.get(), 3u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 5u);
+  EXPECT_EQ(fs.get(), 5u);
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), 8u);
+  EXPECT_EQ(fs.get(), 8u);
 }
 
 TEST(FibonacciSequence, TimeDuration_test)
 {
   FibonacciSequence<TimeDuration> fs(TimeDuration(0, 500000));
+
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(1, 0));
+  EXPECT_EQ(fs.get(), TimeDuration(1, 0));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(1, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(1, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(2, 500000));
+  EXPECT_EQ(fs.get(), TimeDuration(2, 500000));
+
+  fs.advance();
+  EXPECT_EQ(fs.get(), TimeDuration(4, 0));
+  EXPECT_EQ(fs.get(), TimeDuration(4, 0));
+
+  fs.reset();
 
   EXPECT_EQ(fs.get(), TimeDuration(0, 500000));
   EXPECT_EQ(fs.get(), TimeDuration(0, 500000));


### PR DESCRIPTION
Problem: In periods of high congestion, heartbeat traffic can become excessive.

Solution: Allow fallback for heartbeat periods when heartbeats go unanswered.