### PR TITLE
Filter pre-discovery RTPS samples for non-durable readers

### DIFF
--- a/dds/DCPS/DataSampleHeader.h
+++ b/dds/DCPS/DataSampleHeader.h
@@ -14,6 +14,8 @@
 #include "SequenceNumber.h"
 #include "RepoIdTypes.h"
 #include "Message_Block_Ptr.h"
+#include "TimeTypes.h"
+
 #include <iosfwd>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
@@ -260,9 +262,9 @@ struct OpenDDS_Dcps_Export DataSampleHeader : public PoolAllocationBase {
     }
   }
 
-  ACE_Time_Value get_source_timestamp() const
+  SystemTimePoint get_source_timestamp() const
   {
-    return ACE_Time_Value(source_timestamp_sec_, source_timestamp_nanosec_ / 1000);
+    return SystemTimePoint(ACE_Time_Value(source_timestamp_sec_, source_timestamp_nanosec_ / 1000));
   }
 
 private:

--- a/dds/DCPS/DataSampleHeader.h
+++ b/dds/DCPS/DataSampleHeader.h
@@ -260,6 +260,11 @@ struct OpenDDS_Dcps_Export DataSampleHeader : public PoolAllocationBase {
     }
   }
 
+  ACE_Time_Value get_source_timestamp() const
+  {
+    return ACE_Time_Value(source_timestamp_sec_, source_timestamp_nanosec_ / 1000);
+  }
+
 private:
   /// Keep track of the amount of data read from a buffer.
   size_t serialized_size_;

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -41,6 +41,7 @@ TransportClient::TransportClient()
   , durable_(false)
   , reverse_lock_(lock_)
   , repo_id_(GUID_UNKNOWN)
+  , creation_time_(SystemTimePoint::now())
 {
 }
 

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -143,7 +143,6 @@ public:
 
   SystemTimePoint creation_time() const
   {
-    ACE_Guard<ACE_Thread_Mutex> guard(lock_);
     return creation_time_;
   }
 

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -141,6 +141,11 @@ public:
     return repo_id_;
   }
 
+  SystemTimePoint creation_time() const {
+    ACE_Guard<ACE_Thread_Mutex> guard(lock_);
+    return creation_time_;
+  }
+
 private:
 
   // Implemented by derived classes (DataReaderImpl/DataWriterImpl)
@@ -329,6 +334,7 @@ private:
   Reverse_Lock_t reverse_lock_;
 
   RepoId repo_id_;
+  const SystemTimePoint creation_time_;
 };
 
 typedef RcHandle<TransportClient> TransportClient_rch;

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -141,7 +141,8 @@ public:
     return repo_id_;
   }
 
-  SystemTimePoint creation_time() const {
+  SystemTimePoint creation_time() const
+  {
     ACE_Guard<ACE_Thread_Mutex> guard(lock_);
     return creation_time_;
   }

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.h
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.h
@@ -36,6 +36,9 @@ public:
   SequenceNumber sequence() const;
   void set_sequence(const SequenceNumber& value);
 
+  SystemTimePoint source_timestamp() const;
+  void set_source_timestamp(const SystemTimePoint& time);
+
   virtual ACE_Message_Block* duplicate_msg() const;
 
   virtual const ACE_Message_Block* msg() const;
@@ -66,6 +69,7 @@ private:
   RepoId publication_id_;
   RepoId subscription_id_;
   SequenceNumber sequence_;
+  SystemTimePoint source_timestamp_;
   bool fragment_, exclusive_;
 };
 

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.inl
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.inl
@@ -76,6 +76,18 @@ void TransportCustomizedElement::set_sequence(const SequenceNumber& value)
 }
 
 ACE_INLINE
+SystemTimePoint TransportCustomizedElement::source_timestamp() const
+{
+  return source_timestamp_;
+}
+
+ACE_INLINE
+void TransportCustomizedElement::set_source_timestamp(const SystemTimePoint& time)
+{
+  source_timestamp_ = time;
+}
+
+ACE_INLINE
 void TransportCustomizedElement::set_fragment(TransportQueueElement* orig)
 {
   fragment_ = true;

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -13,6 +13,8 @@
 #include "dds/DCPS/GuidUtils.h"
 #include "dds/DCPS/PoolAllocationBase.h"
 #include "dds/DCPS/SequenceNumber.h"
+#include "dds/DCPS/TimeTypes.h"
+
 #include <utility>
 #ifdef ACE_HAS_CPP11
 #  include <atomic>
@@ -118,6 +120,10 @@ public:
 
   virtual SequenceNumber sequence() const {
     return SequenceNumber::SEQUENCENUMBER_UNKNOWN();
+  }
+
+  virtual SystemTimePoint source_timestamp() const {
+    return SystemTimePoint::zero_value;
   }
 
   /// A reference-incremented duplicate of the marshalled sample (sample header + sample data)

--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -370,12 +370,12 @@ SingleSendBuffer::resend(const SequenceRange& range, DisjointSequence* gaps)
 bool
 SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps)
 {
-  return resend_i(range, gaps, GUID_UNKNOWN);
+  return resend_i(range, gaps, GUID_UNKNOWN, SystemTimePoint::zero_value);
 }
 
 bool
 SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps,
-                           const RepoId& destination)
+                           const RepoId& destination, const SystemTimePoint& not_before)
 {
   //Special case, nak to make sure it has all history
   if (buffers_.empty()) throw std::exception();
@@ -387,33 +387,49 @@ SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps,
     // Re-send requested sample if still buffered; missing samples
     // will be scored against the given DisjointSequence:
     BufferMap::iterator it(buffers_.find(sequence));
-    DestinationMap::iterator dest_data;
-    if (has_dest) {
-      dest_data = destinations_.find(sequence);
-    }
-    if (it == buffers_.end() || (has_dest && (dest_data == destinations_.end() ||
-                                              dest_data->second != destination))) {
+    if (it == buffers_.end()) {
       if (gaps) {
         gaps->insert(sequence);
       }
-    } else {
-      if (Transport_debug_level > 5) {
-        ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("(%P|%t) SingleSendBuffer::resend() - ")
-                   ACE_TEXT("resending PDU: %q, (0x%@,0x%@)\n"),
-                   sequence.getValue(),
-                   it->second.first,
-                   it->second.second));
+      continue;
+    }
+
+    const SystemTimePoint source_timestamp = it->second.first->peek()->source_timestamp();
+    if (source_timestamp < not_before) {
+      if (gaps) {
+        gaps->insert(sequence);
       }
-      if (it->second.first && it->second.second) {
-        resend_one(it->second);
-      } else {
-        const FragmentMap::iterator fm_it = fragments_.find(it->first);
-        if (fm_it != fragments_.end()) {
-          for (BufferMap::iterator bm_it = fm_it->second.begin();
-                bm_it != fm_it->second.end(); ++bm_it) {
-            resend_one(bm_it->second);
-          }
+      continue;
+    }
+
+    DestinationMap::iterator dest_data;
+    if (has_dest) {
+      dest_data = destinations_.find(sequence);
+      if (dest_data == destinations_.end() || dest_data->second != destination) {
+        if (gaps) {
+          gaps->insert(sequence);
+        }
+        continue;
+      }
+    }
+
+    if (Transport_debug_level > 5) {
+      ACE_DEBUG((LM_DEBUG,
+                 ACE_TEXT("(%P|%t) SingleSendBuffer::resend() - ")
+                 ACE_TEXT("resending PDU: %q, (0x%@,0x%@)\n"),
+                 sequence.getValue(),
+                 it->second.first,
+                 it->second.second));
+    }
+
+    if (it->second.first && it->second.second) {
+      resend_one(it->second);
+    } else {
+      const FragmentMap::iterator fm_it = fragments_.find(it->first);
+      if (fm_it != fragments_.end()) {
+        for (BufferMap::iterator bm_it = fm_it->second.begin();
+              bm_it != fm_it->second.end(); ++bm_it) {
+          resend_one(bm_it->second);
         }
       }
     }

--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -394,12 +394,14 @@ SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps,
       continue;
     }
 
-    const SystemTimePoint source_timestamp = it->second.first->peek()->source_timestamp();
-    if (source_timestamp < not_before) {
-      if (gaps) {
-        gaps->insert(sequence);
+    if (it->second.first && it->second.second) {
+      const SystemTimePoint source_timestamp = it->second.first->peek()->source_timestamp();
+      if (source_timestamp < not_before) {
+        if (gaps) {
+          gaps->insert(sequence);
+        }
+        continue;
       }
-      continue;
     }
 
     DestinationMap::iterator dest_data;
@@ -427,6 +429,20 @@ SingleSendBuffer::resend_i(const SequenceRange& range, DisjointSequence* gaps,
     } else {
       const FragmentMap::iterator fm_it = fragments_.find(it->first);
       if (fm_it != fragments_.end()) {
+        if (fm_it->second.begin() != fm_it->second.end()) {
+          const SystemTimePoint source_timestamp = fm_it->second.begin()->second.first->peek()->source_timestamp();
+          if (source_timestamp < not_before) {
+            if (gaps) {
+              gaps->insert(sequence);
+            }
+            continue;
+          }
+        } else {
+          if (gaps) {
+            gaps->insert(sequence);
+          }
+          continue;
+        }
         for (BufferMap::iterator bm_it = fm_it->second.begin();
               bm_it != fm_it->second.end(); ++bm_it) {
           resend_one(bm_it->second);

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -172,9 +172,9 @@ public:
     }
 
     bool resend_i(const SequenceRange& range, DisjointSequence* gaps,
-                  const RepoId& destination)
+                  const RepoId& destination, const SystemTimePoint& not_before)
     {
-      return ssb_.resend_i(range, gaps, destination);
+      return ssb_.resend_i(range, gaps, destination, not_before);
     }
 
     void resend_fragments_i(SequenceNumber sequence,
@@ -201,7 +201,7 @@ private:
   // caller must already have the send strategy lock
   bool resend_i(const SequenceRange& range, DisjointSequence* gaps = 0);
   bool resend_i(const SequenceRange& range, DisjointSequence* gaps,
-                const RepoId& destination);
+                const RepoId& destination, const SystemTimePoint& not_before);
   void resend_fragments_i(SequenceNumber sequence,
                           const DisjointSequence& fragments);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1234,7 +1234,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
   }
 
   if (source_time == SystemTimePoint::zero_value) {
-    source_time == SystemTimePoint::now();
+    source_time = SystemTimePoint::now();
   }
 
   if (transport_debug.log_messages) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1197,7 +1197,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     // {DataSampleHeader} -> {Data Payload}
     data.reset(msg->cont()->duplicate());
     const DataSampleElement* dsle = tse->sample();
-    source_time = SystemTimePoint(dsle->get_header().get_source_timestamp());
+    source_time = dsle->get_header().get_source_timestamp();
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
@@ -1208,7 +1208,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     // {DataSampleHeader} -> {Content Filtering GUIDs} -> {Data Payload}
     data.reset(msg->cont()->cont()->duplicate());
     const DataSampleElement* dsle = tce->original_send_element()->sample();
-    source_time = SystemTimePoint(dsle->get_header().get_source_timestamp());
+    source_time = dsle->get_header().get_source_timestamp();
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
@@ -4331,7 +4331,7 @@ RtpsUdpDataLink::RtpsReader::deliver_held_data(const RepoId& src)
     const SequenceNumber ca = wi->second->recvd_.cumulative_ack();
     const WriterInfo::HeldMap::iterator end = wi->second->held_.upper_bound(ca);
     for (WriterInfo::HeldMap::iterator it = wi->second->held_.begin(); it != end; /*increment in loop body*/) {
-      const DCPS::SystemTimePoint source_time(it->second.header_.get_source_timestamp());
+      const DCPS::SystemTimePoint source_time = it->second.header_.get_source_timestamp();
       if (durable_ || creation_time_ < source_time) {
         to_deliver.push_back(it->second);
       }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -688,7 +688,7 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
       if (rr == readers_.end()) {
         pending_reliable_readers_.erase(local_id);
         RtpsUdpDataLink_rch link(this, inc_count());
-        RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id, local_durable);
+        RtpsReader_rch reader = make_rch<RtpsReader>(link, local_id, local_durable, client->creation_time());
         rr = readers_.insert(RtpsReaderMap::value_type(local_id, reader)).first;
       }
       RtpsReader_rch reader = rr->second;
@@ -4331,7 +4331,10 @@ RtpsUdpDataLink::RtpsReader::deliver_held_data(const RepoId& src)
     const SequenceNumber ca = wi->second->recvd_.cumulative_ack();
     const WriterInfo::HeldMap::iterator end = wi->second->held_.upper_bound(ca);
     for (WriterInfo::HeldMap::iterator it = wi->second->held_.begin(); it != end; /*increment in loop body*/) {
-      to_deliver.push_back(it->second);
+      const DCPS::SystemTimePoint source_time(it->second.header_.get_source_timestamp());
+      if (durable_ || creation_time_ < source_time) {
+        to_deliver.push_back(it->second);
+      }
       wi->second->held_.erase(it++);
     }
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1167,6 +1167,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
 
   const ACE_Message_Block* msg = element->msg();
   const RepoId pub_id = element->publication_id();
+  DCPS::SystemTimePoint source_time = SystemTimePoint::zero_value;
 
   // Based on the type of 'element', find and duplicate the data payload
   // continuation block.
@@ -1196,6 +1197,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     // {DataSampleHeader} -> {Data Payload}
     data.reset(msg->cont()->duplicate());
     const DataSampleElement* dsle = tse->sample();
+    source_time = SystemTimePoint(dsle->get_header().get_source_timestamp());
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
@@ -1206,6 +1208,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     // {DataSampleHeader} -> {Content Filtering GUIDs} -> {Data Payload}
     data.reset(msg->cont()->cont()->duplicate());
     const DataSampleElement* dsle = tce->original_send_element()->sample();
+    source_time = SystemTimePoint(dsle->get_header().get_source_timestamp());
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
@@ -1230,6 +1233,10 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     return 0;
   }
 
+  if (source_time == SystemTimePoint::zero_value) {
+    source_time == SystemTimePoint::now();
+  }
+
   if (transport_debug.log_messages) {
     link->send_strategy()->append_submessages(subm);
   }
@@ -1238,6 +1245,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
   hdr->cont(data.release());
   RtpsCustomizedElement* rtps =
     new RtpsCustomizedElement(element, move(hdr));
+  rtps->set_source_timestamp(source_time);
 
   // Handle durability resends
   if (durable) {
@@ -3465,7 +3473,7 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
             // Directed at the reader.
             const RtpsUdpSendStrategy::OverrideToken ot =
               link->send_strategy()->override_destinations(addrs);
-            proxy.resend_i(SequenceRange(seq, seq), 0, reader->id_);
+            proxy.resend_i(SequenceRange(seq, seq), 0, reader->id_, reader->durable_ ? SystemTimePoint::zero_value : reader->discovery_time_);
             continue;
           }
         } else if (proxy.pre_contains(seq)) {
@@ -4323,10 +4331,7 @@ RtpsUdpDataLink::RtpsReader::deliver_held_data(const RepoId& src)
     const SequenceNumber ca = wi->second->recvd_.cumulative_ack();
     const WriterInfo::HeldMap::iterator end = wi->second->held_.upper_bound(ca);
     for (WriterInfo::HeldMap::iterator it = wi->second->held_.begin(); it != end; /*increment in loop body*/) {
-      const DCPS::SystemTimePoint source_time(ACE_Time_Value(it->second.header_.source_timestamp_sec_, it->second.header_.source_timestamp_nanosec_ / 1000));
-      if (durable_ || wi->second->discovery_time_ < source_time) {
-        to_deliver.push_back(it->second);
-      }
+      to_deliver.push_back(it->second);
       wi->second->held_.erase(it++);
     }
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1167,7 +1167,9 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
 
   const ACE_Message_Block* msg = element->msg();
   const RepoId pub_id = element->publication_id();
+
   DCPS::SystemTimePoint source_time = SystemTimePoint::zero_value;
+  bool needs_timestamp = true;
 
   // Based on the type of 'element', find and duplicate the data payload
   // continuation block.
@@ -1198,6 +1200,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     data.reset(msg->cont()->duplicate());
     const DataSampleElement* dsle = tse->sample();
     source_time = dsle->get_header().get_source_timestamp();
+    needs_timestamp = false;
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
@@ -1209,6 +1212,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     data.reset(msg->cont()->cont()->duplicate());
     const DataSampleElement* dsle = tce->original_send_element()->sample();
     source_time = dsle->get_header().get_source_timestamp();
+    needs_timestamp = false;
     // Create RTPS Submessage(s) in place of the OpenDDS DataSampleHeader
     RtpsSampleHeader::populate_data_sample_submessages(
       subm, *dsle, requires_inline_qos);
@@ -1233,7 +1237,7 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
     return 0;
   }
 
-  if (source_time == SystemTimePoint::zero_value) {
+  if (needs_timestamp) {
     source_time = SystemTimePoint::now();
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -345,7 +345,7 @@ private:
     ACE_CDR::Long required_acknack_count_;
     OPENDDS_MAP(SequenceNumber, TransportQueueElement*) durable_data_;
     MonotonicTimePoint durable_timestamp_;
-    SystemTimePoint discovery_time_;
+    const SystemTimePoint discovery_time_;
 #ifdef OPENDDS_SECURITY
     SequenceNumber max_pvs_sn_;
     DisjointSequence pvs_outstanding_;
@@ -553,7 +553,7 @@ private:
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumber_t) frags_;
     CORBA::Long heartbeat_recvd_count_, hb_frag_recvd_count_;
     const ACE_CDR::ULong participant_flags_;
-    SystemTimePoint discovery_time_;
+    const SystemTimePoint discovery_time_;
 
     WriterInfo(const RepoId& id,
                const MonotonicTime_t& participant_discovered_at,
@@ -644,7 +644,7 @@ private:
     CORBA::Long nackfrag_count_;
     typedef PmfSporadicTask<RtpsReader> Sporadic;
     RcHandle<Sporadic> preassociation_task_;
-    SystemTimePoint creation_time_;
+    const SystemTimePoint creation_time_;
   };
   typedef RcHandle<RtpsReader> RtpsReader_rch;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -580,13 +580,14 @@ private:
 
   class RtpsReader : public RcObject {
   public:
-    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable)
+    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable, const SystemTimePoint& creation_time)
       : link_(link)
       , id_(id)
       , durable_(durable)
       , stopping_(false)
       , nackfrag_count_(0)
       , preassociation_task_(make_rch<RtpsReader::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks))
+      , creation_time_(creation_time)
     {}
 
     ~RtpsReader();
@@ -643,6 +644,7 @@ private:
     CORBA::Long nackfrag_count_;
     typedef PmfSporadicTask<RtpsReader> Sporadic;
     RcHandle<Sporadic> preassociation_task_;
+    SystemTimePoint creation_time_;
   };
   typedef RcHandle<RtpsReader> RtpsReader_rch;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -345,6 +345,7 @@ private:
     ACE_CDR::Long required_acknack_count_;
     OPENDDS_MAP(SequenceNumber, TransportQueueElement*) durable_data_;
     MonotonicTimePoint durable_timestamp_;
+    SystemTimePoint discovery_time_;
 #ifdef OPENDDS_SECURITY
     SequenceNumber max_pvs_sn_;
     DisjointSequence pvs_outstanding_;
@@ -362,6 +363,7 @@ private:
       , durable_(durable)
       , participant_flags_(participant_flags)
       , required_acknack_count_(0)
+      , discovery_time_(SystemTimePoint::now())
 #ifdef OPENDDS_SECURITY
       , max_pvs_sn_(SequenceNumber::ZERO())
 #endif

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -551,6 +551,7 @@ private:
     OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumber_t) frags_;
     CORBA::Long heartbeat_recvd_count_, hb_frag_recvd_count_;
     const ACE_CDR::ULong participant_flags_;
+    SystemTimePoint discovery_time_;
 
     WriterInfo(const RepoId& id,
                const MonotonicTime_t& participant_discovered_at,
@@ -561,6 +562,7 @@ private:
       , heartbeat_recvd_count_(0)
       , hb_frag_recvd_count_(0)
       , participant_flags_(participant_flags)
+      , discovery_time_(SystemTimePoint::now())
     { }
 
     bool should_nack() const;
@@ -576,9 +578,10 @@ private:
 
   class RtpsReader : public RcObject {
   public:
-    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id)
+    RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id, bool durable)
       : link_(link)
       , id_(id)
+      , durable_(durable)
       , stopping_(false)
       , nackfrag_count_(0)
       , preassociation_task_(make_rch<RtpsReader::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks))
@@ -631,6 +634,7 @@ private:
     mutable ACE_Thread_Mutex mutex_;
     WeakRcHandle<RtpsUdpDataLink> link_;
     const RepoId id_;
+    const bool durable_;
     WriterInfoMap remote_writers_;
     WriterInfoSet preassociation_writers_;
     bool stopping_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -394,6 +394,11 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
 
   case DATA: {
     receiver_.fill_header(sample.header_);
+    if (sample.header_.source_timestamp_sec_ == 0) {
+      const DDS::Time_t now = SystemTimePoint::now().to_dds_time();
+      sample.header_.source_timestamp_sec_ = now.sec;
+      sample.header_.source_timestamp_nanosec_ = now.nanosec;
+    }
     const DataSubmessage& data = submessage.data_sm();
     if (!check_encoded(data.writerId)) {
       if (transport_debug.log_dropped_messages) {


### PR DESCRIPTION
Problem: non-durable RTPS can currently receive historical samples when writer cache (heartbeat window) is slow to update (e.g. when readers do not shut down cleanly).

Solution: non-durable RTPS readers should filter samples based on source timestamps (or received timestamps, if source timestamps are not available) in order to prevent delivery of samples generated prior to time of discovery / association.