### PR TITLE
RtpsRelay PendingTimeout is unnecessary

### DIFF
--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -14,7 +14,6 @@ public:
     , lifespan_(60) // 1 minute
     , static_limit_(0)
     , max_pending_(0)
-    , pending_timeout_(60) // 1 minute
     , application_domain_(1)
     , allow_empty_partition_(true)
     , log_warnings_(false)
@@ -61,16 +60,6 @@ public:
   size_t max_pending() const
   {
     return max_pending_;
-  }
-
-  void pending_timeout(const OpenDDS::DCPS::TimeDuration& value)
-  {
-    pending_timeout_ = value;
-  }
-
-  const OpenDDS::DCPS::TimeDuration& pending_timeout() const
-  {
-    return pending_timeout_;
   }
 
   void application_domain(DDS::DomainId_t value)
@@ -218,7 +207,6 @@ private:
   OpenDDS::DCPS::TimeDuration lifespan_;
   size_t static_limit_;
   size_t max_pending_;
-  OpenDDS::DCPS::TimeDuration pending_timeout_;
   DDS::DomainId_t application_domain_;
   bool allow_empty_partition_;
   bool log_warnings_;

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -20,6 +20,8 @@ ParticipantListener::ParticipantListener(const Config& config,
 
 void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
 {
+  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+
   DDS::ParticipantBuiltinTopicDataDataReader_var dr = DDS::ParticipantBuiltinTopicDataDataReader::_narrow(reader);
   if (!dr) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::on_data_available failed to narrow PublicationBuiltinTopicDataDataReader\n")));
@@ -48,7 +50,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
       if (info.valid_data) {
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
-        guid_addr_set_.remove_pending(repoid);
+        guid_addr_set_.remove_pending(repoid, now);
 
         const auto p = guids_.insert(repoid);
         if (p.second) {
@@ -56,7 +58,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
             ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::on_data_available add local participant %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
           }
 
-          stats_reporter_.add_local_participant(OpenDDS::DCPS::MonotonicTimePoint::now());
+          stats_reporter_.add_local_participant(now);
         }
       }
       break;
@@ -71,7 +73,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
           ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::on_data_available remove local participant %C\n"), guid_to_string(repoid).c_str()));
         }
 
-        stats_reporter_.remove_local_participant(OpenDDS::DCPS::MonotonicTimePoint::now());
+        stats_reporter_.remove_local_participant(now);
         guids_.erase(repoid);
       }
       break;

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -355,7 +355,7 @@ bool GuidAddrSet::ignore(const OpenDDS::DCPS::GUID_t& guid,
   }
 
   pending_.insert(guid);
-  pending_expiration_queue_.push_back(std::make_pair(now + config_.pending_timeout(), guid));
+  pending_expiration_queue_.push_back(std::make_pair(now + expected_discovery_time_ * 10, guid));
 
   return false;
 }

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -88,7 +88,7 @@ public:
               RelayStatisticsReporter& relay_stats_reporter)
     : config_(config)
     , relay_stats_reporter_(relay_stats_reporter)
-    , expected_discovery_time_(config.lifespan() / 10)
+    , expected_discovery_time_(config.lifespan() * 0.1)
   {}
 
   void spdp_vertical_handler(RelayHandler* spdp_vertical_handler)

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -118,9 +118,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-MaxPending"))) {
       config.max_pending(ACE_OS::atoi(arg));
       args.consume_arg();
-    } else if ((arg = args.get_the_parameter("-PendingTimeout"))) {
-      config.pending_timeout(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
-      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-UserData"))) {
       user_data = arg;
       args.consume_arg();


### PR DESCRIPTION
Problem
-------

Determining the `-PendingTimeout` for the RtpsRelay is tedious.

Solution
--------

Compute the pending timeout by computing the exponentially weighted
moving (.99/.01) average discovery time of each client and then
multiply by a safety factor (10).  The initial expected discovery time
is the lifespan divided by the safety factor.