### PR TITLE
RtpsRelay buffer size is not configurable

### DIFF
--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -15,6 +15,11 @@ public:
     , static_limit_(0)
     , max_pending_(0)
     , pending_timeout_(60) // 1 minute
+#ifdef ACE_DEFAULT_MAX_SOCKET_BUFSIZ
+    , buffer_size_(ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+#else
+    , buffer_size_(16384)
+#endif
     , application_domain_(1)
     , allow_empty_partition_(true)
     , log_warnings_(false)
@@ -71,6 +76,16 @@ public:
   const OpenDDS::DCPS::TimeDuration& pending_timeout() const
   {
     return pending_timeout_;
+  }
+
+  void buffer_size(int value)
+  {
+    buffer_size_ = value;
+  }
+
+  int buffer_size() const
+  {
+    return buffer_size_;
   }
 
   void application_domain(DDS::DomainId_t value)
@@ -219,6 +234,7 @@ private:
   size_t static_limit_;
   size_t max_pending_;
   OpenDDS::DCPS::TimeDuration pending_timeout_;
+  int buffer_size_;
   DDS::DomainId_t application_domain_;
   bool allow_empty_partition_;
   bool log_warnings_;

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -84,17 +84,23 @@ int RelayHandler::open(const ACE_INET_Addr& address)
     return -1;
   }
 
-  int send_buffer_size = 16384;
-#ifdef ACE_DEFAULT_MAX_SOCKET_BUFSIZ
-  send_buffer_size = ACE_DEFAULT_MAX_SOCKET_BUFSIZ;
-#endif
+  const int buffer_size = config_.buffer_size();
 
   if (socket_.set_option(SOL_SOCKET,
                          SO_SNDBUF,
-                         (void *) &send_buffer_size,
-                         sizeof(send_buffer_size)) < 0
+                         (void *) &buffer_size,
+                         sizeof(buffer_size)) < 0
       && errno != ENOTSUP) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayHandler::open %C failed to set the send buffer size to %d errno %m\n"), name_.c_str(), send_buffer_size));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayHandler::open %C failed to set the send buffer size to %d errno %m\n"), name_.c_str(), buffer_size));
+    return -1;
+  }
+
+  if (socket_.set_option(SOL_SOCKET,
+                         SO_RCVBUF,
+                         (void *) &buffer_size,
+                         sizeof(buffer_size)) < 0
+      && errno != ENOTSUP) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RelayHandler::open %C failed to set the receive buffer size to %d errno %m\n"), name_.c_str(), buffer_size));
     return -1;
   }
 

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -121,6 +121,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-PendingTimeout"))) {
       config.pending_timeout(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-BufferSize"))) {
+      config.buffer_size(ACE_OS::atoi(arg));
+      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-UserData"))) {
       user_data = arg;
       args.consume_arg();


### PR DESCRIPTION
Problem
-------

The send and receive buffers for the RtpsRelay are not configurable.

Solution
--------

Expose an option and set the receive buffer size.