### PR TITLE
Writers of Fragmented Data Samples Have Issues Reconnecting

### DIFF
--- a/dds/DCPS/transport/framework/TransportReassembly.cpp
+++ b/dds/DCPS/transport/framework/TransportReassembly.cpp
@@ -233,7 +233,7 @@ TransportReassembly::get_gaps(const SequenceNumber& seq, const RepoId& pub_id,
     DisjointSequence::fill_bitmap_range(0, first.getLow() - 2,
                                         bitmap, length, numBits);
   } else if (flist.size() == 1) {
-    // No gaps, but we know there is (at least 1) more_framents
+    // No gaps, but we know there are (at least 1) more_fragments
     if (iter->second.total_frags_ == 0) {
       DisjointSequence::fill_bitmap_range(0, 0, bitmap, length, numBits);
     } else {

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -188,6 +188,11 @@ public:
     OPENDDS_DELETED_COPY_MOVE_CTOR_ASSIGN(Proxy)
   };
 
+  void pre_clear()
+  {
+    pre_seq_.clear();
+  }
+
 private:
   void check_capacity_i(BufferVec& removed);
   void release_i(BufferMap::iterator buffer_iter);
@@ -222,6 +227,8 @@ private:
 
   typedef OPENDDS_SET(SequenceNumber) SequenceNumberSet;
   SequenceNumberSet pre_seq_;
+
+  SequenceNumber minimum_sn_allowed_;
 
   mutable ACE_Thread_Mutex mutex_;
 };

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -623,7 +623,6 @@ private:
                             bool heartbeat_was_non_final,
                             MetaSubmessageVec& meta_submessages);
     void generate_nack_frags_i(MetaSubmessageVec& meta_submessages,
-                               MetaSubmessage& meta_submessage,
                                const WriterInfo_rch& wi,
                                EntityId_t reader_id,
                                EntityId_t writer_id);


### PR DESCRIPTION
Problem: Writers of fragmented data have issues reconnecting after all readers disconnect (and pre_stop_helper is called) because "late" fragments fool the writer into thinking they have access to the full range of fragments for a given sequence number. When the reconnect occurs, the writer then issues an incorrect heartbeat range, and a reliable reader is never able to recover all the fragments required to deliver sample data.

Solution: advance a "minimum" SN for the send buffer when sequence numbers are acked, preventing futher inserts from being used with that sequence number. This blocks the "late" fragments and prevents the inaccurate heartbeat.

Note: A few other issues were identified and cleaned up in this PR as well, noticeably corruption of NackFrag submessages through reuse of a MetaSubmessage object, parameter shadowing for a few loop iterators, and faulty resends of un-requested fragment data when the correct fragment data wasn't available.