### PR TITLE
RtpsDiscovery buffer sizes are not configurable

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -58,6 +58,13 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , d1_(10)
   , dx_(2)
   , ttl_(1)
+#if defined (ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+  , send_buffer_size_(ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+  , recv_buffer_size_(ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+#else
+  , send_buffer_size_(0)
+  , recv_buffer_size_(0)
+#endif
   , sedp_multicast_(true)
   , sedp_local_address_(u_short(0), "0.0.0.0")
   , spdp_local_address_(u_short(0), "0.0.0.0")
@@ -280,6 +287,28 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                value.c_str(), rtps_name.c_str()), -1);
           }
           config->ttl(static_cast<unsigned char>(ttl_us));
+        } else if (name == "SendBufferSize") {
+          const OPENDDS_STRING& value = it->second;
+          ACE_INT32 send_buffer_size;
+          if (!DCPS::convertToInteger(value, send_buffer_size)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for SendBufferSize in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->send_buffer_size(send_buffer_size);
+        } else if (name == "RecvBufferSize") {
+          const OPENDDS_STRING& value = it->second;
+          ACE_INT32 recv_buffer_size;
+          if (!DCPS::convertToInteger(value, recv_buffer_size)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+               ACE_TEXT("Invalid entry (%C) for RecvBufferSize in ")
+               ACE_TEXT("[rtps_discovery/%C] section.\n"),
+               value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->recv_buffer_size(recv_buffer_size);
         } else if (name == "SedpMulticast") {
           const OPENDDS_STRING& value = it->second;
           int smInt;

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -171,6 +171,28 @@ public:
     ttl_ = time_to_live;
   }
 
+  ACE_INT32 send_buffer_size() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, 0);
+    return send_buffer_size_;
+  }
+  void send_buffer_size(ACE_INT32 buffer_size)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    send_buffer_size_ = buffer_size;
+  }
+
+  ACE_INT32 recv_buffer_size() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, 0);
+    return recv_buffer_size_;
+  }
+  void recv_buffer_size(ACE_INT32 buffer_size)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    recv_buffer_size_ = buffer_size;
+  }
+
   ACE_INET_Addr sedp_local_address() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ACE_INET_Addr());
@@ -621,6 +643,8 @@ private:
   DCPS::TimeDuration lease_extension_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
   unsigned char ttl_;
+  ACE_INT32 send_buffer_size_;
+  ACE_INT32 recv_buffer_size_;
   bool sedp_multicast_;
   OPENDDS_STRING multicast_interface_;
   ACE_INET_Addr sedp_local_address_, sedp_advertised_address_, spdp_local_address_;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -357,6 +357,8 @@ Sedp::init(const RepoId& guid,
   rtps_inst->nak_response_delay_ = disco.config()->sedp_nak_response_delay();
   rtps_inst->responsive_mode_ = disco.config()->sedp_responsive_mode();
   rtps_inst->send_delay_ = disco.config()->sedp_send_delay();
+  rtps_inst->send_buffer_size_ = disco.config()->send_buffer_size();
+  rtps_inst->rcv_buffer_size_ = disco.config()->recv_buffer_size();
 
   if (disco.sedp_multicast()) {
     // Bind to a specific multicast group

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3248,6 +3248,30 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
     throw std::runtime_error("failed to set TTL");
   }
 
+  const int send_buffer_size = outer->config()->send_buffer_size();
+  if (send_buffer_size > 0) {
+    if (unicast_socket_.set_option(SOL_SOCKET,
+                                   SO_SNDBUF,
+                                   (void *) &send_buffer_size,
+                                   sizeof(send_buffer_size)) < 0
+        && errno != ENOTSUP) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket() - failed to set the send buffer size to %d errno %m\n"), send_buffer_size));
+      throw std::runtime_error("failed to set send buffer size");
+    }
+  }
+
+  const int recv_buffer_size = outer->config()->recv_buffer_size();
+  if (recv_buffer_size > 0) {
+    if (unicast_socket_.set_option(SOL_SOCKET,
+                                   SO_RCVBUF,
+                                   (void *) &recv_buffer_size,
+                                   sizeof(recv_buffer_size)) < 0
+        && errno != ENOTSUP) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket() - failed to set the recv buffer size to %d errno %m\n"), recv_buffer_size));
+      throw std::runtime_error("failed to set recv buffer size");
+    }
+  }
+
 #ifdef ACE_RECVPKTINFO
   int sockopt = 1;
   if (unicast_socket_.set_option(IPPROTO_IP, ACE_RECVPKTINFO, &sockopt, sizeof sockopt) == -1) {
@@ -3307,6 +3331,30 @@ Spdp::SpdpTransport::open_unicast_ipv6_socket(u_short port)
                ACE_TEXT("for port:%hu %p\n"),
                outer->config_->ttl(), ipv6_uni_port_, ACE_TEXT("DCPS::set_socket_multicast_ttl:")));
     throw std::runtime_error("failed to set TTL");
+  }
+
+  const int send_buffer_size = outer->config()->send_buffer_size();
+  if (send_buffer_size > 0) {
+    if (unicast_ipv6_socket_.set_option(SOL_SOCKET,
+                                        SO_SNDBUF,
+                                        (void *) &send_buffer_size,
+                                        sizeof(send_buffer_size)) < 0
+        && errno != ENOTSUP) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket() - failed to set the send buffer size to %d errno %m\n"), send_buffer_size));
+      throw std::runtime_error("failed to set send buffer size");
+    }
+  }
+
+  const int recv_buffer_size = outer->config()->recv_buffer_size();
+  if (recv_buffer_size > 0) {
+    if (unicast_ipv6_socket_.set_option(SOL_SOCKET,
+                                        SO_RCVBUF,
+                                        (void *) &recv_buffer_size,
+                                        sizeof(recv_buffer_size)) < 0
+        && errno != ENOTSUP) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket() - failed to set the recv buffer size to %d errno %m\n"), recv_buffer_size));
+      throw std::runtime_error("failed to set recv buffer size");
+    }
   }
 
 #ifdef ACE_RECVPKTINFO6


### PR DESCRIPTION
Problem
-------

The send and receive buffer sizes for RtpsDiscovery (the SPDP socket
and SEDP socket) are not configurable.  Certain applications like the
application participant in the RtpsRelay may need to configure these
buffer sizes.

Solution
--------

Add configuration options for setting the buffer sizes.