### PR TITLE
Fix Deadline test compiling issue on certain configurations.

### DIFF
--- a/tests/DCPS/Deadline/Domain.cpp
+++ b/tests/DCPS/Deadline/Domain.cpp
@@ -6,8 +6,14 @@
 
 #include <stdexcept>
 
+const int Domain::s_id = 11;
 const char* Domain::s_topic = "DeadlineTestTopic";
 const char* Domain::s_topic_type  = "DeadlineTestTopicType";
+const int Domain::s_key1 = 11;
+const int Domain::s_key2 = 13;
+const int Domain::n_msg = 10;
+const int Domain::n_instance = 2;
+const int Domain::n_expiration = 2;
 const DDS::Duration_t Domain::w_deadline = {4, 0}; //writer deadline period 4 second (required .sec > 1)
 const DDS::Duration_t Domain::r_deadline = {5, 0}; //reader deadline period 5 second (required .sec > 1)
 const OpenDDS::DCPS::TimeDuration Domain::w_sleep(w_deadline.sec * n_expiration + 1);

--- a/tests/DCPS/Deadline/Domain.h
+++ b/tests/DCPS/Deadline/Domain.h
@@ -6,14 +6,14 @@
 
 class Domain {
 public:
-  static const int s_id = 11;
+  static const int s_id;
   static const char* s_topic;
   static const char* s_topic_type;
-  static const int s_key1 = 11;
-  static const int s_key2 = 13;
-  static const int n_msg = 10;
-  static const int n_instance = 2;
-  static const int n_expiration = 2;
+  static const int s_key1;
+  static const int s_key2;
+  static const int n_msg;
+  static const int n_instance;
+  static const int n_expiration;
   static const DDS::Duration_t w_deadline;
   static const DDS::Duration_t r_deadline;
   static const OpenDDS::DCPS::TimeDuration w_sleep;


### PR DESCRIPTION
Deadline test failed to compile on the scoreboard:
OpenDDS/build/target/tests/DCPS/Deadline/Writer.cpp:92: undefined reference to `Domain::s_key1'

Initialize static const variables in .cpp.