### PR TITLE
Added DomainParticipantImpl::await_handle

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1413,6 +1413,7 @@ void
 DataReaderImpl::data_received(const ReceivedDataSample& sample)
 {
   DBG_ENTRY_LVL("DataReaderImpl","data_received",6);
+
   // ensure some other thread is not changing the sample container
   // or statuses related to samples.
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->sample_lock_);

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1413,7 +1413,6 @@ void
 DataReaderImpl::data_received(const ReceivedDataSample& sample)
 {
   DBG_ENTRY_LVL("DataReaderImpl","data_received",6);
-
   // ensure some other thread is not changing the sample container
   // or statuses related to samples.
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->sample_lock_);

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1278,7 +1278,6 @@ DomainParticipantImpl::ignore_topic(
   }
 
   RepoId ignoreId = get_repoid(handle);
-
   HandleMap::const_iterator location = this->ignored_topics_.find(ignoreId);
 
   if (location == this->ignored_topics_.end()) {
@@ -1901,7 +1900,6 @@ DDS::InstanceHandle_t DomainParticipantImpl::assign_handle(const GUID_t& id)
     handles_[id] = std::make_pair(handle, 1);
     repoIds_[handle] = id;
     handle_waiters_.notify_all();
-
     return handle;
   }
 
@@ -1929,12 +1927,7 @@ DDS::InstanceHandle_t DomainParticipantImpl::await_handle(const GUID_t& id) cons
 DDS::InstanceHandle_t DomainParticipantImpl::lookup_handle(const GUID_t& id) const
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, handle_protector_, DDS::HANDLE_NIL);
-
   const CountedHandleMap::const_iterator iter = handles_.find(id);
-  if (iter == handles_.end()) {
-    std::stringstream buf;
-    buf << ::OpenDDS::DCPS::to_string(id);
-  }
   return iter == handles_.end() ? DDS::HANDLE_NIL : iter->second.first;
 }
 

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -312,9 +312,11 @@ public:
   /**
    * Similar to lookup_handle in that it will return a previously mapped handle,
    * but will coorindate with assign_handle when a desired handle has not yet
-   * been mapped, but is expected to be.
+   * been mapped, but is expected to be. The optional max_wait argument can be
+   * supplied to limit the time spent waiting for a handle. It the wait times out
+   * a value of HANDLE_NIL is returned.
    */
-  DDS::InstanceHandle_t await_handle(const GUID_t& id) const;
+  DDS::InstanceHandle_t await_handle(const GUID_t& id, TimeDuration max_wait = TimeDuration::zero_value) const;
 
   /**
    * Return a previously-assigned handle.

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -313,7 +313,7 @@ public:
    * Similar to lookup_handle in that it will return a previously mapped handle,
    * but will coorindate with assign_handle when a desired handle has not yet
    * been mapped, but is expected to be. The optional max_wait argument can be
-   * supplied to limit the time spent waiting for a handle. It the wait times out
+   * supplied to limit the time spent waiting for a handle. If the wait times out,
    * a value of HANDLE_NIL is returned.
    */
   DDS::InstanceHandle_t await_handle(const GUID_t& id, TimeDuration max_wait = TimeDuration::zero_value) const;

--- a/tests/DCPS/BuiltInTopic/common.cpp
+++ b/tests/DCPS/BuiltInTopic/common.cpp
@@ -64,7 +64,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_PARTICIPANT,  participant %C ignore participant %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->await_handle(ignore_id);
 
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_PARTICIPANT, ignored participant %C has handle 0x%x.\n"),
@@ -100,7 +100,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_TOPIC, participant %C ignore topic %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->await_handle(ignore_id);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_TOPIC,  ignored topic %C has handle 0x%x.\n"),
         ignoreBuffer.str().c_str(),
@@ -134,7 +134,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_PUBLICATION, participant %C ignore publication %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->await_handle(ignore_id);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_PUBLICATION,  ignored topic %C has handle 0x%x.\n"),
         ignoreBuffer.str().c_str(),
@@ -168,7 +168,7 @@ int ignore ()
                  ACE_TEXT("(%P|%t) IGNORE_SUBSCRIPTION, participant %C ignore subscription %C .\n"),
                  participantBuffer.str().c_str(), ignoreBuffer.str().c_str()));
 
-      InstanceHandle_t handle = participant_servant->lookup_handle(ignore_id);
+      InstanceHandle_t handle = participant_servant->await_handle(ignore_id);
       ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) IGNORE_SUBSCRIPTION,  ignored topic %C has handle 0x%x.\n"),
         ignoreBuffer.str().c_str(),


### PR DESCRIPTION
 it is because of a race between the main thread and a service thread. This commit addresses that case.
It does this by adding a method to the Domain Participant servant impl to wait until it is positively signaled that a desired instance handle has been assigned for a given GUID. The new method is called await_handle() and is similar to the method lookup_handle(). 