### PR TITLE
GitHub Actions: Update .lst flags

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2711,7 +2711,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security -Config ASAN"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security -Config GHA_ASAN"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -550,7 +550,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_EXTENDED -Config RTPS -Config LINUX -Config OPENDDS_SAFETY_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GHA_OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_EXTENDED -Config RTPS -Config LINUX -Config OPENDDS_SAFETY_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -640,7 +640,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_BASE -Config RTPS -Config LINUX -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GHA_OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_BASE -Config RTPS -Config LINUX -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2711,7 +2711,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security -Config GHA_ASAN"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security -Config GH_ACTIONS_ASAN"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -7861,7 +7861,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -Config GH_ACTIONS_W16 --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -8772,7 +8772,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -Config GH_ACTIONS_M10 --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -9055,7 +9055,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -Config NO_UNIT_TESTS --java --modeling --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M10 --java --modeling --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -171,7 +171,7 @@ GitHub Actions runners.
 
 * tests/DCPS/SharedTransport/run_test.pl multicast
 
-  * Multicast times out waiting for remote peer. Fails on ``test_u20_p1_j8_FM-1f`` and ``test_u20_p1_sec`.
+  * Multicast times out waiting for remote peer. Fails on ``test_u20_p1_j8_FM-1f`` and ``test_u20_p1_sec``.
 
 * tests/DCPS/StringKey/run_test.pl
 

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -153,6 +153,40 @@ These blocks are necessary because certain tests cannot properly run on GitHub A
   :doc:`running_tests`
     For how ``auto_run_tests.pl`` works in general.
 
+Blocked Tests
+=============
+
+Certain tests are blocked from GitHub actions because their failures are either unfixable, or are not represented on the
+scoreboard. If this is the case, we have to assume that the failure is due to some sort of limitation caused by the
+GitHub Actions runners.
+
+* performance-tests/bench/run_test.pl fan_frag show-logs
+
+  * Fails due to no available nodes discovered during wait. Fails on ``test_m10_o1d0_sec``.
+
+* tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed
+
+  * The instances tests in general are problematic on safety builds. This in one particular fails for CI but not on the current
+  scoreboard run. Fails on ``u18_esafe_js0`` and ``u18_bsafe_js0_FM-1f``.
+
+* tests/DCPS/SharedTransport/run_test.pl multicast
+
+  * Multicast times out waiting for remote peer. Fails on ``test_u20_p1_j8_FM-1f`` and ``test_u20_p1_sec`.
+
+* tests/DCPS/StringKey/run_test.pl
+
+  * A timeout occurs during the writer writing.  Fails on ``u18_bsafe_js0_FM-1f``.
+
+* tests/DCPS/Thrasher/run_test.pl high/aggressive/medium XXXX XXXX
+
+  * The more intense thrasher tests cause consistent failures due to the increased load from ASAN. GitHub Actions fails
+  these tests very consistently compared to the scoreboard which is more intermittent. Fails on ``test_u20_p1_asan_sec``.
+
+* tests/stress-tests/dds/DCPS/run_test.pl
+
+  * This test fails due to only getting ``17 of the expected >=19 total_count``.  Fails on ``test_m10_i0_j_FM-1f`` and
+  ``test_m10_o1d0_sec``.
+
 Test Results
 ============
 

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -172,11 +172,6 @@ GitHub Actions runners.
 Only Failing on CI
 ------------------
 
-* tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed
-
-  * The instances tests in general are problematic on safety builds. This in one particular fails for CI but not on the current
-    scoreboard run. Fails on ``u18_esafe_js0`` and ``u18_bsafe_js0_FM-1f``.
-
 * tests/DCPS/SharedTransport/run_test.pl multicast
 
   * Multicast times out waiting for remote peer. Fails on ``test_u20_p1_j8_FM-1f`` and ``test_u20_p1_sec``.

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -165,9 +165,8 @@ These blocks are necessary because certain tests cannot properly run on GitHub A
 Blocked Tests
 =============
 
-Certain tests are blocked from GitHub actions because their failures are either unfixable, or are not represented on the
-scoreboard. If this is the case, we have to assume that the failure is due to some sort of limitation caused by the
-GitHub Actions runners.
+Certain tests are blocked from GitHub actions because their failures are either unfixable, or are not represented on the scoreboard.
+If this is the case, we have to assume that the failure is due to some sort of limitation caused by the GitHub Actions runners.
 
 Only Failing on CI
 ------------------
@@ -182,24 +181,25 @@ Only Failing on CI
 
 * tests/DCPS/Thrasher/run_test.pl high/aggressive/medium XXXX XXXX
 
-  * The more intense thrasher tests cause consistent failures due to the increased load from ASAN. GitHub Actions fails
-    these tests very consistently compared to the scoreboard which is more intermittent. Fails on ``test_u20_p1_asan_sec``.
+  * The more intense thrasher tests cause consistent failures due to the increased load from ASAN.
+    GitHub Actions fails these tests very consistently compared to the scoreboard which is more intermittent.
+    Fails on ``test_u20_p1_asan_sec``.
 
 * tests/stress-tests/dds/DCPS/run_test.pl
 
-  * This test fails due to only getting ``17 of the expected >=19 total_count``.  Fails on ``test_m10_i0_j_FM-1f`` and
-    ``test_m10_o1d0_sec``.
+  * This test fails due to only getting ``17 of the expected >=19 total_count``.
+    Fails on ``test_m10_i0_j_FM-1f`` and ``test_m10_o1d0_sec``.
 
 * tests/DCPS/StaticDiscoveryReconnect/run_test.pl
 
-  * This test fails due to ``<StaticDiscoveryTest> failed: No such file or directory``. Fails on ``test_m10_i0_j_FM-1f``
-    and ``test_m10_o1d0_sec``.
+  * This test fails due to ``<StaticDiscoveryTest> failed: No such file or directory``.
+    Fails on ``test_m10_i0_j_FM-1f`` and ``test_m10_o1d0_sec``.
 
 Failing Both CI and scoreboard
 ------------------------------
 
-These tests fail on the CI as well as the scoreboard, but will remain blocked on the CI until fixed. Each test has a list
-of the builds it was failing on before being blocked.
+These tests fail on the CI as well as the scoreboard, but will remain blocked on the CI until fixed.
+Each test has a list of the builds it was failing on before being blocked.
 
 * tests/DCPS/BuiltInTopicTest/run_test.pl
 

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -145,7 +145,16 @@ The last list file used by ``build_and_test.yml`` is :ghfile:`tools/modeling/tes
 
 To disable a test in GitHub Actions, ``!GH_ACTIONS`` must be added next to the test in the .lst file.
 These tests will not run when ``-Config GH_ACTIONS`` is passed alongside the lst file.
-There are similar test blockers which only block for specific github actions configurations: ``!GHA_OPENDDS_SAFETY_PROFILE`` blocks Safety Profile builds from running a test.
+There are similar test blockers which only block for specific github actions configurations from running marked tests:
+
+* ``!GH_ACTIONS_OPENDDS_SAFETY_PROFILE`` blocks Safety Profile builds
+
+* ``!GH_ACTIONS_M10`` blocks the MacOS10 runners
+
+* ``!GH_ACTIONS_ASAN`` blocks the Address Sanitizer builds
+
+* ``!GH_ACTIONS_W16`` blocks the Windows2016 runner
+
 These blocks are necessary because certain tests cannot properly run on GitHub Actions due to how the runners are configured.
 
 .. seealso::
@@ -159,6 +168,9 @@ Blocked Tests
 Certain tests are blocked from GitHub actions because their failures are either unfixable, or are not represented on the
 scoreboard. If this is the case, we have to assume that the failure is due to some sort of limitation caused by the
 GitHub Actions runners.
+
+Only Failing on CI
+------------------
 
 * tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed
 
@@ -182,6 +194,83 @@ GitHub Actions runners.
 
   * This test fails due to only getting ``17 of the expected >=19 total_count``.  Fails on ``test_m10_i0_j_FM-1f`` and
     ``test_m10_o1d0_sec``.
+
+* tests/DCPS/StaticDiscoveryReconnect/run_test.pl
+
+  * This test fails due to ``<StaticDiscoveryTest> failed: No such file or directory``. Fails on ``test_m10_i0_j_FM-1f``
+    and ``test_m10_o1d0_sec``.
+
+Failing Both CI and scoreboard
+------------------------------
+
+These tests fail on the CI as well as the scoreboard, but will remain blocked on the CI until fixed. Each test has a list
+of the builds it was failing on before being blocked.
+
+* tests/DCPS/BuiltInTopicTest/run_test.pl
+
+  * u18_esafe_js0
+
+* tests/DCPS/CompatibilityTest/run_test.pl rtps_disc
+
+  * test_m10_o1d0_sec
+
+* tests/DCPS/Deadline/run_test.pl rtps_disc
+
+  * test_u20_p1_asan_sec
+
+  * test_m10_o1d0_sec
+
+* tests/DCPS/Federation/run_test.pl
+
+  * test_u18_w1_sec
+
+  * test_u18_j_cft0_FM-37
+
+  * test_u18_w1_j_FM-2f
+
+  * test_u20_ace7_j_qt_ws_sec
+
+  * test_u20_p1_asan_sec
+
+  * test_u20_p1_asan_sec
+
+* tests/DCPS/Instances/run_test.pl [Multiple Configurations]
+
+  * u18_bsafe_js0_FM-1f
+
+  * u18_esafe_js0
+
+* tests/DCPS/MultiDPTest/run_test.pl
+
+  * u18_bsafe_js0_FM-1f
+
+  * u18_esafe_js0
+
+* tests/DCPS/NotifyTest/run_test.pl
+
+* tests/DCPS/Reconnect/run_test.pl restart_pub
+
+  * test_w16_x86_i0_sec
+
+* tests/DCPS/Reconnect/run_test.pl restart_sub
+
+  * test_w16_x86_i0_sec
+
+* tests/DCPS/ReliableBestEffortReaders/run_test.pl
+
+  * test_u18_w1_j_FM-2f
+
+  * test_u18_j_cft0_FM-37
+
+  * test_u20_p1_j8_FM-1f
+
+  * test_m10_o1d0_sec
+
+* tests/DCPS/TimeBasedFilter/run_test.pl -reliable
+
+  * u18_bsafe_js0_FM-1f
+
+  * u18_esafe_js0
 
 Test Results
 ============

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -203,69 +203,69 @@ Each test has a list of the builds it was failing on before being blocked.
 
 * tests/DCPS/BuiltInTopicTest/run_test.pl
 
-  * u18_esafe_js0
+  * ``u18_esafe_js0``
 
 * tests/DCPS/CompatibilityTest/run_test.pl rtps_disc
 
-  * test_m10_o1d0_sec
+  * ``test_m10_o1d0_sec``
 
 * tests/DCPS/Deadline/run_test.pl rtps_disc
 
-  * test_u20_p1_asan_sec
+  * ``test_u20_p1_asan_sec``
 
-  * test_m10_o1d0_sec
+  * ``test_m10_o1d0_sec``
 
 * tests/DCPS/Federation/run_test.pl
 
-  * test_u18_w1_sec
+  * ``test_u18_w1_sec``
 
-  * test_u18_j_cft0_FM-37
+  * ``test_u18_j_cft0_FM-37``
 
-  * test_u18_w1_j_FM-2f
+  * ``test_u18_w1_j_FM-2f``
 
-  * test_u20_ace7_j_qt_ws_sec
+  * ``test_u20_ace7_j_qt_ws_sec``
 
-  * test_u20_p1_asan_sec
+  * ``test_u20_p1_asan_sec``
 
-  * test_u20_p1_asan_sec
+  * ``test_u20_p1_asan_sec``
 
 * tests/DCPS/Instances/run_test.pl [Multiple Configurations]
 
-  * u18_bsafe_js0_FM-1f
+  * ``u18_bsafe_js0_FM-1f``
 
-  * u18_esafe_js0
+  * ``u18_esafe_js0``
 
 * tests/DCPS/MultiDPTest/run_test.pl
 
-  * u18_bsafe_js0_FM-1f
+  * ``u18_bsafe_js0_FM-1f``
 
-  * u18_esafe_js0
+  * ``u18_esafe_js0``
 
 * tests/DCPS/NotifyTest/run_test.pl
 
 * tests/DCPS/Reconnect/run_test.pl restart_pub
 
-  * test_w16_x86_i0_sec
+  * ``test_w16_x86_i0_sec``
 
 * tests/DCPS/Reconnect/run_test.pl restart_sub
 
-  * test_w16_x86_i0_sec
+  * ``test_w16_x86_i0_sec``
 
 * tests/DCPS/ReliableBestEffortReaders/run_test.pl
 
-  * test_u18_w1_j_FM-2f
+  * ``test_u18_w1_j_FM-2f``
 
-  * test_u18_j_cft0_FM-37
+  * ``test_u18_j_cft0_FM-37``
 
-  * test_u20_p1_j8_FM-1f
+  * ``test_u20_p1_j8_FM-1f``
 
-  * test_m10_o1d0_sec
+  * ``test_m10_o1d0_sec``
 
 * tests/DCPS/TimeBasedFilter/run_test.pl -reliable
 
-  * u18_bsafe_js0_FM-1f
+  * ``u18_bsafe_js0_FM-1f``
 
-  * u18_esafe_js0
+  * ``u18_esafe_js0``
 
 Test Results
 ============

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -160,10 +160,6 @@ Certain tests are blocked from GitHub actions because their failures are either 
 scoreboard. If this is the case, we have to assume that the failure is due to some sort of limitation caused by the
 GitHub Actions runners.
 
-* performance-tests/bench/run_test.pl fan_frag show-logs
-
-  * Fails due to no available nodes discovered during wait. Fails on ``test_m10_o1d0_sec``.
-
 * tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed
 
   * The instances tests in general are problematic on safety builds. This in one particular fails for CI but not on the current

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -167,7 +167,7 @@ GitHub Actions runners.
 * tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed
 
   * The instances tests in general are problematic on safety builds. This in one particular fails for CI but not on the current
-  scoreboard run. Fails on ``u18_esafe_js0`` and ``u18_bsafe_js0_FM-1f``.
+    scoreboard run. Fails on ``u18_esafe_js0`` and ``u18_bsafe_js0_FM-1f``.
 
 * tests/DCPS/SharedTransport/run_test.pl multicast
 
@@ -180,12 +180,12 @@ GitHub Actions runners.
 * tests/DCPS/Thrasher/run_test.pl high/aggressive/medium XXXX XXXX
 
   * The more intense thrasher tests cause consistent failures due to the increased load from ASAN. GitHub Actions fails
-  these tests very consistently compared to the scoreboard which is more intermittent. Fails on ``test_u20_p1_asan_sec``.
+    these tests very consistently compared to the scoreboard which is more intermittent. Fails on ``test_u20_p1_asan_sec``.
 
 * tests/stress-tests/dds/DCPS/run_test.pl
 
   * This test fails due to only getting ``17 of the expected >=19 total_count``.  Fails on ``test_m10_i0_j_FM-1f`` and
-  ``test_m10_o1d0_sec``.
+    ``test_m10_o1d0_sec``.
 
 Test Results
 ============

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -95,7 +95,7 @@ tests/DCPS/FooTest4/run_test.pl mr: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !DDS_NO_
 tests/DCPS/FooTest4/run_test.pl mri: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !DDS_NO_OBJECT_MODEL_PROFILE
 tests/DCPS/FooTest4/run_test.pl mrit: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !DDS_NO_OBJECT_MODEL_PROFILE
 
-tests/DCPS/FooTest4_0/run_test.pl: !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/FooTest4_0/run_test.pl: !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/FooTest5/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/FooTest5/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -121,11 +121,11 @@ tests/DCPS/FooTest5_0/run_test.pl udp: !DCPS_MIN !STATIC !DDS_NO_OWNERSHIP_PROFI
 tests/DCPS/FooTest5_0/run_test.pl rtps: !DCPS_MIN !STATIC RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/FooTest5_0/run_test.pl shmem: !DCPS_MIN !STATIC !NO_SHMEM !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/FooTest5_0/run_test.pl diff_trans: !DCPS_MIN !STATIC !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
-tests/DCPS/MultiDPTest/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
+tests/DCPS/MultiDPTest/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl rtps: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl rtps_disc: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/TransientLocalTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/TransientLocalTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalTest/run_test.pl rtps: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/DelayedDurable/run_test.pl: !DCPS_MIN RTPS
 tests/DCPS/DelayedDurable/run_test.pl --large-samples: !DCPS_MIN RTPS
@@ -136,32 +136,32 @@ tests/DCPS/Presentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS
 tests/DCPS/ReaderDataLifecycle/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ReaderDataLifecycle/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
-tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl bp_timeout: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/sub_init_loop/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/TcpReconnect/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/TcpReconnect/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
-tests/DCPS/BuiltInTopic/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/BuiltInTopic/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_part: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_topic: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_pub: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_sub: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/BuiltInTopicTest/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !DDS_NO_OWNERSHIP_PROFILE !TARGET !GH_ACTIONS
-tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/BuiltInTopicTest/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !DDS_NO_OWNERSHIP_PROFILE !TARGET
+tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/CorbaSeq/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ViewState/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 
-tests/DCPS/NotifyTest/run_test.pl: !DCPS_MIN !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/Observer/run_test.pl: !DCPS_MIN !GH_ACTIONS
+tests/DCPS/NotifyTest/run_test.pl: !DCPS_MIN
+tests/DCPS/Observer/run_test.pl: !DCPS_MIN
 tests/DCPS/Reliability/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Reliability/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/ReliableBestEffortReaders/run_test.pl: RTPS !DCPS_MIN !GH_ACTIONS
+tests/DCPS/ReliableBestEffortReaders/run_test.pl: RTPS !DCPS_MIN
 
 tests/DCPS/WriteDataContainer/run_test.pl: !DCPS_MIN
 
@@ -203,11 +203,11 @@ tests/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNE
 tests/DCPS/Messenger/run_test.pl default_tcp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl thread_per: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Messenger/run_test.pl default_udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/Messenger/run_test.pl default_udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Messenger/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl multicast_be: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl default_multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Messenger/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/Messenger/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl nobits: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl stack: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl ipv6: IPV6 !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -219,7 +219,7 @@ tests/DCPS/Messenger/run_test.pl rtps_disc_tcp thread_per: !DCPS_MIN !NO_MCAST R
 tests/DCPS/Messenger/run_test.pl rtps_disc_tcp_udp: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl rtps_disc_half_sec_pub: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl rtps_disc_half_sec_sub: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Messenger/run_test.pl rtps_disc_sec: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/Messenger/run_test.pl rtps_disc_sec: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/Messenger/run_corbaloc_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_corbaloc_test.pl host_port_only: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -242,21 +242,21 @@ tests/DCPS/EntityLifecycleStress/run_test.pl publishers 5 subscribers 5: !OPENDD
 tests/DCPS/EntityLifecycleStress/run_test.pl rtps_disc publishers 10 subscribers 10: RTPS
 
 tests/DCPS/LivelinessKeepAliveTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/LivelinessTimeout/run_test.pl: !DCPS_MIN !GH_ACTIONS
+tests/DCPS/LivelinessTimeout/run_test.pl: !DCPS_MIN
 tests/DCPS/LivelinessTimeout/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/BitDataReader/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS
 
 tests/unit-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS
 
-tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN !GH_ACTIONS
+tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN
 
 tests/DCPS/KeyTest/run_test.pl keymarshalling: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl isbounded: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl md5: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl compiler: !DCPS_MIN !TARGET !OPENDDS_SAFETY_PROFILE
-tests/DCPS/CompatibilityTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
-tests/DCPS/CompatibilityTest/run_test.pl rtps_disc: !DCPS_MIN RTPS !GH_ACTIONS
-tests/DCPS/CompatibilityTest/run_test.pl rtps_disc_tcp: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/CompatibilityTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/CompatibilityTest/run_test.pl rtps_disc: !DCPS_MIN RTPS
+tests/DCPS/CompatibilityTest/run_test.pl rtps_disc_tcp: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Partition/run_test.pl: !DCPS_MIN
 tests/DCPS/Deadline/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Deadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
@@ -265,24 +265,24 @@ tests/DCPS/Lifespan/run_test.pl rtps_disc: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE R
 tests/DCPS/TransientDurability/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/PersistentDurability/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/SampleLost/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/SetQosDeadline/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
-tests/DCPS/SetQosDeadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !GH_ACTIONS
+tests/DCPS/SetQosDeadline/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/SetQosDeadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
 tests/DCPS/SetQosPartition/run_test.pl ini=inforepo_tcp.ini: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SetQosPartition/run_test.pl ini=rtps_rtps.ini: !DCPS_MIN !NO_MCAST RTPS
 tests/DCPS/SetQosPartition/run_test.pl ini=rtps_tcp.ini: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/StringKey/run_test.pl: !DCPS_MIN !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/GuardCondition/run_test.pl: !DCPS_MIN !GH_ACTIONS
+tests/DCPS/StringKey/run_test.pl: !DCPS_MIN
+tests/DCPS/GuardCondition/run_test.pl: !DCPS_MIN
 tests/DCPS/StatusCondition/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE
 tests/DCPS/ReadCondition/run_test.pl: !DCPS_MIN
 tests/DCPS/RegisterInstance/run_test.pl: !DCPS_MIN RTPS
 tests/DCPS/Rejects/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Rejects/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/Rejects/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/FilterExpression/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_SUBSCRIPTION
-tests/DCPS/QueryCondition/run_test.pl: !DCPS_MIN !DDS_NO_QUERY_CONDITION !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/QueryCondition/run_test.pl: !DCPS_MIN !DDS_NO_QUERY_CONDITION !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/QueryCondition/run_test.pl rtps_disc: !DCPS_MIN !DDS_NO_QUERY_CONDITION !DDS_NO_CONTENT_SUBSCRIPTION RTPS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/ContentFilteredTopic/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
-tests/DCPS/ContentFilteredTopic/run_test.pl nopub: !DCPS_MIN !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/ContentFilteredTopic/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/ContentFilteredTopic/run_test.pl nopub: !DCPS_MIN !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ContentFilteredTopic/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ContentFilteredTopic/run_test.pl rtps_disc nopub: !DCPS_MIN !NO_MCAST !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TopicExpression/run_test.pl: !DCPS_MIN !DDS_NO_MULTI_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION
@@ -292,7 +292,7 @@ tests/DCPS/MultiTopic/run_test.pl cpp11: !DCPS_MIN !DDS_NO_MULTI_TOPIC !DDS_NO_C
 tests/DCPS/MultiTopic/run_test.pl cpp11 rtps_disc: !DCPS_MIN !DDS_NO_MULTI_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION RTPS !STATIC CXX11
 tests/DCPS/MetaStruct/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_MULTI_TOPIC
 
-tests/DCPS/Federation/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/Federation/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/FileSystemStorage/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Priority/run_test.pl: !DCPS_MIN !QNX !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Priority/run_test.pl --instances: !DCPS_MIN !QNX !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -308,53 +308,53 @@ tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROF
 tests/DCPS/Thrasher/run_test.pl default: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ManualAssertLiveliness/run_test.pl lost: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ManualAssertLiveliness/run_test.pl rtps: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ManualAssertLiveliness/run_test.pl rtps lost: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
-tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco lost: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco lost: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco rtps: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco rtps lost: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/ManualAssertLiveliness/run_test.pl rtpsdisco rtps lost: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Serializer_wstring/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SharedTransport/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/SharedTransport/run_test.pl rtps: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS !GH_ACTIONS
+tests/DCPS/SharedTransport/run_test.pl rtps: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
 tests/DCPS/SharedTransport/run_test.pl rtps 2: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
 tests/DCPS/SharedTransport/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/SharedTransport/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/SharedTransport/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SharedTransport/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SharedTransport/run_test.pl rtps_disc_tcp: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Ownership/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Ownership/run_test.pl update_strength: !DCPS_MIN !NO_BUILT_IN_TOPICS  !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Ownership/run_test.pl liveliness_change: !DCPS_MIN !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/Ownership/run_test.pl liveliness_change: !DCPS_MIN !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Ownership/run_test.pl miss_deadline: !DCPS_MIN !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/GroupPresentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/GroupPresentation/run_test.pl topic: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -363,15 +363,15 @@ tests/DCPS/LargeSample/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OW
 tests/DCPS/LargeSample/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/LargeSample/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/LargeSample/run_test.pl multicast_async: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/LargeSample/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/LargeSample/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/LargeSample/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !TARGET
 tests/DCPS/ConfigFile/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/ConfigTransports/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/ConfigTransports/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/RtpsMessages/run_test.pl: !DCPS_MIN RTPS
 tests/DCPS/RtpsDiscovery/run_test.pl: !DCPS_MIN !NO_MCAST RTPS !NO_BUILT_IN_TOPICS
 tests/DCPS/RtiSerialization/run_test.pl rtps: !DCPS_MIN RTPS
 tests/DCPS/MultiDiscovery/run_test.pl: !DCPS_MIN !NO_MCAST !TARGET
-tests/DCPS/DomainRange/run_test.pl: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/DomainRange/run_test.pl: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/InternalThreadStatus/run_test.pl: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !NO_BUILT_IN_TOPICS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscovery/run_test.pl: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscovery/run_test.pl mp: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
@@ -389,7 +389,7 @@ tests/transport/rtps_directed_write/run_test.pl: !DCPS_MIN RTPS
 tests/transport/best_effort_reader/run_test.pl: !DCPS_MIN RTPS
 
 tests/DCPS/ManyTopicTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/ManyTopicTest/run_test.pl rtps: !DCPS_MIN RTPS !GH_ACTIONS
+tests/DCPS/ManyTopicTest/run_test.pl rtps: !DCPS_MIN RTPS
 
 tests/DCPS/ManyTopicMultiProcess/run_test.pl: !DCPS_MIN
 
@@ -400,15 +400,15 @@ tests/DCPS/QoS_XML/dumpXMLString/run_test.pl dcps_qos_xml_handler: XERCES3
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS
 tests/DCPS/ManyToMany/run_test.pl tcp 12to12 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !LYNXOS
 tests/DCPS/ManyToMany/run_test.pl multicast 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/ManyToMany/run_test.pl multicast 1to1 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/ManyToMany/run_test.pl multicast 1to1 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ManyToMany/run_test.pl multicast_async 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ManyToMany/run_test.pl multicast_async 1to1 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ManyToMany/run_test.pl udp 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ManyToMany/run_test.pl udp 1to1 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ManyToMany/run_test.pl rtps 1to1 small: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ManyToMany/run_test.pl rtps 1to1 large: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/ManyToMany/run_test.pl rtps_disc 12to12 small: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !LYNXOS !GH_ACTIONS
-tests/DCPS/ManyToMany/run_test.pl shmem 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM !GH_ACTIONS
+tests/DCPS/ManyToMany/run_test.pl rtps_disc 12to12 small: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !LYNXOS
+tests/DCPS/ManyToMany/run_test.pl shmem 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM
 tests/DCPS/ManyToMany/run_test.pl shmem 1to1 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM
 tests/DCPS/ManyToMany/run_test.pl tcp 20to20 small orb_csdtp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
@@ -418,10 +418,10 @@ tests/DCPS/Instances/run_test.pl single_instance single_datawriter keyed: !DDS_N
 tests/DCPS/Instances/run_test.pl single_instance single_datawriter nokey: !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/SkipSerialize/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 
 tests/FACE/Messenger/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS
@@ -434,7 +434,7 @@ tests/FACE/SingleProcessMessenger/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_I
 tests/FACE/SingleProcessMessenger/run_test.pl callback: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS
 tests/FACE/CallbackAndReceive/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS
 tests/FACE/Header/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS
-tests/FACE/Reliability/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS !GH_ACTIONS
+tests/FACE/Reliability/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS
 tests/FACE/Partition/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS
 tests/FACE/Compiler/idl_test1_main/run_test.pl: !DCPS_MIN !WCHAR !NO_BUILT_IN_TOPICS
 tests/FACE/Compiler/idl_test3_main/run_test.pl: !DCPS_MIN !WCHAR !NO_BUILT_IN_TOPICS
@@ -446,12 +446,12 @@ tests/DCPS/XTypes/run_test.pl: !DCPS_MIN
 tests/DCPS/UnregisterType/run_test.pl: !DCPS_MIN
 
 performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
-performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+performance-tests/bench/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 
 tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DataRepresentation/run_test.pl rtps_disc: !DCPS_MIN RTPS

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -308,32 +308,32 @@ tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROF
 tests/DCPS/Thrasher/run_test.pl default: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GHA_ASAN
 tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !GHA_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !GHA_ASAN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
 tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN
-tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
@@ -418,7 +418,7 @@ tests/DCPS/Instances/run_test.pl single_instance single_datawriter keyed: !DDS_N
 tests/DCPS/Instances/run_test.pl single_instance single_datawriter nokey: !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
 tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -140,7 +140,7 @@ tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE 
 tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_W16
 tests/DCPS/Reconnect/run_test.pl bp_timeout: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
+tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/sub_init_loop/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -143,7 +143,7 @@ tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFI
 tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/sub_init_loop/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
 tests/DCPS/TcpReconnect/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/BuiltInTopic/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
@@ -151,7 +151,7 @@ tests/DCPS/BuiltInTopic/run_test.pl ignore_part: !DCPS_MIN !NO_BUILT_IN_TOPICS !
 tests/DCPS/BuiltInTopic/run_test.pl ignore_topic: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_pub: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_sub: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/BuiltInTopicTest/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !DDS_NO_OWNERSHIP_PROFILE !TARGET
+tests/DCPS/BuiltInTopicTest/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !DDS_NO_OWNERSHIP_PROFILE !TARGET !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/CorbaSeq/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
@@ -259,7 +259,7 @@ tests/DCPS/CompatibilityTest/run_test.pl rtps_disc: !DCPS_MIN RTPS !GH_ACTIONS_M
 tests/DCPS/CompatibilityTest/run_test.pl rtps_disc_tcp: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Partition/run_test.pl: !DCPS_MIN
 tests/DCPS/Deadline/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Deadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
+tests/DCPS/Deadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !GH_ACTIONS
 tests/DCPS/Lifespan/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Lifespan/run_test.pl rtps_disc: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE RTPS
 tests/DCPS/TransientDurability/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -447,7 +447,7 @@ tests/DCPS/UnregisterType/run_test.pl: !DCPS_MIN
 
 performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -140,7 +140,7 @@ tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE 
 tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl bp_timeout: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
 tests/DCPS/sub_init_loop/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TimeBasedFilter/run_test.pl -reliable: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
@@ -248,7 +248,7 @@ tests/DCPS/BitDataReader/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS
 
 tests/unit-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS
 
-tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN
+tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN !GH_ACTIONS
 
 tests/DCPS/KeyTest/run_test.pl keymarshalling: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl isbounded: !DCPS_MIN
@@ -270,7 +270,7 @@ tests/DCPS/SetQosDeadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
 tests/DCPS/SetQosPartition/run_test.pl ini=inforepo_tcp.ini: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SetQosPartition/run_test.pl ini=rtps_rtps.ini: !DCPS_MIN !NO_MCAST RTPS
 tests/DCPS/SetQosPartition/run_test.pl ini=rtps_tcp.ini: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/StringKey/run_test.pl: !DCPS_MIN
+tests/DCPS/StringKey/run_test.pl: !DCPS_MIN !GHA_OPENDDS_SAFETY_PROFILE
 tests/DCPS/GuardCondition/run_test.pl: !DCPS_MIN
 tests/DCPS/StatusCondition/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE
 tests/DCPS/ReadCondition/run_test.pl: !DCPS_MIN
@@ -308,32 +308,32 @@ tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROF
 tests/DCPS/Thrasher/run_test.pl default: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !ASAN
 tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !ASAN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !ASAN
 tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !ASAN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
@@ -349,7 +349,7 @@ tests/DCPS/SharedTransport/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SharedTransport/run_test.pl rtps: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
 tests/DCPS/SharedTransport/run_test.pl rtps 2: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
 tests/DCPS/SharedTransport/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/SharedTransport/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE
+tests/DCPS/SharedTransport/run_test.pl multicast: !DCPS_MIN !NO_MCAST !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
 tests/DCPS/SharedTransport/run_test.pl shmem: !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SharedTransport/run_test.pl rtps_disc_tcp: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Ownership/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -121,7 +121,7 @@ tests/DCPS/FooTest5_0/run_test.pl udp: !DCPS_MIN !STATIC !DDS_NO_OWNERSHIP_PROFI
 tests/DCPS/FooTest5_0/run_test.pl rtps: !DCPS_MIN !STATIC RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/FooTest5_0/run_test.pl shmem: !DCPS_MIN !STATIC !NO_SHMEM !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/FooTest5_0/run_test.pl diff_trans: !DCPS_MIN !STATIC !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
-tests/DCPS/MultiDPTest/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/MultiDPTest/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
 tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl rtps: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl rtps_disc: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
@@ -136,8 +136,8 @@ tests/DCPS/Presentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS
 tests/DCPS/ReaderDataLifecycle/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ReaderDataLifecycle/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Reconnect/run_test.pl restart_sub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_W16
+tests/DCPS/Reconnect/run_test.pl restart_pub: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_W16
 tests/DCPS/Reconnect/run_test.pl bp_timeout: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Reconnect/run_test.pl sub_init_crash: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Restart/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
@@ -157,11 +157,11 @@ tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS
 tests/DCPS/CorbaSeq/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ViewState/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 
-tests/DCPS/NotifyTest/run_test.pl: !DCPS_MIN
+tests/DCPS/NotifyTest/run_test.pl: !DCPS_MIN !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
 tests/DCPS/Observer/run_test.pl: !DCPS_MIN
 tests/DCPS/Reliability/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Reliability/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/ReliableBestEffortReaders/run_test.pl: RTPS !DCPS_MIN
+tests/DCPS/ReliableBestEffortReaders/run_test.pl: RTPS !DCPS_MIN !GH_ACTIONS
 
 tests/DCPS/WriteDataContainer/run_test.pl: !DCPS_MIN
 
@@ -248,14 +248,14 @@ tests/DCPS/BitDataReader/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS
 
 tests/unit-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS
 
-tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN !GH_ACTIONS
+tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN !GH_ACTIONS_M10
 
 tests/DCPS/KeyTest/run_test.pl keymarshalling: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl isbounded: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl md5: !DCPS_MIN
 tests/DCPS/KeyTest/run_test.pl compiler: !DCPS_MIN !TARGET !OPENDDS_SAFETY_PROFILE
 tests/DCPS/CompatibilityTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/CompatibilityTest/run_test.pl rtps_disc: !DCPS_MIN RTPS
+tests/DCPS/CompatibilityTest/run_test.pl rtps_disc: !DCPS_MIN RTPS !GH_ACTIONS_M10
 tests/DCPS/CompatibilityTest/run_test.pl rtps_disc_tcp: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Partition/run_test.pl: !DCPS_MIN
 tests/DCPS/Deadline/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
@@ -270,7 +270,7 @@ tests/DCPS/SetQosDeadline/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
 tests/DCPS/SetQosPartition/run_test.pl ini=inforepo_tcp.ini: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SetQosPartition/run_test.pl ini=rtps_rtps.ini: !DCPS_MIN !NO_MCAST RTPS
 tests/DCPS/SetQosPartition/run_test.pl ini=rtps_tcp.ini: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/StringKey/run_test.pl: !DCPS_MIN !GHA_OPENDDS_SAFETY_PROFILE
+tests/DCPS/StringKey/run_test.pl: !DCPS_MIN !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
 tests/DCPS/GuardCondition/run_test.pl: !DCPS_MIN
 tests/DCPS/StatusCondition/run_test.pl: !DCPS_MIN !DDS_NO_PERSISTENCE_PROFILE
 tests/DCPS/ReadCondition/run_test.pl: !DCPS_MIN
@@ -292,7 +292,7 @@ tests/DCPS/MultiTopic/run_test.pl cpp11: !DCPS_MIN !DDS_NO_MULTI_TOPIC !DDS_NO_C
 tests/DCPS/MultiTopic/run_test.pl cpp11 rtps_disc: !DCPS_MIN !DDS_NO_MULTI_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION RTPS !STATIC CXX11
 tests/DCPS/MetaStruct/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_MULTI_TOPIC
 
-tests/DCPS/Federation/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Federation/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE !GH_ACTIONS
 tests/DCPS/FileSystemStorage/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Priority/run_test.pl: !DCPS_MIN !QNX !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Priority/run_test.pl --instances: !DCPS_MIN !QNX !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -308,32 +308,32 @@ tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROF
 tests/DCPS/Thrasher/run_test.pl default: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GHA_ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
 tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !GHA_ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !GHA_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
 tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
-tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN
-tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GHA_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
@@ -379,7 +379,7 @@ tests/DCPS/StaticDiscovery/run_test.pl mp delay: !DCPS_MIN !NO_MCAST !DDS_NO_OWN
 tests/DCPS/StaticDiscovery/run_test.pl mr: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscovery/run_test.pl mw: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscovery/run_test.pl mpmrmw: !DCPS_MIN !NO_MCAST !TARGET !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/StaticDiscoveryReconnect/run_test.pl: !DCPS_MIN !NO_MCAST
+tests/DCPS/StaticDiscoveryReconnect/run_test.pl: !DCPS_MIN !NO_MCAST !GH_ACTIONS_M10
 tests/DCPS/SubscriberCycle/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_OWNERSHIP_PROFILE
 
 tests/transport/rtps/run_test.pl: !DCPS_MIN RTPS
@@ -414,14 +414,14 @@ tests/DCPS/ManyToMany/run_test.pl tcp 20to20 small orb_csdtp: !DCPS_MIN !OPENDDS
 
 tests/DCPS/PersistentInfoRepo/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 
-tests/DCPS/Instances/run_test.pl single_instance single_datawriter keyed: !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl single_instance single_datawriter nokey: !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GHA_OPENDDS_SAFETY_PROFILE
-tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance single_datawriter keyed: !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance single_datawriter nokey: !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl multiple_instance single_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl single_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter keyed: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
+tests/DCPS/Instances/run_test.pl multiple_instance multiple_datawriter nokey: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_OPENDDS_SAFETY_PROFILE
 tests/DCPS/SkipSerialize/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 
 tests/FACE/Messenger/run_test.pl: !DCPS_MIN !WCHAR RTPS !NO_BUILT_IN_TOPICS

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -446,12 +446,12 @@ tests/DCPS/XTypes/run_test.pl: !DCPS_MIN
 tests/DCPS/UnregisterType/run_test.pl: !DCPS_MIN
 
 performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl sm10: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 
 tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DataRepresentation/run_test.pl rtps_disc: !DCPS_MIN RTPS


### PR DESCRIPTION
The goal of this PR is to document why we have some tests blocked from running in GitHub Actions, and to unblock things that are failing also on the scoreboard.

I removed the flags and after each run, if a test failed on both the latest scoreboard run, as well as the CI run, I reblocked it and logged the reason for test failure.

Here is my google sheets I used for logging failures: 

https://docs.google.com/spreadsheets/d/1S9UfzzA_2PF9pWW3znLuYKvi2OlA04QG-qwYxDfCJ3k/edit?usp=sharing

If you feel there are any of the tests listed in the spreadsheet that should also be blocked, please let me know.

Additionally, if you feel any of the blocked tests should be unblocked, please let me know.