### PR TITLE
Use mutex protection for TransportReassembly

### DIFF
--- a/dds/DCPS/transport/framework/TransportReassembly.cpp
+++ b/dds/DCPS/transport/framework/TransportReassembly.cpp
@@ -191,12 +191,14 @@ bool
 TransportReassembly::has_frags(const SequenceNumber& seq,
                                const RepoId& pub_id) const
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   return fragments_.count(FragKey(pub_id, seq));
 }
 
 void
 TransportReassembly::clear_completed(const RepoId& pub_id)
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   completed_.erase(pub_id);
 }
 
@@ -205,6 +207,7 @@ TransportReassembly::get_gaps(const SequenceNumber& seq, const RepoId& pub_id,
                               CORBA::Long bitmap[], CORBA::ULong length,
                               CORBA::ULong& numBits) const
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   // length is number of (allocated) words in bitmap, max of 8
   // numBits is number of valid bits in the bitmap, <= length * 32, to account for partial words
   if (length == 0) {
@@ -268,6 +271,7 @@ TransportReassembly::reassemble(const SequenceRange& seqRange,
                                 ReceivedDataSample& data,
                                 ACE_UINT32 total_frags)
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   return reassemble_i(seqRange, seqRange.first == 1, data, total_frags);
 }
 
@@ -277,6 +281,7 @@ TransportReassembly::reassemble(const SequenceNumber& transportSeq,
                                 ReceivedDataSample& data,
                                 ACE_UINT32 total_frags)
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   return reassemble_i(SequenceRange(transportSeq, transportSeq),
                       firstFrag, data, total_frags);
 }
@@ -358,6 +363,7 @@ TransportReassembly::reassemble_i(const SequenceRange& seqRange,
 void
 TransportReassembly::data_unavailable(const SequenceRange& dropped)
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   VDBG((LM_DEBUG, "(%P|%t) DBG:   TransportReassembly::data_unavailable() "
     "dropped %q-%q\n", dropped.first.getValue(), dropped.second.getValue()));
   typedef OPENDDS_LIST(FragRange)::iterator list_iterator;
@@ -412,6 +418,7 @@ void
 TransportReassembly::data_unavailable(const SequenceNumber& dataSampleSeq,
                                       const RepoId& pub_id)
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   if (fragments_.erase(FragKey(pub_id, dataSampleSeq)) &&
       (Transport_debug_level > 5 || transport_debug.log_fragment_storage)) {
       ACE_DEBUG((LM_DEBUG, "(%P|%t) DBG:   TransportReassembly::data_unavailable "

--- a/dds/DCPS/transport/framework/TransportReassembly.h
+++ b/dds/DCPS/transport/framework/TransportReassembly.h
@@ -151,6 +151,8 @@ private:
     MonotonicTimePoint expiration_;
   };
 
+  mutable ACE_Thread_Mutex mutex_;
+
 #ifdef ACE_HAS_CPP11
   typedef OPENDDS_UNORDERED_MAP_CHASH(FragKey, FragInfo, FragKeyHash) FragInfoMap;
 #else

--- a/dds/DCPS/transport/framework/TransportReassembly.h
+++ b/dds/DCPS/transport/framework/TransportReassembly.h
@@ -14,6 +14,7 @@
 #include "dds/DCPS/Definitions.h"
 #include "dds/DCPS/DisjointSequence.h"
 #include "dds/DCPS/PoolAllocator.h"
+#include "dds/DCPS/RcObject.h"
 #include "dds/DCPS/TimeTypes.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -21,7 +22,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class OpenDDS_Dcps_Export TransportReassembly {
+class OpenDDS_Dcps_Export TransportReassembly : public RcObject {
 public:
   explicit TransportReassembly(const TimeDuration& timeout = TimeDuration(300));
 
@@ -176,6 +177,8 @@ private:
                      const SequenceRange& seqRange,
                      ReceivedDataSample& data);
 };
+
+typedef RcHandle<TransportReassembly> TransportReassembly_rch;
 
 }
 }

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
@@ -111,6 +111,9 @@ bool
 UdpReceiveStrategy::check_header(const TransportHeader& header)
 {
   ReassemblyInfo& info = reassembly_[remote_address_];
+  if (!info.first) {
+    info.first = make_rch<TransportReassembly>();
+  }
 
   if (header.sequence_ != info.second &&
       expected_ != SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
@@ -119,7 +122,7 @@ UdpReceiveStrategy::check_header(const TransportHeader& header)
                ACE_TEXT("expected %q received %q\n"),
                info.second.getValue(), header.sequence_.getValue()), 2);
     SequenceRange range(info.second, header.sequence_.previous());
-    info.first.data_unavailable(range);
+    info.first->data_unavailable(range);
   }
 
   info.second = header.sequence_;
@@ -131,8 +134,11 @@ bool
 UdpReceiveStrategy::reassemble(ReceivedDataSample& data)
 {
   ReassemblyInfo& info = reassembly_[remote_address_];
+  if (!info.first) {
+    info.first = make_rch<TransportReassembly>();
+  }
   const TransportHeader& header = received_header();
-  return info.first.reassemble(header.sequence_, header.first_fragment_, data);
+  return info.first->reassemble(header.sequence_, header.first_fragment_, data);
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.h
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.h
@@ -60,7 +60,7 @@ private:
   SequenceNumber expected_;
   ACE_INET_Addr remote_address_; // of the current datagram
 
-  typedef std::pair<TransportReassembly, SequenceNumber> ReassemblyInfo;
+  typedef std::pair<TransportReassembly_rch, SequenceNumber> ReassemblyInfo;
   typedef OPENDDS_MAP(ACE_INET_Addr, ReassemblyInfo) ReassemblyMap;
   ReassemblyMap reassembly_;
 };


### PR DESCRIPTION
Given that the discovery thread is allowed to clear fragments on association / disassociation, mutex protection is required for the TransportReassembly class.