### PR TITLE
Extend QoS XML handlers to allow the user to pass its own XML_Error_Handler

### DIFF
--- a/dds/DCPS/QOS_XML_Handler/QOS_XML_Loader.cpp
+++ b/dds/DCPS/QOS_XML_Handler/QOS_XML_Loader.cpp
@@ -8,7 +8,8 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-  QOS_XML_Loader::QOS_XML_Loader()
+  QOS_XML_Loader::QOS_XML_Loader(XML::XML_Error_Handler* error_handler)
+    : xml_file_ (error_handler)
   {
   }
 

--- a/dds/DCPS/QOS_XML_Handler/QOS_XML_Loader.h
+++ b/dds/DCPS/QOS_XML_Handler/QOS_XML_Loader.h
@@ -18,7 +18,10 @@ namespace DCPS {
   class OpenDDS_XML_QOS_Handler_Export QOS_XML_Loader
   {
   public:
-    QOS_XML_Loader ();
+    /// Pass an optional @error_handler which is called back when
+    /// there are any errors parsing the input XML. The QOS_XML_Loader
+    /// will assume ownership when a pointer is passed
+    QOS_XML_Loader (XML::XML_Error_Handler* error_handler = 0);
     ~QOS_XML_Loader ();
 
     /**

--- a/dds/DCPS/QOS_XML_Handler/XML_File_Intf.cpp
+++ b/dds/DCPS/QOS_XML_Handler/XML_File_Intf.cpp
@@ -1,4 +1,3 @@
-
 #include "XML_File_Intf.h"
 #include "ace/XML_Utils/XML_Typedefs.h"
 #include "ace/XML_Utils/XMLSchema/id_map.hpp"
@@ -10,13 +9,18 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-  QOS_XML_File_Handler::QOS_XML_File_Handler() :
-    QOS_XML_Handler()
+  QOS_XML_File_Handler::QOS_XML_File_Handler(XML::XML_Error_Handler* error_handler) :
+    QOS_XML_Handler(),
+    res_(new XML::XML_Schema_Resolver<XML::Environment_Resolver>()),
+    eh_(error_handler ? error_handler : new XML::XML_Error_Handler()),
+    helper_(res_,eh_)
   {
   }
 
   QOS_XML_File_Handler::~QOS_XML_File_Handler()
   {
+    delete res_;
+    delete eh_;
   }
 
   DDS::ReturnCode_t
@@ -25,7 +29,7 @@ namespace DCPS {
     DDS::ReturnCode_t retcode = DDS::RETCODE_OK;
     try
       {
-        if (!XML_Helper_type::XML_HELPER.is_initialized())
+        if (!helper_.is_initialized())
           {
             ACE_ERROR((LM_ERROR,
               ACE_TEXT("QOS_XML_File_Handler::init - ")
@@ -41,7 +45,7 @@ namespace DCPS {
           }
 
         XERCES_CPP_NAMESPACE::DOMDocument *dom =
-          XML_Helper_type::XML_HELPER.create_dom(file);
+          helper_.create_dom(file);
 
         if (dom == 0)
           {
@@ -93,9 +97,8 @@ namespace DCPS {
   QOS_XML_File_Handler::add_search_path(const ACE_TCHAR *environment,
                                         const ACE_TCHAR *relpath)
   {
-    XML_Helper_type::XML_HELPER.get_resolver().get_resolver().add_path(environment, relpath);
+    helper_.get_resolver().get_resolver().add_path(environment, relpath);
   }
-
 }
 }
 

--- a/dds/DCPS/QOS_XML_Handler/XML_File_Intf.cpp
+++ b/dds/DCPS/QOS_XML_Handler/XML_File_Intf.cpp
@@ -1,5 +1,5 @@
 #include "XML_File_Intf.h"
-#include "ace/XML_Utils/XML_Typedefs.h"
+#include "ace/XML_Utils/XML_Helper.h"
 #include "ace/XML_Utils/XMLSchema/id_map.hpp"
 
 #include "dds/DCPS/debug.h"

--- a/dds/DCPS/QOS_XML_Handler/XML_File_Intf.h
+++ b/dds/DCPS/QOS_XML_Handler/XML_File_Intf.h
@@ -42,7 +42,7 @@ namespace DCPS {
     /// Pass an optional @error_handler which is called back when
     /// there are any errors parsing the input XML. The QOS_XML_File_Handler
     /// will assume ownership when a pointer is passed
-    QOS_XML_File_Handler(XML::XML_Error_Handler* error_handler = 0);
+    explicit QOS_XML_File_Handler(XML::XML_Error_Handler* error_handler = 0);
 
     ~QOS_XML_File_Handler();
 

--- a/dds/DCPS/QOS_XML_Handler/XML_File_Intf.h
+++ b/dds/DCPS/QOS_XML_Handler/XML_File_Intf.h
@@ -19,11 +19,15 @@
 #include "dds_qos.hpp"
 #include "XML_Intf.h"
 #include "dds/DdsDcpsInfrastructureC.h"
+#include "ace/XML_Utils/XML_Helper.h"
 #include "OpenDDS_XML_QOS_Handler_Export.h"
 
 namespace XML
 {
-  class XML_Typedef;
+  struct Environment_Resolver;
+  template <typename Resolver>
+  class XML_Schema_Resolver;
+  class XML_Error_Handler;
 }
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -35,35 +39,41 @@ namespace DCPS {
     public QOS_XML_Handler
   {
   public:
-    QOS_XML_File_Handler();
+    /// Pass an optional @error_handler which is called back when
+    /// there are any errors parsing the input XML. The QOS_XML_File_Handler
+    /// will assume ownership when a pointer is passed
+    QOS_XML_File_Handler(XML::XML_Error_Handler* error_handler = 0);
 
     ~QOS_XML_File_Handler();
 
     /**
-     *
-     * init
-     *
      * The init method will open the file and will validate
      * it against the schema. It returns RETCODE_ERROR
      * when any error occurs during parsing
-     *
      */
-    DDS::ReturnCode_t
-    init(const ACE_TCHAR * file);
+    DDS::ReturnCode_t init(const ACE_TCHAR * file);
 
     /**
-     *
      * add_search_path will add a relative path to the XML
      * parsing library. The XML parsing library will use
      * this path to search for the schema
-     *
      */
     void
     add_search_path(const ACE_TCHAR *environment,
                     const ACE_TCHAR *relpath);
 
   private:
-    typedef XML::XML_Typedef XML_Helper_type;
+    typedef XML::XML_Schema_Resolver<XML::Environment_Resolver> XML_RESOLVER;
+    typedef XML::XML_Helper<XML_RESOLVER, XML::XML_Error_Handler> XML_HELPER;
+
+    /// Schema resolver
+    XML_RESOLVER *res_;
+
+    /// Error handler
+    XML::XML_Error_Handler *eh_;
+
+    /// XML Helper
+    XML_HELPER helper_;
   };
 }
 }

--- a/dds/DCPS/QOS_XML_Handler/XML_Intf.cpp
+++ b/dds/DCPS/QOS_XML_Handler/XML_Intf.cpp
@@ -1,6 +1,6 @@
 
 #include "XML_Intf.h"
-#include "ace/XML_Utils/XML_Typedefs.h"
+#include "ace/XML_Utils/XML_Helper.h"
 #include "ace/XML_Utils/XMLSchema/id_map.hpp"
 
 #include "DataReaderQos_Handler.h"

--- a/dds/DCPS/QOS_XML_Handler/XML_String_Intf.cpp
+++ b/dds/DCPS/QOS_XML_Handler/XML_String_Intf.cpp
@@ -4,7 +4,7 @@
 #include "xercesc/parsers/XercesDOMParser.hpp"
 #include "xercesc/sax/SAXParseException.hpp"
 #include "xercesc/util/TransService.hpp"
-#include "ace/XML_Utils/XML_Typedefs.h"
+#include "ace/XML_Utils/XML_Helper.h"
 #include "ace/XML_Utils/XML_Schema_Resolver.h"
 #include "ace/XML_Utils/XML_Error_Handler.h"
 

--- a/dds/DCPS/QOS_XML_Handler/XML_String_Intf.cpp
+++ b/dds/DCPS/QOS_XML_Handler/XML_String_Intf.cpp
@@ -16,10 +16,10 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-  QOS_XML_String_Handler::QOS_XML_String_Handler(void) :
+  QOS_XML_String_Handler::QOS_XML_String_Handler(XML::XML_Error_Handler* error_handler) :
     QOS_XML_Handler(),
     res_(new XML::XML_Schema_Resolver<XML::Environment_Resolver>()),
-    eh_(new XML::XML_Error_Handler()),
+    eh_(error_handler ? error_handler : new XML::XML_Error_Handler()),
     parser_(0),
     finalDoc_(0)
   {
@@ -46,7 +46,6 @@ namespace DCPS {
       XMLString::release(&qualifiedName);
 
     } catch (const XMLException& toCatch) {
-
       char* message = XMLString::transcode(toCatch.getMessage());
       ACE_ERROR ((LM_ERROR,
         ACE_TEXT ("QOS_XML_String_Handler::QOS_XML_String_Handler - ")
@@ -56,7 +55,7 @@ namespace DCPS {
     }
   }
 
-  QOS_XML_String_Handler::~QOS_XML_String_Handler(void)
+  QOS_XML_String_Handler::~QOS_XML_String_Handler()
   {
     if (finalDoc_ != 0)
       finalDoc_->release();

--- a/dds/DCPS/QOS_XML_Handler/XML_String_Intf.h
+++ b/dds/DCPS/QOS_XML_Handler/XML_String_Intf.h
@@ -42,45 +42,42 @@ namespace DCPS {
     public QOS_XML_Handler
   {
   public:
-    QOS_XML_String_Handler();
+    /// Pass an optional @error_handler which is called back when
+    /// there are any errors parsing the input XML. The QOS_XML_String_Handler
+    /// will assume ownership when a pointer is passed
+    QOS_XML_String_Handler(XML::XML_Error_Handler* error_handler = 0);
 
     ~QOS_XML_String_Handler();
 
     /**
-     *
-     * init
-     *
      * The init method will open the file and will validate
      * it against the schema. It returns RETCODE_ERROR
      * when any error occurs during parsing
-     *
      */
     DDS::ReturnCode_t
     init(const ACE_TCHAR * membuf);
 
     /**
-     *
      * add_search_path will add a relative path to the XML
      * parsing library. The XML parsing library will use
      * this path to search for the schema
-     *
      */
     void
     add_search_path(const ACE_TCHAR *environment,
                     const ACE_TCHAR *relpath);
 
   private:
-    // Schema resolver
+    /// Schema resolver
     XML::XML_Schema_Resolver<XML::Environment_Resolver> * res_;
 
-    // Error handler
+    /// Error handler
     XML::XML_Error_Handler * eh_;
 
-    // Parser
+    /// Parser
     XERCES_CPP_NAMESPACE::XercesDOMParser * parser_;
 
-    // Final DOMDocument that should be passed to
-    // dds::reader::dds method
+    /// Final DOMDocument that should be passed to
+    /// dds::reader::dds method
     XERCES_CPP_NAMESPACE::DOMDocument * finalDoc_;
   };
 }

--- a/dds/DCPS/QOS_XML_Handler/XML_String_Intf.h
+++ b/dds/DCPS/QOS_XML_Handler/XML_String_Intf.h
@@ -45,7 +45,7 @@ namespace DCPS {
     /// Pass an optional @error_handler which is called back when
     /// there are any errors parsing the input XML. The QOS_XML_String_Handler
     /// will assume ownership when a pointer is passed
-    QOS_XML_String_Handler(XML::XML_Error_Handler* error_handler = 0);
+    explicit QOS_XML_String_Handler(XML::XML_Error_Handler* error_handler = 0);
 
     ~QOS_XML_String_Handler();
 


### PR DESCRIPTION
Extend QoS XML handlers to allow the user to pass its own XML_Error_Handler. Also use the XML Helper as member instead of using a hidden global static object which is not needed and could cause cleanup issues.