### PR TITLE
CMake: Prevent Duplicate BUILD_DLL creation

### DIFF
--- a/cmake/api_macros.cmake
+++ b/cmake/api_macros.cmake
@@ -175,7 +175,7 @@ macro(OPENDDS_TARGET_SOURCES target)
 
       string(TOUPPER "${target}" _target_upper)
       target_compile_definitions(${target}
-        PUBLIC
+        PRIVATE
           ${_target_upper}_BUILD_DLL)
     endif()
 


### PR DESCRIPTION
When having an IDL file in a library that is dependent on an IDL file in another library, a duplicate BUILD_DLL would be created for the first library inside the second library.

This can be prevented by changing PUBLIC to PRIVATE as done in this PR.