### PR TITLE
Attempt Workaround for Intermittent NetworkAddress Test Failures

### DIFF
--- a/tests/unit-tests/dds/DCPS/transport/framework/NetworkAddress.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/framework/NetworkAddress.cpp
@@ -121,8 +121,8 @@ TEST(network_address_test, choose_single_coherent_address_double)
 {
   //ScopedDebugLevels sdl(6); // Uncomment for greater debug levels
 
-  ACE_INET_Addr addr1 = choose_single_coherent_address("www.bing.com:80", false);
-  ACE_INET_Addr addr2 = choose_single_coherent_address("www.bing.com:80", false);
+  ACE_INET_Addr addr1 = choose_single_coherent_address("www.bizinta.com:80", false);
+  ACE_INET_Addr addr2 = choose_single_coherent_address("www.bizinta.com:80", false);
 
   // Since tihs test winds up doing real DNS lookups which might fail, allow the result to be be empty but expect it to be consistant
 


### PR DESCRIPTION
Problem: NetworkAddress Test currently fails intermittently due to address resolution issues for bing.com. It's likely that bing is load-balanced in such a way that DNS results are inconsistent, causing repeat lookups (part of the test) to return with different results.

Solution: Try a less popular domain name.