### PR TITLE
Reduce Bundling of RTPS Submessages when Sending to RtpsRelay

### DIFF
--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -46,6 +46,10 @@ struct AddressCacheEntryProxy {
     return (rhs.entry_ && (!entry_ || (entry_->addrs_ < rhs.entry_->addrs_)));
   }
 
+  bool contains(const ACE_INET_Addr& addr) const {
+    return (entry_ && entry_->addrs_.count(addr));
+  }
+
   RcHandle<AddressCacheEntry> entry_;
 };
 

--- a/dds/DCPS/AddressCache.h
+++ b/dds/DCPS/AddressCache.h
@@ -46,10 +46,6 @@ struct AddressCacheEntryProxy {
     return (rhs.entry_ && (!entry_ || (entry_->addrs_ < rhs.entry_->addrs_)));
   }
 
-  bool contains(const ACE_INET_Addr& addr) const {
-    return (entry_ && entry_->addrs_.count(addr));
-  }
-
   RcHandle<AddressCacheEntry> entry_;
 };
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2576,6 +2576,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
 
       // Check to see if we're sending separate messages per destination guid
       if (new_bundle_per_dest_guid) {
+        helper.end_bundle();
         meta_submessage_bundles.push_back(MetaSubmessageIterVec());
         meta_submessage_bundle_addrs.push_back(addr_it->first);
       }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2579,6 +2579,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
         helper.end_bundle();
         meta_submessage_bundles.push_back(MetaSubmessageIterVec());
         meta_submessage_bundle_addrs.push_back(addr_it->first);
+        prev_dst = GUID_UNKNOWN;
       }
 
       for (MetaSubmessageIterVec::iterator resp_it = dest_it->second.begin(); resp_it != dest_it->second.end(); ++resp_it) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2575,7 +2575,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
     for (DestMetaSubmessageMap::iterator dest_it = addr_it->second.begin(); dest_it != addr_it->second.end(); ++dest_it) {
 
       // Check to see if we're sending separate messages per destination guid
-      if (new_bundle_per_dest_guid) {
+      if (new_bundle_per_dest_guid && meta_submessage_bundles.back().size()) {
         helper.end_bundle();
         meta_submessage_bundles.push_back(MetaSubmessageIterVec());
         meta_submessage_bundle_addrs.push_back(addr_it->first);

--- a/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/DataReaderListener.cpp
@@ -20,6 +20,7 @@
 DataReaderListenerImpl::DataReaderListenerImpl()
   : num_reads_(0)
   , valid_(true)
+  , rediscovered_(false)
 {}
 
 DataReaderListenerImpl::~DataReaderListenerImpl()


### PR DESCRIPTION
Problem: Messages sent to the RtpsRelay often need to be routed to different IPs based on the destination GUID. It therefore doesn't make much sense to bundle several destination GUIDs together when sending messages to the RtpsRelay.

Solution: Update the bundling algorithm to create new messages when the outbound set of addresses includes the RtpsRelay and a new destination GUID is encountered.