### PR TITLE
RtpsRelay does not log subject name

### DIFF
--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -5,6 +5,7 @@
 
 #include "AccessControlBuiltInImpl.h"
 
+#include "AuthenticationBuiltInImpl.h"
 #include "CommonUtilities.h"
 #include "TokenWriter.h"
 #include "SSL/SubjectName.h"
@@ -128,7 +129,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   }
 
   TokenReader tr(id_token);
-  const char* id_sn = tr.get_property_value("dds.cert.sn");
+  const char* id_sn = tr.get_property_value(dds_cert_sn);
 
   OpenDDS::Security::SSL::SubjectName sn_id;
 

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -46,8 +46,6 @@ const std::string Auth_Plugin_Name("DDS:Auth:PKI-DH");
 const std::string Auth_Plugin_Major_Version("1");
 const std::string Auth_Plugin_Minor_Version("0");
 
-const std::string Identity_Status_Token_Class_Id("DDS:Auth:PKI-DH:1.0");
-const std::string Auth_Peer_Cred_Token_Class_Id("DDS:Auth:PKI-DH:1.0");
 const std::string Auth_Request_Class_Ext("AuthReq");
 const std::string Handshake_Request_Class_Ext("Req");
 const std::string Handshake_Reply_Class_Ext("Reply");
@@ -171,15 +169,15 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
 
     std::string tmp;
 
-    OpenDDS::Security::TokenWriter identity_wrapper(identity_token, "DDS:Auth:PKI-DH:1.0");
+    OpenDDS::Security::TokenWriter identity_wrapper(identity_token, Identity_Status_Token_Class_Id);
 
     pcert.subject_name_to_str(tmp);
-    identity_wrapper.add_property("dds.cert.sn", tmp.c_str());
-    identity_wrapper.add_property("dds.cert.algo", pcert.keypair_algo());
+    identity_wrapper.add_property(dds_cert_sn.c_str(), tmp.c_str());
+    identity_wrapper.add_property(dds_cert_algo.c_str(), pcert.keypair_algo());
 
     cacert.subject_name_to_str(tmp);
-    identity_wrapper.add_property("dds.ca.sn", tmp.c_str());
-    identity_wrapper.add_property("dds.ca.algo", cacert.keypair_algo());
+    identity_wrapper.add_property(dds_ca_sn.c_str(), tmp.c_str());
+    identity_wrapper.add_property(dds_ca_algo.c_str(), cacert.keypair_algo());
 
     status = true;
 

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -172,12 +172,12 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
     OpenDDS::Security::TokenWriter identity_wrapper(identity_token, Identity_Status_Token_Class_Id);
 
     pcert.subject_name_to_str(tmp);
-    identity_wrapper.add_property(dds_cert_sn.c_str(), tmp.c_str());
-    identity_wrapper.add_property(dds_cert_algo.c_str(), pcert.keypair_algo());
+    identity_wrapper.add_property(dds_cert_sn, tmp.c_str());
+    identity_wrapper.add_property(dds_cert_algo, pcert.keypair_algo());
 
     cacert.subject_name_to_str(tmp);
-    identity_wrapper.add_property(dds_ca_sn.c_str(), tmp.c_str());
-    identity_wrapper.add_property(dds_ca_algo.c_str(), cacert.keypair_algo());
+    identity_wrapper.add_property(dds_ca_sn, tmp.c_str());
+    identity_wrapper.add_property(dds_ca_algo, cacert.keypair_algo());
 
     status = true;
 

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.h
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.h
@@ -36,14 +36,14 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace Security {
 
-const std::string Identity_Status_Token_Class_Id("DDS:Auth:PKI-DH:1.0");
-const std::string Auth_Peer_Cred_Token_Class_Id("DDS:Auth:PKI-DH:1.0");
+const char Identity_Status_Token_Class_Id[] = "DDS:Auth:PKI-DH:1.0";
+const char Auth_Peer_Cred_Token_Class_Id[] = "DDS:Auth:PKI-DH:1.0";
 
-const std::string dds_cert_sn("dds.cert.sn");
-const std::string dds_cert_algo("dds.cert.algo");
+const char dds_cert_sn[] = "dds.cert.sn";
+const char dds_cert_algo[] = "dds.cert.algo";
 
-const std::string dds_ca_sn("dds.ca.sn");
-const std::string dds_ca_algo("dds.ca.algo");
+const char dds_ca_sn[] = "dds.ca.sn";
+const char dds_ca_algo[] = "dds.ca.algo";
 
 /**
 * @class AuthenticationBuiltInImpl

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.h
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.h
@@ -36,6 +36,14 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace Security {
 
+const std::string Identity_Status_Token_Class_Id("DDS:Auth:PKI-DH:1.0");
+const std::string Auth_Peer_Cred_Token_Class_Id("DDS:Auth:PKI-DH:1.0");
+
+const std::string dds_cert_sn("dds.cert.sn");
+const std::string dds_cert_algo("dds.cert.algo");
+
+const std::string dds_ca_sn("dds.ca.sn");
+const std::string dds_ca_algo("dds.ca.algo");
 
 /**
 * @class AuthenticationBuiltInImpl

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -40,6 +40,9 @@ struct AddrSetStats {
   ParticipantStatisticsReporter data_stats_reporter;
   OpenDDS::DCPS::Message_Block_Shared_Ptr spdp_message;
   OpenDDS::DCPS::MonotonicTimePoint first_spdp;
+#ifdef OPENDDS_SECURITY
+  std::string common_name;
+#endif
 
   bool empty() const
   {


### PR DESCRIPTION
Problem
-------

When using security, the subject name of a participant can provide
useful information when debugging connectivity issues.

Solution
--------

Extract the subject name and log it.