### PR TITLE
RtpsUdpDataLink doesn't gap for new reliable reader

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3464,12 +3464,12 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
       continue;
     }
 
+    const SequenceNumber first_sn = std::max(non_durable_first_sn(proxy), reader->start_sn_);
     if (!reader->requests_.empty() &&
-        !proxy.empty() &&
-        reader->requests_.high() < proxy.low()) {
+        reader->requests_.high() < first_sn) {
       // The reader is not going to get any data.
       // Send a gap that is going to to catch them up.
-      gaps.insert(SequenceRange(reader->requests_.low(), proxy.low().previous()));
+      gaps.insert(SequenceRange(reader->requests_.low(), first_sn.previous()));
       reader->requests_.reset();
     }
 


### PR DESCRIPTION
Problem
-------

The following sequence was observed:

1. A reliable reader dies unexpectedly with unacknowledged data.

2. This freezes the heartbeat first number.

3. A subsequent reliable reader was offered the heartbeat first and
   had to nack/gap the entire sequence.

This is effectively the same problem as #2954 which does not address
the case where the reader is initialized with a non-directed
heartbeat.

Solution
--------

Send a "catch up" gap to readers that are nacking sequence numbers
below their starting sequence number.