### PR TITLE
RtpsWriter send buffer leaks with persistent pre-association reader

### DIFF
--- a/dds/DCPS/PoolAllocator.h
+++ b/dds/DCPS/PoolAllocator.h
@@ -135,6 +135,8 @@ typedef std::basic_string<wchar_t, std::char_traits<wchar_t>, OPENDDS_ALLOCATOR(
           OpenDDS::DCPS::PoolAllocator<K > >
 #define OPENDDS_SET_CMP(K, C) std::set<K, C, \
           OpenDDS::DCPS::PoolAllocator<K > >
+#define OPENDDS_MULTISET(K) std::multiset<K, std::less<K >, \
+          OpenDDS::DCPS::PoolAllocator<K > >
 #define OPENDDS_MULTISET_CMP(K, C) std::multiset<K, C, \
           OpenDDS::DCPS::PoolAllocator<K > >
 #define OPENDDS_VECTOR(T) std::vector<T, \
@@ -170,6 +172,7 @@ typedef std::wstring WString;
 #define OPENDDS_MULTIMAP_CMP_T OPENDDS_MULTIMAP_CMP
 #define OPENDDS_SET(K) std::set<K >
 #define OPENDDS_SET_CMP(K, C) std::set<K, C >
+#define OPENDDS_MULTISET(K) std::multiset<K >
 #define OPENDDS_MULTISET_CMP(K, C) std::multiset<K, C >
 #define OPENDDS_VECTOR(T) std::vector<T >
 #define OPENDDS_LIST(T) std::list<T >

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2064,6 +2064,7 @@ RtpsUdpDataLink::RtpsWriter::add_reader(const ReaderInfo_rch& reader)
 #endif
     remote_readers_.insert(ReaderInfoMap::value_type(reader->id_, reader));
     preassociation_readers_.insert(reader);
+    preassociation_reader_start_sns_.insert(reader->start_sn_);
     log_remote_counts("add_reader");
 
     RtpsUdpDataLink_rch link = link_.lock();
@@ -2105,7 +2106,7 @@ RtpsUdpDataLink::RtpsWriter::remove_reader(const RepoId& id)
     if (it != remote_readers_.end()) {
       const ReaderInfo_rch& reader = it->second;
       reader->swap_durable_data(dd);
-      preassociation_readers_.erase(reader);
+      remove_preassociation_reader(reader);
       const SequenceNumber acked_sn = reader->acked_sn();
       const SequenceNumber max_sn = expected_max_sn(reader);
       readers_expecting_data_.erase(reader);
@@ -3133,7 +3134,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
   if (preassociation_readers_.count(reader)) {
     if (is_postassociation) {
-      preassociation_readers_.erase(reader);
+      remove_preassociation_reader(reader);
       if (transport_debug.log_progress) {
         DCPS::log_progress("RTPS writer/reader association complete", id_, reader->id_, reader->participant_discovered_at_);
       }
@@ -3842,15 +3843,12 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
     return;
   }
 
-  // Prevent changes to the send buffer so new readers can get
-  // associated and find the start of their reliable range.
-  if (!preassociation_readers_.empty()) {
-    return;
-  }
-
   //start with the max sequence number writer knows about and decrease
   //by what the min over all readers is
   SequenceNumber all_readers_ack = SequenceNumber::MAX_VALUE;
+  if (!preassociation_readers_.empty()) {
+    all_readers_ack = std::min(all_readers_ack, *preassociation_reader_start_sns_.begin());
+  }
   if (!lagging_readers_.empty()) {
     all_readers_ack = std::min(all_readers_ack, lagging_readers_.begin()->first + 1);
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -495,10 +495,11 @@ private:
 
     void remove_preassociation_reader(const ReaderInfo_rch& reader)
     {
-      preassociation_readers_.erase(reader);
-      SequenceNumberMultiset::iterator pos = preassociation_reader_start_sns_.find(reader->start_sn_);
-      OPENDDS_ASSERT(pos != preassociation_reader_start_sns_.end());
-      preassociation_reader_start_sns_.erase(pos);
+      if (preassociation_readers_.erase(reader)) {
+        SequenceNumberMultiset::iterator pos = preassociation_reader_start_sns_.find(reader->start_sn_);
+        OPENDDS_ASSERT(pos != preassociation_reader_start_sns_.end());
+        preassociation_reader_start_sns_.erase(pos);
+      }
     }
 
     void initialize_heartbeat(const SingleSendBuffer::Proxy& proxy,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -419,6 +419,8 @@ private:
     ReaderInfoMap remote_readers_;
     /// Preassociation readers require a non-final heartbeat.
     ReaderInfoSet preassociation_readers_;
+    typedef OPENDDS_MULTISET(OpenDDS::DCPS::SequenceNumber) SequenceNumberMultiset;
+    SequenceNumberMultiset preassociation_reader_start_sns_;
     /// These readers have not acked everything they are supposed to have
     /// acked.
     SNRIS lagging_readers_;
@@ -490,6 +492,15 @@ private:
       }
       return max_sn_ + 1;
     }
+
+    void remove_preassociation_reader(const ReaderInfo_rch& reader)
+    {
+      preassociation_readers_.erase(reader);
+      SequenceNumberMultiset::iterator pos = preassociation_reader_start_sns_.find(reader->start_sn_);
+      OPENDDS_ASSERT(pos != preassociation_reader_start_sns_.end());
+      preassociation_reader_start_sns_.erase(pos);
+    }
+
     void initialize_heartbeat(const SingleSendBuffer::Proxy& proxy,
                               MetaSubmessage& meta_submessage);
     void gather_directed_heartbeat_i(const SingleSendBuffer::Proxy& proxy,


### PR DESCRIPTION
Problem
-------

The send buffer in an RtpsWriter is never cleaned so long as there is
a pre-association reader.

Solution
--------

Track the sequence numbers promised to preassociation readers so they
are retained when association completes but allow the cleanup to occur.