### PR TITLE
RTPS Discovery max_lease_duration config option

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -50,7 +50,7 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , quick_resend_ratio_(0.1)
   , min_resend_delay_(TimeDuration::from_msec(100))
   , lease_duration_(300)
-  , max_lease_duration_(600)
+  , max_lease_duration_(300)
   , lease_extension_(0)
   , pb_(7400) // see RTPS v2.1 9.6.1.3 for PB, DG, PG, D0, D1 defaults
   , dg_(250)

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -51,6 +51,9 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , min_resend_delay_(TimeDuration::from_msec(100))
   , lease_duration_(300)
   , max_lease_duration_(300)
+#ifdef OPENDDS_SECURITY
+  , security_unsecure_lease_duration_(30)
+#endif
   , lease_extension_(0)
   , pb_(7400) // see RTPS v2.1 9.6.1.3 for PB, DG, PG, D0, D1 defaults
   , dg_(250)
@@ -211,6 +214,19 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
               value.c_str(), rtps_name.c_str()), -1);
           }
           config->max_lease_duration(TimeDuration(duration));
+#ifdef OPENDDS_SECURITY
+        } else if (name == "SecurityUnsecureLeaseDuration") {
+          const OPENDDS_STRING& value = it->second;
+          int duration;
+          if (!DCPS::convertToInteger(value, duration)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+              ACE_TEXT("Invalid entry (%C) for SecurityUnsecureLeaseDuration in ")
+              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+              value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->security_unsecure_lease_duration(TimeDuration(duration));
+#endif
         } else if (name == "LeaseExtension") {
           const OPENDDS_STRING& value = it->second;
           int extension;

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -50,6 +50,7 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , quick_resend_ratio_(0.1)
   , min_resend_delay_(TimeDuration::from_msec(100))
   , lease_duration_(300)
+  , max_lease_duration_(600)
   , lease_extension_(0)
   , pb_(7400) // see RTPS v2.1 9.6.1.3 for PB, DG, PG, D0, D1 defaults
   , dg_(250)
@@ -199,6 +200,17 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
               value.c_str(), rtps_name.c_str()), -1);
           }
           config->lease_duration(TimeDuration(duration));
+        } else if (name == "MaxLeaseDuration") {
+          const OPENDDS_STRING& value = it->second;
+          int duration;
+          if (!DCPS::convertToInteger(value, duration)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")
+              ACE_TEXT("Invalid entry (%C) for MaxLeaseDuration in ")
+              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+              value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->max_lease_duration(TimeDuration(duration));
         } else if (name == "LeaseExtension") {
           const OPENDDS_STRING& value = it->second;
           int extension;

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -83,6 +83,17 @@ public:
     lease_duration_ = period;
   }
 
+  DCPS::TimeDuration max_lease_duration() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return max_lease_duration_;
+  }
+  void max_lease_duration(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    max_lease_duration_ = period;
+  }
+
   DCPS::TimeDuration lease_extension() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
@@ -640,6 +651,7 @@ private:
   double quick_resend_ratio_;
   DCPS::TimeDuration min_resend_delay_;
   DCPS::TimeDuration lease_duration_;
+  DCPS::TimeDuration max_lease_duration_;
   DCPS::TimeDuration lease_extension_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
   unsigned char ttl_;

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -94,6 +94,19 @@ public:
     max_lease_duration_ = period;
   }
 
+#ifdef OPENDDS_SECURITY
+  DCPS::TimeDuration security_unsecure_lease_duration() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
+    return security_unsecure_lease_duration_;
+  }
+  void security_unsecure_lease_duration(const DCPS::TimeDuration& period)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    security_unsecure_lease_duration_ = period;
+  }
+#endif
+
   DCPS::TimeDuration lease_extension() const
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, DCPS::TimeDuration());
@@ -652,6 +665,9 @@ private:
   DCPS::TimeDuration min_resend_delay_;
   DCPS::TimeDuration lease_duration_;
   DCPS::TimeDuration max_lease_duration_;
+#ifdef OPENDDS_SECURITY
+  DCPS::TimeDuration security_unsecure_lease_duration_;
+#endif
   DCPS::TimeDuration lease_extension_;
   u_short pb_, dg_, pg_, d0_, d1_, dx_;
   unsigned char ttl_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -667,7 +667,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         pdata.leaseDuration.seconds, DCPS::LogAddr(from).c_str(), participants_.size()));
     }
     ::CORBA::Long maxLeaseDuration = config_->max_lease_duration().to_dds_duration().sec;
-    if (pdata.leaseDuration.seconds > maxLeaseDuration) {
+    if (maxLeaseDuration && pdata.leaseDuration.seconds > maxLeaseDuration) {
       if (DCPS::DCPS_debug_level >= 2) {
         ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) Spdp::handle_participant_data - overwriting %C lease %ds from %C with %ds\n"),

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -666,7 +666,16 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         DCPS::LogGuid(guid_).c_str(), DCPS::LogGuid(guid).c_str(),
         pdata.leaseDuration.seconds, DCPS::LogAddr(from).c_str(), participants_.size()));
     }
-
+    ::CORBA::Long maxLeaseDuration = config_->max_lease_duration().to_dds_duration().sec;
+    if (pdata.leaseDuration.seconds > maxLeaseDuration) {
+      if (DCPS::DCPS_debug_level >= 2) {
+        ACE_DEBUG((LM_DEBUG,
+          ACE_TEXT("(%P|%t) Spdp::handle_participant_data - overwriting %C lease %ds from %C with %ds\n"),
+          DCPS::LogGuid(guid).c_str(),
+          pdata.leaseDuration.seconds, DCPS::LogAddr(from).c_str(), maxLeaseDuration));
+      }
+      pdata.leaseDuration.seconds = maxLeaseDuration;
+    }
     if (tport_->directed_sender_) {
       if (tport_->directed_guids_.empty()) {
         tport_->directed_sender_->schedule(TimeDuration::zero_value);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -666,15 +666,26 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         DCPS::LogGuid(guid_).c_str(), DCPS::LogGuid(guid).c_str(),
         pdata.leaseDuration.seconds, DCPS::LogAddr(from).c_str(), participants_.size()));
     }
-    ::CORBA::Long maxLeaseDuration = config_->max_lease_duration().to_dds_duration().sec;
-    if (maxLeaseDuration && pdata.leaseDuration.seconds > maxLeaseDuration) {
-      if (DCPS::DCPS_debug_level >= 2) {
-        ACE_DEBUG((LM_DEBUG,
-          ACE_TEXT("(%P|%t) Spdp::handle_participant_data - overwriting %C lease %ds from %C with %ds\n"),
-          DCPS::LogGuid(guid).c_str(),
-          pdata.leaseDuration.seconds, DCPS::LogAddr(from).c_str(), maxLeaseDuration));
+
+    if (!from_sedp) {
+#ifdef OPENDDS_SECURITY
+      if (is_security_enabled()) {
+        pdata.leaseDuration.seconds = config_->security_unsecure_lease_duration().to_dds_duration().sec;
+      } else {
+#endif
+        ::CORBA::Long maxLeaseDuration = config_->max_lease_duration().to_dds_duration().sec;
+        if (maxLeaseDuration && pdata.leaseDuration.seconds > maxLeaseDuration) {
+          if (DCPS::DCPS_debug_level >= 2) {
+            ACE_DEBUG((LM_DEBUG,
+              ACE_TEXT("(%P|%t) Spdp::handle_participant_data - overwriting %C lease %ds from %C with %ds\n"),
+              DCPS::LogGuid(guid).c_str(),
+              pdata.leaseDuration.seconds, DCPS::LogAddr(from).c_str(), maxLeaseDuration));
+          }
+          pdata.leaseDuration.seconds = maxLeaseDuration;
+        }
+#ifdef OPENDDS_SECURITY
       }
-      pdata.leaseDuration.seconds = maxLeaseDuration;
+#endif
     }
     if (tport_->directed_sender_) {
       if (tport_->directed_guids_.empty()) {


### PR DESCRIPTION
This PR creates a max_lease_duration option that limits what participants can set their lease duration to be.

I set the default at 2x the default lease duration (600 seconds).