### PR TITLE
PARTICIPANT_VOLATILE_SECURE_WRITER causes leak in send_buffer

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3853,7 +3853,11 @@ RtpsUdpDataLink::RtpsWriter::acked_by_all_helper_i(TqeSet& to_deliver)
     all_readers_ack = std::min(all_readers_ack, lagging_readers_.begin()->first + 1);
   }
   if (!leading_readers_.empty()) {
-    all_readers_ack = std::min(all_readers_ack, leading_readers_.begin()->first + 1);
+    // When is_pvs_writer_ is true, the leading_readers_ will all be
+    // at different sequence numbers.  The minimum could actually be
+    // before the preassociation readers or lagging readers.  Use the
+    // largest sequence number to avoid holding onto samples.
+    all_readers_ack = std::min(all_readers_ack, leading_readers_.rbegin()->first + 1);
   }
 
   if (all_readers_ack == SequenceNumber::MAX_VALUE) {


### PR DESCRIPTION
Problem
-------

The `acked_by_all_helper_i` method determines the maximum sequence
number that has been acknowledge by all readers by considering
preassociation readers, lagging readers, and leading readers.  In the
special case of PARTICIPANT_VOLATILE_SECURE_WRITER, the leading
readers will all be at different sequence numbers.
`acked_by_all_helper_i` is picking the lowest leading sequence number
which may be lower than the sequence number determined from the
preassociation or lagging readers.  Data can only be acknowledged up
to the sequence number acknowledged by the oldest leading reader.
This causes the `send_buffer` to retain more samples than necessary.

Solution
--------

Use the highest sequence number from the leading readers.