### PR TITLE
Liveliness Test: Remove Counting

### DIFF
--- a/tests/DCPS/LivelinessTest/DataReaderListener.cpp
+++ b/tests/DCPS/LivelinessTest/DataReaderListener.cpp
@@ -98,8 +98,6 @@ void DataReaderListenerImpl::on_liveliness_changed(
       dcs_->post(actor_, "LIVELINESS_LOST_" + OpenDDS::DCPS::to_dds_string(liveliness_gained_count_));
     }
 
-    ++liveliness_changed_count_;
-
     if (liveliness_changed_count_ > 1) {
       if (last_status_.alive_count == 0 && last_status_.not_alive_count == 0) {
         ACE_ERROR ((LM_ERROR,
@@ -135,8 +133,8 @@ void DataReaderListenerImpl::on_liveliness_changed(
     last_status_ = status;
     ACE_DEBUG((LM_DEBUG,
       "(%P|%t) %T DataReaderListenerImpl::on_liveliness_changed %d\n"
-      "alive_count %d not_alive_count %d alive_count_change %d not_alive_count_change %d\n",
-      liveliness_changed_count_, status.alive_count, status.not_alive_count,
+      "%C alive_count %d not_alive_count %d alive_count_change %d not_alive_count_change %d\n",
+      liveliness_changed_count_, actor_.c_str(), status.alive_count, status.not_alive_count,
       status.alive_count_change, status.not_alive_count_change));
   }
 

--- a/tests/DCPS/LivelinessTest/DataReaderListener.cpp
+++ b/tests/DCPS/LivelinessTest/DataReaderListener.cpp
@@ -97,45 +97,7 @@ void DataReaderListenerImpl::on_liveliness_changed(
       ++liveliness_lost_count_;
       dcs_->post(actor_, "LIVELINESS_LOST_" + OpenDDS::DCPS::to_dds_string(liveliness_gained_count_));
     }
-
-    if (liveliness_changed_count_ > 1) {
-      if (last_status_.alive_count == 0 && last_status_.not_alive_count == 0) {
-        ACE_ERROR ((LM_ERROR,
-          "ERROR: DataReaderListenerImpl::on_liveliness_changed"
-          " Both alive_count and not_alive_count 0 should not happen at liveliness_changed_count %d\n",
-          liveliness_changed_count_));
-      } else if (status.alive_count == 0 && status.not_alive_count == 0) {
-        ACE_DEBUG ((LM_DEBUG, "(%P|%t) DataReaderListenerImpl::on_liveliness_changed - this is the time callback\n"));
-      } else {
-        ::DDS::LivelinessChangedStatus expected_status;
-        // expect the alive_count either 0 or 1
-        expected_status.alive_count = 1 - last_status_.alive_count;
-        expected_status.not_alive_count = 1 - last_status_.not_alive_count;
-        expected_status.alive_count_change = status.alive_count - last_status_.alive_count;
-        expected_status.not_alive_count_change = status.not_alive_count - last_status_.not_alive_count;
-
-        if (status.alive_count != expected_status.alive_count ||
-            status.not_alive_count != expected_status.not_alive_count ||
-            status.alive_count_change != expected_status.alive_count_change ||
-            status.not_alive_count_change != expected_status.not_alive_count_change) {
-          ACE_ERROR ((LM_ERROR,
-            "ERROR: DataReaderListenerImpl::on_liveliness_changed"
-            " expected/got alive_count %d/%d not_alive_count %d/%d"
-            " alive_count_change %d/%d not_alive_count_change %d/%d\n",
-            expected_status.alive_count, status.alive_count,
-            expected_status.not_alive_count, status.not_alive_count,
-            expected_status.alive_count_change, status.alive_count_change,
-            expected_status.not_alive_count_change, status.not_alive_count_change ));
-        }
-      }
-    }
-
     last_status_ = status;
-    ACE_DEBUG((LM_DEBUG,
-      "(%P|%t) %T DataReaderListenerImpl::on_liveliness_changed %d\n"
-      "%C alive_count %d not_alive_count %d alive_count_change %d not_alive_count_change %d\n",
-      liveliness_changed_count_, actor_.c_str(), status.alive_count, status.not_alive_count,
-      status.alive_count_change, status.not_alive_count_change));
   }
 
 void DataReaderListenerImpl::on_subscription_matched(

--- a/tests/DCPS/LivelinessTest/LivelinessTest.cpp
+++ b/tests/DCPS/LivelinessTest/LivelinessTest.cpp
@@ -306,26 +306,17 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     return 1;
   }
 
-  int expected_manual_liveliness_changes = 3 + (2 * (num_unlively_periods));
   int expected_no_writers_generation_count = (use_take ? 0 : num_unlively_periods - 1);
   // Determine the test status at this point.
 
   ACE_OS::fprintf(stderr, "**********\n");
-  ACE_OS::fprintf(stderr, "automatic_drl_servant->liveliness_changed_count() = %d\n",
-                  automatic_drl_servant->liveliness_changed_count());
   ACE_OS::fprintf(stderr, "automatic_drl_servant->no_writers_generation_count() = %d\n",
                   automatic_drl_servant->no_writers_generation_count());
   ACE_OS::fprintf(stderr, "********** use_take=%d\n", use_take);
 
   //automatic should stay alive due to reactor,
   //going up at start then coming down at end
-  if (automatic_drl_servant->liveliness_changed_count() != 3) {
-    status = 1;
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: automatic_drl_servant->liveliness_changed_count is %d - ")
-               ACE_TEXT("expected 3\n"), automatic_drl_servant->liveliness_changed_count()
-               ));
-  } else if (automatic_drl_servant->verify_last_liveliness_status() == false) {
+  if (automatic_drl_servant->verify_last_liveliness_status() == false) {
     status = 1;
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: automatic_drl_servant - ")
@@ -339,19 +330,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                ));
   }
   ACE_OS::fprintf(stderr, "**********\n");
-  ACE_OS::fprintf(stderr, "remote_manual_drl_servant->liveliness_changed_count() = %d\n",
-                  remote_manual_drl_servant->liveliness_changed_count());
   ACE_OS::fprintf(stderr, "remote_manual_drl_servant->no_writers_generation_count() = %d\n",
                   remote_manual_drl_servant->no_writers_generation_count());
   ACE_OS::fprintf(stderr, "********** use_take=%d\n", use_take);
 
-  if (remote_manual_drl_servant->liveliness_changed_count() != expected_manual_liveliness_changes) {
-    status = 1;
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: remote_manual_drl_servant->liveliness_changed_count is %d - ")
-               ACE_TEXT("expected %d\n"), remote_manual_drl_servant->liveliness_changed_count(), expected_manual_liveliness_changes
-               ));
-  } else if (remote_manual_drl_servant->verify_last_liveliness_status() == false) {
+  if (remote_manual_drl_servant->verify_last_liveliness_status() == false) {
     status = 1;
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: remote_manual_drl_servant - ")
@@ -365,19 +348,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                ));
   }
   ACE_OS::fprintf(stderr, "**********\n");
-  ACE_OS::fprintf(stderr, "local_manual_drl_servant->liveliness_changed_count() = %d\n",
-                  local_manual_drl_servant->liveliness_changed_count());
   ACE_OS::fprintf(stderr, "local_manual_drl_servant->no_writers_generation_count() = %d\n",
                   local_manual_drl_servant->no_writers_generation_count());
   ACE_OS::fprintf(stderr, "********** use_take=%d\n", use_take);
 
-  if (local_manual_drl_servant->liveliness_changed_count() < expected_manual_liveliness_changes) {
-    status = 1;
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: local_manual_drl_servant->liveliness_changed_count is %d - ")
-               ACE_TEXT("expected %d\n"), local_manual_drl_servant->liveliness_changed_count(), expected_manual_liveliness_changes
-               ));
-  } else if (local_manual_drl_servant->verify_last_liveliness_status() == false) {
+  if (local_manual_drl_servant->verify_last_liveliness_status() == false) {
     status = 1;
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: local_manual_drl_servant - ")


### PR DESCRIPTION
When the LivelinessTest was written 14 years ago, it used a count to keep track of liveliness. 

This lead to a problem with a remote reader where depending on whether the Transport, or the DCPSInfoRepo cleaned up first, we would get a different liveliness count.  In reality, it doesn't matter which order these cleanups happen in, so long as they both happen.

We already ensure this by checking the `verify_last_liveliness_status()` of each reader to make sure everything is clean upon the exiting of the test. As such, I removed the liveliness count because it was reporting problems that were not actually problems, indicating it is a bad metric for the test to be using when determining success.