### PR TITLE
Fix DevGuide Messenger CMakeLists Header Cleanup

### DIFF
--- a/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
+++ b/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
@@ -7,8 +7,9 @@ find_package(OpenDDS REQUIRED)
 # Make sure the MPC-generated headers are gone so the CMake build will use the
 # right ones. This is not needed in a real project.
 file(GLOB headers "*.h")
-list(REMOVE_ITEM headers "DataReaderListenerImpl.h")
-list(LENGTH _headers header_count)
+file(GLOB listener_header "DataReaderListenerImpl.h")
+list(REMOVE_ITEM headers ${listener_header})
+list(LENGTH headers header_count)
 if(header_count GREATER 0)
   file(REMOVE ${headers})
 endif()


### PR DESCRIPTION
Fixes issue seen in https://github.com/objectcomputing/OpenDDS/issues/3017.

The CMakeLists file is supposed to clean up generated headers in the source because they can conflict with the CMake build. It couldn't do that for two reasons:
  - There was a typo in the code: `_headers` instead of `headers`. This made the code non-functional.
  - If the typo is fixed it would remove `DataReaderListenerImpl.h` because the `file(GLOB` paths are absolute and the code the excludes the header isn't.

Fixed the typo and changed it to remove the result of `file(GLOB "DataReaderListenerImpl.h")` instead of just `"DataReaderListenerImpl.h"` from the list headers to remove.