### PR TITLE
RTPS Support For REQUEST_ACK and END_HISTORIC_SAMPLES Heartbeats

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3944,6 +3944,28 @@ Sedp::Writer::end_historic_samples(const RepoId& reader)
 }
 
 void
+Sedp::Writer::request_ack(const RepoId& reader)
+{
+  DCPS::Message_Block_Ptr mb(
+    new ACE_Message_Block(
+      DCPS::DataSampleHeader::get_max_serialized_size(),
+      ACE_Message_Block::MB_DATA,
+      new ACE_Message_Block(
+        reinterpret_cast<const char*>(&reader),
+        sizeof(reader))));
+  if (mb.get()) {
+    mb->cont()->wr_ptr(sizeof(reader));
+    // 'mb' would contain the DSHeader, but we skip it. mb.cont() has the data
+    write_control_msg(move(mb), sizeof(reader), DCPS::REQUEST_ACK,
+                      DCPS::SequenceNumber::SEQUENCENUMBER_UNKNOWN());
+  } else {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: Sedp::Writer::request_ack")
+               ACE_TEXT(" - Failed to allocate message block message\n")));
+  }
+}
+
+void
 Sedp::Writer::write_control_msg(DCPS::Message_Block_Ptr payload,
                                 size_t size,
                                 DCPS::MessageId id,
@@ -3968,7 +3990,7 @@ Sedp::Writer::set_header_fields(DCPS::DataSampleHeader& dsh,
   dsh.message_length_ = static_cast<ACE_UINT32>(size);
   dsh.publication_id_ = repo_id_;
 
-  if (id != DCPS::END_HISTORIC_SAMPLES &&
+  if (id != DCPS::END_HISTORIC_SAMPLES && id != DCPS::REQUEST_ACK &&
       (reader == GUID_UNKNOWN ||
        sequence == DCPS::SequenceNumber::SEQUENCENUMBER_UNKNOWN())) {
     sequence = seq_++;

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -311,6 +311,7 @@ private:
       DCPS::SequenceNumber& sequence);
 
     void end_historic_samples(const DCPS::RepoId& reader);
+    void request_ack(const DCPS::RepoId& reader);
 
     void send_deferred_samples(const GUID_t& reader);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -461,7 +461,11 @@ private:
     void add_gap_submsg_i(RTPS::SubmessageSeq& msg,
                           SequenceNumber gap_start);
     void end_historic_samples_i(const DataSampleHeader& header,
-                                ACE_Message_Block* body);
+                                ACE_Message_Block* body,
+                                MetaSubmessageVec& meta_submessages);
+    void request_ack_i(const DataSampleHeader& header,
+                       ACE_Message_Block* body,
+                       MetaSubmessageVec& meta_submessages);
     void send_heartbeats_manual_i(MetaSubmessageVec& meta_submessages);
     void gather_gaps_i(const ReaderInfo_rch& reader,
                        const DisjointSequence& gaps,


### PR DESCRIPTION
- Add RTPS support for REQUEST_ACK
- Add Sedp method to use it (currently unused)
- Generate RTPS heartbeats for REQUEST_ACK and END_HISTORIC_SAMPLES