### PR TITLE
Fix Building Sphinx Docs for Micro Releases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,9 +61,10 @@ is_release = get_version_prop(bool, 'is_release')
 if is_release:
     vparts = {p: get_version_prop(int, p + '_version') for p in
         ('major', 'minor', 'micro')}
-    github_links_release_tag = 'DDS-{major}.{minor}'.format(**vparts)
-    if vparts['micro']:
-        github_links_release_tag += '.' + vparts['micro']
+    fmt_str = 'DDS-{major}.{minor}'
+    if vparts['micro'] > 0:
+        fmt_str += '.{micro}'
+    github_links_release_tag = fmt_str.format(**vparts)
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
The bit of code to calculate the release tag for GitHub links apparently has never been tested with a micro release. I forgot to cast the micro `int` field to a `str`.

https://readthedocs.org/projects/opendds/builds/14811312/

https://github.com/objectcomputing/OpenDDS/runs/3705194668?check_suite_focus=true