### PR TITLE
Remove `typename` from Non-Template Classes

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -1204,11 +1204,11 @@ bool RtpsDiscovery::remove_domain_participant(
   // does not get deleted until lock as been released.
   ParticipantHandle participant;
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
-  typename DomainParticipantMap::iterator domain = participants_.find(domain_id);
+  DomainParticipantMap::iterator domain = participants_.find(domain_id);
   if (domain == participants_.end()) {
     return false;
   }
-  typename ParticipantMap::iterator part = domain->second.find(participantId);
+  ParticipantMap::iterator part = domain->second.find(participantId);
   if (part == domain->second.end()) {
     return false;
   }
@@ -1393,11 +1393,11 @@ void RtpsDiscovery::update_subscription_locators(
 ParticipantHandle RtpsDiscovery::get_part(const DDS::DomainId_t domain_id, const GUID_t& part_id) const
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ParticipantHandle());
-  typename DomainParticipantMap::const_iterator domain = participants_.find(domain_id);
+  DomainParticipantMap::const_iterator domain = participants_.find(domain_id);
   if (domain == participants_.end()) {
     return ParticipantHandle();
   }
-  typename ParticipantMap::const_iterator part = domain->second.find(part_id);
+  ParticipantMap::const_iterator part = domain->second.find(part_id);
   if (part == domain->second.end()) {
     return ParticipantHandle();
   }

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -6966,7 +6966,7 @@ void Sedp::remove_expired_endpoints(const MonotonicTimePoint& /*now*/)
   }
 
   // Clean up internal data used by getTypeDependencies
-  for (typename OrigSeqNumberMap::iterator it = orig_seq_numbers_.begin(); it != orig_seq_numbers_.end();) {
+  for (OrigSeqNumberMap::iterator it = orig_seq_numbers_.begin(); it != orig_seq_numbers_.end();) {
     if (now - it->second.time_started >= max_type_lookup_service_reply_period_) {
       if (DCPS_debug_level >= 4) {
         ACE_DEBUG((LM_DEBUG, "(%P|%t) EndpointManager::remove_expired_endpoints: "

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -153,7 +153,7 @@ private:
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredSubscription,
                           GUID_tKeyLessThan) DiscoveredSubscriptionMap;
 
-  typedef typename DiscoveredSubscriptionMap::iterator DiscoveredSubscriptionIter;
+  typedef DiscoveredSubscriptionMap::iterator DiscoveredSubscriptionIter;
 
   struct DiscoveredPublication : PoolAllocationBase {
     DiscoveredPublication()
@@ -203,7 +203,7 @@ private:
 
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredPublication,
                           GUID_tKeyLessThan) DiscoveredPublicationMap;
-  typedef typename DiscoveredPublicationMap::iterator DiscoveredPublicationIter;
+  typedef DiscoveredPublicationMap::iterator DiscoveredPublicationIter;
 
 public:
   Sedp(const DCPS::RepoId& participant_id,
@@ -469,15 +469,15 @@ private:
 
   typedef OPENDDS_MAP_CMP(GUID_t, LocalPublication,
                           GUID_tKeyLessThan) LocalPublicationMap;
-  typedef typename LocalPublicationMap::iterator LocalPublicationIter;
-  typedef typename LocalPublicationMap::const_iterator LocalPublicationCIter;
+  typedef LocalPublicationMap::iterator LocalPublicationIter;
+  typedef LocalPublicationMap::const_iterator LocalPublicationCIter;
 
   typedef OPENDDS_MAP_CMP(GUID_t, LocalSubscription,
                           GUID_tKeyLessThan) LocalSubscriptionMap;
-  typedef typename LocalSubscriptionMap::iterator LocalSubscriptionIter;
-  typedef typename LocalSubscriptionMap::const_iterator LocalSubscriptionCIter;
+  typedef LocalSubscriptionMap::iterator LocalSubscriptionIter;
+  typedef LocalSubscriptionMap::const_iterator LocalSubscriptionCIter;
 
-  typedef typename OPENDDS_MAP_CMP(GUID_t, String, GUID_tKeyLessThan) TopicNameMap;
+  typedef OPENDDS_MAP_CMP(GUID_t, String, GUID_tKeyLessThan) TopicNameMap;
 
   struct TypeIdOrigSeqNumber {
     GuidPrefix_t participant; // Prefix of remote participant
@@ -1280,7 +1280,7 @@ protected:
   };
 
   typedef OPENDDS_MAP_T(MatchingPair, MatchingData) MatchingDataMap;
-  typedef typename MatchingDataMap::iterator MatchingDataIter;
+  typedef MatchingDataMap::iterator MatchingDataIter;
 
   typedef DCPS::PmfSporadicTask<Sedp> EndpointManagerSporadic;
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -213,9 +213,8 @@ public:
 
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredParticipant,
                           GUID_tKeyLessThan) DiscoveredParticipantMap;
-  typedef typename DiscoveredParticipantMap::iterator DiscoveredParticipantIter;
-  typedef typename DiscoveredParticipantMap::const_iterator
-    DiscoveredParticipantConstIter;
+  typedef DiscoveredParticipantMap::iterator DiscoveredParticipantIter;
+  typedef DiscoveredParticipantMap::const_iterator DiscoveredParticipantConstIter;
 
 
   Spdp(DDS::DomainId_t domain,

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1145,7 +1145,7 @@ void StaticEndpointManager::remove_expired_endpoints(
   }
 
   // Clean up internal data used by getTypeDependencies
-  for (typename OrigSeqNumberMap::iterator it = orig_seq_numbers_.begin(); it != orig_seq_numbers_.end();) {
+  for (OrigSeqNumberMap::iterator it = orig_seq_numbers_.begin(); it != orig_seq_numbers_.end();) {
     if (now - it->second.time_started >= max_type_lookup_service_reply_period_) {
       if (DCPS_debug_level >= 4) {
         ACE_DEBUG((LM_DEBUG, "(%P|%t) StaticEndpointManager::remove_expired_endpoints: "
@@ -3054,11 +3054,11 @@ bool StaticDiscovery::remove_domain_participant(
   // does not get deleted until lock as been released.
   ParticipantHandle participant;
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
-  typename DomainParticipantMap::iterator domain = participants_.find(domain_id);
+  DomainParticipantMap::iterator domain = participants_.find(domain_id);
   if (domain == participants_.end()) {
     return false;
   }
-  typename ParticipantMap::iterator part = domain->second.find(participantId);
+  ParticipantMap::iterator part = domain->second.find(participantId);
   if (part == domain->second.end()) {
     return false;
   }
@@ -3244,11 +3244,11 @@ StaticDiscovery::ParticipantHandle StaticDiscovery::get_part(
   const DDS::DomainId_t domain_id, const GUID_t& part_id) const
 {
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, ParticipantHandle());
-  typename DomainParticipantMap::const_iterator domain = participants_.find(domain_id);
+  DomainParticipantMap::const_iterator domain = participants_.find(domain_id);
   if (domain == participants_.end()) {
     return ParticipantHandle();
   }
-  typename ParticipantMap::const_iterator part = domain->second.find(part_id);
+  ParticipantMap::const_iterator part = domain->second.find(part_id);
   if (part == domain->second.end()) {
     return ParticipantHandle();
   }

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -169,7 +169,7 @@ protected:
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredSubscription,
                           GUID_tKeyLessThan) DiscoveredSubscriptionMap;
 
-  typedef typename DiscoveredSubscriptionMap::iterator DiscoveredSubscriptionIter;
+  typedef DiscoveredSubscriptionMap::iterator DiscoveredSubscriptionIter;
 
   struct DiscoveredPublication : PoolAllocationBase {
     DiscoveredPublication()
@@ -207,7 +207,7 @@ protected:
 
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredPublication,
                           GUID_tKeyLessThan) DiscoveredPublicationMap;
-  typedef typename DiscoveredPublicationMap::iterator DiscoveredPublicationIter;
+  typedef DiscoveredPublicationMap::iterator DiscoveredPublicationIter;
 
   struct LocalEndpoint {
     LocalEndpoint()
@@ -243,15 +243,15 @@ protected:
 
   typedef OPENDDS_MAP_CMP(GUID_t, LocalPublication,
                           GUID_tKeyLessThan) LocalPublicationMap;
-  typedef typename LocalPublicationMap::iterator LocalPublicationIter;
-  typedef typename LocalPublicationMap::const_iterator LocalPublicationCIter;
+  typedef LocalPublicationMap::iterator LocalPublicationIter;
+  typedef LocalPublicationMap::const_iterator LocalPublicationCIter;
 
   typedef OPENDDS_MAP_CMP(GUID_t, LocalSubscription,
                           GUID_tKeyLessThan) LocalSubscriptionMap;
-  typedef typename LocalSubscriptionMap::iterator LocalSubscriptionIter;
-  typedef typename LocalSubscriptionMap::const_iterator LocalSubscriptionCIter;
+  typedef LocalSubscriptionMap::iterator LocalSubscriptionIter;
+  typedef LocalSubscriptionMap::const_iterator LocalSubscriptionCIter;
 
-  typedef typename OPENDDS_MAP_CMP(GUID_t, String, GUID_tKeyLessThan) TopicNameMap;
+  typedef OPENDDS_MAP_CMP(GUID_t, String, GUID_tKeyLessThan) TopicNameMap;
 
   static DDS::BuiltinTopicKey_t get_key(const DiscoveredPublication& pub)
   {
@@ -445,7 +445,7 @@ private:
     }
   };
   typedef OPENDDS_MAP_T(MatchingPair, MatchingData) MatchingDataMap;
-  typedef typename MatchingDataMap::iterator MatchingDataIter;
+  typedef MatchingDataMap::iterator MatchingDataIter;
 
   void match(const GUID_t& writer, const GUID_t& reader);
   void remove_expired_endpoints(const MonotonicTimePoint& /*now*/);
@@ -833,8 +833,8 @@ private:
 
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredParticipant,
                           GUID_tKeyLessThan) DiscoveredParticipantMap;
-  typedef typename DiscoveredParticipantMap::iterator DiscoveredParticipantIter;
-  typedef typename DiscoveredParticipantMap::const_iterator
+  typedef DiscoveredParticipantMap::iterator DiscoveredParticipantIter;
+  typedef DiscoveredParticipantMap::const_iterator
     DiscoveredParticipantConstIter;
 
   void remove_discovered_participant(DiscoveredParticipantIter& iter);


### PR DESCRIPTION
Cleanup from https://github.com/objectcomputing/OpenDDS/pull/3015