### PR TITLE
Remove `_T` from `MatchingDataMap` `typedef`s

### DIFF
--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -1279,7 +1279,7 @@ protected:
     }
   };
 
-  typedef OPENDDS_MAP_T(MatchingPair, MatchingData) MatchingDataMap;
+  typedef OPENDDS_MAP(MatchingPair, MatchingData) MatchingDataMap;
   typedef MatchingDataMap::iterator MatchingDataIter;
 
   typedef DCPS::PmfSporadicTask<Sedp> EndpointManagerSporadic;

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -444,7 +444,7 @@ private:
       return false;
     }
   };
-  typedef OPENDDS_MAP_T(MatchingPair, MatchingData) MatchingDataMap;
+  typedef OPENDDS_MAP(MatchingPair, MatchingData) MatchingDataMap;
   typedef MatchingDataMap::iterator MatchingDataIter;
 
   void match(const GUID_t& writer, const GUID_t& reader);


### PR DESCRIPTION
Since `OPENDDS_MAP_T` uses `typename` in safety profile.

Follow up to https://github.com/objectcomputing/OpenDDS/pull/3039