### PR TITLE
Fix SEGV in TransportSendStrategy for Empty Packet Chain

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -777,7 +777,7 @@ TransportSendStrategy::clear(SendMode new_mode, SendMode old_mode)
     if (old_mode != MODE_NOT_SET && mode_ != old_mode)
       return;
 
-    if (header_.length_ > 0) {
+    if (header_.length_ > 0 && pkt_chain_) {
       // Clear the messages in the pkt_chain_ that is partially sent.
       // We just reuse these functions for normal partial send except actual sending.
       int num_bytes_left = static_cast<int>(pkt_chain_->total_length());

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -422,11 +422,13 @@ private:
   // amount of private state is shared between both classes.
   friend class TransportSendBuffer;
 
+  /// Current transport packet header.
+  TransportHeader header_;
+
 protected:
   ThreadSynch* synch() const;
 
-  /// Current transport packet header.
-  TransportHeader header_;
+  void set_header_source(ACE_INT64 source);
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/TransportSendStrategy.inl
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.inl
@@ -31,7 +31,6 @@ ThreadSynch* TransportSendStrategy::synch() const
 ACE_INLINE
 void TransportSendStrategy::set_header_source(ACE_INT64 source)
 {
-  GuardType guard(lock_);
   header_.source_ = source;
 }
 

--- a/dds/DCPS/transport/framework/TransportSendStrategy.inl
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.inl
@@ -29,6 +29,13 @@ ThreadSynch* TransportSendStrategy::synch() const
 }
 
 ACE_INLINE
+void TransportSendStrategy::set_header_source(ACE_INT64 source)
+{
+  GuardType guard(lock_);
+  header_.source_ = source;
+}
+
+ACE_INLINE
 void TransportSendStrategy::send_start()
 {
   DBG_ENTRY_LVL("TransportSendStrategy","send_start",6);

--- a/dds/DCPS/transport/multicast/MulticastSendStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastSendStrategy.cpp
@@ -34,7 +34,7 @@ void
 MulticastSendStrategy::prepare_header_i()
 {
   // Tag outgoing packets with our peer ID:
-  this->header_.source_ = this->link_->local_peer();
+  set_header_source(link_->local_peer());
 }
 
 ssize_t


### PR DESCRIPTION
This should fix the SEGV for an empty packet chain in TransportSendStrategy.

It remains confusing to me, though, why this was necessary, since header_.length_ and pkt_chain_ seem to be "reset" at the same time when they are modified.