### PR TITLE
XTypesTest --tcp Static builds

### DIFF
--- a/tests/DCPS/XTypes/Pub/XTypesPub.mpc
+++ b/tests/DCPS/XTypes/Pub/XTypesPub.mpc
@@ -1,4 +1,4 @@
-project(XTypes_Publisher): dcps_test, dcps_rtps_udp, msvc_bigobj {
+project(XTypes_Publisher): dcps_test, dcps_rtps_udp, msvc_bigobj, dcps_transports_for_test {
 
   exename   = xtypes_publisher
 

--- a/tests/DCPS/XTypes/Sub/XTypesSub.mpc
+++ b/tests/DCPS/XTypes/Sub/XTypesSub.mpc
@@ -1,4 +1,4 @@
-project(XTypes_Subscriber): dcps_test, dcps_rtps_udp, msvc_bigobj {
+project(XTypes_Subscriber): dcps_test, dcps_rtps_udp, msvc_bigobj, dcps_transports_for_test {
 
   exename   = xtypes_subscriber
 

--- a/tests/DCPS/XTypes/XTypes.h
+++ b/tests/DCPS/XTypes/XTypes.h
@@ -12,6 +12,7 @@
 #ifdef ACE_AS_STATIC_LIBS
 #  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#  include <dds/DCPS/transport/tcp/Tcp.h>
 #endif
 
 using namespace DDS;


### PR DESCRIPTION
Static builds lacked an mpc include and an include which caused segfaults on static builds.