### PR TITLE
Reduce TCP transport connection errors to warnings

### DIFF
--- a/dds/DCPS/transport/tcp/TcpConnection.cpp
+++ b/dds/DCPS/transport/tcp/TcpConnection.cpp
@@ -485,34 +485,39 @@ OpenDDS::DCPS::TcpConnection::on_active_connection_established()
 
   ACE_UINT32 nlen = htonl(len);
 
-  if (this->peer().send_n(&nlen,
-                          sizeof(ACE_UINT32)) == -1) {
-    ACE_ERROR_RETURN((LM_WARNING,
-                      "(%P|%t) WARNING: TcpConnection::on_active_connection_established: "
-                      "Unable to send address string length to "
-                      "the passive side to complete the active connection "
-                      "establishment.\n"),
-                     -1);
+  if (this->peer().send_n(&nlen, sizeof(ACE_UINT32)) == -1) {
+    if (DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_WARNING,
+                 "(%P|%t) WARNING: TcpConnection::on_active_connection_established: "
+                 "Unable to send address string length to "
+                 "the passive side to complete the active connection "
+                 "establishment.\n"));
+    }
+    return -1;
   }
 
   if (this->peer().send_n(address.c_str(), len)  == -1) {
-    ACE_ERROR_RETURN((LM_WARNING,
-                      "(%P|%t) WARNING: TcpConnection::on_active_connection_established: "
-                      "Unable to send our address to "
-                      "the passive side to complete the active connection "
-                      "establishment.\n"),
-                     -1);
+    if (DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_WARNING,
+                 "(%P|%t) WARNING: TcpConnection::on_active_connection_established: "
+                 "Unable to send our address to "
+                 "the passive side to complete the active connection "
+                 "establishment.\n"));
+    }
+    return -1;
   }
 
   ACE_UINT32 npriority = htonl(this->transport_priority_);
 
   if (this->peer().send_n(&npriority, sizeof(ACE_UINT32)) == -1) {
-    ACE_ERROR_RETURN((LM_WARNING,
-                      "(%P|%t) WARNING: TcpConnection::on_active_connection_established: "
-                      "Unable to send publication priority to "
-                      "the passive side to complete the active connection "
-                      "establishment.\n"),
-                     -1);
+    if (DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_WARNING,
+                 "(%P|%t) WARNING: TcpConnection::on_active_connection_established: "
+                 "Unable to send publication priority to "
+                 "the passive side to complete the active connection "
+                 "establishment.\n"));
+    }
+    return -1;
   }
 
   return 0;

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -164,7 +164,9 @@ TcpTransport::connect_datalink(const RemoteTransport& remote,
 void
 TcpTransport::async_connect_failed(const PriorityKey& key)
 {
-  ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: Failed to make active connection.\n"));
+  if (DCPS_debug_level >= 2) {
+    ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: Failed to make active connection.\n"));
+  }
   GuardType guard(links_lock_);
   TcpDataLink_rch link;
   links_.find(key, link);


### PR DESCRIPTION
Since remote entities may merely be shutting down.