### PR TITLE
Reorganize content and expand commercial section

### DIFF
--- a/support.html
+++ b/support.html
@@ -5,53 +5,63 @@ order: 160
 categories: [opendds]
 ---
 <div id="contenttext">
-  <div class="bodytext" align="justify">
-    <a name="HowToSponsor"><span class="headertext">Where to Get Support</span></a>
-    <p>
+	<div class="bodytext" align="justify">
+		<a name="HowToSponsor"><span class="headertext">Commercial Support</span></a>
 
-      <span class="subheadertext">DDS Mailing Lists</span>
-       <p>
-         Visit <a href="https://objectcomputing.com/products/opendds/resources">Object Computing Inc's (OCI's) OpenDDS resources page</a> to subscribe to the OpenDDS mailing list and receive regular updates, invitations to webinars and events, and more.
-    </p>
-    <p>
-      DDS mailing lists are also available through the
-      <a href="http://sourceforge.net/projects/opendds/" target="_self">SourceForge project page</a>.
-      The archives of previous messages are searchable.
-    </p>
+		<span class="subheadertext">Object Computing, Inc. (OCI)</span>
+			<div class="panel">
+				<p>
+					Members of the core OpenDDS development team are available to provide <a href="https://objectcomputing.com/products/opendds/training">training</a>, consulting, code review, troubleshooting, and more.
+				</p>
+				<p>
+					<a href="https://objectcomputing.com/products/opendds/opendds-consulting-and-support">OCI's pre-paid support packages</a> enable you and your team to get the help you need when you need it at economical hourly rates. Fully managed project delivery is also available; <a href="https://objectcomputing.com/products/opendds/opendds-consulting-and-support#contact">contact OCI for a custom quote</a>.
+				</p>
+			</div>
 
+		<span class="subheadertext">Remedy IT</span>
+			<div class="panel"> 
+				<p>
+					<a href="https://www.remedy.nl/services/opensource-support.html">Remedy's RS_Year support</a> provides you and your team the assistance you need using a pre-purchased pool of hours.
+				</p>
+				<p>
+					Remedy IT also offers <a href="https://www.remedy.nl/training/overview.html"></a>training courses</a> in communication middleware and frameworks, including the OpenDDS project. Ccourses are offered as open enrollment, but on request, can also be delivered at your location.
+				</p>
+			</div>
+		
+		<span class="headertext">Community Support</span>
+		
+		<span class="subheadertext">Mailing Lists</span>
+			<div class="panel">
+				<p>
+					Visit <a href="https://objectcomputing.com/products/opendds/resources">OCI's OpenDDS resources page</a> to subscribe to the OpenDDS mailing list and receive regular updates, invitations to webinars and events, and more.
+				</p>
+				<p>
+					DDS mailing lists are also available through the <a href="http://sourceforge.net/projects/opendds/" target="_self">SourceForge project page</a>. Archives of previous messages are searchable.
+				</p>
+			</div>
 
-    <span class="subheadertext">GitHub Issues</span>
-    <p>
-      View the <a href="https://github.com/objectcomputing/OpenDDS/issues">GitHub issues list</a> for OpenDDS.
-      Please search the list to see if your issue has already been reported before submitting a new one.
-    </p>
+		<span class="subheadertext">GitHub Issues</span>
+			<div class="panel">
+				<p>
+					View the <a href="https://github.com/objectcomputing/OpenDDS/issues">GitHub issues list</a> for the OpenDDS project. Please search the list to see if your issue has already been reported before submitting a new one.
+				</p>
+			</div>
 
-    <span class="subheadertext">Online Documentation</span>
-    <p>
-      View the <a href="documentation.html">online documentation</a> for OpenDDS.
-    </p>
-
-    <span class="subheadertext">The Code</span>
-    <p>
-      The code is commented. Take a look in the header and class files; also see the <a href="doxygen/index.html">doxygen</a>.<br />
-      Some documentation is included with the code in the <code>DDS_ROOT/docs</code> directory.<br />
-      Code examples are included in the OpenDDS distribution in the <code>DDS_ROOT/examples</code> directory.
-    </p>
-
-    <span class="subheadertext">Commercial Support</span>
-    <div class="panel">
-      <p>
-        Commercial support for OpenDDS is provided by <a href="https://objectcomputing.com/products/opendds">Object Computing, Inc. (OCI)</a> and <a href="https://www.remedy.nl">Remedy IT</a>.
-      </p>
-      <p>
-        Members of the core OpenDDS development team are available to provide training, consulting, code review, troubleshooting, and more. <a href="https://objectcomputing.com/products/opendds/opendds-consulting-and-support">OCI's pre-paid support packages</a> enable you and your team to get the help you need when you need it at economical hourly rates. Fully managed project delivery is also available; <a href="https://objectcomputing.com/products/opendds/opendds-consulting-and-support#support">contact OCI for a custom quote</a>.
-      </p>
-    </div>
-
-    <span class="subheadertext">Training</span>
-    <div class="panel">
-      <p>Object Computing offers <a href="https://objectcomputing.com/products/opendds/training">professional OpenDDS training</a> delivered by members of the core OpenDDS development team. Both open-enrollment courses and <a href="https://objectcomputing.com/products/opendds/training#contact">custom engagements</a> are available. Training is also available through <a href="https://www.remedy.nl">Remedy IT</a>.</p>
-    </div>
-  </div>
+		<span class="subheadertext">Online Documentation</span>
+			<div class="panel">
+				<p>
+					View the <a href="documentation.html">online documentation</a> for the OpenDDS project.
+				</p>
+			</div>
+			
+		<span class="subheadertext">The Code</span>
+			<div class="panel">
+				<p>
+					The code is commented. Take a look in the header and class files; also see the <a href="doxygen/index.html">doxygen</a>.
+				</p>
+				<p>
+					Some documentation is included with the code in the <code>DDS_ROOT/docs</code> directory. Code examples are also included in the OpenDDS distribution in the <code>DDS_ROOT/examples</code> directory.
+				</p>
+			</div>
+	</div>
 </div>
-


### PR DESCRIPTION
@mitza-oci I split the page into two primary sections: commercial support and community support. Let me know if you think this will work.