### PR TITLE
ReactorTask catches exceptions

### DIFF
--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -174,9 +174,11 @@ int ReactorTask::svc()
     ACE_ERROR((LM_ERROR,
                "(%P|%t) ERROR: ReactorTask::svc caught exception - %C.\n",
                e.what()));
+    throw;
   } catch (...) {
     ACE_ERROR((LM_ERROR,
                "(%P|%t) ERROR: ReactorTask::svc caught exception.\n"));
+    throw;
   }
 
   if (update_thread_status) {


### PR DESCRIPTION
Problem
-------

The main loop in ReactorTask catches exceptions.  When an exception is
throw, the main loop will log the exception (good) and terminate the
thread without killing the entire process (bad).  Killing the entire
process provides instant feedback that something is wrong and needs to
be corrected.

Solution
--------

Remove the try-catch code.