### PR TITLE
RtpsRelay logging cleanup

### DIFF
--- a/tools/rtpsrelay/GuidPartitionTable.cpp
+++ b/tools/rtpsrelay/GuidPartitionTable.cpp
@@ -87,7 +87,8 @@ GuidPartitionTable::Result GuidPartitionTable::insert(const OpenDDS::DCPS::GUID_
 
   if (config_.log_activity()) {
     const auto part_guid = make_id(guid, OpenDDS::DCPS::ENTITYID_PARTICIPANT);
-    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidPartitionTable::insert %C add partitions %C %C into session\n"), guid_to_string(part_guid).c_str(), OpenDDS::DCPS::to_json(spdp_replay).c_str(), guid_addr_set_.get_session_time(part_guid, now).sec_str().c_str()));
+    GuidAddrSet::Proxy proxy(guid_addr_set_);
+    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidPartitionTable::insert %C add partitions %C %C into session\n"), guid_to_string(part_guid).c_str(), OpenDDS::DCPS::to_json(spdp_replay).c_str(), proxy.get_session_time(part_guid, now).sec_str().c_str()));
   }
 
   return result;

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -50,7 +50,8 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
       if (info.valid_data) {
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
-        guid_addr_set_.remove_pending(repoid);
+        GuidAddrSet::Proxy proxy(guid_addr_set_);
+        proxy.remove_pending(repoid);
 
         const auto p = guids_.insert(repoid);
         if (p.second) {
@@ -58,7 +59,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
             ACE_DEBUG((LM_INFO, "(%P|%t) INFO: ParticipantListener::on_data_available "
               "add local participant %C %C %C into session\n",
               guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-              guid_addr_set_.get_session_time(repoid, now).sec_str().c_str()));
+              proxy.get_session_time(repoid, now).sec_str().c_str()));
           }
 
           stats_reporter_.local_participants(guids_.size(), now);
@@ -70,14 +71,15 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
       {
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
+        GuidAddrSet::Proxy proxy(guid_addr_set_);
         if (config_.log_discovery()) {
           ACE_DEBUG((LM_INFO, "(%P|%t) INFO: ParticipantListener::on_data_available "
                      "remove local participant %C %C into session\n",
                      guid_to_string(repoid).c_str(),
-                     guid_addr_set_.get_session_time(repoid, now).sec_str().c_str()));
+                     proxy.get_session_time(repoid, now).sec_str().c_str()));
         }
 
-        guid_addr_set_.remove(repoid, now);
+        proxy.remove(repoid, now);
         guids_.erase(repoid);
         stats_reporter_.local_participants(guids_.size(), now);
       }

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -57,10 +57,11 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
 
           if (r == GuidPartitionTable::ADDED) {
             if (config_.log_discovery()) {
+              GuidAddrSet::Proxy proxy(guid_addr_set_);
               ACE_DEBUG((LM_INFO, "(%P|%t) INFO: PublicationListener::on_data_available "
-                "add local writer %C %C %C into session\n",
-                guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-                guid_addr_set_.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                         "add local writer %C %C %C into session\n",
+                         guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
+                         proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
             }
             stats_reporter_.local_writers(++count_, OpenDDS::DCPS::MonotonicTimePoint::now());
           } else if (r == GuidPartitionTable::UPDATED) {
@@ -79,10 +80,11 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
         if (config_.log_discovery()) {
+          GuidAddrSet::Proxy proxy(guid_addr_set_);
           ACE_DEBUG((LM_INFO, "(%P|%t) INFO: PublicationListener::on_data_available "
-            "remove local writer %C %C into session\n",
-            guid_to_string(repoid).c_str(),
-            guid_addr_set_.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                     "remove local writer %C %C into session\n",
+                     guid_to_string(repoid).c_str(),
+                     proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
         }
         guid_partition_table_.remove(repoid);
         stats_reporter_.local_writers(--count_, OpenDDS::DCPS::MonotonicTimePoint::now());

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -57,13 +57,13 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
 
         if (r == GuidPartitionTable::ADDED) {
           if (config_.log_discovery()) {
-            ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SubscriptionListener::on_data_available "
-              "add local reader %C %C into session\n",
-              guid_to_string(repoid).c_str(),
-              guid_addr_set_.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
-            ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: SubscriptionListener::on_data_available add local reader %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
+            GuidAddrSet::Proxy proxy(guid_addr_set_);
+            ACE_DEBUG((LM_INFO,
+                       "(%P|%t) INFO: SubscriptionListener::on_data_available "
+                       "add local reader %C %C %C into session\n",
+                       guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
+                       proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
           }
-
           stats_reporter_.local_readers(++count_, OpenDDS::DCPS::MonotonicTimePoint::now());
         } else if (r == GuidPartitionTable::UPDATED) {
           if (config_.log_discovery()) {
@@ -78,10 +78,11 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
         if (config_.log_discovery()) {
+          GuidAddrSet::Proxy proxy(guid_addr_set_);
           ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SubscriptionListener::on_data_available "
-            "remove local reader %C %C into session\n",
-            guid_to_string(repoid).c_str(),
-            guid_addr_set_.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                     "remove local reader %C %C into session\n",
+                     guid_to_string(repoid).c_str(),
+                     proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
         }
 
         guid_partition_table_.remove(repoid);


### PR DESCRIPTION
* Call more functions through the GuidAddrSet::Proxy to avoid
  confusion.

* Save session time before removing participant.

* Remove first_spdp.