### PR TITLE
RtpsRelay: Include order is wrong for some compilers

### DIFF
--- a/tools/rtpsrelay/ParticipantStatisticsReporter.h
+++ b/tools/rtpsrelay/ParticipantStatisticsReporter.h
@@ -2,10 +2,12 @@
 #define RTPSRELAY_PARTICIPANT_STATISTICS_REPORTER_H_
 
 #include "Config.h"
-#include "CommonIoStatsReportHelper.h"
 
 #include <dds/rtpsrelaylib/RelayTypeSupportImpl.h>
 #include <dds/rtpsrelaylib/Utility.h>
+
+// after RelayTypeSupportImpl.h so that set_default is available
+#include "CommonIoStatsReportHelper.h"
 
 #include <dds/DCPS/JsonValueWriter.h>
 

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -2,10 +2,12 @@
 #define RTPSRELAY_RELAY_STATISTICS_REPORTER_H_
 
 #include "Config.h"
-#include "CommonIoStatsReportHelper.h"
 
 #include <dds/rtpsrelaylib/RelayTypeSupportImpl.h>
 #include <dds/rtpsrelaylib/Utility.h>
+
+// after RelayTypeSupportImpl.h so that set_default is available
+#include "CommonIoStatsReportHelper.h"
 
 #include <dds/DCPS/JsonValueWriter.h>
 


### PR DESCRIPTION
Problem
-------

`set_default` is not available due to include order for some
compilers.

Solution
--------

Ensure the type support is included first.