### PR TITLE
Add Counts of Remote Relay Publications to Stats

### DIFF
--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -147,6 +147,9 @@ module RtpsRelay {
     unsigned long local_participants;
     unsigned long local_writers;
     unsigned long local_readers;
+    unsigned long relay_partitions_pub_count;
+    unsigned long relay_address_pub_count;
+    unsigned long spdp_replay_pub_count;
   };
 };
 

--- a/tools/rtpsrelay/RelayAddressListener.cpp
+++ b/tools/rtpsrelay/RelayAddressListener.cpp
@@ -3,11 +3,15 @@
 #include <dds/rtpsrelaylib/RelayTypeSupportImpl.h>
 
 #include <dds/DCPS/DCPS_Utils.h>
+#include <dds/DCPS/TimeTypes.h>
 
 namespace RtpsRelay {
 
-RelayAddressListener::RelayAddressListener(RelayPartitionTable& relay_partition_table)
+RelayAddressListener::RelayAddressListener(
+  RelayPartitionTable& relay_partition_table,
+  RelayStatisticsReporter& relay_statistics_reporter)
   : relay_partition_table_(relay_partition_table)
+  , relay_statistics_reporter_(relay_statistics_reporter)
 {}
 
 void RelayAddressListener::on_data_available(DDS::DataReader_ptr reader)
@@ -51,5 +55,13 @@ void RelayAddressListener::on_data_available(DDS::DataReader_ptr reader)
     }
   }
 }
+
+void RelayAddressListener::on_subscription_matched(
+  DDS::DataReader_ptr /*reader*/, const DDS::SubscriptionMatchedStatus& status)
+{
+  relay_statistics_reporter_.relay_address_pub_count(
+    static_cast<uint32_t>(status.total_count), OpenDDS::DCPS::MonotonicTimePoint::now());
+}
+
 
 }

--- a/tools/rtpsrelay/RelayAddressListener.h
+++ b/tools/rtpsrelay/RelayAddressListener.h
@@ -3,17 +3,22 @@
 
 #include "ListenerBase.h"
 #include "RelayPartitionTable.h"
+#include "RelayStatisticsReporter.h"
 
 namespace RtpsRelay {
 
 class RelayAddressListener : public ListenerBase {
 public:
-  RelayAddressListener(RelayPartitionTable& relay_partition_table);
+  RelayAddressListener(RelayPartitionTable& relay_partition_table,
+    RelayStatisticsReporter& relay_statistics_reporter);
 
 private:
-  void on_data_available(DDS::DataReader_ptr /*reader*/) override;
+  void on_data_available(DDS::DataReader_ptr reader) override;
+  void on_subscription_matched(DDS::DataReader_ptr reader,
+                               const DDS::SubscriptionMatchedStatus& status) override;
 
   RelayPartitionTable& relay_partition_table_;
+  RelayStatisticsReporter& relay_statistics_reporter_;
 };
 
 }

--- a/tools/rtpsrelay/RelayPartitionsListener.cpp
+++ b/tools/rtpsrelay/RelayPartitionsListener.cpp
@@ -3,11 +3,15 @@
 #include <dds/rtpsrelaylib/RelayTypeSupportImpl.h>
 
 #include <dds/DCPS/DCPS_Utils.h>
+#include <dds/DCPS/TimeTypes.h>
 
 namespace RtpsRelay {
 
-RelayPartitionsListener::RelayPartitionsListener(RelayPartitionTable& relay_partition_table)
+RelayPartitionsListener::RelayPartitionsListener(
+  RelayPartitionTable& relay_partition_table,
+  RelayStatisticsReporter& relay_statistics_reporter)
   : relay_partition_table_(relay_partition_table)
+  , relay_statistics_reporter_(relay_statistics_reporter)
 {}
 
 void RelayPartitionsListener::on_data_available(DDS::DataReader_ptr reader)
@@ -49,6 +53,13 @@ void RelayPartitionsListener::on_data_available(DDS::DataReader_ptr reader)
       break;
     }
   }
+}
+
+void RelayPartitionsListener::on_subscription_matched(
+  DDS::DataReader_ptr /*reader*/, const DDS::SubscriptionMatchedStatus& status)
+{
+  relay_statistics_reporter_.relay_partitions_pub_count(
+    static_cast<uint32_t>(status.total_count), OpenDDS::DCPS::MonotonicTimePoint::now());
 }
 
 }

--- a/tools/rtpsrelay/RelayPartitionsListener.h
+++ b/tools/rtpsrelay/RelayPartitionsListener.h
@@ -3,17 +3,22 @@
 
 #include "ListenerBase.h"
 #include "RelayPartitionTable.h"
+#include "RelayStatisticsReporter.h"
 
 namespace RtpsRelay {
 
 class RelayPartitionsListener : public ListenerBase {
 public:
-  RelayPartitionsListener(RelayPartitionTable& relay_partition_table);
+  RelayPartitionsListener(RelayPartitionTable& relay_partition_table,
+    RelayStatisticsReporter& relay_statistics_reporter);
 
 private:
-  void on_data_available(DDS::DataReader_ptr /*reader*/) override;
+  void on_data_available(DDS::DataReader_ptr reader) override;
+  void on_subscription_matched(DDS::DataReader_ptr reader,
+                               const DDS::SubscriptionMatchedStatus& status) override;
 
   RelayPartitionTable& relay_partition_table_;
+  RelayStatisticsReporter& relay_statistics_reporter_;
 };
 
 }

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -137,6 +137,27 @@ public:
     report(now);
   }
 
+  void relay_partitions_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    log_relay_statistics_.relay_partitions_pub_count() = count;
+    publish_relay_statistics_.relay_partitions_pub_count() = count;
+    report(now);
+  }
+
+  void relay_address_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    log_relay_statistics_.relay_address_pub_count() = count;
+    publish_relay_statistics_.relay_address_pub_count() = count;
+    report(now);
+  }
+
+  void spdp_replay_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    log_relay_statistics_.spdp_replay_pub_count() = count;
+    publish_relay_statistics_.spdp_replay_pub_count() = count;
+    report(now);
+  }
+
   void report()
   {
     report(OpenDDS::DCPS::MonotonicTimePoint::now(), true);

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -656,22 +656,24 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   DDS::DataReader_var participant_reader = bit_subscriber->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PARTICIPANT_TOPIC);
 
-  DDS::DataReaderListener_var relay_partition_listener = new RelayPartitionsListener(relay_partition_table);
+  DDS::DataReaderListener_var relay_partition_listener =
+    new RelayPartitionsListener(relay_partition_table, relay_statistics_reporter);
   DDS::DataReader_var relay_partition_reader_var =
     relay_subscriber->create_datareader(relay_partitions_topic, reader_qos,
                                         relay_partition_listener,
-                                        DDS::DATA_AVAILABLE_STATUS);
+                                        DDS::DATA_AVAILABLE_STATUS | DDS::SUBSCRIPTION_MATCHED_STATUS);
 
   if (!relay_partition_reader_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Partition data reader\n")));
     return EXIT_FAILURE;
   }
 
-  DDS::DataReaderListener_var relay_address_listener = new RelayAddressListener(relay_partition_table);
+  DDS::DataReaderListener_var relay_address_listener =
+    new RelayAddressListener(relay_partition_table, relay_statistics_reporter);
   DDS::DataReader_var relay_address_reader_var =
     relay_subscriber->create_datareader(relay_addresses_topic, reader_qos,
                                         relay_address_listener,
-                                        DDS::DATA_AVAILABLE_STATUS);
+                                        DDS::DATA_AVAILABLE_STATUS | DDS::SUBSCRIPTION_MATCHED_STATUS);
 
   if (!relay_address_reader_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Address data reader\n")));
@@ -687,11 +689,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   replay_reader_qos.reader_data_lifecycle.autopurge_nowriter_samples_delay = one_minute;
   replay_reader_qos.reader_data_lifecycle.autopurge_disposed_samples_delay = one_minute;
 
-  DDS::DataReaderListener_var spdp_replay_listener = new SpdpReplayListener(spdp_vertical_handler);
+  DDS::DataReaderListener_var spdp_replay_listener =
+    new SpdpReplayListener(spdp_vertical_handler, relay_statistics_reporter);
   DDS::DataReader_var spdp_replay_reader_var =
     relay_subscriber->create_datareader(spdp_replay_topic, replay_reader_qos,
                                         spdp_replay_listener,
-                                        DDS::DATA_AVAILABLE_STATUS);
+                                        DDS::DATA_AVAILABLE_STATUS | DDS::SUBSCRIPTION_MATCHED_STATUS);
 
   if (!spdp_replay_reader_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Address data reader\n")));

--- a/tools/rtpsrelay/SpdpReplayListener.cpp
+++ b/tools/rtpsrelay/SpdpReplayListener.cpp
@@ -1,11 +1,14 @@
 #include "SpdpReplayListener.h"
 
 #include <dds/DCPS/DCPS_Utils.h>
+#include <dds/DCPS/TimeTypes.h>
 
 namespace RtpsRelay {
 
-SpdpReplayListener::SpdpReplayListener(SpdpHandler& spdp_handler)
+SpdpReplayListener::SpdpReplayListener(SpdpHandler& spdp_handler,
+  RelayStatisticsReporter& relay_statistics_reporter)
   : spdp_handler_(spdp_handler)
+  , relay_statistics_reporter_(relay_statistics_reporter)
 {}
 
 void SpdpReplayListener::on_data_available(DDS::DataReader_ptr reader)
@@ -34,6 +37,13 @@ void SpdpReplayListener::on_data_available(DDS::DataReader_ptr reader)
       spdp_handler_.replay(data[idx]);
     }
   }
+}
+
+void SpdpReplayListener::on_subscription_matched(
+  DDS::DataReader_ptr /*reader*/, const DDS::SubscriptionMatchedStatus& status)
+{
+  relay_statistics_reporter_.spdp_replay_pub_count(
+    static_cast<uint32_t>(status.total_count), OpenDDS::DCPS::MonotonicTimePoint::now());
 }
 
 }

--- a/tools/rtpsrelay/SpdpReplayListener.h
+++ b/tools/rtpsrelay/SpdpReplayListener.h
@@ -3,17 +3,22 @@
 
 #include "ListenerBase.h"
 #include "RelayHandler.h"
+#include "RelayStatisticsReporter.h"
 
 namespace RtpsRelay {
 
 class SpdpReplayListener : public ListenerBase {
 public:
-  SpdpReplayListener(SpdpHandler& spdp_handler);
+  SpdpReplayListener(SpdpHandler& spdp_handler,
+    RelayStatisticsReporter& relay_statistics_reporter);
 
 private:
-  void on_data_available(DDS::DataReader_ptr /*reader*/) override;
+  void on_data_available(DDS::DataReader_ptr reader) override;
+  void on_subscription_matched(DDS::DataReader_ptr reader,
+                               const DDS::SubscriptionMatchedStatus& status) override;
 
   SpdpHandler& spdp_handler_;
+  RelayStatisticsReporter& relay_statistics_reporter_;
 };
 
 }


### PR DESCRIPTION
To make sure clusters of relays are communicating with each other, add count of matches for the SPDP Relay, Relay Partitions, and Relay Addresses DataReaders to the Relay Statistics.