### PR TITLE
GitHub Actions: Split Compiler and Remove Timeouts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -216,7 +216,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_i0_xer0_js0_j12
-    timeout-minutes: 150
 
     steps:
     - name: checkout MPC
@@ -416,7 +415,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_o1d0v1_xer0_j12
-    timeout-minutes: 40
 
     steps:
     - name: checkout MPC
@@ -808,7 +806,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_d0i0v1_sec_js0_FM-08
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -1061,7 +1058,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_clang5_i0w1_sec
-    timeout-minutes: 30
 
     steps:
     - name: install xerces
@@ -1314,7 +1310,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_clang10_sec_js0
-    timeout-minutes: 30
 
     steps:
     - name: install xerces
@@ -1567,7 +1562,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_gcc6_d0w1_cpp03
-    timeout-minutes: 30
 
     steps:
     - name: checkout MPC
@@ -1818,7 +1812,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_gcc8_i0_js0_j
-    timeout-minutes: 30
 
     steps:
     - name: checkout MPC
@@ -2064,7 +2057,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_gcc10_i0w1_xer0
-    timeout-minutes: 30
 
     steps:
     - name: checkout MPC
@@ -2383,7 +2375,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     needs: build_u20_ace7_j_qt_ws_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -2637,7 +2628,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     needs: build_u20_p1_asan_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -2887,7 +2877,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     needs: build_u20_p1_tsan_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -3145,7 +3134,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     needs: build_u20_p1_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -3347,7 +3335,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     needs: build_u20_p1_j8_FM-1f
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -3594,7 +3581,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_w1_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -3796,7 +3782,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_w1_j_FM-2f
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -4059,7 +4044,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_stat_qt_ws_sec
-    timeout-minutes: 30
 
     steps:
     - name: install xerces
@@ -4160,7 +4144,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_stat_qt_ws_sec
-    timeout-minutes: 40
 
     steps:
     - name: install xerces
@@ -4302,7 +4285,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_stat_qt_ws_sec
-    timeout-minutes: 45
 
     steps:
     - name: install xerces
@@ -4441,7 +4423,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_stat_qt_ws_sec
-    timeout-minutes: 45
 
     steps:
     - name: install xerces
@@ -4582,7 +4563,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_stat_qt_ws_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -4883,7 +4863,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     needs: build_u18_j_cft0_FM-37
-    timeout-minutes: 150
 
     steps:
     - name: install xerces
@@ -5151,7 +5130,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_p1_stat_js0
-    timeout-minutes: 30
 
     steps:
     - name: install openssl & xerces-c
@@ -5276,7 +5254,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_p1_stat_js0
-    timeout-minutes: 40
 
     steps:
     - name: install openssl & xerces-c
@@ -5430,7 +5407,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_p1_stat_js0
-    timeout-minutes: 45
 
     steps:
     - name: checkout MPC
@@ -5576,7 +5552,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_p1_stat_js0
-    timeout-minutes: 45
 
     steps:
     - name: checkout MPC
@@ -5724,7 +5699,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_p1_stat_js0
-    timeout-minutes: 150
 
     steps:
     - name: install openssl & xerces-c
@@ -6031,7 +6005,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_p1_stat_FM-08
-    timeout-minutes: 30
 
     steps:
     - name: install openssl & xerces-c
@@ -6156,7 +6129,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_p1_stat_FM-08
-    timeout-minutes: 40
 
     steps:
     - name: install openssl & xerces-c
@@ -6310,7 +6282,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_p1_stat_FM-08
-    timeout-minutes: 45
 
     steps:
     - name: checkout MPC
@@ -6455,7 +6426,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_p1_stat_FM-08
-    timeout-minutes: 45
 
     steps:
     - name: checkout MPC
@@ -6602,7 +6572,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_p1_stat_FM-08
-    timeout-minutes: 150
 
     steps:
     - name: install openssl & xerces-c
@@ -6925,7 +6894,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_o1p1_sec
-    timeout-minutes: 30
 
     steps:
     - name: checkout MPC
@@ -7046,7 +7014,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_o1p1_sec
-    timeout-minutes: 40
 
     steps:
     - name: install openssl & xerces-c
@@ -7200,7 +7167,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_o1p1_sec
-    timeout-minutes: 45
 
     steps:
     - name: install openssl & xerces-c
@@ -7340,7 +7306,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_o1p1_sec
-    timeout-minutes: 150
 
     steps:
     - name: install openssl & xerces-c
@@ -7743,7 +7708,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_j_ws_FM-1f
-    timeout-minutes: 30
 
     steps:
     - name: checkout MPC
@@ -7853,7 +7817,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_j_ws_FM-1f
-    timeout-minutes: 40
 
     steps:
     - name: install xerces-c
@@ -8007,7 +7970,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_j_ws_FM-1f
-    timeout-minutes: 45
 
     steps:
     - name: install xerces-c
@@ -8147,7 +8109,6 @@ jobs:
     runs-on: windows-2019
 
     needs: build_w19_re_j_ws_FM-1f
-    timeout-minutes: 150
 
     steps:
     - name: install xerces-c
@@ -8485,7 +8446,6 @@ jobs:
     runs-on: windows-2016
 
     needs: build_w16_x86_i0_sec
-    timeout-minutes: 150
 
     steps:
     - name: install openssl & xerces-c
@@ -8710,7 +8670,6 @@ jobs:
     runs-on: windows-2016
 
     needs: build_w16_x86_i0_j_FM-1f
-    timeout-minutes: 30
 
     steps:
     - name: install openssl & xerces-c
@@ -9415,7 +9374,6 @@ jobs:
     runs-on: macos-10.15
 
     needs: build_m10_o1d0_sec
-    timeout-minutes: 150
 
     steps:
     - name: install xerces-c
@@ -9698,7 +9656,6 @@ jobs:
     runs-on: macos-10.15
 
     needs: build_m10_i0_j_FM-1f
-    timeout-minutes: 150
 
     steps:
     - name: install xerces-c

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4374,6 +4374,17 @@ jobs:
         cd OpenDDS
         . setenv.sh
         cd tests/DCPS/Compiler
+        rm -rf key_annotation
+        rm -rf keywords
+        rm -rf namespace_conflict
+        rm -rf rapidjson_generator
+        rm -rf sequence_conflict
+        rm -rf TryConstruct
+        rm -rf typecode
+        rm -rf typeobject_hash_consistency
+        rm -rf underscore_fields
+        rm -rf xcdr
+        rm -rf XTypesExtensibility
         perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
     - name: make compiler tests
       shell: bash
@@ -4409,6 +4420,147 @@ jobs:
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_COMPILER -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  compiler2_u18_stat_qt_ws_sec:
+
+    runs-on: ubuntu-18.04
+
+    needs: build_u18_stat_qt_ws_sec
+    timeout-minutes: 45
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: update apt
+      run: sudo apt-get update
+    - name: install qt
+      run: sudo apt-get -y install qtbase5-dev
+    - name: checkout MPC
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_u18_stat_qt_ws_sec_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_u18_stat_qt_ws_sec.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_u18_stat_qt_ws_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_u18_stat_qt_ws_sec.tar.xz
+    - name: setup gtest
+      run: |
+        cd OpenDDS/tests/googletest
+        git submodule init
+        git submodule update
+        mkdir build
+        cd build
+        mkdir install
+        cmake -DCMAKE_INSTALL_PREFIX=./install ..
+        cmake --build . --target install
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: build compiler tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tests/DCPS/Compiler
+        rm -rf anonymous_types
+        rm -rf C++11
+        rm -rf char_literals
+        rm -rf explicit_ints
+        rm -rf idl_test1_lib
+        rm -rf idl_test1_main
+        rm -rf idl_test2_lib
+        rm -rf idl_test2_main
+        rm -rf idl_test3_lib
+        rm -rf idl_test3_main
+        rm -rf idl_test_nested_types_lib
+        rm -rf isolated_types
+        rm -rf is_topic_type
+        perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
+    - name: make compiler tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tests/DCPS/Compiler
+        make
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_COMPILER2 -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -5349,6 +5501,17 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Compiler
+        rm -rf key_annotation
+        rm -rf keywords
+        rm -rf namespace_conflict
+        rm -rf rapidjson_generator
+        rm -rf sequence_conflict
+        rm -rf TryConstruct
+        rm -rf typecode
+        rm -rf typeobject_hash_consistency
+        rm -rf underscore_fields
+        rm -rf xcdr
+        rm -rf XTypesExtensibility
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features no_cxx11=0
     - name: make compiler tests
       shell: cmd
@@ -5385,6 +5548,154 @@ jobs:
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  compiler2_w19_p1_stat_js0:
+
+    runs-on: windows-2019
+
+    needs: build_w19_p1_stat_js0
+    timeout-minutes: 45
+
+    steps:
+    - name: checkout MPC
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_w19_p1_stat_js0_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_w19_p1_stat_js0.tar.xz
+        rm -f ACE_TAO_w19_p1_stat_js0.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_w19_p1_stat_js0_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w19_p1_stat_js0.tar.xz
+        rm -f build_w19_p1_stat_js0.tar.xz
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1
+    - name: setup gtest
+      shell: cmd
+      run: |
+        cd OpenDDS/tests/googletest
+        git submodule init
+        git submodule update
+        mkdir build
+        cd build
+        mkdir install
+        cmake -DCMAKE_INSTALL_PREFIX=./install ..
+        cmake --build . --target install
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: build compiler tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\Compiler
+        rm -rf anonymous_types
+        rm -rf C++11
+        rm -rf char_literals
+        rm -rf explicit_ints
+        rm -rf idl_test1_lib
+        rm -rf idl_test1_main
+        rm -rf idl_test2_lib
+        rm -rf idl_test2_main
+        rm -rf idl_test3_lib
+        rm -rf idl_test3_main
+        rm -rf idl_test_nested_types_lib
+        rm -rf isolated_types
+        rm -rf is_topic_type
+        perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features no_cxx11=0
+    - name: make compiler tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\Compiler
+        dir
+        msbuild -p:Configuration=Debug,Platform=x64 -m Compiler.sln
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER2 -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -6070,6 +6381,17 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Compiler
+        rm -rf key_annotation
+        rm -rf keywords
+        rm -rf namespace_conflict
+        rm -rf rapidjson_generator
+        rm -rf sequence_conflict
+        rm -rf TryConstruct
+        rm -rf typecode
+        rm -rf typeobject_hash_consistency
+        rm -rf underscore_fields
+        rm -rf xcdr
+        rm -rf XTypesExtensibility
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features no_rapidjson=0 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
     - name: make compiler tests
       shell: cmd
@@ -6105,6 +6427,153 @@ jobs:
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  compiler2_w19_re_p1_stat_FM-08:
+
+    runs-on: windows-2019
+
+    needs: build_w19_re_p1_stat_FM-08
+    timeout-minutes: 45
+
+    steps:
+    - name: checkout MPC
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v2
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v2
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: ACE_TAO_w19_re_p1_stat_FM-08_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_w19_re_p1_stat_FM-08.tar.xz
+        rm -f ACE_TAO_w19_re_p1_stat_FM-08.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: build_w19_re_p1_stat_FM-08_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w19_re_p1_stat_FM-08.tar.xz
+        rm -f build_w19_re_p1_stat_FM-08.tar.xz
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1
+    - name: setup gtest
+      shell: cmd
+      run: |
+        cd OpenDDS/tests/googletest
+        git submodule init
+        git submodule update
+        mkdir build
+        cd build
+        mkdir install
+        cmake -DCMAKE_INSTALL_PREFIX=./install ..
+        cmake --build . --target install --config Release
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: build compiler tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\Compiler
+        rm -rf anonymous_types
+        rm -rf C++11
+        rm -rf char_literals
+        rm -rf explicit_ints
+        rm -rf idl_test1_lib
+        rm -rf idl_test1_main
+        rm -rf idl_test2_lib
+        rm -rf idl_test2_main
+        rm -rf idl_test3_lib
+        rm -rf idl_test3_main
+        rm -rf idl_test_nested_types_lib
+        rm -rf isolated_types
+        rm -rf is_topic_type
+        perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features no_rapidjson=0 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
+    - name: make compiler tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\Compiler
+        msbuild -p:Configuration=Release,Platform=x64 -m Compiler.sln
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER2 -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/tests/static_ci_tests.lst
+++ b/tests/static_ci_tests.lst
@@ -32,13 +32,13 @@ tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN STATIC_COMPILER
 tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11 STATIC_COMPILER2
 tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
 tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
-tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
 tests/DCPS/Compiler/xcdr/run_test.pl: !DCPS_MIN STATIC_COMPILER2
 tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN STATIC_COMPILER2
 tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN STATIC_COMPILER2
 tests/DCPS/Compiler/keywords/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
-tests/DCPS/Compiler/explicit_ints/run_test.pl classic: !DCPS_MIN STATIC_COMPILER2
-tests/DCPS/Compiler/explicit_ints/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
+tests/DCPS/Compiler/explicit_ints/run_test.pl classic: !DCPS_MIN STATIC_COMPILER
+tests/DCPS/Compiler/explicit_ints/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
 tests/DCPS/Compiler/char_literals/run_test.pl classic: !DCPS_MIN STATIC_COMPILER
 tests/DCPS/Compiler/char_literals/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
 

--- a/tests/static_ci_tests.lst
+++ b/tests/static_ci_tests.lst
@@ -32,7 +32,7 @@ tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN STATIC_COMPILER
 tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11 STATIC_COMPILER2
 tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
 tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
-tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
+tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
 tests/DCPS/Compiler/xcdr/run_test.pl: !DCPS_MIN STATIC_COMPILER2
 tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN STATIC_COMPILER2
 tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN STATIC_COMPILER2

--- a/tests/static_ci_tests.lst
+++ b/tests/static_ci_tests.lst
@@ -27,12 +27,19 @@ tests/DCPS/Compiler/idl_test1_main/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFIL
 tests/DCPS/Compiler/idl_test3_main/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
 tests/DCPS/Compiler/C++11/idl_test1_main/run_test.pl: !DCPS_MIN CXX11 STATIC_COMPILER
 tests/DCPS/Compiler/C++11/idl_test3_main/run_test.pl: !DCPS_MIN CXX11 STATIC_COMPILER
-tests/DCPS/Compiler/key_annotation/run_test.pl: !DCPS_MIN STATIC_COMPILER
+tests/DCPS/Compiler/key_annotation/run_test.pl: !DCPS_MIN STATIC_COMPILER2
 tests/DCPS/Compiler/is_topic_type/run_test.pl: !DCPS_MIN STATIC_COMPILER
-tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11 STATIC_COMPILER
-tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
-tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
-tests/DCPS/Compiler/xcdr/run_test.pl: !DCPS_MIN STATIC_COMPILER
-tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN STATIC_COMPILER
+tests/DCPS/Compiler/rapidjson_generator/run_test.pl: !DCPS_MIN RAPIDJSON CXX11 STATIC_COMPILER2
+tests/DCPS/Compiler/TryConstruct/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
+tests/DCPS/Compiler/TryConstruct/C++11/run_test.pl: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
+tests/DCPS/Compiler/typeobject_hash_consistency/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Compiler/xcdr/run_test.pl: !DCPS_MIN STATIC_COMPILER2
+tests/DCPS/Compiler/XtypesExtensibility/run_test.pl: !DCPS_MIN STATIC_COMPILER2
+tests/DCPS/Compiler/keywords/run_test.pl classic: !DCPS_MIN STATIC_COMPILER2
+tests/DCPS/Compiler/keywords/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
+tests/DCPS/Compiler/explicit_ints/run_test.pl classic: !DCPS_MIN STATIC_COMPILER2
+tests/DCPS/Compiler/explicit_ints/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER2
+tests/DCPS/Compiler/char_literals/run_test.pl classic: !DCPS_MIN STATIC_COMPILER
+tests/DCPS/Compiler/char_literals/run_test.pl cpp11: !DCPS_MIN CXX11 !OPENDDS_SAFETY_PROFILE STATIC_COMPILER
 
 tests/unit-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS


### PR DESCRIPTION
The Static Compiler jobs were running out of disk space. As a result, I split the Compiler into 2 parts for the static builds. I also added the newer Compiler tests to `static_ci_tests.lst` so we should have more coverage than before.

Recently, we saw a timeout with one of the Static Compiler jobs, and decided to remove the timeouts from our workflow. The timeouts of individual tests are handled by their `run_test.pl` and we would like to run every test rather than cutting short.  This change was made possible because we removed the `check_test_results` workflow recently.