### PR TITLE
CDR Encapsulation option for non-rtps_udp transports: Follow up fixes

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3389,6 +3389,14 @@ DDS::ReturnCode_t DataReaderImpl::setup_deserialization()
   const DDS::DataRepresentationIdSeq repIds =
     get_effective_data_rep_qos(qos_.representation.value, true);
   bool xcdr1_mutable = false;
+  for (size_t i = 0; i < qos_.representation.value.length(); ++i) {
+    if (qos_.representation.value[i] == DDS::XCDR_DATA_REPRESENTATION ||
+        qos_.representation.value[i] == DDS::XCDR2_DATA_REPRESENTATION) {
+      // If the QoS explicitly sets XCDR or XCDR2, force encapsulation
+      cdr_encapsulation(true);
+      break;
+    }
+  }
   if (cdr_encapsulation()) {
     for (CORBA::ULong i = 0; i < repIds.length(); ++i) {
       Encoding::Kind encoding_kind;

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1278,11 +1278,6 @@ DataReaderImpl::enable()
       return DDS::RETCODE_ERROR;
     }
 
-    const DDS::ReturnCode_t setup_deserialization_result = setup_deserialization();
-    if (setup_deserialization_result != DDS::RETCODE_OK) {
-      return setup_deserialization_result;
-    }
-
     const TransportLocatorSeq& trans_conf_info = connection_info();
 
     CORBA::String_var filterClassName = "";
@@ -3382,61 +3377,6 @@ ICE::Endpoint*
 DataReaderImpl::get_ice_endpoint()
 {
   return TransportClient::get_ice_endpoint();
-}
-
-DDS::ReturnCode_t DataReaderImpl::setup_deserialization()
-{
-  const DDS::DataRepresentationIdSeq repIds =
-    get_effective_data_rep_qos(qos_.representation.value, true);
-  bool xcdr1_mutable = false;
-  if (qos_.representation.value.length() > 0) {
-    // If the QoS explicitly sets XCDR, XCDR2, or XML, force encapsulation
-    cdr_encapsulation(true);
-  }
-  if (cdr_encapsulation()) {
-    for (CORBA::ULong i = 0; i < repIds.length(); ++i) {
-      Encoding::Kind encoding_kind;
-      if (repr_to_encoding_kind(repIds[i], encoding_kind)) {
-        if (encoding_kind == Encoding::KIND_XCDR1 && get_max_extensibility() == MUTABLE) {
-          xcdr1_mutable = true;
-        } else {
-          decoding_modes_.insert(encoding_kind);
-        }
-      } else if (DCPS_debug_level) {
-        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: ")
-                   ACE_TEXT("DataReaderImpl::setup_deserialization: ")
-                   ACE_TEXT("Encountered unsupported or unknown data representation: %u\n"),
-                   repIds[i]));
-      }
-    }
-  } else {
-    decoding_modes_.insert(Encoding::KIND_UNALIGNED_CDR);
-  }
-  if (decoding_modes_.empty()) {
-    if (DCPS_debug_level) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
-                 ACE_TEXT("DataReaderImpl::setup_deserialization: ")
-                 ACE_TEXT("Could not find a valid data representation.%C\n"),
-                 xcdr1_mutable ? " Unsupported combination of XCDR1 and mutable" : ""));
-    }
-    return DDS::RETCODE_ERROR;
-  }
-  if (DCPS_debug_level >= 2) {
-    OPENDDS_STRING encodings;
-    EncodingKinds::iterator it = decoding_modes_.begin();
-    for (; it != decoding_modes_.end(); ++it) {
-      if (!encodings.empty()) {
-        encodings += ", ";
-      }
-      encodings += Encoding::kind_to_string(*it);
-    }
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) DataReaderImpl::setup_deserialization: "
-               "Setup successfully with the following data representation%C: %C\n",
-               encodings.size() != 1 ? "s" : "",
-               encodings.c_str()));
-  }
-
-  return DDS::RETCODE_OK;
 }
 
 void DataReaderImpl::accept_sample_processing(const SubscriptionInstance_rch& instance,

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3389,13 +3389,9 @@ DDS::ReturnCode_t DataReaderImpl::setup_deserialization()
   const DDS::DataRepresentationIdSeq repIds =
     get_effective_data_rep_qos(qos_.representation.value, true);
   bool xcdr1_mutable = false;
-  for (size_t i = 0; i < qos_.representation.value.length(); ++i) {
-    if (qos_.representation.value[i] == DDS::XCDR_DATA_REPRESENTATION ||
-        qos_.representation.value[i] == DDS::XCDR2_DATA_REPRESENTATION) {
-      // If the QoS explicitly sets XCDR or XCDR2, force encapsulation
-      cdr_encapsulation(true);
-      break;
-    }
+  if (qos_.representation.value.length() > 0) {
+    // If the QoS explicitly sets XCDR, XCDR2, or XML, force encapsulation
+    cdr_encapsulation(true);
   }
   if (cdr_encapsulation()) {
     for (CORBA::ULong i = 0; i < repIds.length(); ++i) {

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -603,6 +603,9 @@ protected:
 
   void prepare_to_delete();
 
+  /// Setup deserialization options
+  DDS::ReturnCode_t setup_deserialization();
+
   virtual Extensibility get_max_extensibility() = 0;
 
   RcHandle<SubscriberImpl> get_subscriber_servant();
@@ -921,6 +924,10 @@ private:
   unique_ptr<Monitor>  periodic_monitor_;
 
   bool transport_disabled_;
+
+protected:
+  typedef OPENDDS_SET(Encoding::Kind) EncodingKinds;
+  EncodingKinds decoding_modes_;
 
 public:
   class OpenDDS_Dcps_Export OnDataOnReaders : public JobQueue::Job {

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -603,8 +603,6 @@ protected:
 
   void prepare_to_delete();
 
-  /// Setup deserialization options
-  DDS::ReturnCode_t setup_deserialization();
   virtual Extensibility get_max_extensibility() = 0;
 
   RcHandle<SubscriberImpl> get_subscriber_servant();
@@ -923,10 +921,6 @@ private:
   unique_ptr<Monitor>  periodic_monitor_;
 
   bool transport_disabled_;
-
-protected:
-  typedef OPENDDS_SET(Encoding::Kind) EncodingKinds;
-  EncodingKinds decoding_modes_;
 
 public:
   class OpenDDS_Dcps_Export OnDataOnReaders : public JobQueue::Job {

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -979,18 +979,6 @@ namespace OpenDDS {
       if (!encap.to_encoding(encoding, MarshalTraitsType::extensibility())) {
         return;
       }
-
-      if (decoding_modes_.find(encoding.kind()) == decoding_modes_.end()) {
-        if (DCPS_debug_level >= 1) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING ")
-            ACE_TEXT("%CDataReaderImpl::lookup_instance: ")
-            ACE_TEXT("Encoding kind of the received sample (%C) does not ")
-            ACE_TEXT("match the ones specified by DataReader.\n"),
-            TraitsType::type_name(),
-            Encoding::kind_to_string(encoding.kind()).c_str()));
-        }
-        return;
-      }
       if (DCPS_debug_level >= 8) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ")
           ACE_TEXT("%CDataReaderImpl::lookup_instance: ")
@@ -1127,18 +1115,6 @@ protected:
       }
       Encoding encoding;
       if (!encap.to_encoding(encoding, MarshalTraitsType::extensibility())) {
-        return message_holder;
-      }
-
-      if (decoding_modes_.find(encoding.kind()) == decoding_modes_.end()) {
-        if (DCPS_debug_level >= 1) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING ")
-            ACE_TEXT("%CDataReaderImpl::dds_demarshal: ")
-            ACE_TEXT("Encoding kind %C of the received sample does not ")
-            ACE_TEXT("match the ones specified by DataReader.\n"),
-            TraitsType::type_name(),
-            Encoding::kind_to_string(encoding.kind()).c_str()));
-        }
         return message_holder;
       }
       if (DCPS_debug_level >= 8) {

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -979,6 +979,18 @@ namespace OpenDDS {
       if (!encap.to_encoding(encoding, MarshalTraitsType::extensibility())) {
         return;
       }
+
+      if (decoding_modes_.find(encoding.kind()) == decoding_modes_.end()) {
+        if (DCPS_debug_level >= 1) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING ")
+            ACE_TEXT("%CDataReaderImpl::lookup_instance: ")
+            ACE_TEXT("Encoding kind of the received sample (%C) does not ")
+            ACE_TEXT("match the ones specified by DataReader.\n"),
+            TraitsType::type_name(),
+            Encoding::kind_to_string(encoding.kind()).c_str()));
+        }
+        return;
+      }
       if (DCPS_debug_level >= 8) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ")
           ACE_TEXT("%CDataReaderImpl::lookup_instance: ")
@@ -1115,6 +1127,18 @@ protected:
       }
       Encoding encoding;
       if (!encap.to_encoding(encoding, MarshalTraitsType::extensibility())) {
+        return message_holder;
+      }
+
+      if (decoding_modes_.find(encoding.kind()) == decoding_modes_.end()) {
+        if (DCPS_debug_level >= 1) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) WARNING ")
+            ACE_TEXT("%CDataReaderImpl::dds_demarshal: ")
+            ACE_TEXT("Encoding kind %C of the received sample does not ")
+            ACE_TEXT("match the ones specified by DataReader.\n"),
+            TraitsType::type_name(),
+            Encoding::kind_to_string(encoding.kind()).c_str()));
+        }
         return message_holder;
       }
       if (DCPS_debug_level >= 8) {

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -327,11 +327,9 @@ public:
   {
     const DDS::DataRepresentationIdSeq repIds =
       get_effective_data_rep_qos(qos_.representation.value, false);
-    if (qos_.representation.value.length() > 0 &&
-       (qos_.representation.value[0] == DDS::XCDR_DATA_REPRESENTATION ||
-        qos_.representation.value[0] == DDS::XCDR2_DATA_REPRESENTATION))
+    if (qos_.representation.value.length() > 0)
     {
-      // If the QoS explicitly sets XCDR or XCDR2, force encapsulation
+      // If the QoS explicitly sets XCDR, XCDR2, or XML, force encapsulation
       cdr_encapsulation(true);
     }
     if (cdr_encapsulation()) {

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -327,8 +327,7 @@ public:
   {
     const DDS::DataRepresentationIdSeq repIds =
       get_effective_data_rep_qos(qos_.representation.value, false);
-    if (qos_.representation.value.length() > 0)
-    {
+    if (qos_.representation.value.length() > 0) {
       // If the QoS explicitly sets XCDR, XCDR2, or XML, force encapsulation
       cdr_encapsulation(true);
     }

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -327,6 +327,13 @@ public:
   {
     const DDS::DataRepresentationIdSeq repIds =
       get_effective_data_rep_qos(qos_.representation.value, false);
+    if (qos_.representation.value.length() > 0 &&
+       (qos_.representation.value[0] == DDS::XCDR_DATA_REPRESENTATION ||
+        qos_.representation.value[0] == DDS::XCDR2_DATA_REPRESENTATION))
+    {
+      // If the QoS explicitly sets XCDR or XCDR2, force encapsulation
+      cdr_encapsulation(true);
+    }
     if (cdr_encapsulation()) {
       Encoding::Kind encoding_kind;
       // There should only be one data representation in a DataWriter, so

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -145,7 +145,12 @@ public:
 
   bool is_leading(const GUID_t& reader_id) const;
 
- private:
+protected:
+  void cdr_encapsulation(bool encap) {
+    cdr_encapsulation_ = encap;
+  }
+
+private:
 
   // Implemented by derived classes (DataReaderImpl/DataWriterImpl)
   virtual bool check_transport_qos(const TransportInst& inst) = 0;

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -146,7 +146,8 @@ public:
   bool is_leading(const GUID_t& reader_id) const;
 
 protected:
-  void cdr_encapsulation(bool encap) {
+  void cdr_encapsulation(bool encap)
+  {
     cdr_encapsulation_ = encap;
   }
 

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -280,16 +280,6 @@ TransportRegistry::load_transport_configuration(const OPENDDS_STRING& file_name,
                                   value.c_str(), config_id.c_str()),
                                  -1);
               }
-            } else if (name == "cdr_encapsulation") {
-              if ((value == "1") || (value == "true")) {
-                config->cdr_encapsulation_ = true;
-              } else if ((value != "0") && (value != "false")) {
-                ACE_ERROR_RETURN((LM_ERROR,
-                                  ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                                  ACE_TEXT("Illegal boolean value for cdr_encapsulation (%C) in [config/%C] section.\n"),
-                                  value.c_str(), config_id.c_str()),
-                                 -1);
-              }
             } else if (name == "passive_connect_duration") {
               if (!convertToInteger(value,
                                     config->passive_connect_duration_)) {

--- a/tests/DCPS/XTypes/Pub/XTypesPub.idl
+++ b/tests/DCPS/XTypes/Pub/XTypesPub.idl
@@ -53,6 +53,12 @@ struct ModifiedMutableStruct {
 
 @topic
 @mutable
+struct MutableBaseStruct {
+  @id(1) @key long key;
+};
+
+@topic
+@mutable
 struct ModifiedIdMutableStruct {
   @id(1) @key long key;
   @id(3) long additional_field;

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -396,7 +396,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   pub->get_default_datawriter_qos(dw_qos);
   dw_qos.durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
   dw_qos.representation.value.length(1);
-  dw_qos.representation.value[0] = XCDR2_DATA_REPRESENTATION; 
+  dw_qos.representation.value[0] = XCDR2_DATA_REPRESENTATION;
 
   DataWriter_var dw = pub->create_datawriter(topic, dw_qos, 0,
     DEFAULT_STATUS_MASK);

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -374,7 +374,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DataWriterQos control_dw_qos;
   control_pub->get_default_datawriter_qos(control_dw_qos);
   control_dw_qos.durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-
+  
   DataWriter_var control_dw = control_pub->create_datawriter(echo_control_topic, control_dw_qos, 0,
                                                              DEFAULT_STATUS_MASK);
   if (!control_dw) {
@@ -395,6 +395,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DataWriterQos dw_qos;
   pub->get_default_datawriter_qos(dw_qos);
   dw_qos.durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
+  dw_qos.representation.value.length(1);
+  dw_qos.representation.value[0] = XCDR2_DATA_REPRESENTATION; 
 
   DataWriter_var dw = pub->create_datawriter(topic, dw_qos, 0,
     DEFAULT_STATUS_MASK);

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -127,6 +127,22 @@ void write_modified_mutable_struct(const DataWriter_var& dw)
   }
 }
 
+void write_mutable_base_struct(const DataWriter_var& dw)
+{
+  MutableBaseStructDataWriter_var typed_dw = MutableBaseStructDataWriter::_narrow(dw);
+
+  MutableBaseStruct mbs;
+  mbs.key = key_value;
+  const ReturnCode_t ret = typed_dw->write(mbs, HANDLE_NIL);
+  if (ret != RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "ERROR: write_mutable_base_struct returned %C\n",
+               OpenDDS::DCPS::retcode_to_string(ret)));
+  }
+  if (verbose) {
+    ACE_DEBUG((LM_DEBUG, "writer: MutableBaseStruct\n"));
+  }
+}
+
 void write_modified_mutable_union(const DataWriter_var& dw)
 {
   ModifiedMutableUnionDataWriter_var typed_dw = ModifiedMutableUnionDataWriter::_narrow(dw);
@@ -326,6 +342,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   } else if (type == "AppendableStructWithDependency") {
     AppendableStructWithDependencyTypeSupport_var ts = new AppendableStructWithDependencyTypeSupportImpl;
     failed = !get_topic(ts, dp, topic_name, topic, registered_type_name);
+  } else if (type == "MutableBaseStruct") {
+    MutableBaseStructTypeSupport_var ts = new MutableBaseStructTypeSupportImpl;
+    failed = !get_topic(ts, dp, topic_name, topic, registered_type_name);
   } else if (type.empty()) {
     ACE_ERROR((LM_ERROR, "ERROR: Must specify a type name\n"));
     return 1;
@@ -453,6 +472,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       write_modified_name_mutable_struct(dw);
     } else if (type == "ModifiedNameMutableUnion") {
       write_modified_name_mutable_union(dw);
+    } else if (type == "MutableBaseStruct") {
+      write_mutable_base_struct(dw);
     }
   }
 

--- a/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
+++ b/tests/DCPS/XTypes/Pub/XTypesPublisher.cpp
@@ -374,7 +374,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DataWriterQos control_dw_qos;
   control_pub->get_default_datawriter_qos(control_dw_qos);
   control_dw_qos.durability.kind = TRANSIENT_LOCAL_DURABILITY_QOS;
-  
+
   DataWriter_var control_dw = control_pub->create_datawriter(echo_control_topic, control_dw_qos, 0,
                                                              DEFAULT_STATUS_MASK);
   if (!control_dw) {

--- a/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
+++ b/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
@@ -332,6 +332,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
   dr_qos.type_consistency.ignore_member_names = ignore_member_names;
   dr_qos.type_consistency.force_type_validation = force_type_validation;
+  dr_qos.representation.value.length(1);
+  dr_qos.representation.value[0] = XCDR2_DATA_REPRESENTATION;
 
   DataReader_var dr = sub->create_datareader(topic, dr_qos, 0,
     DEFAULT_STATUS_MASK);

--- a/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
+++ b/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
@@ -130,14 +130,14 @@ ReturnCode_t read_appendable_struct_no_xtypes(const DataReader_var& dr)
   return read_struct(dr, pdr, data);
 }
 
-ReturnCode_t read_mutable_struct(const DataReader_var& dr)
+ReturnCode_t read_mutable_struct(const DataReader_var& dr, const AdditionalFieldValue& afv)
 {
   MutableStructDataReader_var pdr = MutableStructDataReader::_narrow(dr);
   ::MutableStructSeq data;
   ReturnCode_t ret;
   ret = read_struct(dr, pdr, data);
   if (ret == RETCODE_OK) {
-    ret = check_additional_field_value(data, MUTABLE_STRUCT_AF);
+    ret = check_additional_field_value(data, afv);
   }
   return ret;
 }
@@ -332,8 +332,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
   dr_qos.type_consistency.ignore_member_names = ignore_member_names;
   dr_qos.type_consistency.force_type_validation = force_type_validation;
-  dr_qos.representation.value.length(1);
-  dr_qos.representation.value[0] = XCDR2_DATA_REPRESENTATION;
 
   DataReader_var dr = sub->create_datareader(topic, dr_qos, 0,
     DEFAULT_STATUS_MASK);
@@ -374,7 +372,11 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if (type == "FinalStructSub") {
       failed = (read_final_struct(dr) != RETCODE_OK);
     } else if (type == "MutableStruct") {
-      failed = (read_mutable_struct(dr) != RETCODE_OK);
+      AdditionalFieldValue afv = MUTABLE_STRUCT_AF;
+      if (topic_name == "MutableBaseStructT") {
+        afv = FINAL_STRUCT_AF;
+      }
+      failed = (read_mutable_struct(dr, afv) != RETCODE_OK);
     } else if (type == "MutableUnion") {
       failed = (read_mutable_union(dr) != RETCODE_OK);
     } else if (type == "Trim20Struct") {

--- a/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
+++ b/tests/DCPS/XTypes/Sub/XTypesSubscriber.cpp
@@ -333,6 +333,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   dr_qos.type_consistency.ignore_member_names = ignore_member_names;
   dr_qos.type_consistency.force_type_validation = force_type_validation;
 
+  dr_qos.representation.value.length(1);
+  dr_qos.representation.value[0] = XCDR2_DATA_REPRESENTATION;
+
   DataReader_var dr = sub->create_datareader(topic, dr_qos, 0,
     DEFAULT_STATUS_MASK);
   if (!dr) {

--- a/tests/DCPS/XTypes/run_test.pl
+++ b/tests/DCPS/XTypes/run_test.pl
@@ -69,6 +69,11 @@ if ($secure) {
       expect_to_fail => 0, topic => "MutableStructT", key_val => 6,
       r_ini => "tcp.ini", w_ini => "tcp.ini",
     },
+    "Tcp_MutableBaseStruct" => {
+      reader_type => "MutableStruct", writer_type => "MutableBaseStruct",
+      expect_to_fail => 0, topic => "MutableBaseStructT", key_val => 7,
+      r_ini => "tcp.ini", w_ini => "tcp.ini",
+    },
     "Tcp_MutableStructNoMatchName" => {
       reader_type => "MutableStruct", writer_type => "ModifiedNameMutableStruct",
       expect_to_fail => 1, topic => "MutableStructT_NoMatchName", key_val => 9,

--- a/tests/DCPS/XTypes/tcp.ini
+++ b/tests/DCPS/XTypes/tcp.ini
@@ -10,7 +10,6 @@ ResendPeriod=2
 
 [config/tcpconfig]
 transports=tcp
-cdr_encapsulation=1
 
 [transport/tcp]
 transport_type=tcp


### PR DESCRIPTION
The previous PR for this option was here https://github.com/objectcomputing/OpenDDS/pull/3040

However, following discussion of the issue here:  https://github.com/objectcomputing/OpenDDS/issues/2946 , it was determined additional work was needed.

Rather than using a config option to determine encapsulation, it is now determined by the default of the transport (false for anything besides RTPS_UDP),

If the user has explicitly (not by default) selected XCDR/XCDR2 as their Data Representation QoS policy, it is enabled for that transport, regardless of the default. 

As a result of these changes, I made a couple updates to the XTypes test to ensure the `--tcp` option runs properly.

