### PR TITLE
TransportReceiveStrategy: guard object must be named

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.cpp
@@ -178,7 +178,7 @@ TransportReceiveStrategy<TH, DSH>::handle_simple_dds_input(ACE_HANDLE fd)
   }
 
   {
-    ScopedHeaderProcessing(*this);
+    const ScopedHeaderProcessing shp(*this);
     while (bytes_remaining > 0) {
       data_sample_header_.pdu_remaining(bytes_remaining);
       data_sample_header_ = *cur_rb;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -917,12 +917,14 @@ RtpsUdpReceiveStrategy::check_header(const RtpsSampleHeader& header)
 }
 
 void
-RtpsUdpReceiveStrategy::begin_transport_header_processing() {
+RtpsUdpReceiveStrategy::begin_transport_header_processing()
+{
   link_->enable_response_queue();
 }
 
 void
-RtpsUdpReceiveStrategy::end_transport_header_processing() {
+RtpsUdpReceiveStrategy::end_transport_header_processing()
+{
   link_->disable_response_queue();
 }
 


### PR DESCRIPTION
unnamed objects live until the end of the statement, unlike named
objects that live until the end of the scope