### PR TITLE
SporadicTask optimizations are ineffective, buggy, and complicated

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1928,7 +1928,7 @@ CORBA::Long DataReaderImpl::total_samples() const
 void
 DataReaderImpl::LivelinessTimer::check_liveliness()
 {
-  execute_or_enqueue(new CheckLivelinessCommand(this));
+  execute_or_enqueue(make_rch<CheckLivelinessCommand>(this));
 }
 
 int
@@ -3520,13 +3520,13 @@ EndHistoricSamplesMissedSweeper::~EndHistoricSamplesMissedSweeper()
 void EndHistoricSamplesMissedSweeper::schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
 {
   info->waiting_for_end_historic_samples_ = true;
-  execute_or_enqueue(new ScheduleCommand(this, info));
+  execute_or_enqueue(make_rch<ScheduleCommand>(this, ref(info)));
 }
 
 void EndHistoricSamplesMissedSweeper::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
 {
   info->waiting_for_end_historic_samples_ = false;
-  execute_or_enqueue(new CancelCommand(this, info));
+  execute_or_enqueue(make_rch<CancelCommand>(this, ref(info)));
 }
 
 int EndHistoricSamplesMissedSweeper::handle_timeout(

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -825,7 +825,7 @@ private:
 
     void cancel_timer()
     {
-      execute_or_enqueue(new CancelCommand(this));
+      execute_or_enqueue(make_rch<CancelCommand>(this));
     }
 
     virtual bool reactor_is_shut_down() const

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -215,7 +215,7 @@ void InstanceState::schedule_release()
   if (delay.sec != DDS::DURATION_INFINITE_SEC &&
       delay.nanosec != DDS::DURATION_INFINITE_NSEC) {
 
-    execute_or_enqueue(new ScheduleCommand(this, TimeDuration(delay)));
+    execute_or_enqueue(make_rch<ScheduleCommand>(this, TimeDuration(delay)));
 
   } else {
     // N.B. instance transitions are always followed by a non-valid
@@ -229,7 +229,7 @@ void InstanceState::schedule_release()
 void InstanceState::cancel_release()
 {
   release_pending_ = false;
-  execute_or_enqueue(new CancelCommand(this));
+  execute_or_enqueue(make_rch<CancelCommand>(this));
 }
 
 bool InstanceState::release_if_empty()

--- a/dds/DCPS/LinuxNetworkConfigMonitor.cpp
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.cpp
@@ -90,7 +90,7 @@ bool LinuxNetworkConfigMonitor::open()
 
   ReactorInterceptor_rch interceptor = interceptor_.lock();
   if (interceptor) {
-    interceptor->execute_or_enqueue(new RegisterHandler(this));
+    interceptor->execute_or_enqueue(make_rch<RegisterHandler>(this));
   }
 
   return true;
@@ -102,7 +102,7 @@ bool LinuxNetworkConfigMonitor::close()
 
   ReactorInterceptor_rch interceptor = interceptor_.lock();
   if (interceptor) {
-    ReactorInterceptor::CommandPtr command = interceptor->execute_or_enqueue(new RemoveHandler(this));
+    ReactorInterceptor::CommandPtr command = interceptor->execute_or_enqueue(make_rch<RemoveHandler>(this));
     command->wait();
   }
 

--- a/dds/DCPS/MultiTask.h
+++ b/dds/DCPS/MultiTask.h
@@ -39,18 +39,18 @@ public:
       worth_passing_along = (timer_ == -1) || ((MonotonicTimePoint::now() + delay + cancel_estimate_) < next_time_);
     }
     if (worth_passing_along) {
-      interceptor_->execute_or_enqueue(new ScheduleEnableCommand(this, delay));
+      interceptor_->execute_or_enqueue(make_rch<ScheduleEnableCommand>(this, delay));
     }
   }
 
   void disable()
   {
-    interceptor_->execute_or_enqueue(new ScheduleDisableCommand(this));
+    interceptor_->execute_or_enqueue(make_rch<ScheduleDisableCommand>(this));
   }
 
   void disable_and_wait()
   {
-    ReactorInterceptor::CommandPtr command = interceptor_->execute_or_enqueue(new ScheduleDisableCommand(this));
+    ReactorInterceptor::CommandPtr command = interceptor_->execute_or_enqueue(make_rch<ScheduleDisableCommand>(this));
     command->wait();
   }
 

--- a/dds/DCPS/PeriodicTask.h
+++ b/dds/DCPS/PeriodicTask.h
@@ -34,7 +34,7 @@ public:
       ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
       user_enabled_ = true;
     }
-    interceptor_->execute_or_enqueue(new ScheduleEnableCommand(this, reenable, period));
+    interceptor_->execute_or_enqueue(make_rch<ScheduleEnableCommand>(this, reenable, period));
   }
 
   void disable()
@@ -43,7 +43,7 @@ public:
       ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
       user_enabled_ = false;
     }
-    interceptor_->execute_or_enqueue(new ScheduleDisableCommand(this));
+    interceptor_->execute_or_enqueue(make_rch<ScheduleDisableCommand>(this));
   }
 
   void disable_and_wait()
@@ -52,7 +52,7 @@ public:
       ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
       user_enabled_ = false;
     }
-    ReactorInterceptor::CommandPtr command = interceptor_->execute_or_enqueue(new ScheduleDisableCommand(this));
+    ReactorInterceptor::CommandPtr command = interceptor_->execute_or_enqueue(make_rch<ScheduleDisableCommand>(this));
     command->wait();
   }
 

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -7,10 +7,11 @@
 
 #include "AgentImpl.h"
 
-#include "dds/DCPS/Service_Participant.h"
-#include "dds/DCPS/TimeTypes.h"
 #include "Task.h"
 #include "EndpointManager.h"
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/TimeTypes.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -42,7 +43,7 @@ void AgentImpl::enqueue(const DCPS::MonotonicTimePoint& a_release_time,
 {
   if (tasks_.empty() || a_release_time < tasks_.top().release_time_) {
     const MonotonicTimePoint release = std::max(last_execute_ + ICE::Configuration::instance()->T_a(), a_release_time);
-    execute_or_enqueue(new ScheduleTimerCommand(reactor(), this, release - MonotonicTimePoint::now()));
+    execute_or_enqueue(DCPS::make_rch<ScheduleTimerCommand>(reactor(), this, release - MonotonicTimePoint::now()));
   }
   tasks_.push(Item(a_release_time, wtask));
 }
@@ -77,7 +78,7 @@ int AgentImpl::handle_timeout(const ACE_Time_Value& a_now, const void* /*act*/)
 
   if (!tasks_.empty()) {
     const MonotonicTimePoint release = std::max(last_execute_ + ICE::Configuration::instance()->T_a(), tasks_.top().release_time_);
-    execute_or_enqueue(new ScheduleTimerCommand(reactor(), this, release - now));
+    execute_or_enqueue(DCPS::make_rch<ScheduleTimerCommand>(reactor(), this, release - now));
   }
 
   return 0;

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -670,8 +670,8 @@ private:
   {
     if (!type_lookup_reply_deadline_processor_) {
       type_lookup_reply_deadline_processor_ =
-        DCPS::make_rch<EndpointManagerSporadic>(reactor_interceptor, ref(*this),
-          &Sedp::remove_expired_endpoints);
+        DCPS::make_rch<EndpointManagerSporadic>(TheServiceParticipant->time_source(), reactor_interceptor,
+                                                ref(*this), &Sedp::remove_expired_endpoints);
     }
   }
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -671,7 +671,7 @@ private:
     if (!type_lookup_reply_deadline_processor_) {
       type_lookup_reply_deadline_processor_ =
         DCPS::make_rch<EndpointManagerSporadic>(TheServiceParticipant->time_source(), reactor_interceptor,
-                                                ref(*this), &Sedp::remove_expired_endpoints);
+                                                rchandle_from(this), &Sedp::remove_expired_endpoints);
     }
   }
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2407,17 +2407,29 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task)
   local_send_task_ = DCPS::make_rch<SpdpMulti>(reactor_task->interceptor(), outer->config_->resend_period(), ref(*this), &SpdpTransport::send_local);
 
   if (outer->config_->periodic_directed_spdp()) {
-    directed_send_task_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::send_directed);
+    directed_send_task_ =
+      DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
+                                   ref(*this), &SpdpTransport::send_directed);
   }
 
-  lease_expiration_task_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::process_lease_expirations);
+  lease_expiration_task_ =
+    DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
+                                 ref(*this), &SpdpTransport::process_lease_expirations);
 
 #ifdef OPENDDS_SECURITY
-  handshake_deadline_task_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::process_handshake_deadlines);
-  handshake_resend_task_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::process_handshake_resends);
+  handshake_deadline_task_ =
+    DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
+                                 ref(*this), &SpdpTransport::process_handshake_deadlines);
+  handshake_resend_task_ =
+    DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
+                                 ref(*this), &SpdpTransport::process_handshake_resends);
 
-  relay_spdp_task_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::send_relay);
-  relay_stun_task_ = DCPS::make_rch<SpdpSporadic>(reactor_task->interceptor(), ref(*this), &SpdpTransport::relay_stun_task);
+  relay_spdp_task_ =
+    DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
+                                 ref(*this), &SpdpTransport::send_relay);
+  relay_stun_task_ =
+    DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
+                                 ref(*this), &SpdpTransport::relay_stun_task);
 #endif
 
 #ifndef DDS_HAS_MINIMUM_BIT

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2151,7 +2151,7 @@ Spdp::fini_bit()
     reactor_task = sedp_->reactor_task();
   }
   if (!reactor_task->is_shut_down()) {
-    DCPS::ReactorInterceptor::CommandPtr command = reactor_task->interceptor()->execute_or_enqueue(new Noop());
+    DCPS::ReactorInterceptor::CommandPtr command = reactor_task->interceptor()->execute_or_enqueue(DCPS::make_rch<Noop>());
     command->wait();
   }
 }
@@ -2395,8 +2395,7 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task)
   }
 #endif
 
-  reactor_task->interceptor()->execute_or_enqueue(
-    new RegisterHandlers(rchandle_from(this), reactor_task));
+  reactor_task->interceptor()->execute_or_enqueue(DCPS::make_rch<RegisterHandlers>(rchandle_from(this), reactor_task));
 
 #ifdef OPENDDS_SECURITY
   // Now that the endpoint is added, SEDP can write the SPDP info.

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2409,27 +2409,27 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task)
   if (outer->config_->periodic_directed_spdp()) {
     directed_send_task_ =
       DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
-                                   ref(*this), &SpdpTransport::send_directed);
+                                   rchandle_from(this), &SpdpTransport::send_directed);
   }
 
   lease_expiration_task_ =
     DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
-                                 ref(*this), &SpdpTransport::process_lease_expirations);
+                                 rchandle_from(this), &SpdpTransport::process_lease_expirations);
 
 #ifdef OPENDDS_SECURITY
   handshake_deadline_task_ =
     DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
-                                 ref(*this), &SpdpTransport::process_handshake_deadlines);
+                                 rchandle_from(this), &SpdpTransport::process_handshake_deadlines);
   handshake_resend_task_ =
     DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
-                                 ref(*this), &SpdpTransport::process_handshake_resends);
+                                 rchandle_from(this), &SpdpTransport::process_handshake_resends);
 
   relay_spdp_task_ =
     DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
-                                 ref(*this), &SpdpTransport::send_relay);
+                                 rchandle_from(this), &SpdpTransport::send_relay);
   relay_stun_task_ =
     DCPS::make_rch<SpdpSporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(),
-                                 ref(*this), &SpdpTransport::relay_stun_task);
+                                 rchandle_from(this), &SpdpTransport::relay_stun_task);
 #endif
 
 #ifndef DDS_HAS_MINIMUM_BIT

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -51,11 +51,9 @@ void ReactorInterceptor::process_command_queue_i()
   state_ = PROCESSING;
   if (!command_queue_.empty()) {
     cq.swap(command_queue_);
-    for (Queue::const_iterator pos = cq.begin(), limit = cq.end(); pos != limit; ++pos) {
-      (*pos)->queue_flushed();
-    }
     ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rev_guard(rev_lock);
     for (Queue::const_iterator pos = cq.begin(), limit = cq.end(); pos != limit; ++pos) {
+      (*pos)->dequeue();
       (*pos)->execute();
       (*pos)->executed();
     }

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -38,7 +38,7 @@ public:
     {
       ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, mutex_, false);
       executed_ = false;
-      bool retval = on_queue_;
+      const bool retval = on_queue_;
       on_queue_ = true;
       return retval;
     }

--- a/dds/DCPS/RemoveAssociationSweeper.h
+++ b/dds/DCPS/RemoveAssociationSweeper.h
@@ -126,7 +126,7 @@ void RemoveAssociationSweeper<T>::schedule_timer(RcHandle<WriterInfo>& info, boo
   info->notify_lost_ = callback;
   info->removal_deadline_ = MonotonicTimePoint(MonotonicTimePoint::now() +
     std::min(info->activity_wait_period(), TimeDuration(10)));
-  execute_or_enqueue(new ScheduleCommand(rchandle_from(this), info));
+  execute_or_enqueue(make_rch<ScheduleCommand>(rchandle_from(this), info));
 }
 
 template <typename T>
@@ -135,7 +135,7 @@ RemoveAssociationSweeper<T>::cancel_timer(RcHandle<WriterInfo>& info)
 {
   info->scheduled_for_removal_ = false;
   info->removal_deadline_ = MonotonicTimePoint::zero_value;
-  return execute_or_enqueue(new CancelCommand(rchandle_from(this), info));
+  return execute_or_enqueue(make_rch<CancelCommand>(rchandle_from(this), info));
 }
 
 template <typename T>

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -235,6 +235,12 @@ Service_Participant::instance()
   return ACE_Singleton<Service_Participant, ACE_SYNCH_MUTEX>::instance();
 }
 
+const TimeSource&
+Service_Participant::time_source() const
+{
+  return time_source_;
+}
+
 ACE_Reactor_Timer_Interface*
 Service_Participant::timer()
 {

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -21,6 +21,7 @@
 #include "NetworkConfigModifier.h"
 #include "Recorder.h"
 #include "Replayer.h"
+#include "TimeSource.h"
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DdsDcpsDomainC.h>
@@ -78,6 +79,8 @@ public:
 
   /// Return a singleton instance of this class.
   static Service_Participant* instance();
+
+  const TimeSource& time_source() const;
 
   /// Get the common timer interface.
   /// Intended for use by OpenDDS internals only.
@@ -519,6 +522,7 @@ private:
   ACE_ARGV ORB_argv_;
 #endif
 
+  const TimeSource time_source_;
   ReactorTask reactor_task_;
   JobQueue_rch job_queue_;
 

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -175,7 +175,8 @@ public:
 
   PmfSporadicTask(const TimeSource& time_source,
                   RcHandle<ReactorInterceptor> interceptor,
-                  const Delegate& delegate, PMF function)
+                  RcHandle<Delegate> delegate,
+                  PMF function)
     : SporadicTask(time_source, interceptor)
     , delegate_(delegate)
     , function_(function)

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -599,8 +599,9 @@ StaticEndpointManager::sub_bit()
 void StaticEndpointManager::type_lookup_init(ReactorInterceptor_rch reactor_interceptor)
 {
   if (!type_lookup_reply_deadline_processor_) {
-    type_lookup_reply_deadline_processor_ = DCPS::make_rch<StaticEndpointManagerSporadic>(
-      reactor_interceptor, ref(*this), &StaticEndpointManager::remove_expired_endpoints);
+    type_lookup_reply_deadline_processor_ =
+      DCPS::make_rch<StaticEndpointManagerSporadic>(TheServiceParticipant->time_source(), reactor_interceptor,
+                                                    ref(*this), &StaticEndpointManager::remove_expired_endpoints);
   }
 }
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -601,7 +601,7 @@ void StaticEndpointManager::type_lookup_init(ReactorInterceptor_rch reactor_inte
   if (!type_lookup_reply_deadline_processor_) {
     type_lookup_reply_deadline_processor_ =
       DCPS::make_rch<StaticEndpointManagerSporadic>(TheServiceParticipant->time_source(), reactor_interceptor,
-                                                    ref(*this), &StaticEndpointManager::remove_expired_endpoints);
+                                                    rchandle_from(this), &StaticEndpointManager::remove_expired_endpoints);
   }
 }
 

--- a/dds/DCPS/TimeSource.h
+++ b/dds/DCPS/TimeSource.h
@@ -1,0 +1,37 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_TIME_SOURCE_H
+#define OPENDDS_DCPS_TIME_SOURCE_H
+
+#include "TimeTypes.h"
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+class TimeSource {
+public:
+  virtual ~TimeSource() {}
+
+  virtual MonotonicTimePoint monotonic_time_point_now() const {
+    return MonotonicTimePoint::now();
+  }
+
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_TIME_SOURCE_H */

--- a/dds/DCPS/Watchdog.cpp
+++ b/dds/DCPS/Watchdog.cpp
@@ -115,7 +115,7 @@ long Watchdog::schedule_timer(const void* act, const TimeDuration& interval)
 long Watchdog::schedule_timer(const void* act, const TimeDuration& delay, const TimeDuration& interval)
 {
   long timer_id = -1;
-  ReactorInterceptor::CommandPtr command = execute_or_enqueue(new ScheduleCommand(this, act, delay, interval, &timer_id));
+  ReactorInterceptor::CommandPtr command = execute_or_enqueue(make_rch<ScheduleCommand>(this, act, delay, interval, &timer_id));
   command->wait();
   return timer_id;
 }
@@ -123,18 +123,18 @@ long Watchdog::schedule_timer(const void* act, const TimeDuration& delay, const 
 int Watchdog::cancel_timer(long timer_id)
 {
 
-  execute_or_enqueue(new CancelCommand(this, timer_id));
+  execute_or_enqueue(make_rch<CancelCommand>(this, timer_id));
   return 1;
 }
 
 void Watchdog::cancel_all()
 {
-  execute_or_enqueue(new CancelCommand(this, -1));
+  execute_or_enqueue(make_rch<CancelCommand>(this, -1));
 }
 
 int Watchdog::reset_timer_interval(long timer_id)
 {
-  execute_or_enqueue(new ResetCommand(this, timer_id, interval_));
+  execute_or_enqueue(make_rch<ResetCommand>(this, timer_id, interval_));
   return 0;
 }
 

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -107,7 +107,7 @@ WriteDataContainer::WriteDataContainer(
   , durability_cache_(durability_cache)
   , durability_service_(durability_service)
 #endif
-  , deadline_task_(DCPS::make_rch<DCPS::PmfSporadicTask<WriteDataContainer> >(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), ref(*this), &WriteDataContainer::process_deadlines))
+  , deadline_task_(DCPS::make_rch<DCPS::PmfSporadicTask<WriteDataContainer> >(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &WriteDataContainer::process_deadlines))
   , deadline_period_(TimeDuration::max_value)
   , deadline_status_lock_(deadline_status_lock)
   , deadline_status_(deadline_status)

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -107,7 +107,7 @@ WriteDataContainer::WriteDataContainer(
   , durability_cache_(durability_cache)
   , durability_service_(durability_service)
 #endif
-  , deadline_task_(DCPS::make_rch<DCPS::PmfSporadicTask<WriteDataContainer> >(TheServiceParticipant->interceptor(), ref(*this), &WriteDataContainer::process_deadlines))
+  , deadline_task_(DCPS::make_rch<DCPS::PmfSporadicTask<WriteDataContainer> >(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), ref(*this), &WriteDataContainer::process_deadlines))
   , deadline_period_(TimeDuration::max_value)
   , deadline_status_lock_(deadline_status_lock)
   , deadline_status_(deadline_status)

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -1315,7 +1315,7 @@ AccessControlBuiltInImpl::RevokePermissionsTask_rch&
 AccessControlBuiltInImpl::make_task(RevokePermissionsTask_rch& task)
 {
   if (!task) {
-    task = DCPS::make_rch<RevokePermissionsTask>(TheServiceParticipant->interceptor(), DCPS::ref(*this));
+    task = DCPS::make_rch<RevokePermissionsTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), DCPS::ref(*this));
   }
   return task;
 }
@@ -1564,9 +1564,10 @@ void AccessControlBuiltInImpl::parse_class_id(
 
 }
 
-AccessControlBuiltInImpl::RevokePermissionsTask::RevokePermissionsTask(DCPS::ReactorInterceptor_rch interceptor,
+AccessControlBuiltInImpl::RevokePermissionsTask::RevokePermissionsTask(const DCPS::TimeSource& time_source,
+                                                                       DCPS::ReactorInterceptor_rch interceptor,
                                                                        AccessControlBuiltInImpl& impl)
-  : SporadicTask(interceptor)
+  : SporadicTask(time_source, interceptor)
   , impl_(impl)
 { }
 

--- a/dds/DCPS/security/AccessControlBuiltInImpl.h
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.h
@@ -259,7 +259,8 @@ private:
 
   class RevokePermissionsTask : public DCPS::SporadicTask {
   public:
-    RevokePermissionsTask(DCPS::ReactorInterceptor_rch interceptor,
+    RevokePermissionsTask(const DCPS::TimeSource& time_source,
+                          DCPS::ReactorInterceptor_rch interceptor,
                           AccessControlBuiltInImpl& impl);
     virtual ~RevokePermissionsTask();
     void insert(DDS::Security::PermissionsHandle pm_handle, const time_t& expiration);

--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -121,7 +121,7 @@ DataLink::add_on_start_callback(const TransportClient_wrch& client, const RepoId
           pending_on_starts_.erase(it);
         }
         guard.release();
-        interceptor_.execute_or_enqueue(new ImmediateStart(link, client, remote));
+        interceptor_.execute_or_enqueue(make_rch<ImmediateStart>(link, client, remote));
       } else {
         on_start_callbacks_[remote][client_id] = client;
       }

--- a/dds/DCPS/transport/framework/DataLinkWatchdog_T.h
+++ b/dds/DCPS/transport/framework/DataLinkWatchdog_T.h
@@ -28,17 +28,17 @@ class DataLinkWatchdog : public ReactorInterceptor {
 public:
 
   bool schedule(const void* arg = 0) {
-    execute_or_enqueue(new ScheduleCommand (this, arg, false));
+    execute_or_enqueue(make_rch<ScheduleCommand>(this, arg, false));
     return true;
   }
 
   bool schedule_now(const void* arg = 0) {
-    execute_or_enqueue(new ScheduleCommand(this, arg, true));
+    execute_or_enqueue(make_rch<ScheduleCommand>(this, arg, true));
     return true;
   }
 
   ReactorInterceptor::CommandPtr cancel() {
-    return execute_or_enqueue(new CancelCommand(this));
+    return execute_or_enqueue(make_rch<CancelCommand>(this));
   }
 
   int handle_timeout(const ACE_Time_Value& now_time_value, const void* arg) {

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -227,12 +227,12 @@ public:
 
     void schedule_timer(TransportClient_rch transport_client, const PendingAssoc_rch& pend)
     {
-      execute_or_enqueue(new ScheduleCommand(this, transport_client, pend));
+      execute_or_enqueue(make_rch<ScheduleCommand>(this, transport_client, pend));
     }
 
     ReactorInterceptor::CommandPtr cancel_timer(const PendingAssoc_rch& pend)
     {
-      return execute_or_enqueue(new CancelCommand(this, pend));
+      return execute_or_enqueue(make_rch<CancelCommand>(this, pend));
     }
 
     virtual bool reactor_is_shut_down() const

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -82,7 +82,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
   , custom_allocator_(TheServiceParticipant->association_chunk_multiplier() * config.anticipated_fragments_, RtpsSampleHeader::FRAG_SIZE)
   , bundle_allocator_(TheServiceParticipant->association_chunk_multiplier(), config.max_message_size_)
   , multi_buff_(this, config.nak_depth_)
-  , flush_send_queue_task_(make_rch<Sporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue))
+  , flush_send_queue_task_(make_rch<Sporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(), rchandle_from(this), &RtpsUdpDataLink::flush_send_queue))
   , best_effort_heartbeat_count_(0)
   , heartbeat_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_heartbeats)
   , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
@@ -4368,8 +4368,8 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(TransportClient_rch client, RcHandle<Rtp
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
  , is_ps_writer_(id_.entityId == RTPS::ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER)
 #endif
- , heartbeat_(make_rch<RtpsWriter::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats))
- , nack_response_(make_rch<RtpsWriter::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses))
+ , heartbeat_(make_rch<RtpsWriter::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), rchandle_from(this), &RtpsWriter::send_heartbeats))
+ , nack_response_(make_rch<RtpsWriter::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), rchandle_from(this), &RtpsWriter::send_nack_responses))
  , fallback_(link->config().heartbeat_period_)
 {
   send_buff_->bind(link->send_strategy().in());

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -82,7 +82,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
   , custom_allocator_(TheServiceParticipant->association_chunk_multiplier() * config.anticipated_fragments_, RtpsSampleHeader::FRAG_SIZE)
   , bundle_allocator_(TheServiceParticipant->association_chunk_multiplier(), config.max_message_size_)
   , multi_buff_(this, config.nak_depth_)
-  , flush_send_queue_task_(make_rch<Sporadic>(reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue))
+  , flush_send_queue_task_(make_rch<Sporadic>(TheServiceParticipant->time_source(), reactor_task->interceptor(), *this, &RtpsUdpDataLink::flush_send_queue))
   , best_effort_heartbeat_count_(0)
   , heartbeat_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::send_heartbeats)
   , heartbeatchecker_(reactor_task->interceptor(), *this, &RtpsUdpDataLink::check_heartbeats)
@@ -4368,8 +4368,8 @@ RtpsUdpDataLink::RtpsWriter::RtpsWriter(TransportClient_rch client, RcHandle<Rtp
  , is_pvs_writer_(id_.entityId == RTPS::ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER)
  , is_ps_writer_(id_.entityId == RTPS::ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER)
 #endif
- , heartbeat_(make_rch<RtpsWriter::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats))
- , nack_response_(make_rch<RtpsWriter::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses))
+ , heartbeat_(make_rch<RtpsWriter::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), *this, &RtpsWriter::send_heartbeats))
+ , nack_response_(make_rch<RtpsWriter::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), *this, &RtpsWriter::send_nack_responses))
  , fallback_(link->config().heartbeat_period_)
 {
   send_buff_->bind(link->send_strategy().in());

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -618,7 +618,7 @@ private:
       , id_(id)
       , stopping_(false)
       , nackfrag_count_(0)
-      , preassociation_task_(make_rch<RtpsReader::Sporadic>(link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks))
+      , preassociation_task_(make_rch<RtpsReader::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks))
     {}
 
     ~RtpsReader();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -618,7 +618,7 @@ private:
       , id_(id)
       , stopping_(false)
       , nackfrag_count_(0)
-      , preassociation_task_(make_rch<RtpsReader::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), *this, &RtpsReader::send_preassociation_acknacks))
+      , preassociation_task_(make_rch<RtpsReader::Sporadic>(TheServiceParticipant->time_source(), link->reactor_task_->interceptor(), rchandle_from(this), &RtpsReader::send_preassociation_acknacks))
     {}
 
     ~RtpsReader();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -554,7 +554,7 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
     start_ice();
   }
 
-  relay_stun_task_= make_rch<Sporadic>(TheServiceParticipant->time_source(), reactor_task()->interceptor(), ref(*this), &RtpsUdpTransport::relay_stun_task);
+  relay_stun_task_= make_rch<Sporadic>(TheServiceParticipant->time_source(), reactor_task()->interceptor(), rchandle_from(this), &RtpsUdpTransport::relay_stun_task);
 #endif
 
   if (config.opendds_discovery_default_listener_) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -554,7 +554,7 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
     start_ice();
   }
 
-  relay_stun_task_= make_rch<Sporadic>(reactor_task()->interceptor(), ref(*this), &RtpsUdpTransport::relay_stun_task);
+  relay_stun_task_= make_rch<Sporadic>(TheServiceParticipant->time_source(), reactor_task()->interceptor(), ref(*this), &RtpsUdpTransport::relay_stun_task);
 #endif
 
   if (config.opendds_discovery_default_listener_) {

--- a/tests/DCPS/SharedTransport/TestCase.cpp
+++ b/tests/DCPS/SharedTransport/TestCase.cpp
@@ -58,6 +58,9 @@ TestCase::init_datareader(
 {
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: TestCase::init_datareader\n")));
 
+  if (ACE_OS::getenv("OPENDDS_TEST_BEST_EFFORT") == 0) {
+    qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+  }
   qos.liveliness.lease_duration.sec = 1;
   qos.liveliness.lease_duration.nanosec = 0;
   return DDS::RETCODE_OK;

--- a/tests/DCPS/SharedTransport/run_test.pl
+++ b/tests/DCPS/SharedTransport/run_test.pl
@@ -22,6 +22,7 @@ foreach my $arg (@ARGV) {
   if ($arg eq 'tcp') {
     $transport = "tcp.ini";
   } elsif ($arg eq 'udp') {
+    $ENV{'OPENDDS_TEST_BEST_EFFORT'} = 1;
     $transport = "udp.ini";
   } elsif ($arg eq 'multicast') {
     $transport = "multicast.ini";

--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -43,7 +43,8 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   reactor_task.open(0);
   TestObj obj;
   {
-    PmfSporadicTask<TestObj> sporadic(reactor_task.interceptor(), obj, &TestObj::execute);
+    TimeSource time_source;
+    PmfSporadicTask<TestObj> sporadic(time_source, reactor_task.interceptor(), obj, &TestObj::execute);
     obj.sporadic_ = &sporadic;
     sporadic.schedule(TimeDuration::from_msec(2000));
     ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));

--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -17,60 +17,65 @@ using namespace OpenDDS::DCPS;
 
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> total_count = 0;
 
-struct TestObj : RcObject
+struct TestObj : public RcObject
 {
-  TestObj() : sporadic_(0), do_enable_(false) {}
+  typedef PmfSporadicTask<TestObj> Sporadic;
+
+  TestObj(const TimeSource& time_source,
+          RcHandle<ReactorInterceptor> reactor_interceptor)
+    : do_schedule_(false)
+  {
+    sporadic_ = make_rch<Sporadic>(time_source, reactor_interceptor, rchandle_from(this), &TestObj::execute);
+  }
 
   void execute(const MonotonicTimePoint&) {
     ACE_DEBUG((LM_DEBUG, "TestObj::execute() called at %T\n"));
     ++total_count;
-    if (do_enable_.value()) {
+    if (do_schedule_.value()) {
       sporadic_->schedule(TimeDuration::from_msec(100));
     }
   }
 
-  void set_do_enable(bool do_enable) { do_enable_ = do_enable; }
+  void set_do_schedule(bool do_schedule) { do_schedule_ = do_schedule; }
 
-  PmfSporadicTask<TestObj>* sporadic_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, bool> do_enable_;
+  RcHandle<Sporadic> sporadic_;
+  ACE_Atomic_Op<ACE_Thread_Mutex, bool> do_schedule_;
 };
 
 int
 ACE_TMAIN(int, ACE_TCHAR*[])
 {
   using namespace OpenDDS::DCPS;
+  TimeSource time_source;
   ReactorTask reactor_task(false);
   reactor_task.open(0);
-  TestObj obj;
-  {
-    TimeSource time_source;
-    PmfSporadicTask<TestObj> sporadic(time_source, reactor_task.interceptor(), obj, &TestObj::execute);
-    obj.sporadic_ = &sporadic;
-    sporadic.schedule(TimeDuration::from_msec(2000));
-    ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
-    TEST_CHECK(total_count == 0);
-    ACE_OS::sleep(5);
-    ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
-    TEST_CHECK(total_count == 1);
-    obj.set_do_enable(true);
-    const MonotonicTimePoint deadline = MonotonicTimePoint::now() + TimeDuration::from_msec(2000);
-    size_t schedule_calls = 0;
-    while (MonotonicTimePoint::now() < deadline) {
-      ++schedule_calls;
-      sporadic.schedule(TimeDuration::from_msec(100));
-      ACE_OS::sleep(ACE_Time_Value(0, 1000));
-    }
-    obj.set_do_enable(false);
-    ACE_DEBUG((LM_DEBUG, "schedule_calls = %d\n", schedule_calls));
-    ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
-    TEST_CHECK(total_count >= 19);
-    TEST_CHECK(total_count <= 21);
-    const unsigned int prev_total_count = total_count.value();
-    ACE_OS::sleep(5);
-    ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
-    TEST_CHECK(total_count == prev_total_count + 1);
-    sporadic.cancel_and_wait();
+
+  RcHandle<TestObj> obj = make_rch<TestObj>(time_source, reactor_task.interceptor());
+  obj->sporadic_->schedule(TimeDuration::from_msec(2000));
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  TEST_CHECK(total_count == 0);
+  ACE_OS::sleep(5);
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  TEST_CHECK(total_count == 1);
+  obj->set_do_schedule(true);
+  const MonotonicTimePoint deadline = MonotonicTimePoint::now() + TimeDuration::from_msec(2000);
+  size_t schedule_calls = 0;
+  while (MonotonicTimePoint::now() < deadline) {
+    ++schedule_calls;
+    obj->sporadic_->schedule(TimeDuration::from_msec(100));
+    ACE_OS::sleep(ACE_Time_Value(0, 1000));
   }
+  obj->set_do_schedule(false);
+  ACE_DEBUG((LM_DEBUG, "schedule_calls = %d\n", schedule_calls));
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  TEST_CHECK(total_count >= 19);
+  TEST_CHECK(total_count <= 21);
+  const unsigned int prev_total_count = total_count.value();
+  ACE_OS::sleep(5);
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  TEST_CHECK(total_count == prev_total_count + 1);
+  obj->sporadic_->cancel_and_wait();
+
   reactor_task.stop();
   return 0;
 }

--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -53,14 +53,14 @@ ACE_TMAIN(int, ACE_TCHAR*[])
     TEST_CHECK(total_count == 1);
     obj.set_do_enable(true);
     const MonotonicTimePoint deadline = MonotonicTimePoint::now() + TimeDuration::from_msec(2000);
-    size_t enable_calls = 0;
+    size_t schedule_calls = 0;
     while (MonotonicTimePoint::now() < deadline) {
-      ++enable_calls;
+      ++schedule_calls;
       sporadic.schedule(TimeDuration::from_msec(100));
       ACE_OS::sleep(ACE_Time_Value(0, 1000));
     }
     obj.set_do_enable(false);
-    ACE_DEBUG((LM_DEBUG, "enable_calls = %d\n", enable_calls));
+    ACE_DEBUG((LM_DEBUG, "schedule_calls = %d\n", schedule_calls));
     ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
     TEST_CHECK(total_count >= 19);
     TEST_CHECK(total_count <= 21);

--- a/tests/unit-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/unit-tests/dds/DCPS/SporadicTask.cpp
@@ -1,0 +1,290 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "dds/DCPS/SporadicTask.h"
+
+#include <ace/Thread_Manager.h>
+
+using namespace OpenDDS::DCPS;
+
+class MyTimeSource : public TimeSource {
+public:
+  MOCK_CONST_METHOD0(monotonic_time_point_now, MonotonicTimePoint());
+};
+
+class MyReactor : public ACE_Reactor {
+public:
+  MOCK_METHOD4(schedule_timer, long(ACE_Event_Handler*, const void*, const ACE_Time_Value&, const ACE_Time_Value&));
+  MOCK_METHOD2(cancel_timer, int(ACE_Event_Handler*, int));
+};
+
+class MyReactorInterceptor : public ReactorInterceptor {
+public:
+  MyReactorInterceptor(ACE_Reactor* reactor)
+    : ReactorInterceptor(reactor, ACE_Thread_Manager::instance()->thr_self())
+  {}
+
+  bool reactor_is_shut_down() const { return false; }
+};
+
+class MySporadicTask : public SporadicTask {
+public:
+  MySporadicTask(const TimeSource& time_source,
+                 RcHandle<ReactorInterceptor> interceptor)
+    : SporadicTask(time_source, interceptor)
+  {}
+
+  MOCK_METHOD1(execute, void(const MonotonicTimePoint&));
+};
+
+class MyTestClass : public RcObject {
+public:
+  MyTestClass(const TimeSource& time_source,
+              RcHandle<ReactorInterceptor> interceptor)
+    : sporadic_task_(time_source, interceptor, *this, &MyTestClass::myfunc)
+  {}
+
+  MOCK_METHOD1(myfunc, void(const MonotonicTimePoint&));
+  PmfSporadicTask<MyTestClass> sporadic_task_;
+};
+
+TEST(dds_DCPS_SporadicTask, schedule)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration one_second(1);
+  const ACE_Time_Value now(7);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .Times(1)
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, one_second.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+  EXPECT_CALL(*sporadic_task.get(), execute(MonotonicTimePoint(now)));
+
+  sporadic_task->schedule(one_second);
+
+  // Execute.
+  RcHandle<RcEventHandler> eh = sporadic_task;
+  eh->handle_timeout(now);
+}
+
+TEST(dds_DCPS_SporadicTask, schedule_pmf)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  MyTestClass mtc(time_source, reactor_interceptor);
+  const TimeDuration one_second(1);
+  const ACE_Time_Value now(7);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .Times(1)
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+  EXPECT_CALL(reactor, schedule_timer(&mtc.sporadic_task_, 0, one_second.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+  EXPECT_CALL(mtc, myfunc(MonotonicTimePoint(now)));
+
+  mtc.sporadic_task_.schedule(one_second);
+
+  // Execute.
+  RcEventHandler* eh = &mtc.sporadic_task_;
+  eh->handle_timeout(now);
+}
+
+TEST(dds_DCPS_SporadicTask, schedule_error)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration one_second(1);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .Times(1)
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, one_second.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(-1));
+
+  sporadic_task->schedule(one_second);
+}
+
+TEST(dds_DCPS_SporadicTask, schedule_earlier)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration one_second(1);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .Times(2)
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value))
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
+    .WillOnce(testing::Return(1));
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, one_second.value(), ACE_Time_Value::zero))
+    .WillOnce(testing::Return(1));
+  EXPECT_CALL(reactor, cancel_timer(sporadic_task.get(), 1))
+    .WillOnce(testing::Return(0));
+
+  sporadic_task->schedule(two_seconds);
+  sporadic_task->schedule(one_second);
+}
+
+TEST(dds_DCPS_SporadicTask, schedule_later)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value))
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+
+  sporadic_task->schedule(two_seconds);
+  sporadic_task->schedule(two_seconds);
+}
+
+TEST(dds_DCPS_SporadicTask, schedule_no_interceptor)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  reactor_interceptor.reset();
+  DCPS_debug_level = 1;
+  sporadic_task->schedule(two_seconds);
+  DCPS_debug_level = 0;
+}
+
+TEST(dds_DCPS_SporadicTask, cancel_not_scheduled)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+
+  sporadic_task->cancel();
+}
+
+TEST(dds_DCPS_SporadicTask, cancel_scheduled)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+
+  EXPECT_CALL(reactor, cancel_timer(sporadic_task.get(), 1))
+    .WillOnce(testing::Return(0));
+
+  sporadic_task->schedule(two_seconds);
+  sporadic_task->cancel();
+}
+
+TEST(dds_DCPS_SporadicTask, cancel_no_interceptor)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+
+  sporadic_task->schedule(two_seconds);
+  reactor_interceptor.reset();
+  DCPS_debug_level = 1;
+  sporadic_task->cancel();
+}
+
+TEST(dds_DCPS_SporadicTask, cancel_and_wait_not_scheduled)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+
+  sporadic_task->cancel_and_wait();
+}
+
+TEST(dds_DCPS_SporadicTask, cancel_and_wait_scheduled)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+
+  EXPECT_CALL(reactor, cancel_timer(sporadic_task.get(), 1))
+    .WillOnce(testing::Return(0));
+
+  sporadic_task->schedule(two_seconds);
+  sporadic_task->cancel_and_wait();
+}
+
+TEST(dds_DCPS_SporadicTask, cancel_and_wait_no_interceptor)
+{
+  MyTimeSource time_source;
+  MyReactor reactor;
+  RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
+  RcHandle<MySporadicTask> sporadic_task = make_rch<MySporadicTask>(time_source, reactor_interceptor);
+  const TimeDuration two_seconds(2);
+
+  EXPECT_CALL(time_source, monotonic_time_point_now())
+    .WillOnce(testing::Return(MonotonicTimePoint::zero_value));
+
+  EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
+    .Times(1)
+    .WillOnce(testing::Return(1));
+
+  sporadic_task->schedule(two_seconds);
+  reactor_interceptor.reset();
+  DCPS_debug_level = 1;
+  sporadic_task->cancel_and_wait();
+}


### PR DESCRIPTION
Problem
-------

There are two optimizations for SporadicTask:

1. The first optimization attempts to only submit a schedule command
   if not scheduled or the scheduled dispatch time is nearer than the
   desired dispatch time.

   This logic is controlled by variables that are only set by the
   reactor thread.  Thus, a non-reactor thread attempting to schedule
   could still create a large number of ScheduleCommands before the
   reactor thread gets around to processing the first one.

   The optmization that examines the next dispatch time changes the
   semantics of SporadicTask in that it is implied that the user can
   schedule a dispatch nearer in time without canceling.  With the
   introduction of code that modulates a SporadicTask, this created a
   bug where calls to cancel the timer were dropped and/or not
   written.  By not canceling the timer, the `scheduled_` flag was
   never reset meaning that scheduling for an earlier dispatch never
   occurred.

2. The second optmization attempts to reduce the number of calls into
   the reactor itself.  This took the form of hooks around the
   lifecycle of a ReactorInterceptor::Command.  For SporadicTask, the
   goal of the implementation was to skip commands that were
   effectively no-ops.

Solution
--------

The new design of SporadicTask is based on the idea that there is a
desired state provided by the user (scheduled or not scheduled) and
there is an actual state which is the result of interacting with the
reactor.  When scheduling or canceling, the same
ReactorInterceptor::Command is submitted to the reactor.  When
executed, the command attempts to make the actual state the desired
state if they differ.  To avoid dynamic allocation, the command is
allocated once and only put on the ReactorInterceptors queue if it is
not on the queue already.

Notes
-----

The pattern for SporadicTask should be adopted by PeriodicTask,
MultiTask, and other uses of the ReactorInterceptor.