### PR TITLE
Made previous TransportReceiveStrategy change compatible with older compilers

### DIFF
--- a/dds/DCPS/transport/framework/TransportReceiveStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy.cpp
@@ -1,0 +1,22 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "DCPS/DdsDcps_pch.h" // Only the _pch include should start with DCPS/
+
+#include "TransportReceiveStrategy_T.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+const size_t TransportReceiveConstants::RECEIVE_BUFFERS;
+const size_t TransportReceiveConstants::BUFFER_LOW_WATER;
+const size_t TransportReceiveConstants::MESSAGE_BLOCKS;
+const size_t TransportReceiveConstants::DATA_BLOCKS;
+
+}
+}
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -25,13 +25,31 @@ namespace DCPS {
 
 class TransportInst;
 
+struct OpenDDS_Dcps_Export TransportReceiveConstants { // non-template base for constants only
+  //
+  // The total available space in the receive buffers must have enough to hold
+  // a max sized message.  The max message is about 64K and the low water for
+  // a buffer is 4096.  Therefore, 16 receive buffers is appropriate.
+  //
+  static const size_t RECEIVE_BUFFERS = 16;
+  static const size_t BUFFER_LOW_WATER = 4096;
+
+  //
+  // Message Block Allocators are more plentiful since they hold samples
+  // as well as data read from the handle(s).
+  //
+  static const size_t MESSAGE_BLOCKS = 1000;
+  static const size_t DATA_BLOCKS = 100;
+};
+
+
 /**
  * This class provides buffer for data received by transports, de-assemble
  * the data to individual samples and deliver them.
  */
 template<typename TH = TransportHeader, typename DSH = DataSampleHeader>
 class TransportReceiveStrategy
-  : public TransportStrategy {
+  : public TransportStrategy, public TransportReceiveConstants {
 public:
 
   virtual ~TransportReceiveStrategy();
@@ -131,21 +149,6 @@ private:
 
   /// Current receive TransportHeader.
   TH receive_transport_header_;
-
-  //
-  // The total available space in the receive buffers must have enough to hold
-  // a max sized message.  The max message is about 64K and the low water for
-  // a buffer is 4096.  Therefore, 16 receive buffers is appropriate.
-  //
-  static const size_t RECEIVE_BUFFERS = 16;
-  static const size_t BUFFER_LOW_WATER = 4096;
-
-  //
-  // Message Block Allocators are more plentiful since they hold samples
-  // as well as data read from the handle(s).
-  //
-  static const size_t MESSAGE_BLOCKS = 1000;
-  static const size_t DATA_BLOCKS = 100;
 
 //MJM: We should probably bring the allocator typedefs down into this
 //MJM: class since they are limited to this scope.

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.cpp
@@ -16,7 +16,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 MulticastReceiveStrategy::MulticastReceiveStrategy(MulticastDataLink* link)
-  : TransportReceiveStrategy(link->config())
+  : TransportReceiveStrategy<>(link->config())
   , link_(link)
 {
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -35,7 +35,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix)
-  : TransportReceiveStrategy(link->config())
+  : BaseReceiveStrategy(link->config())
   , link_(link)
   , last_received_()
   , recvd_sample_(0)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -124,6 +124,8 @@ private:
 
   bool check_encoded(const EntityId_t& sender);
 
+  typedef TransportReceiveStrategy<RtpsTransportHeader, RtpsSampleHeader> BaseReceiveStrategy;
+
   RtpsUdpDataLink* link_;
   SequenceNumber last_received_;
 

--- a/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemReceiveStrategy.cpp
@@ -21,7 +21,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 ShmemReceiveStrategy::ShmemReceiveStrategy(ShmemDataLink* link)
-  : TransportReceiveStrategy(link->impl().config())
+  : TransportReceiveStrategy<>(link->impl().config())
   , link_(link)
   , current_data_(0)
   , partial_recv_remaining_(0)

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.cpp
@@ -23,7 +23,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 OpenDDS::DCPS::TcpReceiveStrategy::TcpReceiveStrategy(
   TcpDataLink& link, const ReactorTask_rch& task)
-  : TransportReceiveStrategy(link.impl().config())
+  : TransportReceiveStrategy<>(link.impl().config())
   , link_(link)
   , reactor_task_(task)
 {

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.cpp
@@ -19,7 +19,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 UdpReceiveStrategy::UdpReceiveStrategy(UdpDataLink* link)
-  : TransportReceiveStrategy(link->impl().config())
+  : TransportReceiveStrategy<>(link->impl().config())
   , link_(link)
   , expected_(SequenceNumber::SEQUENCENUMBER_UNKNOWN())
 {


### PR DESCRIPTION
GCC 4.4 in particular needs a linkable symbol for these constants so we need it to live in a non-template translation unit.