### PR TITLE
Avoid Error Case For Sent Data In WriteDataContainer

### DIFF
--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -911,8 +911,8 @@ WriteDataContainer::remove_oldest_sample(
     if (this->writer_->remove_sample(stale)) {
       if (this->sent_data_.dequeue(stale)) {
         release_buffer(stale);
-        result = true;
       }
+      result = true;
 
     } else {
       if (this->sending_data_.dequeue(stale)) {


### PR DESCRIPTION
Problem: It appears that sometimes data is removed from sent_data_ before remove_oldest_sample is able to remove it based on the contents of what can be removed from the writer.

Solution: This is probably a race condition of sorts, but when we detect it in the code it's probably not worth flagging as an error (with subsequent error messages and test failures).