### PR TITLE
Fix V8 Generator BuiltInSeq Check Logic

### DIFF
--- a/dds/idl/v8_generator.cpp
+++ b/dds/idl/v8_generator.cpp
@@ -67,7 +67,7 @@ namespace {
   bool builtInSeq(AST_Type* type)
   {
     const std::string name = scoped(type->name());
-    static const char PRE[] = "CORBA::";
+    static const char PRE[] = " ::CORBA::";
     if (std::strncmp(name.c_str(), PRE, sizeof(PRE) - 1)) return false;
     return name.rfind("Seq") == name.size() - 3;
   }


### PR DESCRIPTION
Problem: The idl compiler's "scoped" method was updated to return a safer prefix, but the V8 generator which used it to check for builtin sequence types was not updated.

Solution: Update v8 generator's builtin sequence logic