### PR TITLE
Spdp 'from_relay' Coverity Fix (1510150)

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3076,10 +3076,11 @@ Spdp::SpdpTransport::handle_input(ACE_HANDLE h)
   }
 
   const bool relay_in_use = (outer->config_->rtps_relay_only() || outer->config_->use_rtps_relay());
-  const bool from_relay = relay_in_use && (remote == outer->config_->spdp_rtps_relay_address());
+  const bool remote_matches_relay_addr = (remote == outer->config_->spdp_rtps_relay_address());
+  const bool from_relay = relay_in_use && remote_matches_relay_addr;
 
   // Ignore messages from the relay when not using it.
-  if (!relay_in_use && from_relay) {
+  if (!relay_in_use && remote_matches_relay_addr) {
     return 0;
   }
 


### PR DESCRIPTION
Problem: Recent code changes introduced dead code. Spdp's early return from processing messages from the relay when the relay isn't being used would never be called due to the way the boolean flags were defined.

Solution: differentiate between whether a message is from the known relay address and whether we can treat it as (validly, relay in use) from the relay.