### PR TITLE
Update get_member_id_at_index and get_complex_value in DynamicData

### DIFF
--- a/dds/DCPS/XTypes/DynamicData.h
+++ b/dds/DCPS/XTypes/DynamicData.h
@@ -236,7 +236,7 @@ private:
 
   /// Skip a member of a final or appendable struct at the given index.
   ///
-  bool skip_struct_member_by_index(ACE_CDR::ULong index);
+  bool skip_struct_member_at_index(ACE_CDR::ULong index, ACE_CDR::ULong& num_skipped);
 
   /// Skip a member with the given type. The member can be a part of any containing type,
   /// such as a member in a struct or union, an element in a sequence or array, etc.

--- a/dds/DCPS/XTypes/DynamicData.h
+++ b/dds/DCPS/XTypes/DynamicData.h
@@ -267,6 +267,7 @@ private:
   // TODO: This method can be moved to DynamicType-related classes.
   DynamicType_rch get_base_type(const DynamicType_rch& alias_type) const;
   bool is_primitive(TypeKind tk, ACE_CDR::ULong& size) const;
+  bool has_optional_member(bool& has_optional) const;
 
   bool get_index_from_id(MemberId id, ACE_CDR::ULong& index, ACE_CDR::ULong bound) const;
   const char* typekind_to_string(TypeKind tk) const;

--- a/tests/DCPS/UnitTests/DynamicData/DynamicData.cpp
+++ b/tests/DCPS/UnitTests/DynamicData/DynamicData.cpp
@@ -517,7 +517,7 @@ void verify_int32_union(XTypes::DynamicData& data)
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(ACE_CDR::Long(10), int_32);
 
-  const XTypes::MemberId disc_id = data.get_member_id_by_name("discriminator");
+  const XTypes::MemberId disc_id = data.get_member_id_at_index(0);
   EXPECT_EQ(XTypes::DISCRIMINATOR_ID, disc_id);
   ACE_CDR::Long disc_val;
   ret = data.get_int32_value(disc_val, disc_id);
@@ -540,7 +540,7 @@ void verify_uint32_union(XTypes::DynamicData& data)
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(ACE_CDR::ULong(11), uint_32);
 
-  const XTypes::MemberId disc_id = data.get_member_id_by_name("discriminator");
+  const XTypes::MemberId disc_id = data.get_member_id_at_index(0);
   EXPECT_EQ(XTypes::DISCRIMINATOR_ID, disc_id);
   ACE_CDR::Long disc_val;
   ret = data.get_int32_value(disc_val, disc_id);

--- a/tests/DCPS/UnitTests/DynamicData/DynamicData.cpp
+++ b/tests/DCPS/UnitTests/DynamicData/DynamicData.cpp
@@ -92,13 +92,18 @@ void verify_single_value_struct(XTypes::DynamicData& data)
   StructType expected;
   set_single_value_struct(expected);
 
+  ACE_CDR::ULong count = data.get_item_count();
+  EXPECT_EQ(count, ACE_CDR::ULong(19));
+
   ACE_CDR::Long my_enum;
-  DDS::ReturnCode_t ret = data.get_int32_value(my_enum, 0);
+  XTypes::MemberId id = data.get_member_id_at_index(0);
+  EXPECT_EQ(id, ACE_CDR::ULong(0));
+  DDS::ReturnCode_t ret = data.get_int32_value(my_enum, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.my_enum, my_enum);
 
   XTypes::DynamicData nested_dd;
-  ret = data.get_complex_value(nested_dd, 0);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   const XTypes::MemberId random_id = 111;
   ret = nested_dd.get_int32_value(my_enum, random_id);
@@ -106,172 +111,207 @@ void verify_single_value_struct(XTypes::DynamicData& data)
   EXPECT_EQ(expected.my_enum, my_enum);
 
   ACE_CDR::Long int_32;
-  ret = data.get_int32_value(int_32, 1);
+  id = data.get_member_id_at_index(1);
+  EXPECT_EQ(id, ACE_CDR::ULong(1));
+  ret = data.get_int32_value(int_32, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_32, int_32);
 
-  ret = data.get_complex_value(nested_dd, 1);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_int32_value(int_32, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_32, int_32);
 
   ACE_CDR::ULong uint_32;
-  ret = data.get_uint32_value(uint_32, 2);
+  id = data.get_member_id_at_index(2);
+  EXPECT_EQ(id, ACE_CDR::ULong(2));
+  ret = data.get_uint32_value(uint_32, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_32, uint_32);
 
-  ret = data.get_complex_value(nested_dd, 2);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_uint32_value(uint_32, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_32, uint_32);
 
   ACE_CDR::Int8 int_8;
-  ret = data.get_int8_value(int_8, 3);
+  id = data.get_member_id_at_index(3);
+  EXPECT_EQ(id, ACE_CDR::ULong(3));
+  ret = data.get_int8_value(int_8, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_8, int_8);
 
-  ret = data.get_complex_value(nested_dd, 3);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_int8_value(int_8, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_8, int_8);
 
   ACE_CDR::UInt8 uint_8;
-  ret = data.get_uint8_value(uint_8, 4);
+  id = data.get_member_id_at_index(4);
+  EXPECT_EQ(id, ACE_CDR::ULong(4));
+  ret = data.get_uint8_value(uint_8, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_8, uint_8);
 
-  ret = data.get_complex_value(nested_dd, 4);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_uint8_value(uint_8, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_8, uint_8);
 
   ACE_CDR::Int16 int_16;
-  ret = data.get_int16_value(int_16, 5);
+  id = data.get_member_id_at_index(5);
+  EXPECT_EQ(id, ACE_CDR::ULong(5));
+  ret = data.get_int16_value(int_16, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_16, int_16);
 
-  ret = data.get_complex_value(nested_dd, 5);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_int16_value(int_16, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_16, int_16);
 
   ACE_CDR::UInt16 uint_16;
-  ret = data.get_uint16_value(uint_16, 6);
+  id = data.get_member_id_at_index(6);
+  EXPECT_EQ(id, ACE_CDR::ULong(6));
+  ret = data.get_uint16_value(uint_16, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_16, uint_16);
 
-  ret = data.get_complex_value(nested_dd, 6);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_uint16_value(uint_16, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_16, uint_16);
 
   ACE_CDR::Int64 int_64;
-  ret = data.get_int64_value(int_64, 7);
+  id = data.get_member_id_at_index(7);
+  EXPECT_EQ(id, ACE_CDR::ULong(7));
+  ret = data.get_int64_value(int_64, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_64, int_64);
 
-  ret = data.get_complex_value(nested_dd, 7);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_int64_value(int_64, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.int_64, int_64);
 
   ACE_CDR::UInt64 uint_64;
-  ret = data.get_uint64_value(uint_64, 8);
+  id = data.get_member_id_at_index(8);
+  EXPECT_EQ(id, ACE_CDR::ULong(8));
+  ret = data.get_uint64_value(uint_64, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_64, uint_64);
 
-  ret = data.get_complex_value(nested_dd, 8);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_uint64_value(uint_64, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.uint_64, uint_64);
 
   ACE_CDR::Float float_32;
-  ret = data.get_float32_value(float_32, 9);
+  id = data.get_member_id_at_index(9);
+  EXPECT_EQ(id, ACE_CDR::ULong(9));
+  ret = data.get_float32_value(float_32, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.float_32, float_32);
 
-  ret = data.get_complex_value(nested_dd, 9);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_float32_value(float_32, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.float_32, float_32);
 
   ACE_CDR::Double float_64;
-  ret = data.get_float64_value(float_64, 10);
+  id = data.get_member_id_at_index(10);
+  EXPECT_EQ(id, ACE_CDR::ULong(10));
+  ret = data.get_float64_value(float_64, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.float_64, float_64);
 
-  ret = data.get_complex_value(nested_dd, 10);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_float64_value(float_64, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.float_64, float_64);
 
   ACE_CDR::LongDouble float_128;
-  ret = data.get_float128_value(float_128, 11);
+  id = data.get_member_id_at_index(11);
+  EXPECT_EQ(id, ACE_CDR::ULong(11));
+  ret = data.get_float128_value(float_128, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   check_float128(expected.float_128, float_128);
-  ret = data.get_complex_value(nested_dd, 11);
+
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_float128_value(float_128, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   check_float128(expected.float_128, float_128);
 
   ACE_CDR::Char char_8;
-  ret = data.get_char8_value(char_8, 12);
+  id = data.get_member_id_at_index(12);
+  EXPECT_EQ(id, ACE_CDR::ULong(12));
+  ret = data.get_char8_value(char_8, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.char_8, char_8);
 
-  ret = data.get_complex_value(nested_dd, 12);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_char8_value(char_8, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.char_8, char_8);
 
   ACE_CDR::WChar char_16;
-  ret = data.get_char16_value(char_16, 13);
+  id = data.get_member_id_at_index(13);
+  EXPECT_EQ(id, ACE_CDR::ULong(13));
+  ret = data.get_char16_value(char_16, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.char_16, char_16);
 
-  ret = data.get_complex_value(nested_dd, 13);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_char16_value(char_16, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.char_16, char_16);
 
   ACE_CDR::Octet byte;
-  ret = data.get_byte_value(byte, 14);
+  id = data.get_member_id_at_index(14);
+  EXPECT_EQ(id, ACE_CDR::ULong(14));
+  ret = data.get_byte_value(byte, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.byte, byte);
 
-  ret = data.get_complex_value(nested_dd, 14);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_byte_value(byte, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.byte, byte);
 
   ACE_CDR::Boolean bool_;
-  ret = data.get_boolean_value(bool_, 15);
+  id = data.get_member_id_at_index(15);
+  EXPECT_EQ(id, ACE_CDR::ULong(15));
+  ret = data.get_boolean_value(bool_, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected._cxx_bool, bool_);
 
-  ret = data.get_complex_value(nested_dd, 15);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_boolean_value(bool_, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected._cxx_bool, bool_);
 
   ACE_CDR::Long l;
-  ret = data.get_complex_value(nested_dd, 16);
+  id = data.get_member_id_at_index(16);
+  EXPECT_EQ(id, ACE_CDR::ULong(16));
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
+  count = nested_dd.get_item_count();
+  EXPECT_EQ(count, ACE_CDR::ULong(1));
   ret = nested_dd.get_int32_value(l, 0);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.nested_struct.l, l);
@@ -284,13 +324,15 @@ void verify_single_value_struct(XTypes::DynamicData& data)
   EXPECT_EQ(expected.nested_struct.l, l);
 
   ACE_CDR::Char* str = 0;
-  ret = data.get_string_value(str, 17);
+  id = data.get_member_id_at_index(17);
+  EXPECT_EQ(id, ACE_CDR::ULong(17));
+  ret = data.get_string_value(str, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_STREQ(expected.str.in(), str);
   CORBA::string_free(str);
 
   str = 0;
-  ret = data.get_complex_value(nested_dd, 17);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_string_value(str, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
@@ -298,13 +340,15 @@ void verify_single_value_struct(XTypes::DynamicData& data)
   CORBA::string_free(str);
 
   ACE_CDR::WChar* wstr = 0;
-  ret = data.get_wstring_value(wstr, 18);
+  id = data.get_member_id_at_index(18);
+  EXPECT_EQ(id, ACE_CDR::ULong(18));
+  ret = data.get_wstring_value(wstr, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_STREQ(expected.wstr.in(), wstr);
   CORBA::wstring_free(wstr);
 
   wstr = 0;
-  ret = data.get_complex_value(nested_dd, 18);
+  ret = data.get_complex_value(nested_dd, id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   ret = nested_dd.get_wstring_value(wstr, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
@@ -523,6 +567,9 @@ void verify_int32_union(XTypes::DynamicData& data)
   ret = data.get_int32_value(disc_val, disc_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(disc_val, E_INT32);
+  ACE_CDR::LongLong wrong_disc_val;
+  ret = data.get_int64_value(wrong_disc_val, disc_id);
+  EXPECT_EQ(ret, DDS::RETCODE_ERROR);
 
   XTypes::DynamicData disc_data;
   ret = data.get_complex_value(disc_data, disc_id);
@@ -546,6 +593,9 @@ void verify_uint32_union(XTypes::DynamicData& data)
   ret = data.get_int32_value(disc_val, disc_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(disc_val, E_UINT32);
+  ACE_CDR::Short wrong_disc_val;
+  ret = data.get_int16_value(wrong_disc_val, disc_id);
+  EXPECT_EQ(ret, DDS::RETCODE_ERROR);
 
   XTypes::DynamicData disc_data;
   ret = data.get_complex_value(disc_data, disc_id);

--- a/tests/DCPS/UnitTests/DynamicData/DynamicData.cpp
+++ b/tests/DCPS/UnitTests/DynamicData/DynamicData.cpp
@@ -100,7 +100,7 @@ void verify_single_value_struct(XTypes::DynamicData& data)
   XTypes::DynamicData nested_dd;
   ret = data.get_complex_value(nested_dd, 0);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
-  XTypes::MemberId random_id = 111;
+  const XTypes::MemberId random_id = 111;
   ret = nested_dd.get_int32_value(my_enum, random_id);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(expected.my_enum, my_enum);
@@ -516,6 +516,21 @@ void verify_int32_union(XTypes::DynamicData& data)
   DDS::ReturnCode_t ret = data.get_int32_value(int_32, 1);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(ACE_CDR::Long(10), int_32);
+
+  const XTypes::MemberId disc_id = data.get_member_id_by_name("discriminator");
+  EXPECT_EQ(XTypes::DISCRIMINATOR_ID, disc_id);
+  ACE_CDR::Long disc_val;
+  ret = data.get_int32_value(disc_val, disc_id);
+  EXPECT_EQ(ret, DDS::RETCODE_OK);
+  EXPECT_EQ(disc_val, E_INT32);
+
+  XTypes::DynamicData disc_data;
+  ret = data.get_complex_value(disc_data, disc_id);
+  EXPECT_EQ(ret, DDS::RETCODE_OK);
+  const XTypes::MemberId any_id = 100;
+  ret = disc_data.get_int32_value(disc_val, any_id);
+  EXPECT_EQ(ret, DDS::RETCODE_OK);
+  EXPECT_EQ(disc_val, E_INT32);
 }
 
 void verify_uint32_union(XTypes::DynamicData& data)
@@ -524,6 +539,21 @@ void verify_uint32_union(XTypes::DynamicData& data)
   DDS::ReturnCode_t ret = data.get_uint32_value(uint_32, 2);
   EXPECT_EQ(ret, DDS::RETCODE_OK);
   EXPECT_EQ(ACE_CDR::ULong(11), uint_32);
+
+  const XTypes::MemberId disc_id = data.get_member_id_by_name("discriminator");
+  EXPECT_EQ(XTypes::DISCRIMINATOR_ID, disc_id);
+  ACE_CDR::Long disc_val;
+  ret = data.get_int32_value(disc_val, disc_id);
+  EXPECT_EQ(ret, DDS::RETCODE_OK);
+  EXPECT_EQ(disc_val, E_UINT32);
+
+  XTypes::DynamicData disc_data;
+  ret = data.get_complex_value(disc_data, disc_id);
+  EXPECT_EQ(ret, DDS::RETCODE_OK);
+  const XTypes::MemberId any_id = 100;
+  ret = disc_data.get_int32_value(disc_val, any_id);
+  EXPECT_EQ(ret, DDS::RETCODE_OK);
+  EXPECT_EQ(disc_val, E_UINT32);
 }
 
 void verify_int8_union(XTypes::DynamicData& data)


### PR DESCRIPTION
- Update `get_item_count` and `get_member_id_at_index` to handle omitted optional members in structures.
- Update `get_member_id_at_index` to handle member reordering in mutable structures.
- Update `get_value_from_union` to check for error conditions when reading union discriminator.
- Update `get_complex_value` to allow reading union discriminator into a `DynamicData` object.