### PR TITLE
Increase EntityLifecycleStress Test Process Run Times and Coverage

### DIFF
--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -325,21 +325,21 @@ DataLink::notify_reactor()
 void
 DataLink::stop()
 {
-  this->pre_stop_i();
+  pre_stop_i();
 
   TransportSendStrategy_rch send_strategy;
   TransportStrategy_rch recv_strategy;
 
   {
-    GuardType guard(this->strategy_lock_);
+    GuardType guard(strategy_lock_);
 
-    if (this->stopped_) return;
+    if (stopped_) return;
 
-    send_strategy = this->send_strategy_;
-    this->send_strategy_.reset();
+    send_strategy = send_strategy_;
+    send_strategy_.reset();
 
-    recv_strategy = this->receive_strategy_;
-    this->receive_strategy_.reset();
+    recv_strategy = receive_strategy_;
+    receive_strategy_.reset();
   }
 
   if (!send_strategy.is_nil()) {
@@ -350,16 +350,19 @@ DataLink::stop()
     recv_strategy->stop();
   }
 
-  this->stop_i();
-  this->stopped_ = true;
+  stop_i();
+  stopped_ = true;
   scheduled_to_stop_at_ = MonotonicTimePoint::zero_value;
 }
 
 void
 DataLink::resume_send()
 {
-  if (!this->send_strategy_->isDirectMode())
-    this->send_strategy_->resume_send();
+  TransportSendStrategy_rch strategy = get_send_strategy();
+
+  if (strategy && strategy->isDirectMode()) {
+    strategy->resume_send();
+  }
 }
 
 int
@@ -380,13 +383,12 @@ DataLink::make_reservation(const RepoId& remote_subscription_id,
                OPENDDS_STRING(remote).c_str()));
   }
 
-  {
-    GuardType guard(strategy_lock_);
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
-    if (!send_strategy_.is_nil()) {
-      send_strategy_->link_released(false);
-    }
+  if (strategy) {
+    strategy->link_released(false);
   }
+
   {
     GuardType guard(pub_sub_maps_lock_);
 
@@ -421,13 +423,12 @@ DataLink::make_reservation(const RepoId& remote_publication_id,
                OPENDDS_STRING(local).c_str(), OPENDDS_STRING(remote).c_str()));
   }
 
-  {
-    GuardType guard(strategy_lock_);
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
-    if (!send_strategy_.is_nil()) {
-      send_strategy_->link_released(false);
-    }
+  if (strategy) {
+    strategy->link_released(false);
   }
+
   {
     GuardType guard(pub_sub_maps_lock_);
 
@@ -551,12 +552,14 @@ DataLink::schedule_delayed_release()
   // The samples have to be removed at this point, otherwise the samples
   // can not be delivered when new association is added and still use
   // this connection/datalink.
-  if (!this->send_strategy_.is_nil()) {
-    this->send_strategy_->clear(TransportSendStrategy::MODE_DIRECT);
+  TransportSendStrategy_rch strategy = get_send_strategy();
+
+  if (strategy) {
+    strategy->clear(TransportSendStrategy::MODE_DIRECT);
   }
 
   const MonotonicTimePoint future_release_time(MonotonicTimePoint::now() + datalink_release_delay_);
-  this->schedule_stop(future_release_time);
+  schedule_stop(future_release_time);
 }
 
 bool
@@ -1221,8 +1224,11 @@ operator<<(std::ostream& str, const DataLink& value)
 void
 DataLink::terminate_send_if_suspended()
 {
-  if (send_strategy_)
-    send_strategy_->terminate_send_if_suspended();
+  TransportSendStrategy_rch strategy = get_send_strategy();
+
+  if (strategy) {
+    strategy->terminate_send_if_suspended();
+  }
 }
 
 }

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -438,8 +438,10 @@ protected:
 
   /// The transport send strategy object for this DataLink.
   TransportSendStrategy_rch send_strategy_;
-
   LockType strategy_lock_;
+
+  TransportSendStrategy_rch get_send_strategy();
+
   typedef OPENDDS_MAP_CMP(RepoId, TransportClient_wrch, GUID_tKeyLessThan) RepoToClientMap;
   typedef OPENDDS_MAP_CMP(RepoId, RepoToClientMap, GUID_tKeyLessThan) OnStartCallbackMap;
   OnStartCallbackMap on_start_callbacks_;

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -83,12 +83,7 @@ DataLink::send_start_i()
   // This one is easy.  Simply delegate to our TransportSendStrategy
   // data member.
 
-  TransportSendStrategy_rch strategy;
-  {
-    GuardType guard(this->strategy_lock_);
-
-    strategy = this->send_strategy_;
-  }
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
   if (!strategy.is_nil()) {
     strategy->send_start();
@@ -128,12 +123,7 @@ DataLink::send_i(TransportQueueElement* element, bool relink)
   // This one is easy.  Simply delegate to our TransportSendStrategy
   // data member.
 
-  TransportSendStrategy_rch strategy;
-  {
-    GuardType guard(this->strategy_lock_);
-
-    strategy = this->send_strategy_;
-  }
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
   if (strategy) {
     strategy->send(element, relink);
@@ -161,12 +151,7 @@ DataLink::send_stop_i(RepoId repoId)
   // This one is easy.  Simply delegate to our TransportSendStrategy
   // data member.
 
-  TransportSendStrategy_rch strategy;
-  {
-    GuardType guard(this->strategy_lock_);
-
-    strategy = this->send_strategy_;
-  }
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
   if (!strategy.is_nil()) {
     strategy->send_stop(repoId);
@@ -193,12 +178,7 @@ DataLink::remove_sample(const DataSampleElement* sample)
     }
   }
 
-  TransportSendStrategy_rch strategy;
-  {
-    GuardType guard(this->strategy_lock_);
-
-    strategy = this->send_strategy_;
-  }
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
   if (!strategy.is_nil()) {
     return strategy->remove_sample(sample);
@@ -215,12 +195,7 @@ DataLink::remove_all_msgs(const RepoId& pub_id)
   // This one is easy.  Simply delegate to our TransportSendStrategy
   // data member.
 
-  TransportSendStrategy_rch strategy;
-  {
-    GuardType guard(this->strategy_lock_);
-
-    strategy = this->send_strategy_;
-  }
+  TransportSendStrategy_rch strategy = get_send_strategy();
 
   if (!strategy.is_nil()) {
     strategy->remove_all_msgs(pub_id);
@@ -304,7 +279,10 @@ ACE_INLINE
 void
 DataLink::terminate_send()
 {
-  this->send_strategy_->terminate_send(false);
+  TransportSendStrategy_rch strategy = get_send_strategy();
+  if (strategy) {
+    strategy->terminate_send(false);
+  }
 }
 
 ACE_INLINE
@@ -390,6 +368,14 @@ ACE_INLINE
 void
 DataLink::send_final_acks (const RepoId& /*readerid*/)
 {
+}
+
+ACE_INLINE
+TransportSendStrategy_rch
+DataLink::get_send_strategy()
+{
+  GuardType guard(strategy_lock_);
+  return send_strategy_;
 }
 
 }

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -885,6 +885,7 @@ TransportSendStrategy::stop()
                    ACE_TEXT("terminating with %d unsent bytes.\n"),
                    size));
       }
+      pkt_chain_ = 0;
     }
 
     if (elems_.size()) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1262,6 +1262,8 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
 #endif
 
   if (stopping_) {
+    g.release();
+    element->data_dropped(true);
     return 0;
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1164,6 +1164,8 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
 
   RtpsUdpDataLink_rch link = link_.lock();
   if (stopping_ || !link) {
+    g.release();
+    element->data_dropped(true);
     return 0;
   }
 

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -97,6 +97,11 @@ OpenDDS::DCPS::TcpDataLink::client_stop(const RepoId& local_id)
 {
   ACE_Guard<ACE_Thread_Mutex> guard(stopped_clients_mutex_);
   stopped_clients_.insert(local_id);
+
+  TcpSendStrategy_rch strategy = send_strategy();
+  if (strategy) { 
+    strategy->remove_all_msgs(local_id);
+  }
 }
 
 void

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -99,7 +99,7 @@ OpenDDS::DCPS::TcpDataLink::client_stop(const RepoId& local_id)
   stopped_clients_.insert(local_id);
 
   TcpSendStrategy_rch strategy = send_strategy();
-  if (strategy) { 
+  if (strategy) {
     strategy->remove_all_msgs(local_id);
   }
 }

--- a/dds/DCPS/transport/tcp/TcpDataLink.h
+++ b/dds/DCPS/transport/tcp/TcpDataLink.h
@@ -51,6 +51,10 @@ public:
 
   TcpConnection_rch get_connection();
 
+  bool check_active_client(const RepoId& local_id);
+
+  void client_stop(const RepoId& local_id);
+
   virtual void pre_stop_i();
 
   /// Set release pending flag.
@@ -84,6 +88,9 @@ protected:
   /// handling a shutdown() call.
   virtual void stop_i();
 
+  virtual void send_i(TransportQueueElement* element, bool relink = true);
+  virtual void send_stop_i(RepoId repoId);
+
 private:
   bool handle_send_request_ack(TransportQueueElement* element);
   void send_graceful_disconnect_message();
@@ -100,6 +107,9 @@ private:
   typedef OPENDDS_VECTOR(TransportQueueElement*) PendingRequestAcks;
   ACE_SYNCH_MUTEX pending_request_acks_lock_;
   PendingRequestAcks pending_request_acks_;
+  typedef OPENDDS_SET_CMP(RepoId, GUID_tKeyLessThan) RepoIdSetType;
+  RepoIdSetType stopped_clients_;
+  mutable ACE_Thread_Mutex stopped_clients_mutex_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -389,6 +389,10 @@ TcpTransport::client_stop(const RepoId& local_id)
   for (AddrLinkMap::ITERATOR itr(links_); itr.next(entry); itr.advance()) {
     entry->int_id_->client_stop(local_id);
   }
+
+  for (AddrLinkMap::ITERATOR itr(pending_release_links_); itr.next(entry); itr.advance()) {
+    entry->int_id_->client_stop(local_id);
+  }
 }
 
 void

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -379,6 +379,17 @@ TcpTransport::configure_i(TcpInst& config)
   return true;
 }
 
+void
+TcpTransport::client_stop(const RepoId& local_id)
+{
+  GuardType guard(links_lock_);
+
+  AddrLinkMap::ENTRY* entry;
+
+  for (AddrLinkMap::ITERATOR itr(links_); itr.next(entry); itr.advance()) {
+    entry->int_id_->client_stop(local_id);
+  }
+}
 
 void
 TcpTransport::shutdown_i()

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -73,6 +73,8 @@ private:
 
   virtual bool configure_i(TcpInst& config);
 
+  virtual void client_stop(const RepoId& local_id);
+
   virtual void shutdown_i();
 
   virtual bool connection_info_i(TransportLocator& local_info, ConnectionInfoFlags flags) const;

--- a/tests/DCPS/EntityLifecycleStress/publisher.cpp
+++ b/tests/DCPS/EntityLifecycleStress/publisher.cpp
@@ -112,7 +112,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     const ACE_Time_Value delay(0, 10000);
 
-    const size_t count = 250u;
+    const size_t count = 750u;
     for (size_t i = 0; i < count; ++i) {
       ACE_OS::sleep(delay);
       ++message.count;

--- a/tests/DCPS/EntityLifecycleStress/publisher.cpp
+++ b/tests/DCPS/EntityLifecycleStress/publisher.cpp
@@ -27,6 +27,11 @@ using namespace std;
 
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
+  sigset_t mask, prev;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGPIPE);
+  sigprocmask(SIG_BLOCK, &mask, &prev);
+
   try
   {
     DDS::DomainParticipantFactory_var dpf =

--- a/tests/DCPS/EntityLifecycleStress/publisher.cpp
+++ b/tests/DCPS/EntityLifecycleStress/publisher.cpp
@@ -28,9 +28,9 @@ using namespace std;
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
   sigset_t mask, prev;
-  sigemptyset(&mask);
-  sigaddset(&mask, SIGPIPE);
-  sigprocmask(SIG_BLOCK, &mask, &prev);
+  ACE_OS::sigemptyset(&mask);
+  ACE_OS::sigaddset(&mask, SIGPIPE);
+  ACE_OS::sigprocmask(SIG_BLOCK, &mask, &prev);
 
   try
   {

--- a/tests/DCPS/EntityLifecycleStress/rtps_disc.ini
+++ b/tests/DCPS/EntityLifecycleStress/rtps_disc.ini
@@ -9,9 +9,7 @@ DiscoveryConfig=uni_rtps
 InteropMulticastOverride=239.255.1.0
 SedpMulticast=1
 ResendPeriod=2
-TTL=8
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp
-TTL=8
 multicast_group_address=239.255.2.0

--- a/tests/DCPS/EntityLifecycleStress/subscriber.cpp
+++ b/tests/DCPS/EntityLifecycleStress/subscriber.cpp
@@ -192,7 +192,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       exit(1);
     }
 
-    const OpenDDS::DCPS::MonotonicTimePoint deadline = OpenDDS::DCPS::MonotonicTimePoint::now() + OpenDDS::DCPS::TimeDuration(2, 500000);
+    const OpenDDS::DCPS::MonotonicTimePoint deadline = OpenDDS::DCPS::MonotonicTimePoint::now() + OpenDDS::DCPS::TimeDuration(7, 500000);
 
     drli->wait_valid_data(deadline);
 

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -241,7 +241,8 @@ tests/DCPS/RecorderLogging/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS
 
 examples/DCPS/Messenger_Imr/run_test.pl: !DCPS_MIN !MIN_CORBA !CORBA_E_COMPACT !CORBA_E_MICRO !DDS_NO_ORBSVCS !OPENDDS_SAFETY_PROFILE
 
-tests/DCPS/EntityLifecycleStress/run_test.pl publishers 5 subscribers 5: !OPENDDS_SAFETY_PROFILE
+tests/DCPS/EntityLifecycleStress/run_test.pl publishers 10 subscribers 10: !OPENDDS_SAFETY_PROFILE
+tests/DCPS/EntityLifecycleStress/run_test.pl rtps publishers 10 subscribers 10: RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/EntityLifecycleStress/run_test.pl rtps_disc publishers 10 subscribers 10: RTPS
 tests/DCPS/EntityLifecycleStress/run_test.pl rtps_disc_tcp publishers 10 subscribers 10: RTPS !OPENDDS_SAFETY_PROFILE
 


### PR DESCRIPTION
RTPS Discovery is too slow to reliably discover in 2.5 seconds, even for small numbers of processes. Increase timeouts to actually exercise discovery, increase dcps tests to match tsan tests.