### PR TITLE
Improve Nan usage in V8 generator

### DIFF
--- a/dds/idl/v8_generator.cpp
+++ b/dds/idl/v8_generator.cpp
@@ -39,6 +39,7 @@ namespace {
     if (cls & CL_PRIMITIVE) {
       AST_Type* actual = resolveActualType(type);
       AST_PredefinedType* p = dynamic_cast<AST_PredefinedType*>(actual);
+      OPENDDS_ASSERT(p);
       if (pt) *pt = p->pt();
       switch (p->pt()) {
       case AST_PredefinedType::PT_char:
@@ -144,6 +145,7 @@ namespace {
     } else if ((cls & CL_SEQUENCE) && builtInSeq(type)) {
       AST_Type* real_type = resolveActualType(type);
       AST_Sequence* seq = dynamic_cast<AST_Sequence*>(real_type);
+      OPENDDS_ASSERT(seq);
       AST_Type* elem = seq->base_type();
       strm <<
         "  {\n"
@@ -300,6 +302,7 @@ namespace {
     } else if ((cls & CL_SEQUENCE) && builtInSeq(type)) {
       AST_Type* real_type = resolveActualType(type);
       AST_Sequence* seq = dynamic_cast<AST_Sequence*>(real_type);
+      OPENDDS_ASSERT(seq);
       AST_Type* elem = seq->base_type();
       if (prop_index) {
         strm <<
@@ -491,6 +494,7 @@ bool v8_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
   case AST_Decl::NT_sequence: {
     NamespaceGuard ng;
     AST_Sequence* seq = dynamic_cast<AST_Sequence*>(type);
+    OPENDDS_ASSERT(seq);
     const std::string cxx = scoped(name);
     AST_Type* elem = seq->base_type();
     {
@@ -528,6 +532,7 @@ bool v8_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
   case AST_Decl::NT_array: {
     NamespaceGuard ng;
     AST_Array* array = dynamic_cast<AST_Array*>(type);
+    OPENDDS_ASSERT(array);
     const std::string cxx = scoped(name);
     AST_Type* elem = array->base_type();
     {


### PR DESCRIPTION
Problem: The v8_generator for opendds_idl neglects to use Nan in a number of places, causing build issues for other V8 versions.

Solution: Use Nan when possible to avoid version-lock