### PR TITLE
XTypes Dynamic: Fix Warnings, Cleanup Code, Improve `dynamic-data-monitor`

### DIFF
--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -233,8 +233,7 @@ void RecorderImpl::data_received(const ReceivedDataSample& sample)
       Encoding enc;
       Serializer ser(sample.sample_.get(), enc);
       EncapsulationHeader encap;
-      if (ser >> encap) {
-        encap.to_encoding(enc, EXTENSIBILITY_ANY);
+      if (ser >> encap && encap.to_any_encoding(enc)) {
         kind = enc.kind();
       }
     }

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -1,11 +1,9 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
-#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+#include <DCPS/DdsDcps_pch.h> // Only the _pch include should start with DCPS/
 
 #include "RecorderImpl.h"
 
@@ -114,11 +112,11 @@ RecorderImpl::cleanup()
   if (!disco->remove_subscription(this->domain_id_,
                                   participant_servant_->get_id(),
                                   this->subscription_id_)) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: ")
-                      ACE_TEXT("RecorderImpl::cleanup: ")
-                      ACE_TEXT(" could not remove subscription from discovery.\n")),
-                     DDS::RETCODE_ERROR);
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RecorderImpl::cleanup: "
+        "could not remove subscription from discovery\n"));
+    }
+    return DDS::RETCODE_ERROR;
   }
 
   // Call remove association before unregistering the datareader from the transport,
@@ -154,11 +152,8 @@ void RecorderImpl::init(
   DomainParticipantImpl*     participant,
   DDS::SubscriberQos         subqos)
 {
-  //
-  if (DCPS_debug_level >= 1) {
-
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) RecorderImpl::init\n")));
+  if (DCPS_debug_level >= 2) {
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) RecorderImpl::init\n"));
   }
 
 
@@ -218,10 +213,10 @@ void RecorderImpl::data_received(const ReceivedDataSample& sample)
   // or statuses related to samples.
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->sample_lock_);
 
-  if (DCPS_debug_level > 9) {
+  if (DCPS_debug_level >= 8) {
     ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) RecorderImpl::data_received: ")
-               ACE_TEXT("%C received sample: %C.\n"),
+               "(%P|%t) RecorderImpl::data_received: "
+               "%C received sample: %C\n",
                LogGuid(subscription_id_).c_str(),
                to_string(sample.header_).c_str()));
   }
@@ -271,14 +266,9 @@ RecorderImpl::add_association(const RepoId&            yourId,
                               const WriterAssociation& writer,
                               bool                     active)
 {
-    ACE_DEBUG((LM_DEBUG, "RecorderImpl::add_association\n"));
-  //
-  // The following block is for diagnostic purposes only.
-  //
-  if (DCPS_debug_level >= 1) {
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) RecorderImpl::add_association - ")
-               ACE_TEXT("bit %d local %C remote %C\n"),
+  if (DCPS_debug_level >= 4) {
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) RecorderImpl::add_association: "
+               "bit %d local %C remote %C\n",
                is_bit_,
                LogGuid(yourId).c_str(),
                LogGuid(writer.writerId).c_str()));
@@ -377,10 +367,9 @@ RecorderImpl::add_association(const RepoId&            yourId,
       (writer.writerQos.durability.kind > DDS::VOLATILE_DURABILITY_QOS);
 
     if (!this->associate(data, active)) {
-      if (DCPS_debug_level) {
-        ACE_ERROR((LM_ERROR,
-                   ACE_TEXT("(%P|%t) RecorderImpl::add_association: ")
-                   ACE_TEXT("ERROR: transport layer failed to associate.\n")));
+      if (log) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RecorderImpl::add_association: ")
+                   "transport layer failed to associate\n"));
       }
       return;
     }
@@ -437,16 +426,18 @@ RecorderImpl::add_association(const RepoId&            yourId,
   XTypes::TypeLookupService_rch tls = participant_servant_->get_type_lookup_service();
   XTypes::TypeInformation type_info;
   if (!XTypes::deserialize_type_info(type_info, writer.serializedTypeInfo)) {
-    ACE_ERROR((LM_ERROR,
-               "(%P|%t) RecorderImpl::add_association:"
-               " Failed to deserialize TypeInformation\n"));
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) ERROR: RecorderImpl::add_association: "
+                 "Failed to deserialize TypeInformation\n"));
+    }
     return;
   }
   XTypes::TypeObject cto = tls->get_type_object(type_info.complete.typeid_with_size.type_id);
   XTypes::DynamicType_rch dt = tls->complete_to_dynamic(cto.complete, writer.writerId);
   if (DCPS_debug_level >= 4) {
     ACE_DEBUG((LM_DEBUG,
-               "(%P|%t) RecorderImpl::add_association:"
+               "(%P|%t) RecorderImpl::add_association: "
                "DynamicType added to map with guid: %C\n", LogGuid(writer.writerId).c_str()));
   }
   dt_map_.insert(std::make_pair(writer.writerId, dt));
@@ -527,7 +518,7 @@ RecorderImpl::remove_associations(const WriterIdSeq& writers,
     return;
   }
 
-  if (DCPS_debug_level >= 1) {
+  if (DCPS_debug_level >= 4) {
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) RecorderImpl::remove_associations: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
@@ -590,7 +581,7 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
     return;
   }
 
-  if (DCPS_debug_level >= 1) {
+  if (DCPS_debug_level >= 4) {
     GuidConverter reader_converter(subscription_id_);
     GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
@@ -638,7 +629,7 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
       }
 
       if (this->writers_.erase(writer_id) == 0) {
-        if (DCPS_debug_level >= 1) {
+        if (DCPS_debug_level >= 4) {
           GuidConverter converter(writer_id);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) RecorderImpl::remove_associations_i: ")
@@ -872,10 +863,10 @@ DDS::ReturnCode_t RecorderImpl::set_qos(
           qos,
           subscriber_qos);
       if (!status) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) RecorderImpl::set_qos, ")
-                          ACE_TEXT("qos not updated.\n")),
-                         DDS::RETCODE_ERROR);
+        if (log_level >= LogLevel::Error) {
+          ACE_ERROR((LM_ERROR, "(%P|%t) RecorderImpl::set_qos: qos not updated\n",
+        }
+        return DDS::RETCODE_ERROR;
       }
     }
 
@@ -946,7 +937,7 @@ RecorderImpl::lookup_instance_handles(const WriterIdSeq&       ids,
 DDS::ReturnCode_t
 RecorderImpl::enable()
 {
-  if (DCPS_debug_level >= 1) {
+  if (DCPS_debug_level >= 2) {
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) RecorderImpl::enable\n")));
   }
@@ -964,16 +955,17 @@ RecorderImpl::enable()
 
   // if (topic_servant_ && !transport_disabled_) {
   if (topic_servant_) {
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) RecorderImpl::enable_transport\n")));
+    if (DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) RecorderImpl::enable: enable_transport\n"));
+    }
 
     try {
       this->enable_transport(this->qos_.reliability.kind == DDS::RELIABLE_RELIABILITY_QOS,
                              this->qos_.durability.kind > DDS::VOLATILE_DURABILITY_QOS);
     } catch (const Transport::Exception&) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: RecorderImpl::enable, ")
-                 ACE_TEXT("Transport Exception.\n")));
+      if (log_level >= LogLevel::Error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RecorderImpl::enable: Transport Exception\n"));
+      }
       return DDS::RETCODE_ERROR;
     }
 
@@ -986,8 +978,9 @@ RecorderImpl::enable()
     Discovery_rch disco =
       TheServiceParticipant->get_discovery(this->domain_id_);
 
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) RecorderImpl::add_subscription\n")));
+    if (DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) RecorderImpl::enable: add_subscription\n"));
+    }
 
     XTypes::TypeInformation type_info;
 
@@ -1005,9 +998,10 @@ RecorderImpl::enable()
                               type_info);
 
     if (this->subscription_id_ == OpenDDS::DCPS::GUID_UNKNOWN) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: RecorderImpl::enable, ")
-                 ACE_TEXT("add_subscription returned invalid id.\n")));
+      if (log_level >= LogLevel::Error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RecorderImpl::enable: "
+          "add_subscription returned invalid id\n"));
+      }
       return DDS::RETCODE_ERROR;
     }
   }

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -153,6 +153,19 @@ bool EncapsulationHeader::from_encoding(
 bool EncapsulationHeader::to_encoding(
   Encoding& encoding, Extensibility expected_extensibility)
 {
+  return to_encoding_i(encoding, &expected_extensibility);
+}
+
+bool EncapsulationHeader::to_any_encoding(Encoding& encoding)
+{
+  return to_encoding_i(encoding, 0);
+}
+
+bool EncapsulationHeader::to_encoding_i(
+  Encoding& encoding, Extensibility* expected_extensibility_ptr)
+{
+  Extensibility expected_extensibility = expected_extensibility_ptr ?
+    *expected_extensibility_ptr : FINAL; // Placeholder, doesn't matter
   bool wrong_extensibility = true;
   switch (kind_) {
   case KIND_CDR_BE:
@@ -223,7 +236,7 @@ bool EncapsulationHeader::to_encoding(
     return false;
   }
 
-  if (wrong_extensibility && expected_extensibility != EXTENSIBILITY_ANY) {
+  if (expected_extensibility_ptr && wrong_extensibility) {
     if (DCPS_debug_level > 0) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR EncapsulationHeader::to_encoding: ")
         ACE_TEXT("Unexpected Extensibility Encoding: %C\n"),

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -69,8 +69,7 @@ String endianness_to_string(Endianness endianness);
 enum Extensibility {
   FINAL,
   APPENDABLE,
-  MUTABLE,
-  EXTENSIBILITY_ANY
+  MUTABLE
 };
 
 const size_t boolean_cdr_size = 1;
@@ -266,6 +265,11 @@ public:
    */
   bool to_encoding(Encoding& encoding, Extensibility expected_extensibility);
 
+  /**
+   * Like to_encoding, but without an expected extensibility.
+   */
+  bool to_any_encoding(Encoding& encoding);
+
   String to_string() const;
 
   static bool set_encapsulation_options(Message_Block_Ptr& mb);
@@ -275,6 +279,8 @@ private:
   Kind kind_;
   /// The last two bytes as a big endian integer
   ACE_CDR::UShort options_;
+
+  bool to_encoding_i(Encoding& encoding, Extensibility* expected_extensibility_ptr);
 };
 
 class Serializer;

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -87,7 +87,6 @@ StaticEndpointManager::StaticEndpointManager(const RepoId& participant_id,
 #endif
   , max_type_lookup_service_reply_period_(0)
   , type_lookup_service_sequence_number_(0)
-  , use_xtypes_(true)
   , use_xtypes_complete_(false)
 {
 #ifdef DDS_HAS_MINIMUM_BIT

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -513,7 +513,6 @@ private:
   RcHandle<StaticEndpointManagerSporadic> type_lookup_reply_deadline_processor_;
   TimeDuration max_type_lookup_service_reply_period_;
   SequenceNumber type_lookup_service_sequence_number_;
-  const bool use_xtypes_;
   bool use_xtypes_complete_;
 
   struct TypeIdOrigSeqNumber {

--- a/dds/DCPS/ValueHelper.h
+++ b/dds/DCPS/ValueHelper.h
@@ -13,6 +13,11 @@
 #include <iostream>
 #include <iomanip>
 
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
 template <typename IntType>
 std::ostream& signed_int_helper(std::ostream& o, IntType value, IntType min)
 {
@@ -39,8 +44,8 @@ inline ostream& operator<<(ostream& os, const ACE_CDR::LongDouble& val)
   os << ACE_CDR::LongDouble::NativeImpl(val);
   return os;
 }
-
 #endif
+
 inline
 std::ostream& hex_value(std::ostream& o, unsigned value, size_t bytes)
 {
@@ -100,12 +105,17 @@ std::ostream& char_helper(std::ostream& o, CharType value)
 }
 
 template <typename CharType>
-std::ostream& string_helper(std::ostream& o, CharType* value)
+std::ostream& string_helper(std::ostream& o, const CharType* value)
 {
   for (size_t i = 0; value[i] != 0; ++i) {
     char_helper<CharType>(o, value[i]);
   }
   return o;
 }
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #endif /* OPENDDS_DCPS_VALUE_HELPER_H */

--- a/dds/DCPS/XTypes/DynamicData.cpp
+++ b/dds/DCPS/XTypes/DynamicData.cpp
@@ -2604,7 +2604,7 @@ bool print_integral_value(DynamicData& dd, DCPS::String& type_string, DynamicTyp
       return false;
     }
     std::stringstream os;
-    char_helper<ACE_CDR::Char>(os, my_char);
+    DCPS::char_helper<ACE_CDR::Char>(os, my_char);
     type_string += " = '" + os.str() + "'\n";
     break;
   }
@@ -2618,7 +2618,7 @@ bool print_integral_value(DynamicData& dd, DCPS::String& type_string, DynamicTyp
       return false;
     }
     std::stringstream os;
-    char_helper<ACE_CDR::WChar>(os, my_wchar);
+    DCPS::char_helper<ACE_CDR::WChar>(os, my_wchar);
     type_string += " = L'" + os.str() + "'\n";
     break;
   }
@@ -2698,7 +2698,7 @@ bool print_dynamic_data(DynamicData& dd, DCPS::String& type_string, DCPS::String
       return false;
     }
     std::stringstream os;
-    string_helper(os, my_string.inout());
+    DCPS::string_helper(os, my_string.inout());
     type_string += DCPS::String(" = \"") + os.str() + "\"\n";
     break;
   }
@@ -2712,7 +2712,7 @@ bool print_dynamic_data(DynamicData& dd, DCPS::String& type_string, DCPS::String
       return false;
     }
     std::stringstream os;
-    string_helper(os, my_wstring.inout());
+    DCPS::string_helper(os, my_wstring.inout());
     type_string += " = L\"" + os.str() + "\"\n";
     break;
   }

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -597,7 +597,8 @@ inline
 std::ostream& operator<<(std::ostream& o,
                          const AST_Expression::AST_ExprValue& ev)
 {
-  OpenDDS::DCPS::RestoreOutputStreamState ross(o);
+  using namespace OpenDDS::DCPS;
+  RestoreOutputStreamState ross(o);
   switch (ev.et) {
   case AST_Expression::EV_octet:
     return hex_value(o << "0x", static_cast<int>(ev.u.oval), 1);

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -632,6 +632,7 @@ operator<<(std::ostream& out, const OpenDDS::XTypes::NameHash& name_hash)
 std::ostream&
 operator<<(std::ostream& out, const OpenDDS::XTypes::AnnotationParameterValue& param_value)
 {
+  using namespace OpenDDS::DCPS;
   out << "XTypes::AnnotationParameterValue(";
   switch (param_value.kind) {
   case OpenDDS::XTypes::TK_BOOLEAN:

--- a/tests/DCPS/DynamicTypes/Pub/XTypesDynamicPub.cpp
+++ b/tests/DCPS/DynamicTypes/Pub/XTypesDynamicPub.cpp
@@ -103,8 +103,16 @@ void outer_union_narrow_write(DataWriter_var dw)
 
 int ACE_TMAIN(int argc, ACE_TCHAR * argv[])
 {
-  const ACE_TCHAR* type_name = argv[1];
   DomainParticipantFactory_var dpf = TheParticipantFactoryWithArgs(argc, argv);
+  const ACE_TCHAR* type_name = argv[1];
+  if (argc < 2) {
+    ACE_ERROR((LM_ERROR, "ERROR: Must pass type name\n"));
+    return 1;
+  } else if (argc > 3) {
+    ACE_ERROR((LM_ERROR, "ERROR: Too many arguments\n"));
+    return 1;
+  }
+
   DomainParticipant_var dp =
     dpf->create_participant(153,
                             PARTICIPANT_QOS_DEFAULT,
@@ -126,6 +134,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR * argv[])
     ts_var = new Dynamic::inner_unionTypeSupportImpl;
   } else if (!ACE_OS::strcmp(type_name, ACE_TEXT("outer_union"))) {
     ts_var = new Dynamic::outer_unionTypeSupportImpl;
+  } else {
+    ACE_ERROR((LM_ERROR, "ERROR: Invalid type name: \"%s\"\n", type_name));
+    return 1;
   }
   ts_var->register_type(dp, ACE_TEXT_ALWAYS_CHAR(type_name));
 

--- a/tools/dynamicdatamonitor/DynamicDataMonitor.cpp
+++ b/tools/dynamicdatamonitor/DynamicDataMonitor.cpp
@@ -9,55 +9,206 @@
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/XTypes/DynamicData.h>
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/framework/TransportRegistry.h>
+#include <dds/DCPS/transport/framework/TransportConfig.h>
+#include <dds/DCPS/transport/framework/TransportInst.h>
 #if defined ACE_AS_STATIC_LIBS && !defined OPENDDS_SAFETY_PROFILE
 #  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #endif
 
-#include <ace/Arg_Shifter.h>
-#include <ace/Semaphore.h>
-#include <ace/Thread_Semaphore.h>
-
 #include <iostream>
 #include <sstream>
 
 using namespace OpenDDS::DCPS;
+using namespace OpenDDS::RTPS;
 
-long num_samples = 0;
-long num_seconds = 0;
-// parse the command line arguments
-int parse_args (int& argc, ACE_TCHAR* argv[])
+typedef std::vector<std::string> Args;
+typedef Args::iterator ArgsIt;
+typedef std::pair<bool, ArgsIt> AfterOpt;
+
+AfterOpt get_option(Args& args, const std::string& opt)
 {
-  u_long mask =  ACE_LOG_MSG->priority_mask(ACE_Log_Msg::PROCESS);
-  ACE_LOG_MSG->priority_mask(mask | LM_TRACE | LM_DEBUG, ACE_Log_Msg::PROCESS);
-  ACE_Arg_Shifter arg_shifter(argc, argv);
-
-  while (arg_shifter.is_anything_left()) {
-    // options:
-    //  -samples num_samples       defaults to infinite
-    //  -time num_seconds          defaults to infinite
-
-    const ACE_TCHAR* currentArg = 0;
-
-    if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("--samples"))) != 0) {
-      num_samples = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("--time"))) != 0) {
-      num_seconds = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-    } else {
-      arg_shifter.ignore_arg();
+  for (ArgsIt args_it = args.begin(); args_it != args.end(); ++args_it) {
+    if (*args_it == "--") {
+      // Remaining arguments should be interpreted as positional arguments
+      return AfterOpt(false, args.end());
+    }
+    if (opt.length() <= args_it->length()) {
+      const bool starts_with = args_it->substr(0, opt.length()) == opt;
+      const bool same_size = args_it->length() == opt.length();
+      if (starts_with && !same_size && args_it->at(opt.length()) == '=') {
+        // Form is OPT=VALUE, replace current with VALUE
+        *args_it = args_it->substr(opt.length() + 1);
+        return AfterOpt(true, args_it);
+      } else if (same_size && starts_with) {
+        // Form is OPT VALUE?, return next argument
+        return AfterOpt(true, args.erase(args_it));
+      }
     }
   }
-  // Indicates successful parsing of the command line
+  return AfterOpt(false, args.end());
+}
+
+bool has_option(Args& args, const std::string& opt)
+{
+  return get_option(args, opt).first;
+}
+
+std::string get_option_argument(Args& args, AfterOpt& after_opt, const std::string& opt)
+{
+  ArgsIt& args_it = after_opt.second;
+  if (args_it == args.end()) {
+    std::cerr << "ERROR: Option " << opt << " requires an argument" << std::endl;
+    throw 1;
+  }
+  const std::string value = *args_it;
+  args_it = args.erase(args_it);
+  return value;
+}
+
+unsigned get_option_argument_uint(Args& args, AfterOpt& after_opt, const std::string& opt)
+{
+  unsigned value;
+  try {
+    value = static_cast<unsigned>(std::stoul(get_option_argument(args, after_opt, opt)));
+  } catch (const std::exception&) {
+    std::cerr << "ERROR: Option " << opt
+      << " requires an argument that's a valid positive number" << std::endl;
+    throw 1;
+  }
+  return value;
+}
+
+void check_for_unknown_options(Args& args)
+{
+  for (ArgsIt args_it = args.begin(); args_it != args.end(); ++args_it) {
+    if (*args_it == "--") {
+      // Remaining arguments should be interpreted as positional arguments
+      return;
+    }
+    if (args_it->length() && args_it->at(0) == '-') {
+      std::cerr << "ERROR: Option " << *args_it << " is invalid" << std::endl;
+      throw 1;
+    }
+  }
+}
+
+unsigned get_pos_argument_uint(Args& args, size_t pos, const std::string& what)
+{
+  unsigned value;
+  try {
+    value = static_cast<unsigned>(std::stoul(args[pos]));
+  } catch (const std::exception&) {
+    std::cerr << "ERROR: positional argument " << what
+      << " should be a valid positive number" << std::endl;
+    throw 1;
+  }
+  return value;
+}
+
+std::string prog_name;
+
+std::string topic_name;
+std::string type_name;
+DDS::DomainId_t domainid = 0;
+unsigned num_samples = 0;
+unsigned num_seconds = 0;
+bool help = false;
+bool writer_count = false;
+
+void print_usage(bool for_error = false)
+{
+  std::ostream& os = for_error ? std::cout : std::cerr;
+  os <<
+    "usage: " << prog_name << " [OPTIONS] TOPIC_NAME TYPE_NAME DOMAIN_ID\n"
+    "usage: " << prog_name << " [--help|-h]\n";
+  if (for_error) {
+    os << "See -h for more details\n";
+  }
+}
+
+void print_help()
+{
+  print_usage();
+  std::cout <<
+    "\n"
+    "Print samples written to the given topic when the remotes support DDS XTypes\n"
+    "complete TypeObjects.\n"
+    "\n"
+    "Positional Arguments:\n"
+    "  TOPIC_NAME              The name of the topic to listen for.\n"
+    "  TYPE_NAME               The full name (including any modules) of the topic\n"
+    "                          type.\n"
+    "  DOMAIN_ID               The DDS Domain to participant in.\n"
+    "\n"
+    "Options\n"
+    "  -h | --help             Displays this message.\n"
+    "  -w | --writer-count     Print number of associated writers when they change.\n"
+    "                          Default is not to.\n"
+    "  --samples COUNT         Wait for at least this number of samples and exit.\n"
+    "                          May actually print more. Default is to print samples\n"
+    "                          forever.\n"
+    "  --time SECONDS          Print samples for an ammount of seconds and exit.\n"
+    "                          Default to print samples forever.\n";
+}
+
+// parse the command line arguments
+int parse_args(int argc, ACE_TCHAR* argv[])
+{
+  unsigned long mask = ACE_LOG_MSG->priority_mask(ACE_Log_Msg::PROCESS);
+  ACE_LOG_MSG->priority_mask(mask | LM_TRACE | LM_DEBUG, ACE_Log_Msg::PROCESS);
+
+  prog_name = ACE_TEXT_ALWAYS_CHAR(argv[0]);
+  std::vector<std::string> args;
+  for (int i = 1; i < argc; ++i) {
+    args.push_back(ACE_TEXT_ALWAYS_CHAR(argv[i]));
+  }
+
+  try {
+    // Parse options
+    if (has_option(args, "-h") || has_option(args, "--help")) {
+      print_help();
+      std::exit(0);
+    }
+    writer_count = has_option(args, "-w") || has_option(args, "--writer-count");
+    {
+      const std::string opt = "--samples";
+      AfterOpt after_opt = get_option(args, opt);
+      if (after_opt.first) {
+        num_samples = get_option_argument_uint(args, after_opt, opt);
+      }
+    }
+    {
+      const std::string opt = "--time";
+      AfterOpt after_opt = get_option(args, opt);
+      if (after_opt.first) {
+        num_seconds = get_option_argument_uint(args, after_opt, opt);
+      }
+    }
+    check_for_unknown_options(args);
+
+    // Parse positional arguments
+    if (args.size() != 3) {
+      std::cerr << "ERROR: incorrect number of arguments: expected 3, received " << args.size() << "\n";
+      throw 1;
+    }
+    topic_name = args[0];
+    type_name = args[1];
+    domainid = get_pos_argument_uint(args, 2, "DOMAIN_ID");
+  } catch(int value) {
+    print_usage(true);
+    return value;
+  }
+
   return 0;
 }
 
-class TestRecorderListener : public RecorderListener {
+class RecorderListenerImpl : public RecorderListener {
 public:
-  explicit TestRecorderListener(DDS::GuardCondition_var gc)
-    : sem_(0)
-    , sample_count_(0)
+  explicit RecorderListenerImpl(DDS::GuardCondition_var gc)
+    : sample_count_(0)
     , gc_(gc)
   {
   }
@@ -69,7 +220,7 @@ public:
     String my_type;
     String indent;
     if (!OpenDDS::XTypes::print_dynamic_data(dd, my_type, indent)) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: TestRecorderListener::on_sample_data_received: "
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RecorderListenerImpl::on_sample_data_received: "
         "Failed to read dynamic data\n"));
     }
     std::cout << my_type;
@@ -82,56 +233,45 @@ public:
   virtual void on_recorder_matched(Recorder*,
                                    const ::DDS::SubscriptionMatchedStatus& status)
   {
-    if (status.current_count == 1 && DCPS_debug_level >= 4) {
-        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TestRecorderListener::on_recorder_matched:"
-          " a writer connected to recorder\n")));
-    } else if (status.current_count == 0 && status.total_count > 0) {
-      if (DCPS_debug_level >= 4) {
-        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TestRecorderListener::on_recorder_matched:"
-          " a writer disconnected with recorder\n")));
-      }
-      sem_.release();
+    if (writer_count) {
+      std::cout << "Listening to " << status.current_count << " writer(s)\n";
     }
   }
 
-  int wait(const ACE_Time_Value& tv)
-  {
-    ACE_Time_Value timeout = ACE_OS::gettimeofday() + tv;
-    return sem_.acquire(timeout);
-  }
-
-  long sample_count() const
+  unsigned sample_count() const
   {
     return sample_count_;
   }
+
 private:
-  ACE_Thread_Semaphore sem_;
-  long sample_count_;
+  unsigned sample_count_;
   DDS::GuardCondition_var gc_;
 };
 
-
-int run_test(int argc, ACE_TCHAR* argv[])
+int run(int argc, ACE_TCHAR* argv[])
 {
   int ret_val = 0;
   try {
+    TransportConfig_rch transport_config =
+      TheTransportRegistry->create_config("default_rtps_transport_config");
+    TransportInst_rch transport_inst =
+      TheTransportRegistry->create_inst("default_rtps_transport", "rtps_udp");
+    transport_config->instances_.push_back(transport_inst);
+    TheTransportRegistry->global_config(transport_config);
+
     DDS::DomainParticipantFactory_var dpf =
       TheParticipantFactoryWithArgs(argc, argv);
-    parse_args(argc, argv);
-    if (argc != 4) {
-      if (log_level >= LogLevel::Error) {
-        ACE_ERROR((LM_ERROR,
-                   "(%P|%t) ERROR: main():"
-                   " dynamic-data-monitor was passed an incorrect number of arguments:"
-                   " expected 3, received %d\n"
-                   "Format should be ./dynamic-data-monitor [topic name] [type name] [domain id]\n", argc-1));
-      }
-      return 1;
+    ret_val = parse_args(argc, argv);
+    if (ret_val) {
+      return ret_val;
     }
-    const ACE_TCHAR* topic_name = argv[1];
-    const ACE_TCHAR* type_name = argv[2];
-    DDS::DomainId_t domainid = ACE_OS::atoi(argv[3]);
-    Service_Participant* service = TheServiceParticipant;
+
+    OpenDDS::RTPS::RtpsDiscovery_rch disc =
+      make_rch<OpenDDS::RTPS::RtpsDiscovery>("rtps_disc");
+    disc->use_xtypes(OpenDDS::RTPS::RtpsDiscoveryConfig::XTYPES_COMPLETE);
+    Service_Participant* const service = TheServiceParticipant;
+    service->add_discovery(static_rchandle_cast<Discovery>(disc));
+    service->set_repo_domain(domainid, disc->key());
 
     // Create DomainParticipant
     DDS::DomainParticipant_var participant =
@@ -153,8 +293,8 @@ int run_test(int argc, ACE_TCHAR* argv[])
     {
       DDS::Topic_var topic =
         service->create_typeless_topic(participant,
-                                       ACE_TEXT_ALWAYS_CHAR(topic_name),
-                                       ACE_TEXT_ALWAYS_CHAR(type_name),
+                                       topic_name.c_str(),
+                                       type_name.c_str(),
                                        true,
                                        TOPIC_QOS_DEFAULT,
                                        0,
@@ -167,7 +307,7 @@ int run_test(int argc, ACE_TCHAR* argv[])
         return 1;
       }
 
-      RcHandle<TestRecorderListener> recorder_listener = make_rch<TestRecorderListener>(gc);
+      RcHandle<RecorderListenerImpl> recorder_listener = make_rch<RecorderListenerImpl>(gc);
 
       DDS::SubscriberQos sub_qos;
       participant->get_default_subscriber_qos(sub_qos);
@@ -176,6 +316,7 @@ int run_test(int argc, ACE_TCHAR* argv[])
       dr_qos.representation.value.length(1);
       dr_qos.representation.value[0] = DDS::XCDR2_DATA_REPRESENTATION;
       dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
       // Create Recorder
       Recorder_var recorder =
         service->create_recorder(participant,
@@ -183,13 +324,13 @@ int run_test(int argc, ACE_TCHAR* argv[])
                                  sub_qos,
                                  dr_qos,
                                  recorder_listener);
-
       if (!recorder.in()) {
         if (log_level >= LogLevel::Error) {
           ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: main(): create_recorder failed!\n"));
         }
         return 1;
       }
+
       DDS::Duration_t timeout = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
       if (num_seconds > 0) {
         timeout.sec = num_seconds;
@@ -203,6 +344,7 @@ int run_test(int argc, ACE_TCHAR* argv[])
         }
         return 1;
       }
+
       ws->detach_condition(gc);
       service->delete_recorder(recorder);
     }
@@ -224,7 +366,9 @@ int run_test(int argc, ACE_TCHAR* argv[])
 
 int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
-  int ret = run_test(argc, argv);
-  ACE_Thread_Manager::instance()->wait();
+  int ret = run(argc, argv);
+  if (!ret) {
+    ACE_Thread_Manager::instance()->wait();
+  }
   return ret;
 }

--- a/tools/dynamicdatamonitor/DynamicDataMonitor.mpc
+++ b/tools/dynamicdatamonitor/DynamicDataMonitor.mpc
@@ -1,6 +1,7 @@
-project(Dynamic_Data_Monitor): dcps_rtps_udp {
-  requires += no_opendds_safety_profile
+project(Dynamic_Data_Monitor): dcps_rtps_udp, install {
   exename = dynamic-data-monitor
+  exeout = $(DDS_ROOT)/bin
+  requires += no_opendds_safety_profile
 
   Source_Files {
     DynamicDataMonitor.cpp


### PR DESCRIPTION
- Fix warnings from `use_xtypes_` and `ANY_EXTENSIBILITY`.
- Add namespaces to `ValueHelper.h`.
- Make logging in `RecorderImpl.cpp` align to guidelines, most significantly three unconditional debug logging points.
- Check for invalid arguments in the DynamicTypes test publisher.
- Several improvements to `dynamic-data-monitor`:
  - Cleaned up unused code.
  - Setup RTPS programmatically, so an ini file isn't always required.
  - Put `dynamic-data-monitor` in `$DDS_ROOT/bin`.
  - Improved argument parsing:
    - Replaced `ACE_Arg_Shifter` with a more systematic approach with stricter checks loosely based on argument parsing in the bench 2 programs.
    - Added a `--help` message.
    - Added a `--writer-count` option to display the number of writers when they associate and disassociate.