### PR TITLE
RtpsRelay statistics contain total count for publishers

### DIFF
--- a/tools/rtpsrelay/RelayAddressListener.cpp
+++ b/tools/rtpsrelay/RelayAddressListener.cpp
@@ -60,7 +60,7 @@ void RelayAddressListener::on_subscription_matched(
   DDS::DataReader_ptr /*reader*/, const DDS::SubscriptionMatchedStatus& status)
 {
   relay_statistics_reporter_.relay_address_pub_count(
-    static_cast<uint32_t>(status.total_count), OpenDDS::DCPS::MonotonicTimePoint::now());
+    static_cast<uint32_t>(status.current_count), OpenDDS::DCPS::MonotonicTimePoint::now());
 }
 
 

--- a/tools/rtpsrelay/RelayPartitionsListener.cpp
+++ b/tools/rtpsrelay/RelayPartitionsListener.cpp
@@ -59,7 +59,7 @@ void RelayPartitionsListener::on_subscription_matched(
   DDS::DataReader_ptr /*reader*/, const DDS::SubscriptionMatchedStatus& status)
 {
   relay_statistics_reporter_.relay_partitions_pub_count(
-    static_cast<uint32_t>(status.total_count), OpenDDS::DCPS::MonotonicTimePoint::now());
+    static_cast<uint32_t>(status.current_count), OpenDDS::DCPS::MonotonicTimePoint::now());
 }
 
 }

--- a/tools/rtpsrelay/SpdpReplayListener.cpp
+++ b/tools/rtpsrelay/SpdpReplayListener.cpp
@@ -43,7 +43,7 @@ void SpdpReplayListener::on_subscription_matched(
   DDS::DataReader_ptr /*reader*/, const DDS::SubscriptionMatchedStatus& status)
 {
   relay_statistics_reporter_.spdp_replay_pub_count(
-    static_cast<uint32_t>(status.total_count), OpenDDS::DCPS::MonotonicTimePoint::now());
+    static_cast<uint32_t>(status.current_count), OpenDDS::DCPS::MonotonicTimePoint::now());
 }
 
 }


### PR DESCRIPTION
Problem
-------

The relay statistics for the RtpsRelay report the total publisher
count for various topics.  This is not useful for measuring cluster
connectivity.

Solution
--------

Report the current count.