### PR TITLE
Update use of receive address in RtpsUdpDataLink::accumulate_addresses

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4598,13 +4598,15 @@ bool RtpsUdpDataLink::RemoteInfo::insert_recv_addr(AddrSet& aset) const
   if (last_recv_addr_ == ACE_INET_Addr()) {
     return false;
   }
-  for (AddrSet::iterator it = unicast_addrs_.begin(); it != unicast_addrs_.end(); ++it) {
-    if (it->get_type() == last_recv_addr_.get_type() &&
-        it->get_addr_size() == last_recv_addr_.get_addr_size() &&
-        std::memcmp(it->get_addr(), last_recv_addr_.get_addr(), it->get_addr_size()) == 0) {
-      aset.insert(last_recv_addr_);
-      return true;
-    }
+  ACE_INET_Addr recv_no_port(last_recv_addr_);
+  recv_no_port.set_port_number(0);
+  const AddrSet::iterator it = unicast_addrs_.lower_bound(recv_no_port);
+  if (it != unicast_addrs_.end() &&
+      it->get_type() == last_recv_addr_.get_type() &&
+      it->get_addr_size() == last_recv_addr_.get_addr_size() &&
+      std::memcmp(it->get_addr(), last_recv_addr_.get_addr(), it->get_addr_size()) == 0) {
+    aset.insert(last_recv_addr_);
+    return true;
   }
   return false;
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4593,11 +4593,26 @@ RtpsUdpDataLink::get_addresses_i(const RepoId& local) const {
   return retval;
 }
 
+bool RtpsUdpDataLink::RemoteInfo::insert_recv_addr(AddrSet& aset) const
+{
+  if (last_recv_addr_ == ACE_INET_Addr()) {
+    return false;
+  }
+  for (AddrSet::iterator it = unicast_addrs_.begin(); it != unicast_addrs_.end(); ++it) {
+    if (it->get_type() == last_recv_addr_.get_type() &&
+        it->get_addr_size() == last_recv_addr_.get_addr_size() &&
+        std::memcmp(it->get_addr(), last_recv_addr_.get_addr(), it->get_addr_size()) == 0) {
+      aset.insert(last_recv_addr_);
+      return true;
+    }
+  }
+  return false;
+}
+
 void
 RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
                                       AddrSet& addresses, bool prefer_unicast) const
 {
-  ACE_UNUSED_ARG(local);
   OPENDDS_ASSERT(local != GUID_UNKNOWN);
   OPENDDS_ASSERT(remote != GUID_UNKNOWN);
 
@@ -4624,8 +4639,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
 
   const RemoteInfoMap::const_iterator pos = locators_.find(remote);
   if (pos != locators_.end()) {
-    if (prefer_unicast && pos->second.last_recv_addr_ != NO_ADDR) {
-      normal_addrs.insert(pos->second.last_recv_addr_);
+    if (prefer_unicast && pos->second.insert_recv_addr(normal_addrs)) {
       normal_addrs_expires = pos->second.last_recv_time_ + config().receive_address_duration_;
       valid_last_recv_addr = (MonotonicTimePoint::now() - pos->second.last_recv_time_) <= config().receive_address_duration_;
     } else if (prefer_unicast && !pos->second.unicast_addrs_.empty()) {
@@ -4645,8 +4659,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
 #else
       normal_addrs = pos->second.multicast_addrs_;
 #endif
-    } else if (pos->second.last_recv_addr_ != NO_ADDR) {
-      normal_addrs.insert(pos->second.last_recv_addr_);
+    } else if (pos->second.insert_recv_addr(normal_addrs)) {
       normal_addrs_expires = pos->second.last_recv_time_ + config().receive_address_duration_;
       valid_last_recv_addr = (MonotonicTimePoint::now() - pos->second.last_recv_time_) <= config().receive_address_duration_;
     } else {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -276,6 +276,7 @@ private:
     ACE_INET_Addr last_recv_addr_;
     MonotonicTimePoint last_recv_time_;
     size_t ref_count_;
+    bool insert_recv_addr(AddrSet& aset) const;
   };
 
 #ifdef ACE_HAS_CPP11


### PR DESCRIPTION
The receive address may not be a valid locator since datagrams can be
sent from different addresses (other than those in the locator list).

This change makes it so that the receive address, without port number,
is used to find a matching locator.