### PR TITLE
Source IP check cannot be overridden

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -98,6 +98,7 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , sedp_responsive_mode_(false)
   , sedp_receive_preallocated_message_blocks_(0)
   , sedp_receive_preallocated_data_blocks_(0)
+  , check_source_ip_(true)
 {}
 
 RtpsDiscovery::RtpsDiscovery(const RepoKey& key)
@@ -835,6 +836,17 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                               "[rtps_discovery/%C] section.\n",
                               string_value.c_str(), rtps_name.c_str()), -1);
           }
+        } else if (name == "CheckSourceIp") {
+          const OPENDDS_STRING& value = it->second;
+          int smInt;
+          if (!DCPS::convertToInteger(value, smInt)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config ")
+                              ACE_TEXT("Invalid entry (%C) for CheckSourceIp in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->check_source_ip(bool(smInt));
         } else {
           ACE_ERROR_RETURN((LM_ERROR,
             ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -699,6 +699,15 @@ public:
     sedp_receive_preallocated_data_blocks_ = n;
   }
 
+  bool check_source_ip() const
+  {
+    return check_source_ip_;
+  }
+  void check_source_ip(bool flag)
+  {
+    check_source_ip_ = flag;
+  }
+
 private:
   mutable ACE_Thread_Mutex lock_;
   DCPS::TimeDuration resend_period_;
@@ -752,6 +761,7 @@ private:
   CORBA::ULong participant_flags_;
   ACE_Atomic_Op<ACE_Thread_Mutex, bool> sedp_responsive_mode_;
   size_t sedp_receive_preallocated_message_blocks_, sedp_receive_preallocated_data_blocks_;
+  bool check_source_ip_;
 };
 
 typedef OpenDDS::DCPS::RcHandle<RtpsDiscoveryConfig> RtpsDiscoveryConfig_rch;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1052,7 +1052,7 @@ Spdp::data_received(const DataSubmessage& data,
   const bool relay_in_use = (config_->rtps_relay_only() || config_->use_rtps_relay());
   const bool from_relay = relay_in_use && (from == config_->spdp_rtps_relay_address());
 
-  if (!from_relay && !ip_in_locator_list(from, pdata.participantProxy.metatrafficUnicastLocatorList) && !ip_in_AgentInfo(from, plist)) {
+  if (config_->check_source_ip() && !from_relay && !ip_in_locator_list(from, pdata.participantProxy.metatrafficUnicastLocatorList) && !ip_in_AgentInfo(from, plist)) {
     if (DCPS::DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) Spdp::data_received - dropped IP: %C\n"), DCPS::LogAddr(from).c_str()));
     }
@@ -1065,7 +1065,7 @@ Spdp::data_received(const DataSubmessage& data,
   const bool relay_in_use = (config_->rtps_relay_only() || config_->use_rtps_relay());
   const bool from_relay = relay_in_use && (from == config_->spdp_rtps_relay_address());
 
-  if (!from_relay && !ip_in_locator_list(from, pdata.participantProxy.metatrafficUnicastLocatorList)) {
+  if (config_->check_source_ip() && !from_relay && !ip_in_locator_list(from, pdata.participantProxy.metatrafficUnicastLocatorList)) {
     if (DCPS::DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) Spdp::data_received - IP not in locator list: %C\n"), DCPS::LogAddr(from).c_str()));
     }


### PR DESCRIPTION
Problem
-------

Cloud environments without multicast may simulate it via unicast via a
repeater.  SPDP packets coming from the repeater fail the source IP
check.

Solution
--------

Provide option to disable the source IP check.