### PR TITLE
Unable to compile due to variable name conflicts with some Windows API headers

### DIFF
--- a/dds/DCPS/NetworkConfigMonitor.h
+++ b/dds/DCPS/NetworkConfigMonitor.h
@@ -105,21 +105,21 @@ struct NetworkInterfaceName {
 
 class OpenDDS_Dcps_Export NetworkConfigListener : public virtual RcObject {
 public:
-  virtual void add_interface(const NetworkInterface& interface)
+  virtual void add_interface(const NetworkInterface& nic)
   {
-    NetworkInterface::AddressSet addresses = interface.get_addresses();
+    NetworkInterface::AddressSet addresses = nic.get_addresses();
     for (NetworkInterface::AddressSet::const_iterator pos = addresses.begin(), limit = addresses.end();
          pos != limit; ++pos) {
-      add_address(interface, *pos);
+      add_address(nic, *pos);
     }
   }
 
-  virtual void remove_interface(const NetworkInterface& interface)
+  virtual void remove_interface(const NetworkInterface& nic)
   {
-    NetworkInterface::AddressSet addresses = interface.get_addresses();
+    NetworkInterface::AddressSet addresses = nic.get_addresses();
     for (NetworkInterface::AddressSet::const_iterator pos = addresses.begin(), limit = addresses.end();
          pos != limit; ++pos) {
-      remove_address(interface, *pos);
+      remove_address(nic, *pos);
     }
   }
 

--- a/dds/DCPS/RTPS/GuidGenerator.h
+++ b/dds/DCPS/RTPS/GuidGenerator.h
@@ -46,7 +46,7 @@ public:
 
   /// override the MAC address to use a specific network interface
   /// instead of just the first (non-loopback) interface
-  int interfaceName(const char* interface);
+  int interfaceName(const char* nic);
 
   /// populate a GUID container with a unique ID. This will increment
   /// the counter, and use a lock (if compiled with MT ACE) while

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -545,9 +545,9 @@ private:
     void join_multicast_group(const DCPS::NetworkInterface& nic,
                               bool all_interfaces = false);
     void leave_multicast_group(const DCPS::NetworkInterface& nic);
-    void add_address(const DCPS::NetworkInterface& interface,
+    void add_address(const DCPS::NetworkInterface& nic,
                      const ACE_INET_Addr& address);
-    void remove_address(const DCPS::NetworkInterface& interface,
+    void remove_address(const DCPS::NetworkInterface& nic,
                         const ACE_INET_Addr& address);
 
     ICE::Endpoint* get_ice_endpoint();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -236,9 +236,9 @@ private:
   void join_multicast_group(const NetworkInterface& nic,
                             bool all_interfaces = false);
   void leave_multicast_group(const NetworkInterface& nic);
-  void add_address(const NetworkInterface& interface,
+  void add_address(const NetworkInterface& nic,
                    const ACE_INET_Addr& address);
-  void remove_address(const NetworkInterface& interface,
+  void remove_address(const NetworkInterface& nic,
                       const ACE_INET_Addr& address);
 
   // Internal non-locking versions of the above

--- a/dds/InfoRepo/DCPSInfo_i.cpp
+++ b/dds/InfoRepo/DCPSInfo_i.cpp
@@ -74,8 +74,8 @@ TAO_DDS_DCPSInfo_i::handle_timeout(const ACE_Time_Value& /*now*/,
       if (this->dispatchingOrb_->work_pending())
       {
         // Ten microseconds
-        ACE_Time_Value small(0,10);
-        this->dispatchingOrb_->perform_work(small);
+        ACE_Time_Value smallval(0,10);
+        this->dispatchingOrb_->perform_work(smallval);
       }
     }
   }


### PR DESCRIPTION
In Visual Studio (test with 2019, 2022) the names of the variables are confused and cannot be compiled. (`interface`, `small`)