### PR TITLE
`lint.pl` Fixes

### DIFF
--- a/tools/scripts/lint.pl
+++ b/tools/scripts/lint.pl
@@ -2,6 +2,10 @@
 
 # Linter for style and usage checks
 
+# "   \n"
+# 
+#	Hello Tab
+
 use strict;
 use warnings;
 

--- a/tools/scripts/lint.pl
+++ b/tools/scripts/lint.pl
@@ -2,10 +2,6 @@
 
 # Linter for style and usage checks
 
-# "   \n"
-# 
-#	Hello Tab
-
 use strict;
 use warnings;
 


### PR DESCRIPTION
- Replaced all whitespace with a dot (`·`) in marked error output when color is enabled. This dot is used in other software to explicitly mark whitespace. This should make it less confusing if output hides this whitespace.
- Fixed ability to check files outside an OpenDDS repo. Remove unneeded `--ext-path` option.
- Check if directories are ignored by git to avoid unnecessary checks on the contents.
- Removed possibly confusing usage of both "color" and "colour".
- Rename `--files-only` to `--files-only-ouput` to be consistent with `--simple-output`. `--files-only` should still work though.
- Spelling and other minor fixes.