### PR TITLE
Performance Improvements For AddressCache

### DIFF
--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -64,7 +64,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public RcObject {
 
   bool operator<(const BundlingCacheKey& rhs) const
   {
-    int r = std::memcmp(&dst_guid_, &(rhs.dst_guid_), 2 * sizeof (GUID_t));
+    int r = std::memcmp(&dst_guid_, &rhs.dst_guid_, 2 * sizeof (GUID_t));
     if (r < 0) {
       return true;
     } else if (r == 0) {
@@ -75,7 +75,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public RcObject {
 
   bool operator==(const BundlingCacheKey& rhs) const
   {
-    return std::memcmp(&dst_guid_, &(rhs.dst_guid_), 2 * sizeof (GUID_t)) == 0 && to_guids_ == rhs.to_guids_;
+    return std::memcmp(&dst_guid_, &rhs.dst_guid_, 2 * sizeof (GUID_t)) == 0 && to_guids_ == rhs.to_guids_;
   }
 
   BundlingCacheKey& operator=(const BundlingCacheKey& rhs)

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -26,11 +26,14 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
+struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public RcObject {
   BundlingCacheKey(const GUID_t& dst_guid, const GUID_t& from_guid, const GuidSet& to_guids)
     : dst_guid_(dst_guid)
     , from_guid_(from_guid)
     , to_guids_(to_guids)
+#if defined ACE_HAS_CPP11
+    , hash_(calculate_hash())
+#endif
   {
   }
 
@@ -38,13 +41,30 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
     : dst_guid_(dst_guid)
     , from_guid_(from_guid)
     , to_guids_()
+#if defined ACE_HAS_CPP11
+    , hash_(0)
+#endif
   {
     const_cast<GuidSet&>(to_guids_).swap(to_guids);
+#if defined ACE_HAS_CPP11
+    const_cast<size_t&>(hash_) = calculate_hash();
+#endif
+  }
+
+  BundlingCacheKey(const BundlingCacheKey& val)
+    : RcObject()
+    , dst_guid_(val.dst_guid_)
+    , from_guid_(val.from_guid_)
+    , to_guids_(val.to_guids_)
+#if defined ACE_HAS_CPP11
+    , hash_(val.hash_)
+#endif
+  {
   }
 
   bool operator<(const BundlingCacheKey& rhs) const
   {
-    int r = std::memcmp(this, &rhs, 2 * sizeof (GUID_t));
+    int r = std::memcmp(&dst_guid_, &(rhs.dst_guid_), 2 * sizeof (GUID_t));
     if (r < 0) {
       return true;
     } else if (r == 0) {
@@ -55,7 +75,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
 
   bool operator==(const BundlingCacheKey& rhs) const
   {
-    return std::memcmp(this, &rhs, 2 * sizeof (GUID_t)) == 0 && to_guids_ == rhs.to_guids_;
+    return std::memcmp(&dst_guid_, &(rhs.dst_guid_), 2 * sizeof (GUID_t)) == 0 && to_guids_ == rhs.to_guids_;
   }
 
   BundlingCacheKey& operator=(const BundlingCacheKey& rhs)
@@ -78,6 +98,18 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
   const GUID_t dst_guid_;
   const GUID_t from_guid_;
   const GuidSet to_guids_;
+#if defined ACE_HAS_CPP11
+  const size_t hash_;
+
+  size_t calculate_hash()
+  {
+    uint32_t hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&dst_guid_), 2 * sizeof (OpenDDS::DCPS::GUID_t));
+    for (auto it = to_guids_.begin(); it != to_guids_.end(); ++it) {
+      hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&(*it)), sizeof (OpenDDS::DCPS::GUID_t), hash);
+    }
+    return static_cast<size_t>(hash);
+  }
+#endif
 };
 
 #pragma pack(pop)
@@ -95,11 +127,7 @@ template<> struct OpenDDS_Rtps_Udp_Export hash<OpenDDS::DCPS::BundlingCacheKey>
 {
   std::size_t operator()(const OpenDDS::DCPS::BundlingCacheKey& val) const noexcept
   {
-    uint32_t hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&val), 2 * sizeof (OpenDDS::DCPS::GUID_t));
-    for (auto it = val.to_guids_.begin(); it != val.to_guids_.end(); ++it) {
-      hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&(*it)), sizeof (OpenDDS::DCPS::GUID_t), hash);
-    }
-    return static_cast<size_t>(hash);
+    return val.hash_;
   }
 };
 

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -26,11 +26,19 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
+struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public RcObject {
   LocatorCacheKey(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
     : remote_(remote)
     , local_(local)
     , prefer_unicast_(prefer_unicast)
+  {
+  }
+
+  LocatorCacheKey(const LocatorCacheKey& val)
+    : RcObject()
+    , remote_(val.remote_)
+    , local_(val.local_)
+    , prefer_unicast_(val.prefer_unicast_)
   {
   }
 

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -44,12 +44,12 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public RcObject {
 
   bool operator<(const LocatorCacheKey& rhs) const
   {
-    return std::memcmp(this, &rhs, sizeof (LocatorCacheKey)) < 0;
+    return std::memcmp(&remote_, &rhs.remote_, sizeof (LocatorCacheKey)) < 0;
   }
 
   bool operator==(const LocatorCacheKey& rhs) const
   {
-    return std::memcmp(this, &rhs, sizeof (LocatorCacheKey)) == 0;
+    return std::memcmp(&remote_, &rhs.remote_, sizeof (LocatorCacheKey)) == 0;
   }
 
   LocatorCacheKey& operator=(const LocatorCacheKey& rhs)
@@ -82,7 +82,19 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public RcObject {
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #if defined ACE_HAS_CPP11
-OPENDDS_OOAT_STD_HASH(OpenDDS::DCPS::LocatorCacheKey, OpenDDS_Rtps_Udp_Export);
+namespace std
+{
+
+template<> struct OpenDDS_Rtps_Udp_Export hash<OpenDDS::DCPS::LocatorCacheKey>
+{
+  std::size_t operator()(const OpenDDS::DCPS::LocatorCacheKey& val) const noexcept
+  {
+    uint32_t hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&val.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool));
+    return static_cast<size_t>(hash);
+  }
+};
+
+}
 #endif
 
 #endif /* OPENDDS_DCPS_TRANSPORT_RTPS_UDP_LOCATORCACHEKEY_H */

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -44,12 +44,12 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public RcObject {
 
   bool operator<(const LocatorCacheKey& rhs) const
   {
-    return std::memcmp(&remote_, &rhs.remote_, sizeof (LocatorCacheKey)) < 0;
+    return std::memcmp(&remote_, &rhs.remote_, 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) < 0;
   }
 
   bool operator==(const LocatorCacheKey& rhs) const
   {
-    return std::memcmp(&remote_, &rhs.remote_, sizeof (LocatorCacheKey)) == 0;
+    return std::memcmp(&remote_, &rhs.remote_, 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) == 0;
   }
 
   LocatorCacheKey& operator=(const LocatorCacheKey& rhs)

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -11,8 +11,9 @@
 
 using namespace OpenDDS::DCPS;
 
-struct TestKey {
+struct TestKey : public RcObject {
   TestKey(const RepoId& from, const RepoId& to) : from_(from), to_(to) {}
+  TestKey(const TestKey& val) : RcObject(), from_(val.from_), to_(val.to_) {}
   bool operator<(const TestKey& rhs) const {
     return std::memcmp(this, &rhs, sizeof (TestKey)) < 0;
   }

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -18,7 +18,7 @@ struct TestKey : public RcObject {
     return std::memcmp(this, &rhs, sizeof (TestKey)) < 0;
   }
   bool operator==(const TestKey& rhs) const {
-    return std::memcmp(this, &rhs, sizeof (TestKey)) == 0;
+    return std::memcmp(&(from_), &(rhs.from_), 2 * sizeof (RepoId)) == 0;
   }
   void get_contained_guids(RepoIdSet& set) const {
     set.clear();


### PR DESCRIPTION
Improvements based on profiling from centipede test environment. The bundling cache was having pretty significant slowdown copying keys when keys had large numbers of "to" guids.

Primary improvements are:
 - AddressCache id_map_ (reverse map) now holds a vector of RcHandles to keys, keeping key-copying to a minimum when adding keys to the reverse map
 - Precalculate hash value for bundling keys to avoid repeated lengthy calls to the hash function