### PR TITLE
ICE shutdown leads to segfault

### DIFF
--- a/dds/DCPS/DataReaderCallbacks.h
+++ b/dds/DCPS/DataReaderCallbacks.h
@@ -64,7 +64,7 @@ public:
   virtual void update_locators(const RepoId& /*remote*/,
                                const TransportLocatorSeq& /*locators*/) { }
 
-  virtual ICE::Endpoint* get_ice_endpoint() = 0;
+  virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint() = 0;
 };
 
 typedef RcHandle<DataReaderCallbacks> DataReaderCallbacks_rch;

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3406,7 +3406,7 @@ DataReaderImpl::update_locators(const RepoId& writerId,
   TransportClient::update_locators(writerId, locators);
 }
 
-ICE::Endpoint*
+WeakRcHandle<ICE::Endpoint>
 DataReaderImpl::get_ice_endpoint()
 {
   return TransportClient::get_ice_endpoint();

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -580,7 +580,7 @@ public:
   virtual void update_locators(const RepoId& remote,
                                const TransportLocatorSeq& locators);
 
-  virtual ICE::Endpoint* get_ice_endpoint();
+  virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
   const RepoId& get_repo_id() const
   {

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -64,7 +64,7 @@ public:
   virtual void update_locators(const RepoId& /*remote*/,
                                const TransportLocatorSeq& /*locators*/) { }
 
-  virtual ICE::Endpoint* get_ice_endpoint() = 0;
+  virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint() = 0;
 };
 
 typedef RcHandle<DataWriterCallbacks> DataWriterCallbacks_rch;

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -2770,7 +2770,7 @@ DataWriterImpl::send_control(const DataSampleHeader& header,
   return status;
 }
 
-ICE::Endpoint*
+WeakRcHandle<ICE::Endpoint>
 DataWriterImpl::get_ice_endpoint()
 {
   return TransportClient::get_ice_endpoint();

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -458,7 +458,7 @@ public:
   PublicationInstance_rch get_handle_instance(
     DDS::InstanceHandle_t handle);
 
-  virtual ICE::Endpoint* get_ice_endpoint();
+  virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
   const RepoId& get_repo_id() const {
     ACE_Guard<ACE_Recursive_Thread_Mutex> guard(get_lock());

--- a/dds/DCPS/NetworkConfigMonitor.h
+++ b/dds/DCPS/NetworkConfigMonitor.h
@@ -105,6 +105,8 @@ struct NetworkInterfaceName {
 
 class OpenDDS_Dcps_Export NetworkConfigListener : public virtual RcObject {
 public:
+  virtual ~NetworkConfigListener() {}
+
   virtual void add_interface(const NetworkInterface& nic)
   {
     NetworkInterface::AddressSet addresses = nic.get_addresses();

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -93,7 +93,7 @@ AgentImpl::AgentImpl() :
     TheServiceParticipant->set_shutdown_listener(this);
   }
 
-void AgentImpl::add_endpoint(Endpoint* a_endpoint)
+void AgentImpl::add_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint)
 {
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
   check_invariants();
@@ -115,7 +115,7 @@ void AgentImpl::add_endpoint(Endpoint* a_endpoint)
   }
 }
 
-void AgentImpl::remove_endpoint(Endpoint* a_endpoint)
+void AgentImpl::remove_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint)
 {
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
   check_invariants();
@@ -140,7 +140,7 @@ void AgentImpl::remove_endpoint(Endpoint* a_endpoint)
   }
 }
 
-AgentInfo AgentImpl::get_local_agent_info(Endpoint* a_endpoint) const
+AgentInfo AgentImpl::get_local_agent_info(DCPS::WeakRcHandle<Endpoint> a_endpoint) const
 {
   ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, mutex, AgentInfo());
   EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
@@ -148,9 +148,9 @@ AgentInfo AgentImpl::get_local_agent_info(Endpoint* a_endpoint) const
   return pos->second->agent_info();
 }
 
-void AgentImpl::add_local_agent_info_listener(Endpoint* a_endpoint,
+void AgentImpl::add_local_agent_info_listener(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                               const DCPS::RepoId& a_local_guid,
-                                              AgentInfoListener* a_agent_info_listener)
+                                              DCPS::WeakRcHandle<AgentInfoListener> a_agent_info_listener)
 {
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
   EndpointManagerMapType::const_iterator pos = endpoint_managers_.find(a_endpoint);
@@ -158,7 +158,7 @@ void AgentImpl::add_local_agent_info_listener(Endpoint* a_endpoint,
   pos->second->add_agent_info_listener(a_local_guid, a_agent_info_listener);
 }
 
-void AgentImpl::remove_local_agent_info_listener(Endpoint* a_endpoint,
+void AgentImpl::remove_local_agent_info_listener(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                                  const DCPS::RepoId& a_local_guid)
 {
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, mutex);
@@ -167,7 +167,7 @@ void AgentImpl::remove_local_agent_info_listener(Endpoint* a_endpoint,
   pos->second->remove_agent_info_listener(a_local_guid);
 }
 
-void  AgentImpl::start_ice(Endpoint* a_endpoint,
+void  AgentImpl::start_ice(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                            const DCPS::RepoId& a_local_guid,
                            const DCPS::RepoId& a_remote_guid,
                            const AgentInfo& a_remote_agent_info)
@@ -180,7 +180,7 @@ void  AgentImpl::start_ice(Endpoint* a_endpoint,
   check_invariants();
 }
 
-void AgentImpl::stop_ice(Endpoint* a_endpoint,
+void AgentImpl::stop_ice(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                          const DCPS::RepoId& a_local_guid,
                          const DCPS::RepoId& a_remote_guid)
 {
@@ -192,7 +192,7 @@ void AgentImpl::stop_ice(Endpoint* a_endpoint,
   check_invariants();
 }
 
-ACE_INET_Addr  AgentImpl::get_address(Endpoint* a_endpoint,
+ACE_INET_Addr  AgentImpl::get_address(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                       const DCPS::RepoId& a_local_guid,
                                       const DCPS::RepoId& a_remote_guid) const
 {
@@ -203,7 +203,7 @@ ACE_INET_Addr  AgentImpl::get_address(Endpoint* a_endpoint,
 }
 
 // Receive a STUN message.
-void  AgentImpl::receive(Endpoint* a_endpoint,
+void  AgentImpl::receive(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                          const ACE_INET_Addr& a_local_address,
                          const ACE_INET_Addr& a_remote_address,
                          const STUN::Message& a_message)

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -84,14 +84,15 @@ int AgentImpl::handle_timeout(const ACE_Time_Value& a_now, const void* /*act*/)
   return 0;
 }
 
-AgentImpl::AgentImpl() :
-  ReactorInterceptor(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner()),
-  unfreeze_(false),
-  ncm_listener_added_(false),
-  remote_peer_reflexive_counter_(0)
-  {
-    TheServiceParticipant->set_shutdown_listener(this);
-  }
+AgentImpl::AgentImpl()
+  : ReactorInterceptor(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner())
+  , unfreeze_(false)
+  , ncm_listener_added_(false)
+  , remote_peer_reflexive_counter_(0)
+{
+  // Bind the lifetime of this to the service participant.
+  TheServiceParticipant->set_shutdown_listener(DCPS::static_rchandle_cast<ShutdownListener>(rchandle_from(this)));
+}
 
 void AgentImpl::add_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint)
 {

--- a/dds/DCPS/RTPS/ICE/AgentImpl.h
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.h
@@ -32,7 +32,7 @@ namespace ICE {
 
 typedef std::vector<FoundationType> FoundationList;
 
-class AgentImpl : public Agent, public DCPS::ReactorInterceptor, public DCPS::ShutdownListener, public virtual DCPS::NetworkConfigListener {
+class AgentImpl : public virtual Agent, public virtual DCPS::ReactorInterceptor, public virtual DCPS::ShutdownListener, public virtual DCPS::NetworkConfigListener {
 public:
   AgentImpl();
 
@@ -40,33 +40,33 @@ public:
 
   void notify_shutdown();
 
-  void add_endpoint(Endpoint* a_endpoint);
+  void add_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint);
 
-  void remove_endpoint(Endpoint* a_endpoint);
+  void remove_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint);
 
-  AgentInfo get_local_agent_info(Endpoint* a_endpoint) const;
+  AgentInfo get_local_agent_info(DCPS::WeakRcHandle<Endpoint> a_endpoint) const;
 
-  void add_local_agent_info_listener(Endpoint* a_endpoint,
+  void add_local_agent_info_listener(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                      const DCPS::RepoId& a_local_guid,
-                                     AgentInfoListener* a_agent_info_listener);
+                                     DCPS::WeakRcHandle<AgentInfoListener> a_agent_info_listener);
 
-  void remove_local_agent_info_listener(Endpoint* a_endpoint,
+  void remove_local_agent_info_listener(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                         const DCPS::RepoId& a_local_guid);
 
-  void start_ice(Endpoint* a_endpoint,
+  void start_ice(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                  const DCPS::RepoId& a_local_guid,
                  const DCPS::RepoId& a_remote_guid,
                  const AgentInfo& a_remote_agent_info);
 
-  void stop_ice(Endpoint* a_endpoint,
+  void stop_ice(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                 const DCPS::RepoId& a_local_guid,
                 const DCPS::RepoId& a_remote_guid);
 
-  ACE_INET_Addr get_address(Endpoint* a_endpoint,
+  ACE_INET_Addr get_address(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                             const DCPS::RepoId& a_local_guid,
                             const DCPS::RepoId& a_remote_guid) const;
 
-  void receive(Endpoint* a_endpoint,
+  void receive(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                const ACE_INET_Addr& a_local_address,
                const ACE_INET_Addr& a_remote_address,
                const STUN::Message& a_message);
@@ -107,7 +107,7 @@ private:
   bool unfreeze_;
   bool ncm_listener_added_;
   size_t remote_peer_reflexive_counter_;
-  typedef std::map<Endpoint*, EndpointManagerPtr> EndpointManagerMapType;
+  typedef std::map<DCPS::WeakRcHandle<Endpoint>, EndpointManagerPtr> EndpointManagerMapType;
   EndpointManagerMapType endpoint_managers_;
   struct Item {
     DCPS::MonotonicTimePoint release_time_;

--- a/dds/DCPS/RTPS/ICE/Ice.cpp
+++ b/dds/DCPS/RTPS/ICE/Ice.cpp
@@ -111,9 +111,17 @@ Configuration* Configuration::instance()
   return ACE_Singleton<Configuration, ACE_Thread_Mutex>::instance();
 }
 
-DCPS::WeakRcHandle<Agent> Agent::instance()
+struct AgentHolder {
+  AgentHolder()
+    : agent_impl(DCPS::make_rch<AgentImpl>())
+  {}
+
+  DCPS::RcHandle<AgentImpl> agent_impl;
+};
+
+DCPS::RcHandle<Agent> Agent::instance()
 {
-  return DCPS::static_rchandle_cast<Agent>(rchandle_from(ACE_Singleton<AgentImpl, ACE_Thread_Mutex>::instance()));
+  return DCPS::static_rchandle_cast<Agent>(ACE_Singleton<AgentHolder, ACE_Thread_Mutex>::instance()->agent_impl);
 }
 
 ServerReflexiveStateMachine::StateChange

--- a/dds/DCPS/RTPS/ICE/Ice.cpp
+++ b/dds/DCPS/RTPS/ICE/Ice.cpp
@@ -111,9 +111,9 @@ Configuration* Configuration::instance()
   return ACE_Singleton<Configuration, ACE_Thread_Mutex>::instance();
 }
 
-Agent* Agent::instance()
+DCPS::WeakRcHandle<Agent> Agent::instance()
 {
-  return ACE_Singleton<AgentImpl, ACE_Thread_Mutex>::instance();
+  return DCPS::static_rchandle_cast<Agent>(rchandle_from(ACE_Singleton<AgentImpl, ACE_Thread_Mutex>::instance()));
 }
 
 ServerReflexiveStateMachine::StateChange

--- a/dds/DCPS/RTPS/ICE/Ice.h
+++ b/dds/DCPS/RTPS/ICE/Ice.h
@@ -12,6 +12,7 @@
 #include "dds/DCPS/Ice.h"
 #include "Stun.h"
 #include "dds/DCPS/TimeTypes.h"
+#include "dds/DCPS/RcObject.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -56,7 +57,7 @@ struct OpenDDS_Rtps_Export GuidPair {
 
 typedef std::set<GuidPair> GuidSetType;
 
-class OpenDDS_Rtps_Export Endpoint {
+class OpenDDS_Rtps_Export Endpoint : public virtual DCPS::RcObject {
 public:
   virtual ~Endpoint() {}
   virtual AddressListType host_addresses() const = 0;
@@ -66,7 +67,7 @@ public:
   virtual void ice_disconnect(const GuidSetType&, const ACE_INET_Addr&) {}
 };
 
-class OpenDDS_Rtps_Export AgentInfoListener {
+class OpenDDS_Rtps_Export AgentInfoListener : public virtual DCPS::RcObject {
 public:
   virtual ~AgentInfoListener() {}
   virtual void update_agent_info(const DCPS::RepoId& a_local_guid,
@@ -193,37 +194,37 @@ private:
   DCPS::TimeDuration change_password_period_;
 };
 
-class OpenDDS_Rtps_Export Agent {
+class OpenDDS_Rtps_Export Agent : public virtual DCPS::RcObject {
 public:
   virtual ~Agent() {}
-  virtual void add_endpoint(Endpoint* a_endpoint) = 0;
-  virtual void remove_endpoint(Endpoint* a_endpoint) = 0;
-  virtual AgentInfo get_local_agent_info(Endpoint* a_endpoint) const = 0;
-  virtual void add_local_agent_info_listener(Endpoint* a_endpoint,
+  virtual void add_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint) = 0;
+  virtual void remove_endpoint(DCPS::WeakRcHandle<Endpoint> a_endpoint) = 0;
+  virtual AgentInfo get_local_agent_info(DCPS::WeakRcHandle<Endpoint> a_endpoint) const = 0;
+  virtual void add_local_agent_info_listener(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                              const DCPS::RepoId& a_local_guid,
-                                             AgentInfoListener* a_agent_info_listener) = 0;
-  virtual void remove_local_agent_info_listener(Endpoint* a_endpoint,
+                                             DCPS::WeakRcHandle<AgentInfoListener> a_agent_info_listener) = 0;
+  virtual void remove_local_agent_info_listener(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                                 const DCPS::RepoId& a_local_guid) = 0;
-  virtual void start_ice(Endpoint* a_endpoint,
+  virtual void start_ice(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                          const DCPS::RepoId& a_local_guid,
                          const DCPS::RepoId& a_remote_guid,
                          const AgentInfo& a_remote_agent_info) = 0;
-  virtual void stop_ice(Endpoint* a_endpoint,
+  virtual void stop_ice(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                         const DCPS::RepoId& a_local_guid,
                         const DCPS::RepoId& a_remote_guid) = 0;
-  virtual ACE_INET_Addr get_address(Endpoint* a_endpoint,
+  virtual ACE_INET_Addr get_address(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                                     const DCPS::RepoId& a_local_guid,
                                     const DCPS::RepoId& a_remote_guid) const = 0;
 
   // Receive a STUN message.
-  virtual void receive(Endpoint* a_endpoint,
+  virtual void receive(DCPS::WeakRcHandle<Endpoint> a_endpoint,
                        const ACE_INET_Addr& a_local_address,
                        const ACE_INET_Addr& a_remote_address,
                        const STUN::Message& a_message) = 0;
 
   virtual void shutdown() = 0;
 
-  static Agent* instance();
+  static DCPS::WeakRcHandle<Agent> instance();
 };
 
 class OpenDDS_Rtps_Export ServerReflexiveStateMachine {

--- a/dds/DCPS/RTPS/ICE/Ice.h
+++ b/dds/DCPS/RTPS/ICE/Ice.h
@@ -224,7 +224,7 @@ public:
 
   virtual void shutdown() = 0;
 
-  static DCPS::WeakRcHandle<Agent> instance();
+  static DCPS::RcHandle<Agent> instance();
 };
 
 class OpenDDS_Rtps_Export ServerReflexiveStateMachine {

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1932,9 +1932,8 @@ Sedp::remove_publication_i(const RepoId& publicationId, LocalPublication& pub)
   DCPS::DataWriterCallbacks_rch pl = pub.publication_.lock();
   if (pl) {
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (endpoint && agent) {
-      agent->remove_local_agent_info_listener(endpoint, publicationId);
+    if (endpoint) {
+      ICE::Agent::instance()->remove_local_agent_info_listener(endpoint, publicationId);
     }
   }
 
@@ -1983,9 +1982,8 @@ Sedp::remove_subscription_i(const RepoId& subscriptionId,
   DCPS::DataReaderCallbacks_rch sl = sub.subscription_.lock();
   if (sl) {
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (endpoint && agent) {
-      agent->remove_local_agent_info_listener(endpoint, subscriptionId);
+    if (endpoint) {
+      ICE::Agent::instance()->remove_local_agent_info_listener(endpoint, subscriptionId);
     }
   }
 
@@ -3526,14 +3524,13 @@ Sedp::DiscoveryWriter::write_dcps_participant_secure(const Security::SPDPdiscove
   }
 
   ICE::AgentInfoMap ai_map;
-  DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
   DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = get_ice_endpoint();
-  if (sedp_endpoint && agent) {
-    ai_map[SEDP_AGENT_INFO_KEY] = agent->get_local_agent_info(sedp_endpoint);
+  if (sedp_endpoint) {
+    ai_map[SEDP_AGENT_INFO_KEY] = ICE::Agent::instance()->get_local_agent_info(sedp_endpoint);
   }
   DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = sedp_.spdp_.get_ice_endpoint_if_added();
-  if (spdp_endpoint && agent) {
-    ai_map[SPDP_AGENT_INFO_KEY] = agent->get_local_agent_info(spdp_endpoint);
+  if (spdp_endpoint) {
+    ai_map[SPDP_AGENT_INFO_KEY] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
   }
   if (!ParameterListConverter::to_param_list(ai_map, plist)) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
@@ -4860,11 +4857,8 @@ Sedp::add_publication_i(const DCPS::RepoId& rid,
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
     if (endpoint) {
       pub.have_ice_agent_info = true;
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        pub.ice_agent_info = agent->get_local_agent_info(endpoint);
-        agent->add_local_agent_info_listener(endpoint, rid, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(publication_agent_info_listener_));
-      }
+      pub.ice_agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+      ICE::Agent::instance()->add_local_agent_info_listener(endpoint, rid, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(publication_agent_info_listener_));
       start_ice(rid, pub);
     }
   }
@@ -5015,11 +5009,8 @@ Sedp::add_subscription_i(const DCPS::RepoId& rid,
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
     if (endpoint) {
       sub.have_ice_agent_info = true;
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        sub.ice_agent_info = agent->get_local_agent_info(endpoint);
-        agent->add_local_agent_info_listener(endpoint, rid, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(subscription_agent_info_listener_));
-      }
+      sub.ice_agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+      ICE::Agent::instance()->add_local_agent_info_listener(endpoint, rid, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(subscription_agent_info_listener_));
       start_ice(rid, sub);
     }
   }
@@ -5671,9 +5662,8 @@ Sedp::add_assoc_i(const DCPS::RepoId& local_guid, const LocalPublication& lpub,
   DCPS::DataWriterCallbacks_rch pl = lpub.publication_.lock();
   if (pl) {
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (endpoint && dsub.have_ice_agent_info_ && agent) {
-      agent->start_ice(endpoint, local_guid, remote_guid, dsub.ice_agent_info_);
+    if (endpoint && dsub.have_ice_agent_info_) {
+      ICE::Agent::instance()->start_ice(endpoint, local_guid, remote_guid, dsub.ice_agent_info_);
     }
   }
 #else
@@ -5691,9 +5681,8 @@ Sedp::remove_assoc_i(const DCPS::RepoId& local_guid, const LocalPublication& lpu
   DCPS::DataWriterCallbacks_rch pl = lpub.publication_.lock();
   if (pl) {
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (endpoint && agent) {
-      agent->stop_ice(endpoint, local_guid, remote_guid);
+    if (endpoint) {
+      ICE::Agent::instance()->stop_ice(endpoint, local_guid, remote_guid);
     }
   }
 #else
@@ -5710,9 +5699,8 @@ Sedp::add_assoc_i(const DCPS::RepoId& local_guid, const LocalSubscription& lsub,
   DCPS::DataReaderCallbacks_rch sl = lsub.subscription_.lock();
   if (sl) {
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (endpoint && dpub.have_ice_agent_info_ && agent) {
-      agent->start_ice(endpoint, local_guid, remote_guid, dpub.ice_agent_info_);
+    if (endpoint && dpub.have_ice_agent_info_) {
+      ICE::Agent::instance()->start_ice(endpoint, local_guid, remote_guid, dpub.ice_agent_info_);
     }
   }
 #else
@@ -5730,9 +5718,8 @@ Sedp::remove_assoc_i(const DCPS::RepoId& local_guid, const LocalSubscription& ls
   DCPS::DataReaderCallbacks_rch sl = lsub.subscription_.lock();
   if (sl) {
     DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (endpoint && agent) {
-      agent->stop_ice(endpoint, local_guid, remote_guid);
+    if (endpoint) {
+      ICE::Agent::instance()->stop_ice(endpoint, local_guid, remote_guid);
     }
   }
 #else
@@ -5808,10 +5795,7 @@ Sedp::start_ice(const DCPS::RepoId& guid, const LocalPublication& lpub) {
       DiscoveredSubscriptionIter dsi = discovered_subscriptions_.find(*it);
       if (dsi != discovered_subscriptions_.end()) {
         if (dsi->second.have_ice_agent_info_) {
-          DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-          if (agent) {
-            agent->start_ice(endpoint, guid, dsi->first, dsi->second.ice_agent_info_);
-          }
+          ICE::Agent::instance()->start_ice(endpoint, guid, dsi->first, dsi->second.ice_agent_info_);
         }
       }
     }
@@ -5838,10 +5822,7 @@ Sedp::start_ice(const DCPS::RepoId& guid, const LocalSubscription& lsub) {
       DiscoveredPublicationIter dpi = discovered_publications_.find(*it);
       if (dpi != discovered_publications_.end()) {
         if (dpi->second.have_ice_agent_info_) {
-          DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-          if (agent) {
-            agent->start_ice(endpoint, guid, dpi->first, dpi->second.ice_agent_info_);
-          }
+          ICE::Agent::instance()->start_ice(endpoint, guid, dpi->first, dpi->second.ice_agent_info_);
         }
       }
     }
@@ -5867,9 +5848,8 @@ Sedp::start_ice(const DCPS::RepoId& guid, const DiscoveredPublication& dpub) {
       DCPS::DataReaderCallbacks_rch sl = lsi->second.subscription_.lock();
       if (sl) {
         DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
-        DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-        if (endpoint && agent) {
-          agent->start_ice(endpoint, lsi->first, guid, dpub.ice_agent_info_);
+        if (endpoint) {
+          ICE::Agent::instance()->start_ice(endpoint, lsi->first, guid, dpub.ice_agent_info_);
         }
       }
     }
@@ -5897,9 +5877,8 @@ Sedp::start_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub) {
         DCPS::DataWriterCallbacks_rch pl = lpi->second.publication_.lock();
         if (pl) {
           DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
-          DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-          if (endpoint && agent) {
-            agent->start_ice(endpoint, lpi->first, guid, dsub.ice_agent_info_);
+          if (endpoint) {
+            ICE::Agent::instance()->start_ice(endpoint, lpi->first, guid, dsub.ice_agent_info_);
           }
         }
       }
@@ -5925,9 +5904,8 @@ Sedp::stop_ice(const DCPS::RepoId& guid, const DiscoveredPublication& dpub)
         DCPS::DataReaderCallbacks_rch sl = lsi->second.subscription_.lock();
         if (sl) {
           DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
-          DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-          if (endpoint && agent) {
-            agent->stop_ice(endpoint, lsi->first, guid);
+          if (endpoint) {
+            ICE::Agent::instance()->stop_ice(endpoint, lsi->first, guid);
           }
         }
       }
@@ -5953,9 +5931,8 @@ Sedp::stop_ice(const DCPS::RepoId& guid, const DiscoveredSubscription& dsub)
         DCPS::DataWriterCallbacks_rch pl = lpi->second.publication_.lock();
         if (pl) {
           DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
-          DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-          if (endpoint && agent) {
-            agent->stop_ice(endpoint, lpi->first, guid);
+          if (endpoint) {
+            ICE::Agent::instance()->stop_ice(endpoint, lpi->first, guid);
           }
         }
       }
@@ -5998,11 +5975,8 @@ Sedp::use_ice_now(bool f)
       DCPS::WeakRcHandle<ICE::Endpoint> endpoint = pl->get_ice_endpoint();
       if (endpoint) {
         pub.have_ice_agent_info = true;
-        DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-        if (agent) {
-          pub.ice_agent_info = agent->get_local_agent_info(endpoint);
-          agent->add_local_agent_info_listener(endpoint, pos->first, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(publication_agent_info_listener_));
-        }
+        pub.ice_agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+        ICE::Agent::instance()->add_local_agent_info_listener(endpoint, pos->first, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(publication_agent_info_listener_));
         start_ice(pos->first, pub);
       }
     }
@@ -6014,11 +5988,8 @@ Sedp::use_ice_now(bool f)
       DCPS::WeakRcHandle<ICE::Endpoint> endpoint = sl->get_ice_endpoint();
       if (endpoint) {
         sub.have_ice_agent_info = true;
-        DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-        if (agent) {
-          sub.ice_agent_info = agent->get_local_agent_info(endpoint);
-          agent->add_local_agent_info_listener(endpoint, pos->first, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(subscription_agent_info_listener_));
-        }
+        sub.ice_agent_info = ICE::Agent::instance()->get_local_agent_info(endpoint);
+        ICE::Agent::instance()->add_local_agent_info_listener(endpoint, pos->first, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(subscription_agent_info_listener_));
         start_ice(pos->first, sub);
       }
     }

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -577,7 +577,7 @@ public:
   void signal_liveliness_secure(DDS::LivelinessQosPolicyKind kind);
 #endif
 
-  ICE::Endpoint* get_ice_endpoint();
+  DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
   void rtps_relay_only_now(bool f);
   void use_rtps_relay_now(bool f);
@@ -1755,8 +1755,8 @@ protected:
 #endif
 
 #ifdef OPENDDS_SECURITY
-  PublicationAgentInfoListener publication_agent_info_listener_;
-  SubscriptionAgentInfoListener subscription_agent_info_listener_;
+  RcHandle<PublicationAgentInfoListener> publication_agent_info_listener_;
+  RcHandle<SubscriptionAgentInfoListener> subscription_agent_info_listener_;
 #endif
 
   void cleanup_writer_association(DCPS::DataWriterCallbacks_wrch callbacks,

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -223,10 +223,7 @@ void Spdp::init(DDS::DomainId_t /*domain*/,
   DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = sedp_->get_ice_endpoint();
   if (sedp_endpoint) {
     const RepoId l = make_id(guid_, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER);
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->add_local_agent_info_listener(sedp_endpoint, l, DCPS::static_rchandle_cast<AgentInfoListener>(rchandle_from(this)));
-    }
+    ICE::Agent::instance()->add_local_agent_info_listener(sedp_endpoint, l, DCPS::static_rchandle_cast<AgentInfoListener>(rchandle_from(this)));
   }
 #endif
   initialized_flag_ = true;
@@ -400,10 +397,7 @@ Spdp::shutdown()
       }
       DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = tport_->get_ice_endpoint();
       if (spdp_endpoint) {
-        DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-        if (agent) {
-          agent->stop_ice(spdp_endpoint, guid_, part->first);
-        }
+        ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, part->first);
       }
       purge_handshake_deadlines(part);
 #endif
@@ -415,10 +409,7 @@ Spdp::shutdown()
   DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = sedp_->get_ice_endpoint();
   if (sedp_endpoint) {
     const RepoId l = make_id(guid_, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER);
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->remove_local_agent_info_listener(sedp_endpoint, l);
-    }
+    ICE::Agent::instance()->remove_local_agent_info_listener(sedp_endpoint, l);
   }
 #endif
 
@@ -926,10 +917,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       }
       DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = tport_->get_ice_endpoint();
       if (spdp_endpoint) {
-        DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-        if (agent) {
-          agent->stop_ice(spdp_endpoint, guid_, iter->first);
-        }
+        ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, iter->first);
       }
       purge_handshake_deadlines(iter);
 #endif
@@ -1736,10 +1724,7 @@ Spdp::process_handshake_deadlines(const DCPS::MonotonicTimePoint& now)
         }
         DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = tport_->get_ice_endpoint();
         if (spdp_endpoint) {
-          DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-          if (agent) {
-            agent->stop_ice(spdp_endpoint, guid_, pit->first);
-          }
+          ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, pit->first);
         }
         handshake_deadlines_.erase(pos);
         remove_discovered_participant(pit);
@@ -2438,12 +2423,9 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task)
   // Add the endpoint before any sending and receiving occurs.
   DCPS::WeakRcHandle<ICE::Endpoint> endpoint = get_ice_endpoint();
   if (endpoint) {
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->add_endpoint(endpoint);
-      ice_endpoint_added_ = true;
-      agent->add_local_agent_info_listener(endpoint, outer->guid_, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(outer));
-    }
+    ICE::Agent::instance()->add_endpoint(endpoint);
+    ice_endpoint_added_ = true;
+    ICE::Agent::instance()->add_local_agent_info_listener(endpoint, outer->guid_, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(outer));
   }
 #endif
 
@@ -2652,10 +2634,7 @@ Spdp::SpdpTransport::close(const DCPS::ReactorTask_rch& reactor_task)
 #ifdef OPENDDS_SECURITY
   DCPS::WeakRcHandle<ICE::Endpoint> endpoint = get_ice_endpoint();
   if (endpoint) {
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->remove_endpoint(endpoint);
-    }
+    ICE::Agent::instance()->remove_endpoint(endpoint);
     ice_endpoint_added_ = false;
   }
 
@@ -2754,17 +2733,11 @@ Spdp::SpdpTransport::write_i(WriteFlags flags)
     ICE::AgentInfoMap ai_map;
     DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = outer->sedp_->get_ice_endpoint();
     if (sedp_endpoint) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        ai_map[SEDP_AGENT_INFO_KEY] = agent->get_local_agent_info(sedp_endpoint);
-      }
+      ai_map[SEDP_AGENT_INFO_KEY] = ICE::Agent::instance()->get_local_agent_info(sedp_endpoint);
     }
     DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = get_ice_endpoint();
     if (spdp_endpoint) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        ai_map[SPDP_AGENT_INFO_KEY] = agent->get_local_agent_info(spdp_endpoint);
-      }
+      ai_map[SPDP_AGENT_INFO_KEY] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
     }
 
     if (!ParameterListConverter::to_param_list(ai_map, plist)) {
@@ -2895,17 +2868,11 @@ Spdp::SpdpTransport::write_i(const DCPS::RepoId& guid, const ACE_INET_Addr& loca
     ICE::AgentInfoMap ai_map;
     DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = outer->sedp_->get_ice_endpoint();
     if (sedp_endpoint) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        ai_map[SEDP_AGENT_INFO_KEY] = agent->get_local_agent_info(sedp_endpoint);
-      }
+      ai_map[SEDP_AGENT_INFO_KEY] = ICE::Agent::instance()->get_local_agent_info(sedp_endpoint);
     }
     DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = get_ice_endpoint();
     if (spdp_endpoint) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        ai_map[SPDP_AGENT_INFO_KEY] = agent->get_local_agent_info(spdp_endpoint);
-      }
+      ai_map[SPDP_AGENT_INFO_KEY] = ICE::Agent::instance()->get_local_agent_info(spdp_endpoint);
     }
 
     if (!ParameterListConverter::to_param_list(ai_map, plist)) {
@@ -3293,10 +3260,7 @@ Spdp::SpdpTransport::handle_input(ACE_HANDLE h)
     } else {
       DCPS::WeakRcHandle<ICE::Endpoint> endpoint = get_ice_endpoint();
       if (endpoint) {
-        DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-        if (agent) {
-          agent->receive(endpoint, local, remote, message);
-        }
+        ICE::Agent::instance()->receive(endpoint, local, remote, message);
       }
     }
   }
@@ -3940,10 +3904,7 @@ Spdp::process_lease_expirations(const DCPS::MonotonicTimePoint& now)
     }
     DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = tport_->get_ice_endpoint();
     if (spdp_endpoint) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        agent->stop_ice(spdp_endpoint, guid_, part->first);
-      }
+      ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, part->first);
     }
     purge_handshake_deadlines(part);
 #endif
@@ -4058,82 +4019,52 @@ void Spdp::start_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, RepoId r, Built
   if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_WRITER) {
     l.entityId = ENTITYID_TL_SVC_REQ_READER;
     r.entityId = ENTITYID_TL_SVC_REQ_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_READER) {
     l.entityId = ENTITYID_TL_SVC_REQ_WRITER;
     r.entityId = ENTITYID_TL_SVC_REQ_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_WRITER) {
     l.entityId = ENTITYID_TL_SVC_REPLY_READER;
     r.entityId = ENTITYID_TL_SVC_REPLY_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_READER) {
     l.entityId = ENTITYID_TL_SVC_REPLY_WRITER;
     r.entityId = ENTITYID_TL_SVC_REPLY_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
 
   using namespace DDS::Security;
@@ -4141,130 +4072,82 @@ void Spdp::start_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, RepoId r, Built
   if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
     l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
     r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
     l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
     r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REQUEST_WRITER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REQ_READER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REQ_WRITER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REQUEST_READER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REQ_WRITER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REQ_READER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REPLY_WRITER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REPLY_READER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REPLY_WRITER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REPLY_READER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REPLY_WRITER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REPLY_READER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->start_ice(endpoint, l, r, agent_info);
-    }
+    ICE::Agent::instance()->start_ice(endpoint, l, r, agent_info);
   }
 }
 
@@ -4276,82 +4159,52 @@ void Spdp::stop_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, DCPS::RepoId r, 
   if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_WRITER) {
     l.entityId = ENTITYID_TL_SVC_REQ_READER;
     r.entityId = ENTITYID_TL_SVC_REQ_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_READER) {
     l.entityId = ENTITYID_TL_SVC_REQ_WRITER;
     r.entityId = ENTITYID_TL_SVC_REQ_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_WRITER) {
     l.entityId = ENTITYID_TL_SVC_REPLY_READER;
     r.entityId = ENTITYID_TL_SVC_REPLY_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_READER) {
     l.entityId = ENTITYID_TL_SVC_REPLY_WRITER;
     r.entityId = ENTITYID_TL_SVC_REPLY_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
 
   using namespace DDS::Security;
@@ -4359,130 +4212,82 @@ void Spdp::stop_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, DCPS::RepoId r, 
   if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) {
     l.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER;
     r.entityId = ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) {
     l.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER;
     r.entityId = ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) {
     l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
     r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (avail & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) {
     l.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER;
     r.entityId = ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REQUEST_WRITER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REQ_READER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REQ_WRITER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REQUEST_READER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REQ_WRITER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REQ_READER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REPLY_WRITER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REPLY_READER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REPLY_WRITER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
   if (extended_avail & TYPE_LOOKUP_SERVICE_REPLY_READER_SECURE) {
     l.entityId = ENTITYID_TL_SVC_REPLY_WRITER_SECURE;
     r.entityId = ENTITYID_TL_SVC_REPLY_READER_SECURE;
-    DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-    if (agent) {
-      agent->stop_ice(endpoint, l, r);
-    }
+    ICE::Agent::instance()->stop_ice(endpoint, l, r);
   }
 }
 
@@ -4774,15 +4579,9 @@ void Spdp::process_participant_ice(const ParameterList& plist,
   DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = tport_->get_ice_endpoint();
   if (spdp_endpoint) {
     if (spdp_pos != ai_map.end()) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        agent->start_ice(spdp_endpoint, guid_, guid, spdp_pos->second);
-      }
+      ICE::Agent::instance()->start_ice(spdp_endpoint, guid_, guid, spdp_pos->second);
     } else {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        agent->stop_ice(spdp_endpoint, guid_, guid);
-      }
+      ICE::Agent::instance()->stop_ice(spdp_endpoint, guid_, guid);
 #ifndef DDS_HAS_MINIMUM_BIT
       ACE_GUARD(ACE_Thread_Mutex, g, lock_);
       DiscoveredParticipantIter iter = participants_.find(guid);
@@ -4916,35 +4715,25 @@ Spdp::use_ice_now(bool flag)
 #ifdef OPENDDS_SECURITY
   sedp_->use_ice_now(flag);
 
-  DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-
   if (flag) {
     DCPS::WeakRcHandle<ICE::Endpoint> spdp_endpoint = tport_->get_ice_endpoint();
     DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = sedp_->get_ice_endpoint();
 
     if (sedp_endpoint) {
       const RepoId l = make_id(guid_, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER);
-      if (agent) {
-        agent->add_local_agent_info_listener(sedp_endpoint, l, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(DCPS::rchandle_from(this)));
-      }
+      ICE::Agent::instance()->add_local_agent_info_listener(sedp_endpoint, l, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(DCPS::rchandle_from(this)));
     }
 
-    if (agent) {
-      agent->add_endpoint(DCPS::static_rchandle_cast<ICE::Endpoint>(tport_));
-    }
+    ICE::Agent::instance()->add_endpoint(DCPS::static_rchandle_cast<ICE::Endpoint>(tport_));
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
     tport_->ice_endpoint_added_ = true;
     if (spdp_endpoint) {
-      if (agent) {
-        agent->add_local_agent_info_listener(spdp_endpoint, guid_, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(DCPS::rchandle_from(this)));
-      }
+      ICE::Agent::instance()->add_local_agent_info_listener(spdp_endpoint, guid_, DCPS::static_rchandle_cast<ICE::AgentInfoListener>(DCPS::rchandle_from(this)));
     }
 
     for (DiscoveredParticipantConstIter pos = participants_.begin(), limit = participants_.end(); pos != limit; ++pos) {
       if (spdp_endpoint && pos->second.have_spdp_info_) {
-        if (agent) {
-          agent->start_ice(spdp_endpoint, guid_, pos->first, pos->second.spdp_info_);
-        }
+        ICE::Agent::instance()->start_ice(spdp_endpoint, guid_, pos->first, pos->second.spdp_info_);
       }
 
       if (sedp_endpoint && pos->second.have_sedp_info_) {
@@ -4953,9 +4742,7 @@ Spdp::use_ice_now(bool flag)
       }
     }
   } else {
-    if (agent) {
-      agent->remove_endpoint(DCPS::static_rchandle_cast<ICE::Endpoint>(tport_));
-    }
+    ICE::Agent::instance()->remove_endpoint(DCPS::static_rchandle_cast<ICE::Endpoint>(tport_));
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
     tport_->ice_endpoint_added_ = false;
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -66,9 +66,9 @@ const char SEDP_AGENT_INFO_KEY[] = "SEDP";
 /// Each instance of class Spdp represents the implementation of the RTPS
 /// Simple Participant Discovery Protocol for a single local DomainParticipant.
 class OpenDDS_Rtps_Export Spdp
-  : public DCPS::RcObject
+  : public virtual DCPS::RcObject
 #ifdef OPENDDS_SECURITY
-  , public ICE::AgentInfoListener
+  , public virtual ICE::AgentInfoListener
 #endif
 {
 public:
@@ -216,7 +216,7 @@ public:
   }
 #endif
 
-  ICE::Endpoint* get_ice_endpoint_if_added();
+  DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint_if_added();
 
   ParticipantData_t build_local_pdata(
 #ifdef OPENDDS_SECURITY
@@ -484,7 +484,7 @@ private:
     : public virtual DCPS::RcEventHandler
     , public virtual DCPS::NetworkConfigListener
 #ifdef OPENDDS_SECURITY
-    , public ICE::Endpoint
+    , public virtual ICE::Endpoint
 #endif
   {
     typedef size_t WriteFlags;
@@ -550,7 +550,7 @@ private:
     void remove_address(const DCPS::NetworkInterface& nic,
                         const ACE_INET_Addr& address);
 
-    ICE::Endpoint* get_ice_endpoint();
+    DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
 #ifdef OPENDDS_SECURITY
     ICE::AddressListType host_addresses() const;
@@ -733,10 +733,10 @@ private:
 
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
 
-  void start_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t avail,
+  void start_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t avail,
                  DDS::Security::ExtendedBuiltinEndpointSet_t extended_avail,
                  const ICE::AgentInfo& agent_info);
-  void stop_ice(ICE::Endpoint* endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t avail,
+  void stop_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t avail,
                 DDS::Security::ExtendedBuiltinEndpointSet_t extended_avail);
 
   void purge_handshake_deadlines(DiscoveredParticipantIter iter);

--- a/dds/DCPS/RecorderImpl.h
+++ b/dds/DCPS/RecorderImpl.h
@@ -139,7 +139,7 @@ public:
                                      const RepoId& /*readerid*/,
                                      const RepoId& /*writerid*/);
 
-  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+  virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint() { return WeakRcHandle<ICE::Endpoint>(); }
 
 protected:
   virtual void remove_associations_i(const WriterIdSeq& writers, bool callback);

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -154,7 +154,7 @@ public:
                                      const RepoId& writerid,
                                      const RepoId& readerid);
 
-  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+  virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint() { return DCPS::WeakRcHandle<ICE::Endpoint>(); }
 
   DDS::ReturnCode_t enable();
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -210,7 +210,6 @@ Service_Participant::Service_Participant()
     bidir_giop_(true),
     monitor_enabled_(false),
     shut_down_(false),
-    shutdown_listener_(0),
     default_configuration_file_(ACE_TEXT("")),
     type_object_encoding_(Encoding_Normal)
 {
@@ -2742,7 +2741,7 @@ Service_Participant::add_discovery(Discovery_rch discovery)
 }
 
 void
-Service_Participant::set_shutdown_listener(ShutdownListener* listener)
+Service_Participant::set_shutdown_listener(RcHandle<ShutdownListener> listener)
 {
   shutdown_listener_ = listener;
 }

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -50,7 +50,7 @@ class DataDurabilityCache;
 
 const char DEFAULT_ORB_NAME[] = "OpenDDS_DCPS";
 
-class ShutdownListener {
+class ShutdownListener : public virtual RcObject {
 public:
   virtual ~ShutdownListener() {}
   virtual void notify_shutdown() = 0;
@@ -94,7 +94,7 @@ public:
 
   JobQueue_rch job_queue() const;
 
-  void set_shutdown_listener(ShutdownListener* listener);
+  void set_shutdown_listener(RcHandle<ShutdownListener> listener);
 
   /**
    * Initialize the DDS client environment and get the
@@ -757,7 +757,7 @@ private:
   /// Used to track state of service participant
   bool shut_down_;
 
-  ShutdownListener* shutdown_listener_;
+  RcHandle<ShutdownListener> shutdown_listener_;
 
   /// Guard access to the internal maps.
   ACE_Recursive_Thread_Mutex maps_lock_;

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -284,7 +284,7 @@ public:
 
   virtual void send_final_acks (const RepoId& readerid);
 
-  virtual ICE::Endpoint* get_ice_endpoint() const { return 0; }
+  virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint() const { return WeakRcHandle<ICE::Endpoint>(); }
 
   virtual bool is_leading(const GUID_t& /*writer*/,
                           const GUID_t& /*reader*/) const { return false; }

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -17,6 +17,7 @@
 #include <dds/DCPS/SendStateDataSampleList.h>
 #include <dds/DCPS/GuidConverter.h>
 #include <dds/DCPS/Definitions.h>
+#include <dds/DCPS/RTPS/ICE/Ice.h>
 
 #include <dds/DdsDcpsInfoUtilsC.h>
 
@@ -823,25 +824,25 @@ TransportClient::update_locators(const RepoId& remote,
   }
 }
 
-ICE::Endpoint*
+WeakRcHandle<ICE::Endpoint>
 TransportClient::get_ice_endpoint()
 {
   // The one-to-many relationship with impls implies that this should
   // return a set of endpoints instead of a single endpoint or null.
   // For now, we will assume a single impl.
 
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, lock_, 0);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, lock_, WeakRcHandle<ICE::Endpoint>());
   for (ImplsType::iterator pos = impls_.begin(), limit = impls_.end();
        pos != limit;
        ++pos) {
     RcHandle<TransportImpl> impl = pos->lock();
     if (impl) {
-      ICE::Endpoint* endpoint = impl->get_ice_endpoint();
+      WeakRcHandle<ICE::Endpoint> endpoint = impl->get_ice_endpoint();
       if (endpoint) { return endpoint; }
     }
   }
 
-  return 0;
+  return WeakRcHandle<ICE::Endpoint>();
 }
 
 bool

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -101,7 +101,7 @@ public:
   void update_locators(const RepoId& remote,
                        const TransportLocatorSeq& locators);
 
-  ICE::Endpoint* get_ice_endpoint();
+  WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
   // Data transfer:
 

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -163,7 +163,7 @@ public:
     DataLink_rch link_;
   };
 
-  virtual ICE::Endpoint* get_ice_endpoint() { return 0; }
+  virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint() { return WeakRcHandle<ICE::Endpoint>(); }
   virtual void rtps_relay_only_now(bool /*flag*/) {}
   virtual void use_rtps_relay_now(bool /*flag*/) {}
   virtual void use_ice_now(bool /*flag*/) {}

--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -177,11 +177,11 @@ OpenDDS::DCPS::TransportInst::set_port_in_addr_string(OPENDDS_STRING& addr_str, 
   addr_str = result;
 }
 
-OpenDDS::ICE::Endpoint*
+OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>
 OpenDDS::DCPS::TransportInst::get_ice_endpoint()
 {
   const OpenDDS::DCPS::TransportImpl_rch temp = impl();
-  return temp ? temp->get_ice_endpoint() : 0;
+  return temp ? temp->get_ice_endpoint() : OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>();
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -127,7 +127,7 @@ public:
   /// Populate a transport locator sequence.  Return the number of "locators."
   virtual size_t populate_locator(OpenDDS::DCPS::TransportLocator& trans_info, ConnectionInfoFlags flags) const = 0;
 
-  ICE::Endpoint* get_ice_endpoint();
+  DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
   void rtps_relay_only_now(bool flag);
   void use_rtps_relay_now(bool flag);
   void use_ice_now(bool flag);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4692,9 +4692,10 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   }
 
 #ifdef OPENDDS_SECURITY
-  ICE::Endpoint* endpoint = get_ice_endpoint();
-  if (endpoint) {
-    ice_addr = ICE::Agent::instance()->get_address(endpoint, local, remote);
+  DCPS::WeakRcHandle<ICE::Endpoint> endpoint = get_ice_endpoint();
+  DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
+  if (endpoint && agent) {
+    ice_addr = agent->get_address(endpoint, local, remote);
   }
 #endif
 
@@ -4721,7 +4722,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   entry.value().expires_ = normal_addrs_expires;
 }
 
-ICE::Endpoint*
+DCPS::WeakRcHandle<ICE::Endpoint>
 RtpsUdpDataLink::get_ice_endpoint() const {
   return impl().get_ice_endpoint();
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4693,9 +4693,8 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
 
 #ifdef OPENDDS_SECURITY
   DCPS::WeakRcHandle<ICE::Endpoint> endpoint = get_ice_endpoint();
-  DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-  if (endpoint && agent) {
-    ice_addr = agent->get_address(endpoint, local, remote);
+  if (endpoint) {
+    ice_addr = ICE::Agent::instance()->get_address(endpoint, local, remote);
   }
 #endif
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -203,7 +203,7 @@ public:
 
   virtual void pre_stop_i();
 
-  virtual ICE::Endpoint* get_ice_endpoint() const;
+  virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint() const;
 
   virtual bool is_leading(const GUID_t& writer_id,
                           const GUID_t& reader_id) const;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -65,7 +65,7 @@ RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
                                              int n,
                                              const ACE_SOCK_Dgram& socket,
                                              ACE_INET_Addr& remote_address,
-                                             ICE::Endpoint* endpoint,
+                                             DCPS::WeakRcHandle<ICE::Endpoint> endpoint,
                                              RtpsUdpTransport& tport,
                                              bool& stop)
 {
@@ -134,7 +134,10 @@ RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
     if (tport.relay_srsm().is_response(message)) {
       tport.process_relay_sra(tport.relay_srsm().receive(message));
     } else if (endpoint) {
-      ICE::Agent::instance()->receive(endpoint, local_address, remote_address, message);
+      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
+      if (agent) {
+        agent->receive(endpoint, local_address, remote_address, message);
+      }
     }
   }
   head->release();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -134,10 +134,7 @@ RtpsUdpReceiveStrategy::receive_bytes_helper(iovec iov[],
     if (tport.relay_srsm().is_response(message)) {
       tport.process_relay_sra(tport.relay_srsm().receive(message));
     } else if (endpoint) {
-      DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-      if (agent) {
-        agent->receive(endpoint, local_address, remote_address, message);
-      }
+      ICE::Agent::instance()->receive(endpoint, local_address, remote_address, message);
     }
   }
   head->release();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -74,7 +74,7 @@ public:
                                       int n,
                                       const ACE_SOCK_Dgram& socket,
                                       ACE_INET_Addr& remote_address,
-                                      ICE::Endpoint* endpoint,
+                                      DCPS::WeakRcHandle<ICE::Endpoint> endpoint,
                                       RtpsUdpTransport& tport,
                                       bool& stop);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -795,10 +795,7 @@ RtpsUdpTransport::start_ice()
     ACE_DEBUG((LM_INFO, "(%P|%t) RtpsUdpTransport::start_ice\n"));
   }
 
-  DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-  if (agent) {
-    agent->add_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
-  }
+  ICE::Agent::instance()->add_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
 
   if (!link_) {
     if (reactor()->register_handler(unicast_socket_.get_handle(), ice_endpoint_.get(),
@@ -852,10 +849,7 @@ RtpsUdpTransport::stop_ice()
 #endif
   }
 
-  DCPS::RcHandle<ICE::Agent> agent = ICE::Agent::instance().lock();
-  if (agent) {
-    agent->remove_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
-  }
+  ICE::Agent::instance()->remove_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -29,7 +29,7 @@ class OpenDDS_Rtps_Udp_Export RtpsUdpTransport : public TransportImpl {
 public:
   RtpsUdpTransport(RtpsUdpInst& inst);
   RtpsUdpInst& config() const;
-  virtual ICE::Endpoint* get_ice_endpoint();
+  virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
   virtual void rtps_relay_only_now(bool flag);
   virtual void use_rtps_relay_now(bool flag);
   virtual void use_ice_now(bool flag);
@@ -157,7 +157,7 @@ private:
   ConnectionRecords deferred_connection_records_;
 #endif
 
-  struct IceEndpoint : public ACE_Event_Handler, public ICE::Endpoint {
+  struct IceEndpoint : public virtual ACE_Event_Handler, public virtual ICE::Endpoint {
     RtpsUdpTransport& transport;
 
     IceEndpoint(RtpsUdpTransport& a_transport)
@@ -174,7 +174,7 @@ private:
 
     bool network_is_unreachable_;
   };
-  IceEndpoint ice_endpoint_;
+  RcHandle<IceEndpoint> ice_endpoint_;
 
   typedef PmfSporadicTask<RtpsUdpTransport> Sporadic;
   void relay_stun_task(const MonotonicTimePoint& now);

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
@@ -53,7 +53,7 @@ public:
   DDS::DomainId_t domainId_;
   ::OpenDDS::DCPS::RepoId participantId_;
 
-  OpenDDS::ICE::Endpoint* get_ice_endpoint() { return 0; }
+  OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint> get_ice_endpoint() { return OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>(); }
 
 private:
   DiscReceivedCalls received_;

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
@@ -47,7 +47,7 @@ public:
       return received_;
     }
 
-  OpenDDS::ICE::Endpoint* get_ice_endpoint() { return 0; }
+  OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint> get_ice_endpoint() { return OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>(); }
 
 private:
   DiscReceivedCalls received_;


### PR DESCRIPTION
Problem
-------

Shutting down with ICE sometimes segfaults.  This is caused by
shutdown order in concert with pointers that are no longer valid.

Solution
--------

Use weak pointers.