### PR TITLE
Fix SEDP Data Race

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -448,7 +448,8 @@ Sedp::init(const RepoId& guid,
   rtps_inst->opendds_discovery_default_listener_ = publications_reader_;
   rtps_inst->opendds_discovery_guid_ = guid;
 
-  const_cast<bool&>(use_xtypes_) = disco.config()->use_xtypes();
+  const_cast<bool&>(use_xtypes_) = disco.use_xtypes();
+  const_cast<bool&>(use_xtypes_complete_) = disco.use_xtypes_complete();
 
   reactor_task_ = transport_inst_->reactor_task();
   // One should assume that the transport is configured after this
@@ -563,8 +564,6 @@ Sedp::init(const RepoId& guid,
 #endif
 
   max_type_lookup_service_reply_period_ = disco.config()->max_type_lookup_service_reply_period();
-  const_cast<bool&>(use_xtypes_) = disco.use_xtypes();
-  use_xtypes_complete_ = disco.use_xtypes_complete();
 
   return DDS::RETCODE_OK;
 }

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -1691,7 +1691,7 @@ protected:
   TimeDuration max_type_lookup_service_reply_period_;
   DCPS::SequenceNumber type_lookup_service_sequence_number_;
   const bool use_xtypes_;
-  bool use_xtypes_complete_;
+  const bool use_xtypes_complete_;
 
 #ifdef OPENDDS_SECURITY
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;


### PR DESCRIPTION
Problem: Occassionally, TSAN builds complain about a data race for use_xtypes_ in Sedp::init(). As an example, see https://github.com/objectcomputing/OpenDDS/runs/4512178391?check_suite_focus=true

Solution: Attempt to initialize variables early in the method, prior to triggering other threads, and then leave the values alone (and constant).