### PR TITLE
RtpsRelay topics are not partitioned

### DIFF
--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -441,7 +441,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::SubscriberQos subscriber_qos;
   relay_participant->get_default_subscriber_qos(subscriber_qos);
   subscriber_qos.partition.name.length(1);
-  subscriber_qos.partition.name[0] = "*"; // Subscriber to all partitions.
+  subscriber_qos.partition.name[0] = "*"; // Subscribe to all partitions.
 
   DDS::Subscriber_var relay_subscriber = relay_participant->create_subscriber(subscriber_qos, nullptr,
                                                                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -425,7 +425,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   // Setup relay publisher and subscriber.
-  DDS::Publisher_var relay_publisher = relay_participant->create_publisher(PUBLISHER_QOS_DEFAULT, nullptr,
+  DDS::PublisherQos publisher_qos;
+  relay_participant->get_default_publisher_qos(publisher_qos);
+  publisher_qos.partition.name.length(1);
+  publisher_qos.partition.name[0] = config.relay_id().c_str(); // Publish to dedicated partition.
+
+  DDS::Publisher_var relay_publisher = relay_participant->create_publisher(publisher_qos, nullptr,
                                                                            OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   if (!relay_publisher) {
@@ -433,7 +438,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
-  DDS::Subscriber_var relay_subscriber = relay_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, nullptr,
+  DDS::SubscriberQos subscriber_qos;
+  relay_participant->get_default_subscriber_qos(subscriber_qos);
+  subscriber_qos.partition.name.length(1);
+  subscriber_qos.partition.name[0] = "*"; // Subscriber to all partitions.
+
+  DDS::Subscriber_var relay_subscriber = relay_participant->create_subscriber(subscriber_qos, nullptr,
                                                                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   if (!relay_subscriber) {


### PR DESCRIPTION
Problem
-------

When building infrastructure around the RtpsRelay, it is useful to
subscribe to individual relay instances.  One way is to use content
filtering, however, this is not supported on the publisher side for
RTPS and therefore will lead to many wasted messages.

Solution
--------

Partition the relay domain by the id of each instance.  Processes
interested in a specific relay instance can subscribe to that partition.