### PR TITLE
Fix RtpsUdpSendStrategy::send_bytes_i Handling of Empty Address Set

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.cpp
@@ -118,8 +118,11 @@ RtpsUdpSendStrategy::send_bytes_i_helper(const iovec iov[], int n)
   }
 
   if (addrs.empty()) {
-    errno = ENOTCONN;
-    return -1;
+    ssize_t result = 0;
+    for (int i = 0; i < n; ++i) {
+      result += iov[i].iov_len;
+    }
+    return result;
   }
 
   return send_multi_i(iov, n, addrs);


### PR DESCRIPTION
Problem: When send_bytes_i determines there are no viable addresses, it returns an error value, which suspends the send strategy and causes problems for subsequent sends.

Solution: If there are no valid addresses for the send, count the send as a success and return the full byte count.