### PR TITLE
RtpsRelay does not expose client status

### DIFF
--- a/tests/DCPS/RtpsRelay/Smoke/.gitignore
+++ b/tests/DCPS/RtpsRelay/Smoke/.gitignore
@@ -1,2 +1,3 @@
+/monitor
 /publisher
 /subscriber

--- a/tests/DCPS/RtpsRelay/Smoke/Smoke.mpc
+++ b/tests/DCPS/RtpsRelay/Smoke/Smoke.mpc
@@ -27,3 +27,14 @@ project(RtpsRelaySubscriber): dcps_test, dcps_cm, opendds_optional_security, dcp
     DataReaderListener.cpp
   }
 }
+
+project(RtpsRelayMonitor): dcps_test, opendds_optional_security, dcps_rtps_udp, opendds_cxx11, rtps_relay_lib {
+  exename   = monitor
+
+  Idl_Files {
+  }
+
+  Source_Files {
+    monitor.cpp
+  }
+}

--- a/tests/DCPS/RtpsRelay/Smoke/monitor.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/monitor.cpp
@@ -1,0 +1,138 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <dds/DCPS/JsonValueWriter.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+
+#include <dds/rtpsrelaylib/RelayTypeSupportImpl.h>
+#include <dds/rtpsrelaylib/Utility.h>
+
+void append(DDS::PropertySeq& props, const char* name, const std::string& value, bool propagate = false)
+{
+  const DDS::Property_t prop = {name, value.c_str(), propagate};
+  const unsigned int len = props.length();
+  props.length(len + 1);
+  try {
+    props[len] = prop;
+  } catch (const CORBA::BAD_PARAM& /*ex*/) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Exception caught when appending parameter\n"));
+  }
+}
+
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
+{
+  DDS::DomainParticipantFactory_var factory = TheParticipantFactoryWithArgs(argc, argv);
+  if (!factory) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Failed to initialize participant factory\n")));
+    return EXIT_FAILURE;
+  }
+
+  DDS::DomainId_t relay_domain = 0;
+
+  // Set up the relay participant.
+  DDS::DomainParticipantQos participant_qos;
+  factory->get_default_participant_qos(participant_qos);
+  DDS::PropertySeq& relay_properties = participant_qos.property.value;
+  append(relay_properties, OpenDDS::RTPS::RTPS_REFLECT_HEARTBEAT_COUNT, "true");
+
+  DDS::DomainParticipant_var relay_participant = factory->create_participant(relay_domain, participant_qos, nullptr,
+                                                                             OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  if (!relay_participant) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Failed to create relay participant\n")));
+    return EXIT_FAILURE;
+  }
+
+  // Set up relay topics.
+  RtpsRelay::RelayParticipantStatusTypeSupport_var relay_participant_status_ts = new RtpsRelay::RelayParticipantStatusTypeSupportImpl;
+  if (relay_participant_status_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to register RelayParticipantStatus type\n")));
+    return EXIT_FAILURE;
+  }
+  CORBA::String_var relay_participant_status_type_name = relay_participant_status_ts->get_type_name();
+
+  DDS::Topic_var relay_participant_status_topic =
+    relay_participant->create_topic(RtpsRelay::RELAY_PARTICIPANT_STATUS_TOPIC_NAME.c_str(),
+                                    relay_participant_status_type_name,
+                                    TOPIC_QOS_DEFAULT, nullptr,
+                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_participant_status_topic) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Participant Status topic\n")));
+    return EXIT_FAILURE;
+  }
+
+  // Setup relay subscriber.
+  DDS::SubscriberQos subscriber_qos;
+  relay_participant->get_default_subscriber_qos(subscriber_qos);
+  subscriber_qos.partition.name.length(1);
+  subscriber_qos.partition.name[0] = "*"; // Subscribe to all partitions.
+
+  DDS::Subscriber_var relay_subscriber = relay_participant->create_subscriber(subscriber_qos, nullptr,
+                                                                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_subscriber) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay subscriber\n")));
+    return EXIT_FAILURE;
+  }
+
+  // Setup relay reader/writer qos.
+  DDS::DataReaderQos reader_qos;
+  relay_subscriber->get_default_datareader_qos(reader_qos);
+
+  reader_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+  reader_qos.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
+  reader_qos.history.depth = 1;
+
+  DDS::DataReader_var relay_participant_status_dr =
+    relay_subscriber->create_datareader(relay_participant_status_topic.in(),
+                                        reader_qos,
+                                        0,
+                                        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_participant_status_dr) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      "(%P|%t) ERROR: create_datareader failed\n"),
+                     -1);
+  }
+
+  RtpsRelay::RelayParticipantStatusDataReader_var relay_participant_status_reader = RtpsRelay::RelayParticipantStatusDataReader::_narrow(relay_participant_status_dr.in());
+
+  if (!relay_participant_status_reader) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      "(%P|%t) ERROR: _narrow failed\n"),
+                     -1);
+  }
+
+  DDS::ReadCondition_var rc = relay_participant_status_reader->create_readcondition(DDS::ANY_SAMPLE_STATE,
+                                                                                    DDS::ANY_VIEW_STATE,
+                                                                                    DDS::ANY_INSTANCE_STATE);
+  DDS::WaitSet_var ws = new DDS::WaitSet;
+  ws->attach_condition(rc);
+  while (true) {
+    DDS::ConditionSeq active;
+    const DDS::Duration_t max_wait = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
+    ws->wait(active, max_wait);
+    RtpsRelay::RelayParticipantStatusSeq data;
+    DDS::SampleInfoSeq info;
+    DDS::ReturnCode_t ret;
+    while ((ret = relay_participant_status_reader->take_w_condition(data, info, DDS::LENGTH_UNLIMITED, rc)) == DDS::RETCODE_OK) {
+#if OPENDDS_HAS_JSON_VALUE_WRITER
+      for (CORBA::ULong idx = 0; idx != data.length(); ++idx) {
+        std::cout << "MONITOR " << RtpsRelay::RELAY_PARTICIPANT_STATUS_TOPIC_NAME.c_str() << ' ' << OpenDDS::DCPS::to_json(info[idx]);
+        if (info[idx].valid_data) {
+          std::cout << ' ' << OpenDDS::DCPS::to_json(data[idx]);
+        }
+        std::cout << std::endl;
+      }
+#endif
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/DCPS/RtpsRelay/Smoke/monitor.ini
+++ b/tests/DCPS/RtpsRelay/Smoke/monitor.ini
@@ -1,0 +1,12 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[domain/0]
+DiscoveryConfig=relay_rtps_discovery
+
+[rtps_discovery/relay_rtps_discovery]
+SedpMulticast=0
+
+[transport/relay1]
+transport_type=rtps_udp
+use_multicast=0

--- a/tests/DCPS/RtpsRelay/Smoke/publisher.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/publisher.cpp
@@ -54,6 +54,8 @@ void append(DDS::PropertySeq& props, const char* name, const char* value, bool p
 bool check_lease_recovery = false;
 bool expect_unmatch = false;
 
+const char USER_DATA[] = "The Publisher";
+
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
   DDS::DomainParticipantFactory_var dpf;
@@ -76,6 +78,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
       DDS::DomainParticipantQos part_qos;
       dpf->get_default_participant_qos(part_qos);
+      part_qos.user_data.value.length(std::strlen(USER_DATA));
+      std::memcpy(part_qos.user_data.value.get_buffer(), USER_DATA, std::strlen(USER_DATA));
 
 #if defined(OPENDDS_SECURITY)
       if (TheServiceParticipant->get_security()) {

--- a/tests/DCPS/RtpsRelay/Smoke/run_lease_duration_test.pl
+++ b/tests/DCPS/RtpsRelay/Smoke/run_lease_duration_test.pl
@@ -40,10 +40,13 @@ if ($test->flag('reverse')) {
   $sub_ini = " rtps_ld_60_sec.ini -e";
 }
 
+$test->process("monitor", "monitor", "-DCPSConfigFile monitor.ini");
 $test->process("relay1a", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay1a -LogDiscovery 1 -LogActivity 1 -LogRelayStatistics 3 -DCPSConfigFile relay1.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 -UserData relay1a" . $relay_security_opts);
 $test->process("relay1b", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay1b -LogDiscovery 1 -LogActivity 1 -LogRelayStatistics 3 -DCPSConfigFile relay1.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 -UserData relay1b" . $relay_security_opts);
 $test->process("publisher", "publisher", "-l -ORBDebugLevel 1 -DCPSConfigFile". $pub_ini . $pub_sub_security_opts);
 $test->process("subscriber", "subscriber", "-l -ORBDebugLevel 1 -DCPSConfigFile" . $sub_ini . $pub_sub_security_opts);
+
+$test->start_process("monitor");
 
 if ($test->flag('reverse')) {
   $test->start_process("relay1a");
@@ -68,5 +71,6 @@ if ($test->flag('reverse')) {
 sleep 30;
 
 $test->kill_process(1, "relay1b");
+$test->kill_process(5, "monitor");
 
 exit $test->finish(15);

--- a/tests/DCPS/RtpsRelay/Smoke/run_test.pl
+++ b/tests/DCPS/RtpsRelay/Smoke/run_test.pl
@@ -64,10 +64,13 @@ sub get_relay_args {
   );
 }
 
+$test->process("monitor", "monitor", "-DCPSConfigFile monitor.ini");
 $test->process("relay1", "$ENV{DDS_ROOT}/bin/RtpsRelay", get_relay_args(1,"AceLog") . $relay_security_opts);
 $test->process("relay2", "$ENV{DDS_ROOT}/bin/RtpsRelay", get_relay_args(2) . $relay_security_opts);
 $test->process("publisher", "publisher", "-ORBDebugLevel 1 -DCPSConfigFile". $pub_ini . $pub_sub_security_opts);
 $test->process("subscriber", "subscriber", "-ORBDebugLevel 1 -DCPSConfigFile" . $sub_ini . $pub_sub_security_opts);
+
+$test->start_process("monitor");
 
 if ($test->flag('join')) {
     $test->start_process("relay2");
@@ -91,5 +94,6 @@ $test->stop_process(5, "publisher");
 
 $test->kill_process(5, "relay1");
 $test->kill_process(5, "relay2");
+$test->kill_process(5, "monitor");
 
 exit $test->finish();

--- a/tests/DCPS/RtpsRelay/Smoke/subscriber.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/subscriber.cpp
@@ -53,6 +53,8 @@ bool expect_unmatch = false;
 bool reliable = false;
 bool wait_for_acks = false;
 
+const char USER_DATA[] = "The Subscriber";
+
 int
 ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
@@ -74,6 +76,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     DDS::DomainParticipantQos part_qos;
     dpf->get_default_participant_qos(part_qos);
+    part_qos.user_data.value.length(std::strlen(USER_DATA));
+    std::memcpy(part_qos.user_data.value.get_buffer(), USER_DATA, std::strlen(USER_DATA));
 
 #if defined(OPENDDS_SECURITY)
     if (TheServiceParticipant->get_security()) {

--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -63,6 +63,19 @@ module RtpsRelay {
     boolean admitting;
   };
 
+  const string RELAY_PARTICIPANT_STATUS_TOPIC_NAME = "Relay Participant Status";
+
+  @topic
+  @mutable
+  @autoid(HASH)
+  struct RelayParticipantStatus {
+    @key string relay_id;
+    @key GUID_t guid;
+    boolean active;
+    boolean alive;
+    DDS::UserDataQosPolicy user_data;
+  };
+
   const string SPDP_REPLAY_TOPIC_NAME = "SPDP Replay";
   @topic
   struct SpdpReplay {

--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -14,6 +14,7 @@ public:
   Config()
     : application_participant_guid_(OpenDDS::DCPS::GUID_UNKNOWN)
     , lifespan_(60) // 1 minute
+    , inactive_period_(60) // 1 minute
     , max_pending_(0)
     , pending_timeout_(60) // 1 minute
 #ifdef ACE_DEFAULT_MAX_SOCKET_BUFSIZ
@@ -63,6 +64,16 @@ public:
   const OpenDDS::DCPS::TimeDuration& lifespan() const
   {
     return lifespan_;
+  }
+
+  void inactive_period(const OpenDDS::DCPS::TimeDuration& value)
+  {
+    inactive_period_ = value;
+  }
+
+  const OpenDDS::DCPS::TimeDuration& inactive_period() const
+  {
+    return inactive_period_;
   }
 
   void max_pending(size_t value)
@@ -279,6 +290,7 @@ private:
   std::string relay_id_;
   OpenDDS::DCPS::GUID_t application_participant_guid_;
   OpenDDS::DCPS::TimeDuration lifespan_;
+  OpenDDS::DCPS::TimeDuration inactive_period_;
   size_t max_pending_;
   OpenDDS::DCPS::TimeDuration pending_timeout_;
   int buffer_size_;

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -1,27 +1,17 @@
 #include "ParticipantListener.h"
 
-#include <dds/rtpsrelaylib/Utility.h>
-
-#include <dds/DCPS/DCPS_Utils.h>
-#include <dds/DCPS/JsonValueWriter.h>
-#include <dds/DdsDcpsCoreTypeSupportImpl.h>
-
 namespace RtpsRelay {
 
-ParticipantListener::ParticipantListener(const Config& config,
+ParticipantListener::ParticipantListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
                                          GuidAddrSet& guid_addr_set,
-                                         OpenDDS::DCPS::DomainParticipantImpl* participant,
-                                         RelayStatisticsReporter& stats_reporter)
-  : config_(config)
+                                         RelayParticipantStatusReporter& participant_status_reporter)
+  : participant_(participant)
   , guid_addr_set_(guid_addr_set)
-  , participant_(participant)
-  , stats_reporter_(stats_reporter)
+  , participant_status_reporter_(participant_status_reporter)
 {}
 
 void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
 {
-  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
-
   DDS::ParticipantBuiltinTopicDataDataReader_var dr = DDS::ParticipantBuiltinTopicDataDataReader::_narrow(reader);
   if (!dr) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::on_data_available failed to narrow PublicationBuiltinTopicDataDataReader\n")));
@@ -48,43 +38,15 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
     switch (infos[idx].instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       if (info.valid_data) {
-        const auto repoid = participant_->get_repoid(info.instance_handle);
-
-        const auto p = guids_.insert(repoid);
-
         GuidAddrSet::Proxy proxy(guid_addr_set_);
-        proxy.remove_pending(repoid);
-
-        if (p.second) {
-          if (config_.log_discovery()) {
-            ACE_DEBUG((LM_INFO, "(%P|%t) INFO: ParticipantListener::on_data_available "
-              "add local participant %C %C %C into session\n",
-              guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-              proxy.get_session_time(repoid, now).sec_str().c_str()));
-          }
-
-          stats_reporter_.local_participants(guids_.size(), now);
-        }
+        participant_status_reporter_.add_participant(proxy, participant_->get_repoid(info.instance_handle), data);
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:
     case DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE:
       {
-        const auto repoid = participant_->get_repoid(info.instance_handle);
-
-        {
-          GuidAddrSet::Proxy proxy(guid_addr_set_);
-          if (config_.log_discovery()) {
-            ACE_DEBUG((LM_INFO, "(%P|%t) INFO: ParticipantListener::on_data_available "
-                       "remove local participant %C %C into session\n",
-                       guid_to_string(repoid).c_str(),
-                       proxy.get_session_time(repoid, now).sec_str().c_str()));
-          }
-
-          proxy.remove(repoid, now);
-        }
-        guids_.erase(repoid);
-        stats_reporter_.local_participants(guids_.size(), now);
+        GuidAddrSet::Proxy proxy(guid_addr_set_);
+        participant_status_reporter_.remove_participant(proxy, participant_->get_repoid(info.instance_handle));
       }
       break;
     }

--- a/tools/rtpsrelay/ParticipantListener.h
+++ b/tools/rtpsrelay/ParticipantListener.h
@@ -2,29 +2,24 @@
 #define RTPSRELAY_PARTICIPANT_LISTENER_H_
 
 #include "ListenerBase.h"
-#include "RelayStatisticsReporter.h"
-#include "RelayHandler.h"
+#include "RelayParticipantStatusReporter.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
-#include <dds/DCPS/TimeTypes.h>
 
 namespace RtpsRelay {
 
 class ParticipantListener : public ListenerBase {
 public:
-  ParticipantListener(const Config& config,
+  ParticipantListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
                       GuidAddrSet& guid_addr_set,
-                      OpenDDS::DCPS::DomainParticipantImpl* participant,
-                      RelayStatisticsReporter& stats_reporter);
+                      RelayParticipantStatusReporter& participant_status_reporter);
 
 private:
   void on_data_available(DDS::DataReader_ptr reader) override;
 
-  const Config& config_;
-  GuidAddrSet& guid_addr_set_;
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
-  RelayStatisticsReporter& stats_reporter_;
-  std::unordered_set<OpenDDS::DCPS::GUID_t> guids_;
+  GuidAddrSet& guid_addr_set_;
+  RelayParticipantStatusReporter& participant_status_reporter_;
 };
 
 }

--- a/tools/rtpsrelay/ParticipantStatisticsReporter.h
+++ b/tools/rtpsrelay/ParticipantStatisticsReporter.h
@@ -58,6 +58,16 @@ public:
     }
   }
 
+  void unregister()
+  {
+    if (config->publish_participant_statistics()) {
+      const auto ret = writer->unregister_instance(participant_statistics_, DDS::HANDLE_NIL);
+      if (ret != DDS::RETCODE_OK) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: unregistering participant %C statistics\n"), guid_to_string(relay_guid_to_rtps_guid(participant_statistics_.guid())).c_str()));
+      }
+    }
+  }
+
 private:
   ParticipantStatistics participant_statistics_;
   Helper helper_;

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -41,7 +41,7 @@ void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
 }
 
 void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& proxy,
-                                                  const OpenDDS::DCPS::GUID_t& repoid)
+                                                        const OpenDDS::DCPS::GUID_t& repoid)
 {
   const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
@@ -75,8 +75,8 @@ void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& prox
 }
 
 void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy*/,
-                                         const OpenDDS::DCPS::GUID_t& repoid,
-                                         bool alive)
+                                               const OpenDDS::DCPS::GUID_t& repoid,
+                                               bool alive)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -98,8 +98,8 @@ void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy
 }
 
 void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*proxy*/,
-                                          const OpenDDS::DCPS::GUID_t& repoid,
-                                          bool active)
+                                                const OpenDDS::DCPS::GUID_t& repoid,
+                                                bool active)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -121,9 +121,9 @@ void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*prox
 }
 
 void RelayParticipantStatusReporter::set_alive_active(const GuidAddrSet::Proxy& /*proxy*/,
-                                                const OpenDDS::DCPS::GUID_t& repoid,
-                                                bool alive,
-                                                bool active)
+                                                      const OpenDDS::DCPS::GUID_t& repoid,
+                                                      bool alive,
+                                                      bool active)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -1,0 +1,148 @@
+#include "RelayParticipantStatusReporter.h"
+
+namespace RtpsRelay {
+
+void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
+                                                     const OpenDDS::DCPS::GUID_t& repoid,
+                                                     const DDS::ParticipantBuiltinTopicData& data)
+{
+  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+
+  RelayParticipantStatus status;
+  status.relay_id(config_.relay_id());
+  status.guid(rtps_guid_to_relay_guid(repoid));
+  status.active(true);
+  status.alive(true);
+  status.user_data(data.user_data);
+
+  if (writer_->write(status, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+               "RelayParticipantStatusReporter::add_participant failed to write participant status\n"));
+  }
+
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+    const auto p = guids_.insert(std::make_pair(repoid, status));
+
+    proxy.remove_pending(repoid);
+
+    if (p.second) {
+      if (config_.log_discovery()) {
+        ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::add_participant "
+                   "add local participant %C %C %C into session\n",
+                   guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
+                   proxy.get_session_time(repoid, now).sec_str().c_str()));
+      }
+    }
+
+    stats_reporter_.local_participants(guids_.size(), now);
+  }
+}
+
+void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& proxy,
+                                                  const OpenDDS::DCPS::GUID_t& repoid)
+{
+  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  const auto pos = guids_.find(repoid);
+  if (pos == guids_.end()) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+               "RelayParticipantStatusReporter::remove_participant participant %C not found\n",
+               guid_to_string(repoid).c_str()));
+    return;
+  }
+
+  if (writer_->unregister_instance(pos->second, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+               "RelayParticipantStatusReporter::remove_participant failed to unregister participant\n"));
+  }
+
+  if (config_.log_discovery()) {
+    ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::remove_participant "
+               "remove local participant %C %C into session\n",
+               guid_to_string(repoid).c_str(),
+               proxy.get_session_time(repoid, now).sec_str().c_str()));
+  }
+
+  proxy.remove(repoid, now, nullptr);
+
+  guids_.erase(pos);
+
+  stats_reporter_.local_participants(guids_.size(), now);
+}
+
+void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy*/,
+                                         const OpenDDS::DCPS::GUID_t& repoid,
+                                         bool alive)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  const auto pos = guids_.find(repoid);
+  if (pos == guids_.end()) {
+    return;
+  }
+
+  if (pos->second.alive() == alive) {
+    return;
+  }
+
+  pos->second.alive(alive);
+
+  if (writer_->write(pos->second, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+               "RelayParticipantStatusReporter::set_alive failed to write participant status\n"));
+  }
+}
+
+void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*proxy*/,
+                                          const OpenDDS::DCPS::GUID_t& repoid,
+                                          bool active)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  const auto pos = guids_.find(repoid);
+  if (pos == guids_.end()) {
+    return;
+  }
+
+  if (pos->second.active() == active) {
+    return;
+  }
+
+  pos->second.active(active);
+
+  if (writer_->write(pos->second, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+               "RelayParticipantStatusReporter::set_active failed to write participant status\n"));
+  }
+}
+
+void RelayParticipantStatusReporter::set_alive_active(const GuidAddrSet::Proxy& /*proxy*/,
+                                                const OpenDDS::DCPS::GUID_t& repoid,
+                                                bool alive,
+                                                bool active)
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+  const auto pos = guids_.find(repoid);
+  if (pos == guids_.end()) {
+    return;
+  }
+
+  if (pos->second.alive() == alive && pos->second.active() == active) {
+    return;
+  }
+
+  pos->second.alive(alive);
+  pos->second.active(active);
+
+  if (writer_->write(pos->second, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+               "RelayParticipantStatusReporter::set_alive_active failed to write participant status\n"));
+  }
+}
+
+}

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.h
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.h
@@ -1,0 +1,55 @@
+#ifndef RTPSRELAY_RELAY_PARTICIPANT_STATUS_REPORTER_H_
+#define RTPSRELAY_RELAY_PARTICIPANT_STATUS_REPORTER_H_
+
+#include "GuidAddrSet.h"
+
+#include <dds/rtpsrelaylib/RelayTypeSupportImpl.h>
+
+#include <unordered_map>
+
+namespace RtpsRelay {
+
+class RelayParticipantStatusReporter {
+public:
+
+  RelayParticipantStatusReporter(const Config& config,
+                                 RelayParticipantStatusDataWriter_var writer,
+                                 RelayStatisticsReporter& stats_reporter)
+    : config_(config)
+    , writer_(writer)
+    , stats_reporter_(stats_reporter)
+  {}
+
+  void add_participant(GuidAddrSet::Proxy& proxy,
+                       const OpenDDS::DCPS::GUID_t& repoid,
+                       const DDS::ParticipantBuiltinTopicData& data);
+
+  void remove_participant(GuidAddrSet::Proxy& proxy,
+                          const OpenDDS::DCPS::GUID_t& repoid);
+
+  void set_alive(const GuidAddrSet::Proxy& proxy,
+                 const OpenDDS::DCPS::GUID_t& repoid,
+                 bool alive);
+
+  void set_active(const GuidAddrSet::Proxy& proxy,
+                  const OpenDDS::DCPS::GUID_t& repoid,
+                  bool active);
+
+  void set_alive_active(const GuidAddrSet::Proxy& proxy,
+                        const OpenDDS::DCPS::GUID_t& repoid,
+                        bool alive,
+                        bool active);
+
+private:
+
+  const Config& config_;
+  RelayParticipantStatusDataWriter_var writer_;
+  RelayStatisticsReporter& stats_reporter_;
+
+  mutable ACE_Thread_Mutex mutex_;
+  std::unordered_map<OpenDDS::DCPS::GUID_t, RelayParticipantStatus> guids_;
+};
+
+}
+
+#endif // RTPSRELAY_RELAY_PARTICIPANT_STATUS_REPORTER_H_

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -121,6 +121,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-Lifespan"))) {
       config.lifespan(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-InactivePeriod"))) {
+      config.inactive_period(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
+      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-MaxPending"))) {
       config.max_pending(ACE_OS::atoi(arg));
       args.consume_arg();
@@ -313,6 +316,24 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   if (!relay_partitions_topic) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Partitions topic\n")));
+    return EXIT_FAILURE;
+  }
+
+  RelayParticipantStatusTypeSupport_var relay_participant_status_ts = new RelayParticipantStatusTypeSupportImpl;
+  if (relay_participant_status_ts->register_type(relay_participant, "") != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to register RelayParticipantStatus type\n")));
+    return EXIT_FAILURE;
+  }
+  CORBA::String_var relay_participant_status_type_name = relay_participant_status_ts->get_type_name();
+
+  DDS::Topic_var relay_participant_status_topic =
+    relay_participant->create_topic(RELAY_PARTICIPANT_STATUS_TOPIC_NAME.c_str(),
+                                    relay_participant_status_type_name,
+                                    TOPIC_QOS_DEFAULT, nullptr,
+                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_participant_status_topic) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Participant Status topic\n")));
     return EXIT_FAILURE;
   }
 
@@ -612,6 +633,22 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
+  DDS::DataWriter_var relay_participant_status_writer_var =
+    relay_publisher->create_datawriter(relay_participant_status_topic, writer_qos, nullptr,
+                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  if (!relay_participant_status_writer_var) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Participant Status data writer\n")));
+    return EXIT_FAILURE;
+  }
+
+  RelayParticipantStatusDataWriter_var relay_participant_status_writer = RelayParticipantStatusDataWriter::_narrow(relay_participant_status_writer_var);
+
+  if (!relay_participant_status_writer) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to narrow Relay Participant Status data writer\n")));
+    return EXIT_FAILURE;
+  }
+
   DDS::DataWriterQos replay_writer_qos;
   relay_publisher->get_default_datawriter_qos(replay_writer_qos);
 
@@ -636,7 +673,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   RelayStatisticsReporter relay_statistics_reporter(config, relay_statistics_writer);
-  GuidAddrSet guid_addr_set(config, rtps_discovery, relay_statistics_reporter);
+  RelayParticipantStatusReporter relay_participant_status_reporter(config, relay_participant_status_writer, relay_statistics_reporter);
+  GuidAddrSet guid_addr_set(config, rtps_discovery, relay_participant_status_reporter, relay_statistics_reporter);
   ACE_Reactor reactor_(new ACE_Select_Reactor, true);
   const auto reactor = &reactor_;
   GuidPartitionTable guid_partition_table(config, guid_addr_set, spdp_horizontal_addr, relay_partitions_writer, spdp_replay_writer);
@@ -728,7 +766,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   ParticipantListener* participant_listener =
-    new ParticipantListener(config, guid_addr_set, application_participant_impl, relay_statistics_reporter);
+    new ParticipantListener(application_participant_impl, guid_addr_set, relay_participant_status_reporter);
   DDS::DataReaderListener_var participant_listener_var(participant_listener);
   DDS::ReturnCode_t ret = participant_reader->set_listener(participant_listener_var, DDS::DATA_AVAILABLE_STATUS);
   if (ret != DDS::RETCODE_OK) {


### PR DESCRIPTION
Problem
-------

The RtpsRelay does not expose the dynamic status of a client.  The
goal of exposing such information is to be able to determine if a
particular client is connected.  The desired status is:

1. Discovered - Client has completed discovery with the client.
2. Active - message received from client recently
3. Alive - not purged from relay handler
4. User data

Solution
--------

* Add a "Relay Participants" topic that has the desired status.  The
  existence of an instance for a client says that it has been
  discovered.

* Add a parameter `-InactivePeriod` to set the inactivity threshold.