### PR TITLE
Temporarily Disable CMake Tests For w16_x86_i0_sec Build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8526,15 +8526,15 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         msbuild -p:Configuration=Debug,Platform=Win32 -m DDS.sln
-    - name: Build CMake Tests
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        mkdir tests\cmake\build
-        cd tests\cmake\build
-        cmake ..
-        cmake --build .
+#    - name: Build CMake Tests
+#      shell: cmd
+#      run: |
+#        cd OpenDDS
+#        call setenv.cmd
+#        mkdir tests\cmake\build
+#        cd tests\cmake\build
+#        cmake ..
+#        cmake --build .
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |


### PR DESCRIPTION
Until we resolve disk space issues for the Windows 2016 Server virtual environment runner, disable CMake tests on the larger (security) job in order to allow full test suite to run as normal.