### PR TITLE
Improve Fragment NACKing Behavior

### DIFF
--- a/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.cpp
@@ -87,6 +87,12 @@ TransportCustomizedElement::original_send_element() const
   return original_send_element_;
 }
 
+bool
+TransportCustomizedElement::is_last_fragment() const
+{
+  return original_send_element_ ? original_send_element_->is_last_fragment() : false;
+}
+
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/transport/framework/TransportCustomizedElement.h
+++ b/dds/DCPS/transport/framework/TransportCustomizedElement.h
@@ -49,6 +49,8 @@ public:
 
   const TransportSendElement* original_send_element() const;
 
+  virtual bool is_last_fragment() const;
+
 protected:
   virtual void release_element(bool dropped_by_transport);
 

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -169,6 +169,9 @@ public:
   /// Is this QueueElement the result of fragmentation?
   virtual bool is_fragment() const { return false; }
 
+  /// Is this QueueElement the last result of fragmentation?
+  virtual bool is_last_fragment() const { return false; }
+
   virtual bool is_request_ack() const { return false; }
 
   virtual bool is_retained_replaced() const { return false; }

--- a/dds/DCPS/transport/framework/TransportReassembly.cpp
+++ b/dds/DCPS/transport/framework/TransportReassembly.cpp
@@ -17,14 +17,14 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-TransportReassembly::FragKey::FragKey(const PublicationId& pubId,
+FragKey::FragKey(const PublicationId& pubId,
                                       const SequenceNumber& dataSampleSeq)
   : publication_(pubId)
   , data_sample_seq_(dataSampleSeq)
 {
 }
 
-GUID_tKeyLessThan TransportReassembly::FragKey::compare_;
+GUID_tKeyLessThan FragKey::compare_;
 
 TransportReassembly::FragRange::FragRange(const SequenceRange& seqRange,
                                           const ReceivedDataSample& data)
@@ -189,10 +189,16 @@ TransportReassembly::insert(FragRangeList& flist,
 
 bool
 TransportReassembly::has_frags(const SequenceNumber& seq,
-                               const RepoId& pub_id) const
+                               const RepoId& pub_id,
+                               ACE_UINT32& total_frags) const
 {
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-  return fragments_.count(FragKey(pub_id, seq));
+  const FragInfoMap::const_iterator iter = fragments_.find(FragKey(pub_id, seq));
+  if (iter != fragments_.end()) {
+    total_frags = iter->second.total_frags_;
+    return true;
+  }
+  return false;
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -305,6 +305,7 @@ SingleSendBuffer::insert_buffer(BufferType& buffer,
 void
 SingleSendBuffer::insert_fragment(SequenceNumber sequence,
                                   SequenceNumber fragment,
+                                  bool is_last_fragment,
                                   TransportSendStrategy::QueueType* queue,
                                   ACE_Message_Block* chain)
 {
@@ -322,7 +323,9 @@ SingleSendBuffer::insert_fragment(SequenceNumber sequence,
                                       static_cast<ACE_Message_Block*>(0));
 
   BufferType& buffer = fragments_[sequence][fragment];
-  pre_seq_.erase(sequence);
+  if (is_last_fragment) {
+    pre_seq_.erase(sequence);
+  }
   insert_buffer(buffer, queue, chain);
 
   if (Transport_debug_level > 5) {

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -93,6 +93,7 @@ public:
               ACE_Message_Block* chain);
   void insert_fragment(SequenceNumber sequence,
                        SequenceNumber fragment,
+                       bool is_last_fragment,
                        TransportSendStrategy::QueueType* queue,
                        ACE_Message_Block* chain);
 

--- a/dds/DCPS/transport/framework/TransportSendControlElement.h
+++ b/dds/DCPS/transport/framework/TransportSendControlElement.h
@@ -73,6 +73,8 @@ public:
 
   virtual bool is_request_ack() const { return header_.message_id_ == REQUEST_ACK; }
 
+  virtual bool is_last_fragment() const { return !header_.more_fragments(); }
+
 protected:
 
   virtual void release_element(bool dropped_by_transport);

--- a/dds/DCPS/transport/framework/TransportSendElement.h
+++ b/dds/DCPS/transport/framework/TransportSendElement.h
@@ -44,6 +44,8 @@ public:
 
   virtual bool owned_by_transport();
 
+  virtual bool is_last_fragment() const { return !element_->get_header().more_fragments(); }
+
 protected:
 
   virtual void release_element(bool dropped_by_transport);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3705,11 +3705,6 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
   }
 
   {
-    for (FragmentInfo::const_iterator pos = consolidated_fragment_requests.begin(),
-           limit = consolidated_fragment_requests.end(); pos != limit; ++pos) {
-      consolidated_requests.erase(pos->first);
-    }
-
     // Send the consolidated requests.
     const OPENDDS_VECTOR(SequenceRange) ranges = consolidated_requests.present_sequence_ranges();
     for (OPENDDS_VECTOR(SequenceRange)::const_iterator pos = ranges.begin(), limit = ranges.end();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2934,7 +2934,7 @@ RtpsUdpDataLink::RtpsReader::generate_nack_frags_i(MetaSubmessageVec& meta_subme
     link->receive_strategy()->has_fragments(missing[i], wi->id_, &frag_info);
   }
   // 1b. larger than the last received seq# but less than the heartbeat.lastSN
-  if (!wi->recvd_.empty()) {
+  if (!wi->recvd_.empty() && wi->recvd_.high() < wi->hb_last_) {
     const SequenceRange range(wi->recvd_.high() + 1, wi->hb_last_);
     link->receive_strategy()->has_fragments(range, wi->id_, &frag_info);
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -346,7 +346,8 @@ private:
 
   // RTPS reliability support for local writers:
 
-  typedef OPENDDS_MAP(CORBA::ULong, RTPS::FragmentNumberSet) RequestedFragMap;
+  typedef CORBA::ULong FragmentNumberValue;
+  typedef OPENDDS_MAP(FragmentNumberValue, RTPS::FragmentNumberSet) RequestedFragMap;
   typedef OPENDDS_MAP(SequenceNumber, RequestedFragMap) RequestedFragSeqMap;
 
   struct ReaderInfo : public RcObject {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -346,12 +346,15 @@ private:
 
   // RTPS reliability support for local writers:
 
+  typedef OPENDDS_MAP(CORBA::ULong, RTPS::FragmentNumberSet) RequestedFragMap;
+  typedef OPENDDS_MAP(SequenceNumber, RequestedFragMap) RequestedFragSeqMap;
+
   struct ReaderInfo : public RcObject {
     const RepoId id_;
     const MonotonicTime_t participant_discovered_at_;
     CORBA::Long acknack_recvd_count_, nackfrag_recvd_count_;
     DisjointSequence requests_;
-    OPENDDS_MAP(SequenceNumber, RTPS::FragmentNumberSet) requested_frags_;
+    RequestedFragSeqMap requested_frags_;
     SequenceNumber cur_cumulative_ack_;
     const bool durable_;
     const ACE_CDR::ULong participant_flags_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -1054,17 +1054,17 @@ RtpsUdpReceiveStrategy::has_fragments(const SequenceRange& range,
     if (reassembly_.has_frags(sn, pub_id, total_frags)) {
       if (frag_info) {
         if (total_frags > 256) {
-          const CORBA::Long empty_buffer[8] { 0, 0, 0, 0, 0, 0, 0, 0};
+          const CORBA::Long empty_buffer[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
           OPENDDS_VECTOR(CORBA::Long) buffer(total_frags + 31/ 32, 0);
           ACE_UINT32 numBits = 0;
           size_t idx = 0;
-          const ACE_UINT32 base = reassembly_.get_gaps(sn, pub_id, &buffer[0], buffer.size(), numBits);
-          const size_t end = base + numBits;
-          for (size_t i = base; i <= end; i += 256) {
-            const size_t remain = end - i;
-            const size_t len = std::min(remain, static_cast<size_t>(256));
-            const size_t len32 = (len + 31) / 32;
-            const size_t len8 = len32 * 4;
+          const ACE_UINT32 base = reassembly_.get_gaps(sn, pub_id, &buffer[0], static_cast<CORBA::ULong>(buffer.size()), numBits);
+          const CORBA::ULong end = base + numBits;
+          for (CORBA::ULong i = base; i <= end; i += 256) {
+            const CORBA::ULong remain = end - i;
+            const CORBA::ULong len = std::min(remain, static_cast<CORBA::ULong>(256));
+            const CORBA::ULong len32 = (len + 31) / 32;
+            const CORBA::ULong len8 = len32 * 4;
             if (memcmp(&buffer[idx], &empty_buffer[0], len8) != 0) {
               std::pair<SequenceNumber, RTPS::FragmentNumberSet> p;
               p.first = sn;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -1054,8 +1054,8 @@ RtpsUdpReceiveStrategy::has_fragments(const SequenceRange& range,
     if (reassembly_.has_frags(sn, pub_id, total_frags)) {
       if (frag_info) {
         if (total_frags > 256) {
-          const CORBA::Long empty_buffer[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-          OPENDDS_VECTOR(CORBA::Long) buffer(total_frags + 31/ 32, 0);
+          static const CORBA::Long empty_buffer[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+          OPENDDS_VECTOR(CORBA::Long) buffer(total_frags + 31 / 32, 0);
           ACE_UINT32 numBits = 0;
           size_t idx = 0;
           const ACE_UINT32 base = reassembly_.get_gaps(sn, pub_id, &buffer[0], static_cast<CORBA::ULong>(buffer.size()), numBits);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -1054,18 +1054,18 @@ RtpsUdpReceiveStrategy::has_fragments(const SequenceRange& range,
     if (reassembly_.has_frags(sn, pub_id, total_frags)) {
       if (frag_info) {
         if (total_frags > 256) {
-          CORBA::Long empty_buffer[8];
-          memset(empty_buffer, 0, sizeof (empty_buffer));
+          const CORBA::Long empty_buffer[8] { 0, 0, 0, 0, 0, 0, 0, 0};
           OPENDDS_VECTOR(CORBA::Long) buffer(total_frags + 31/ 32, 0);
           ACE_UINT32 numBits = 0;
           size_t idx = 0;
           const ACE_UINT32 base = reassembly_.get_gaps(sn, pub_id, &buffer[0], buffer.size(), numBits);
-          for (size_t i = base; i <= numBits; i += 256) {
-            const size_t remain = numBits + 1 - base;
+          const size_t end = base + numBits;
+          for (size_t i = base; i <= end; i += 256) {
+            const size_t remain = end - i;
             const size_t len = std::min(remain, static_cast<size_t>(256));
             const size_t len32 = (len + 31) / 32;
             const size_t len8 = len32 * 4;
-            if (memcmp(&buffer[idx], empty_buffer, len8) != 0) {
+            if (memcmp(&buffer[idx], &empty_buffer[0], len8) != 0) {
               std::pair<SequenceNumber, RTPS::FragmentNumberSet> p;
               p.first = sn;
               frag_info->push_back(p);


### PR DESCRIPTION
Problem: Fragment NACKing is non-optimal for a number of reasons:
- Heartbeats are sent for the sample before the final fragment has been sent, causing pre-emptive NACK_FRAGs
- Only one NACK_FRAG range is stored per sequence number, causing a delay in resends when multiple NACK_FRAGs have been sent between heartbeats
- NACK_FRAGs are being generated for fully "received" samples (i.e. unneeded)

Solution: Don't do those things.