### PR TITLE
Fix LivelinessChangedStatus Count Values In DataReaderImpl

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2865,12 +2865,12 @@ void DataReaderImpl::notify_liveliness_change()
   = listener_for(DDS::LIVELINESS_CHANGED_STATUS);
 
   if (!CORBA::is_nil(listener.in())) {
-    listener->on_liveliness_changed(this, liveliness_changed_status_);
-
-    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
-
+    ACE_Guard<ACE_Recursive_Thread_Mutex> guard(sample_lock_);
+    DDS::LivelinessChangedStatus status = liveliness_changed_status_;
     liveliness_changed_status_.alive_count_change = 0;
     liveliness_changed_status_.not_alive_count_change = 0;
+    guard.release();
+    listener->on_liveliness_changed(this, status);
   }
   notify_status_condition();
 

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2866,7 +2866,7 @@ void DataReaderImpl::notify_liveliness_change()
 
   if (!CORBA::is_nil(listener.in())) {
     ACE_Guard<ACE_Recursive_Thread_Mutex> guard(sample_lock_);
-    DDS::LivelinessChangedStatus status = liveliness_changed_status_;
+    const DDS::LivelinessChangedStatus status = liveliness_changed_status_;
     liveliness_changed_status_.alive_count_change = 0;
     liveliness_changed_status_.not_alive_count_change = 0;
     guard.release();


### PR DESCRIPTION
Problem: There's a race condition for resetting LivelinessChangedStatus *_count_change values in DataReaderImpl (as well as a data race for the internal object when releasing the lock).

Solution: Use the lock to copy status & reset values, pass the copy.