### PR TITLE
Fix Windows Iterator Assertion In RemoveAssociationSweeper

### DIFF
--- a/dds/DCPS/RemoveAssociationSweeper.h
+++ b/dds/DCPS/RemoveAssociationSweeper.h
@@ -159,7 +159,13 @@ template <typename T>
 RcHandle<WriterInfo> RemoveAssociationSweeper<T>::remove_info(WriterInfo* info)
 {
   RcHandle<WriterInfo> result;
+
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+
+  if (info_set_.empty()) {
+    return result;
+  }
+
   OPENDDS_VECTOR(RcHandle<WriterInfo>)::iterator itr, last = --info_set_.end();
   // find the RcHandle holds the pointer info in info_set_
   // and then swap the found element with the last element in the


### PR DESCRIPTION
Problem: RemoveAssociationSweeper tries to pre-calculate the last iterator, but on Windows this causes an iterator assertion when the set is empty (despite the fact it's never used).

Solution: Don't even proceed to making the calculation if the set is empty.