### PR TITLE
Synchronization Fixes for TransientLocalMultiInstance Test

### DIFF
--- a/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.cpp
@@ -22,8 +22,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
     if (CORBA::is_nil(message_dr)) {
@@ -34,6 +32,8 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     Messenger::Message message;
     DDS::SampleInfo si;
     DDS::ReturnCode_t status = message_dr->take_next_sample(message, si);
+
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
 
     if (si.valid_data) {
       if (status == DDS::RETCODE_OK) {

--- a/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.cpp
@@ -22,6 +22,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);
     if (CORBA::is_nil(message_dr)) {
@@ -107,6 +109,8 @@ void DataReaderListenerImpl::on_sample_lost(
 
 long DataReaderListenerImpl::num_reads() const
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+
   long num_reads = 0;
   std::map<int, int>::const_iterator map_iter = read_intances_message_count_.begin();
   for (; map_iter != read_intances_message_count_.end(); ++map_iter) {
@@ -117,6 +121,8 @@ long DataReaderListenerImpl::num_reads() const
 
 bool DataReaderListenerImpl::received_all_expected_messages() const
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+
   for (int i = 0; i < 4; ++i) {
     int message_instance = i + 1;
     if (!read_intances_message_count_.count(message_instance))

--- a/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.h
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.h
@@ -49,9 +49,15 @@ public:
 
   bool received_all_expected_messages() const;
 
-  bool ok_;
+  bool ok() const
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    return ok_;
+  }
 
 private:
+  mutable ACE_Thread_Mutex mutex_;
+  bool ok_;
   std::map<int, int> read_intances_message_count_;
 };
 

--- a/tests/DCPS/TransientLocalMultiInstanceTest/publisher.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/publisher.cpp
@@ -227,7 +227,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       ACE_OS::sleep(1);
     }
 
-    ok = listener_servant1->ok_;
+    ok = listener_servant1->ok();
     if (ok) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Reader 1 in pub process received all samples\n")));
     } else {
@@ -267,7 +267,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     }
 
     if (ok) {
-      ok = listener_servant2->ok_;
+      ok = listener_servant2->ok();
       if (ok) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Reader 2 in pub process received all samples\n")));
       } else {

--- a/tests/DCPS/TransientLocalMultiInstanceTest/subscriber.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/subscriber.cpp
@@ -102,7 +102,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       ACE_OS::sleep(1);
     }
 
-    ok = listener_servant->ok_;
+    ok = listener_servant->ok();
     if (ok)
     {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Reader received all samples.\n")));


### PR DESCRIPTION
Problem: No thread synchronization mechanisms existed for the TransientLocalMultiInstance test. This caused data races in ThreadSanitizer reports.

Solution: Add a mutex to the DataReaderListener and use it.