### PR TITLE
Extend DpShutdown Test, PerlDDS Improvements

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -5,14 +5,13 @@
 use strict;
 use warnings;
 
+package PerlDDS;
+
 use PerlACE::Run_Test;
 use PerlDDS::Process;
 use PerlDDS::ProcessFactory;
 use Cwd;
 use POSIX qw(strftime);
-
-package PerlDDS;
-
 use File::Spec::Functions qw(catfile catdir);
 
 sub is_executable {
@@ -384,6 +383,7 @@ sub new {
   $self->{transport} = "";
   $self->{ini} = "";
   $self->{report_errors_in_log_file} = 1;
+  $self->{dcps_log_level} = $ENV{DCPSLogLevel} // "";
   $self->{dcps_debug_level} = 1;
   $self->{dcps_transport_debug_level} = 1;
   $self->{dcps_security_debug} = defined $ENV{DCPSSecurityDebug} ?
@@ -406,14 +406,9 @@ sub new {
         " pair with an empty name.\n";
       $flag_name = "<No Name Provided>";
     }
-    my $flag_value;
-    if (defined($3)) {
-      $flag_value = $3;
-    }
-    else {
-      $flag_value = "<FLAG>";
-    }
-    $self->_info("TestFramework storing \"$flag_name\"=\"$flag_value\"\n");
+    my $flag_value = $3;
+    my $flag_value_str = defined($flag_value) ? "\"$flag_value\"" : 'undef';
+    $self->_info("TestFramework storing \"$flag_name\"=$flag_value_str\n");
     $self->{flags}->{$flag_name} = $flag_value;
     my $transport = _is_transport($arg);
     if ($transport && $self->{transport} eq "") {
@@ -432,7 +427,7 @@ sub new {
       $self->_time_info("Test starting ($left arguments remaining)\n");
     } elsif (lc($arg) eq "nobits") {
       $self->{nobits} = 1;
-    } elsif ($flag_name eq "ini") {
+    } elsif ($flag_name eq "ini" && defined($flag_value)) {
       $flag_value =~ /^([^_]+)_([^_]+).ini/;
       if ($1 eq "inforepo") {
         $self->{discovery} = "info_repo";
@@ -534,54 +529,21 @@ sub finish {
 
 sub flag {
   my $self = shift;
-  my $flag_passed = shift;
+  my $flag_name = shift;
+  my $flag_value_ref = shift;
 
-  my $present = defined($self->{flags}->{$flag_passed});
-  $self->_info("TestFramework::flag $flag_passed present=$present\n");
+  my $present = exists($self->{flags}->{$flag_name});
+  $self->_info("TestFramework::flag $flag_name present=$present\n");
   if ($present) {
-    if ($self->{flags}->{$flag_passed} ne "<FLAG>") {
-      print STDERR "WARNING: you are treating a name-value pair as a flag, should call value_flag. \"$flag_passed=" .
-        $self->{flags}->{$flag_passed} . "\"\n";
+    my $flag_value = $self->{flags}->{$flag_name};
+    if (defined($flag_value_ref)) {
+      die("Flag \"$flag_name\" is missing required value!") if (!defined($flag_value));
+      ${$flag_value_ref} = $flag_value;
     }
-    delete($self->{flags}->{unused}->{$flag_passed});
-  }
-  return $present;
-}
-
-sub value_flag {
-  my $self = shift;
-  my $flag_passed = shift;
-
-  my $present = defined($self->{flags}->{$flag_passed});
-  $self->_info("TestFramework::value_flag $flag_passed present=$present\n");
-  if ($present) {
-    if ($self->{flags}->{$flag_passed} eq "<FLAG>") {
-      # this is indicating if a flag with a value is present, but this is just a flag
-      return 0;
+    else {
+      die("Flag \"$flag_name\" was passed a value, but it isn't used") if (defined($flag_value));
     }
-    delete($self->{flags}->{unused}->{$flag_passed});
-  }
-  return $present;
-}
-
-sub get_value_flag {
-  my $self = shift;
-  my $flag_passed = shift;
-
-  my $present = defined($self->{flags}->{$flag_passed});
-  $self->_info("TestFramework::get_value_flag $flag_passed present=$present\n");
-  if ($present) {
-    if ($self->{flags}->{$flag_passed} eq "<FLAG>") {
-      print STDERR "ERROR: $flag_passed does not have a value, should not call get_value_flag\n";
-    }
-    if (defined($self->{flags}->{unused}->{$flag_passed})) {
-      print STDERR "WARNING: calling get_value_flag($flag_passed) without first verifying that "
-        . "it is present with value_flag($flag_passed)\n";
-      delete($self->{flags}->{unused}->{$flag_passed});
-    }
-  }
-  else {
-    print STDERR "ERROR: $flag_passed is not present, should have called value_flag before calling get_value_flag\n";
+    delete($self->{flags}->{unused}->{$flag_name});
   }
   return $present;
 }
@@ -638,34 +600,40 @@ sub process {
     return;
   }
 
-  if (defined $ENV{DCPSDebugLevel}) {
-    $self->{dcps_debug_level} = $ENV{DCPSDebugLevel};
+  my $debug_logging = 1;
+
+  if ($params !~ /-DCPSLogLevel / && $self->{dcps_log_level}) {
+    $params .=  " -DCPSLogLevel $self->{dcps_log_level}";
+    $debug_logging = $self->{dcps_log_level} eq "debug";
   }
 
-  if ($params !~ /-DCPSDebugLevel / && $self->{dcps_debug_level}) {
-    my $debug = " -DCPSDebugLevel $self->{dcps_debug_level}";
-    if ($params !~ /-ORBVerboseLogging /) {
-      $debug .= " -ORBVerboseLogging 1";
+  if ($debug_logging) {
+    if (defined $ENV{DCPSDebugLevel}) {
+      $self->{dcps_debug_level} = $ENV{DCPSDebugLevel};
     }
-    $params .= $debug;
-  }
-
-  if (defined $ENV{DCPSTransportDebugLevel}) {
-    $self->{dcps_transport_debug_level} = $ENV{DCPSTransportDebugLevel};
-  }
-
-  if ($params !~ /-DCPSTransportDebugLevel / &&
-      $self->{dcps_transport_debug_level}) {
-    my $debug = " -DCPSTransportDebugLevel $self->{dcps_transport_debug_level}";
-    $params .= $debug;
-  }
-
-  if ($params !~ /-DCPSSecurityDebug(?:Level)? /) {
-    if ($self->{dcps_security_debug}) {
-      $params .=  " -DCPSSecurityDebug $self->{dcps_security_debug}";
+    if ($params !~ /-DCPSDebugLevel / && $self->{dcps_debug_level}) {
+      my $debug = " -DCPSDebugLevel $self->{dcps_debug_level}";
+      if ($params !~ /-ORBVerboseLogging /) {
+        $debug .= " -ORBVerboseLogging 1";
+      }
+      $params .= $debug;
     }
-    elsif ($self->{dcps_security_debug_level}) {
-      $params .=  " -DCPSSecurityDebugLevel $self->{dcps_security_debug_level}";
+
+    if (defined $ENV{DCPSTransportDebugLevel}) {
+      $self->{dcps_transport_debug_level} = $ENV{DCPSTransportDebugLevel};
+    }
+    if ($params !~ /-DCPSTransportDebugLevel / &&
+        $self->{dcps_transport_debug_level}) {
+      $params .= " -DCPSTransportDebugLevel $self->{dcps_transport_debug_level}";
+    }
+
+    if ($params !~ /-DCPSSecurityDebug(?:Level)? /) {
+      if ($self->{dcps_security_debug}) {
+        $params .=  " -DCPSSecurityDebug $self->{dcps_security_debug}";
+      }
+      elsif ($self->{dcps_security_debug_level}) {
+        $params .=  " -DCPSSecurityDebugLevel $self->{dcps_security_debug_level}";
+      }
     }
   }
 
@@ -676,8 +644,7 @@ sub process {
     $file_name =~ s/ /_/g;
     $file_name =~ s/#//g;
 
-    my $debug = " -ORBLogFile $file_name.log";
-    $params .= $debug;
+    $params = "-ORBLogFile $file_name.log $params"
   }
 
   if ($self->{add_transport_config} &&

--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -603,7 +603,7 @@ sub process {
   my $debug_logging = 1;
 
   if ($params !~ /-DCPSLogLevel / && $self->{dcps_log_level}) {
-    $params .=  " -DCPSLogLevel $self->{dcps_log_level}";
+    $params .= " -DCPSLogLevel $self->{dcps_log_level}";
     $debug_logging = $self->{dcps_log_level} eq "debug";
   }
 
@@ -644,7 +644,7 @@ sub process {
     $file_name =~ s/ /_/g;
     $file_name =~ s/#//g;
 
-    $params = "-ORBLogFile $file_name.log $params"
+    $params = "-ORBLogFile $file_name.log $params";
   }
 
   if ($self->{add_transport_config} &&

--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -365,7 +365,7 @@ sub new {
   my $self = bless {}, $class;
 
   $self->{processes} = {};
-  $self->{flags} = {};
+  $self->{_flags} = {};
   $self->{status} = 0;
   $self->{log_files} = [];
   $self->{temp_files} = [];
@@ -409,7 +409,7 @@ sub new {
     my $flag_value = $3;
     my $flag_value_str = defined($flag_value) ? "\"$flag_value\"" : 'undef';
     $self->_info("TestFramework storing \"$flag_name\"=$flag_value_str\n");
-    $self->{flags}->{$flag_name} = $flag_value;
+    $self->{_flags}->{$flag_name} = $flag_value;
     my $transport = _is_transport($arg);
     if ($transport && $self->{transport} eq "") {
       $self->{transport} = $arg;
@@ -439,7 +439,7 @@ sub new {
     } elsif (!$transport) {
       # also keep a copy to delete so we can see which parameters
       # are unused (above args are already "used")
-      $self->{flags}->{unused}->{$flag_name} = $flag_value;
+      $self->{_flags}->{unused}->{$flag_name} = $flag_value;
     }
     ++$index;
   }
@@ -532,10 +532,10 @@ sub flag {
   my $flag_name = shift;
   my $flag_value_ref = shift;
 
-  my $present = exists($self->{flags}->{$flag_name});
+  my $present = exists($self->{_flags}->{$flag_name});
   $self->_info("TestFramework::flag $flag_name present=$present\n");
   if ($present) {
-    my $flag_value = $self->{flags}->{$flag_name};
+    my $flag_value = $self->{_flags}->{$flag_name};
     if (defined($flag_value_ref)) {
       die("Flag \"$flag_name\" is missing required value!") if (!defined($flag_value));
       ${$flag_value_ref} = $flag_value;
@@ -543,7 +543,7 @@ sub flag {
     else {
       die("Flag \"$flag_name\" was passed a value, but it isn't used") if (defined($flag_value));
     }
-    delete($self->{flags}->{unused}->{$flag_name});
+    delete($self->{_flags}->{unused}->{$flag_name});
   }
   return $present;
 }
@@ -554,7 +554,7 @@ sub report_unused_flags {
   $exit_if_unidentified = 0 if !defined($exit_if_unidentified);
 
   $self->_info("TestFramework::report_unused_flags\n");
-  my @unused = keys(%{$self->{flags}->{unused}});
+  my @unused = keys(%{$self->{_flags}->{unused}});
   if (scalar(@unused) == 0) {
     return;
   }
@@ -577,7 +577,7 @@ sub report_unused_flags {
 sub unused_flags {
   my $self = shift;
 
-  return keys(%{$self->{flags}->{unused}});
+  return keys(%{$self->{_flags}->{unused}});
 }
 
 sub process {

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2117,7 +2117,7 @@ bool DomainParticipantImpl::is_clean(String* leftover_entities) const
     if (leftover_entities->size()) {
       *leftover_entities += ", ";
     }
-    *leftover_entities += to_dds_string(pub_count) + " topic(s)";
+    *leftover_entities += to_dds_string(pub_count) + " publisher(s)";
   }
 
   return topic_count == 0 && sub_count == 0 && pub_count == 0;

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -229,7 +229,7 @@ Service_Participant::~Service_Participant()
       if (count > 0 && log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Service_Participant::~Service_Participant: "
           "There are %B remaining domain participant(s). "
-          "It is recommented to delete them before shutdown.\n",
+          "It is recommended to delete them before shutdown.\n",
           count));
       }
 

--- a/tests/DCPS/DpShutdown/dpshutdown.cpp
+++ b/tests/DCPS/DpShutdown/dpshutdown.cpp
@@ -1,322 +1,395 @@
-// -*- C++ -*-
-// ============================================================================
-/**
- *  @file   dpshutdown.cpp
- *
- */
-// ============================================================================
+#include <MessengerTypeSupportImpl.h>
+#include <tests/Utils/ExceptionStreams.h>
 
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
 #include <dds/DCPS/Qos_Helper.h>
+#include <dds/DCPS/DCPS_Utils.h>
 #include <dds/DCPS/transport/framework/TransportType_rch.h>
 #include <dds/DCPS/transport/framework/TransportRegistry.h>
 #include <dds/DCPS/transport/framework/TransportConfig_rch.h>
 #include <dds/DCPS/transport/framework/TransportExceptions.h>
-#include "MessengerTypeSupportImpl.h"
-
 #ifndef DDS_HAS_MINIMUM_BIT
-#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #endif
-
 #ifdef ACE_AS_STATIC_LIBS
-#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
-#include <dds/DCPS/transport/shmem/Shmem.h>
-#include <dds/DCPS/transport/udp/Udp.h>
-#include <dds/DCPS/transport/multicast/Multicast.h>
-#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#  include <dds/DCPS/transport/shmem/Shmem.h>
+#  include <dds/DCPS/transport/udp/Udp.h>
+#  include <dds/DCPS/transport/multicast/Multicast.h>
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #endif
-
-#include "dds/DCPS/StaticIncludes.h"
 
 #include <ace/Arg_Shifter.h>
 #include <ace/streams.h>
-#include "tests/Utils/ExceptionStreams.h"
-#include "ace/Get_Opt.h"
+#include <ace/Get_Opt.h>
 
 #include <memory>
 using namespace std;
+using OpenDDS::DCPS::TransportConfig_rch;
+using OpenDDS::DCPS::TransportRegistry;
+using OpenDDS::DCPS::String;
 
-int ACE_TMAIN (int argc, ACE_TCHAR *argv[]) {
+TransportConfig_rch create_transport(const String& transport, const String& suffix)
+{
+  const String prefix("dpshutdown_");
+  const String config_name = prefix + transport + "_config_" + suffix;
+  TransportConfig_rch config = TransportRegistry::instance()->get_config(config_name);
+  if (!config) {
+    config = TransportRegistry::instance()->create_config(config_name);
+  }
+  if (!config) {
+    ACE_ERROR((LM_ERROR, "%N:%l ERROR: could not get TransportConfig for %C\n",
+      transport.c_str()));
+    return TransportConfig_rch();
+  }
 
+  const String inst_name = prefix + transport + "_inst_" + suffix;
+  OpenDDS::DCPS::TransportInst_rch inst = TransportRegistry::instance()->get_inst(inst_name);
+  if (!inst) {
+    inst = TransportRegistry::instance()->create_inst(inst_name, transport);
+    config->instances_.push_back(inst);
+  }
+  if (!inst) {
+    ACE_ERROR((LM_ERROR, "%N:%l ERROR: could not get TransportInst for %C\n",
+      transport.c_str()));
+    return TransportConfig_rch();
+  }
+
+  return config;
+}
+
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
+{
   OPENDDS_STRING transport("rtps_udp");
 
   ACE_Arg_Shifter arg_shifter(argc, argv);
-  while (arg_shifter.is_anything_left())
-  {
+  while (arg_shifter.is_anything_left()) {
     const ACE_TCHAR* current_arg = 0;
     // The '-t' option for transport
     if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-t")))) {
       transport = ACE_TEXT_ALWAYS_CHAR(current_arg);
       ACE_DEBUG((LM_DEBUG, "Using transport:%C\n", transport.c_str()));
       arg_shifter.consume_arg();
-    }
-    else {
+    } else {
       arg_shifter.ignore_arg();
     }
   }
 
-  OPENDDS_STRING config_1("dds4ccm_");
-  config_1 += transport + "_1";
+  try {
+    DDS::DomainParticipantFactory_var dpf = TheParticipantFactoryWithArgs(argc, argv);
 
-  OPENDDS_STRING instance_1("the_");
-  instance_1 += transport + "_transport_1";
+    TransportConfig_rch config1 = create_transport(transport, "1");
+    if (!config1) {
+      return 1;
+    }
+    TransportRegistry::instance()->global_config(config1);
 
-  OPENDDS_STRING config_2("dds4ccm_");
-  config_2 += transport + "_2";
-
-  OPENDDS_STRING instance_2("the_");
-  instance_2 += transport + "_transport_2";
-
-  try
-    {
-      DDS::DomainParticipantFactory_var dpf =
-        TheParticipantFactoryWithArgs(argc, argv);
-
-      OpenDDS::DCPS::TransportConfig_rch config =
-        OpenDDS::DCPS::TransportRegistry::instance()->get_config(config_1.c_str());
-
-      if (config.is_nil())
-        {
-          config =
-            OpenDDS::DCPS::TransportRegistry::instance()->create_config(config_1.c_str());
-        }
-
-      OpenDDS::DCPS::TransportInst_rch inst =
-        OpenDDS::DCPS::TransportRegistry::instance()->get_inst(instance_1.c_str());
-
-      if (inst.is_nil())
-        {
-          inst =
-            OpenDDS::DCPS::TransportRegistry::instance()->create_inst(instance_1.c_str(),
-                                                                      transport.c_str());
-
-          config->instances_.push_back(inst);
-
-          OpenDDS::DCPS::TransportRegistry::instance()->global_config(config);
-        }
-
-      // Create another transport instance for participant2 since RTPS transport instances
-      // cannot be shared by domain participants.
-      OpenDDS::DCPS::TransportConfig_rch config2 =
-        OpenDDS::DCPS::TransportRegistry::instance()->get_config(config_2.c_str());
-
-      if (config2.is_nil())
-        {
-          config2 =
-            OpenDDS::DCPS::TransportRegistry::instance()->create_config(config_2.c_str());
-        }
-
-      OpenDDS::DCPS::TransportInst_rch inst2 =
-        OpenDDS::DCPS::TransportRegistry::instance()->get_inst(instance_2.c_str());
-
-      if (inst2.is_nil())
-        {
-          inst2 =
-            OpenDDS::DCPS::TransportRegistry::instance()->create_inst(instance_2.c_str(),
-                                                                      transport.c_str());
-          config2->instances_.push_back(inst2);
-
-        }
-
+    // Create another transport instance for participant2 since RTPS transport instances
+    // cannot be shared by domain participants.
+    TransportConfig_rch config2 = create_transport(transport, "2");
+    if (!config2) {
+      return 1;
+    }
 
 #ifndef DDS_HAS_MINIMUM_BIT
-      OpenDDS::RTPS::RtpsDiscovery_rch disc =
-        OpenDDS::DCPS::make_rch<OpenDDS::RTPS::RtpsDiscovery>(OpenDDS::DCPS::Discovery::DEFAULT_RTPS);
+    OpenDDS::RTPS::RtpsDiscovery_rch disc =
+      OpenDDS::DCPS::make_rch<OpenDDS::RTPS::RtpsDiscovery>(OpenDDS::DCPS::Discovery::DEFAULT_RTPS);
 
-      // The recommended value for the resend period is 2 seconds for
-      // the current implementation of OpenDDS.
-      disc->resend_period(OpenDDS::DCPS::TimeDuration(2));
+    // The recommended value for the resend period is 2 seconds for
+    // the current implementation of OpenDDS.
+    disc->resend_period(OpenDDS::DCPS::TimeDuration(2));
 
-      TheServiceParticipant->add_discovery(disc);
-      TheServiceParticipant->set_repo_domain(11, disc->key());
+    TheServiceParticipant->add_discovery(disc);
+    TheServiceParticipant->set_repo_domain(11, disc->key());
 #endif
-      TheServiceParticipant->set_default_discovery (OpenDDS::DCPS::Discovery::DEFAULT_RTPS);
+    TheServiceParticipant->set_default_discovery(OpenDDS::DCPS::Discovery::DEFAULT_RTPS);
 
-      DDS::DomainParticipant_var participant1 =
-        dpf->create_participant(11,
-                                PARTICIPANT_QOS_DEFAULT,
-                                DDS::DomainParticipantListener::_nil(),
-                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-      if (CORBA::is_nil (participant1.in ())) {
-        cerr << "create_participant failed." << endl;
-        return 1;
-      }
-      else
-      {
-        ACE_DEBUG ((LM_DEBUG, "Created participant 1 with instance handle %d\n",
-                    participant1->get_instance_handle ()));
-      }
-      try
-      {
-        OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config, participant1.in());
-      }
-      catch (const OpenDDS::DCPS::Transport::MiscProblem &) {
-        ACE_ERROR_RETURN((LM_ERROR,
-          ACE_TEXT("%N:%l: main()")
-          ACE_TEXT(" ERROR: TransportRegistry::bind_config() throws")
-          ACE_TEXT(" Transport::MiscProblem exception\n")),
-          -1);
-      }
-      catch (const OpenDDS::DCPS::Transport::NotFound &) {
-        ACE_ERROR_RETURN((LM_ERROR,
-          ACE_TEXT("%N:%l: main()")
-          ACE_TEXT(" ERROR: TransportRegistry::bind_config() throws")
-          ACE_TEXT(" Transport::NotFound exception\n")),
-          -1);
-      }
+    DDS::DomainParticipant_var participant1 = dpf->create_participant(11,
+      PARTICIPANT_QOS_DEFAULT,
+      DDS::DomainParticipantListener::_nil(),
+      ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!participant1) {
+      cerr << "create_participant failed." << endl;
+      return 1;
+    } else {
+      ACE_DEBUG((LM_DEBUG, "Created participant 1 with instance handle %d\n",
+        participant1->get_instance_handle()));
+    }
+    try {
+      OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config1, participant1.in());
+    } catch (const OpenDDS::DCPS::Transport::MiscProblem&) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: TransportRegistry::bind_config() throws"
+        " Transport::MiscProblem exception\n"), 1);
+    } catch (const OpenDDS::DCPS::Transport::NotFound&) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: "
+        "TransportRegistry::bind_config() throws Transport::NotFound exception\n"), 1);
+    }
 
-      DDS::DomainParticipant_var participant2 =
-        dpf->create_participant(11,
-                                PARTICIPANT_QOS_DEFAULT,
-                                DDS::DomainParticipantListener::_nil(),
-                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-      if (CORBA::is_nil (participant2.in ())) {
-        cerr << "create_participant failed." << endl;
-        return 1;
-      }
-      else
-      {
-        ACE_DEBUG ((LM_DEBUG, "Created participant 2 with instance handle %d\n",
-                    participant2->get_instance_handle ()));
-      }
+    DDS::DomainParticipant_var participant2 = dpf->create_participant(11,
+      PARTICIPANT_QOS_DEFAULT,
+      DDS::DomainParticipantListener::_nil(),
+      ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!participant2.in()) {
+      cerr << "create_participant failed." << endl;
+      return 1;
+    } else {
+      ACE_DEBUG((LM_DEBUG,
+        "Created participant 2 with instance handle %d\n",
+        participant2->get_instance_handle()));
+    }
 
-      try {
-        OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config2, participant2.in());
-      }
-      catch (const OpenDDS::DCPS::Transport::MiscProblem &) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: TransportRegistry::bind_config() throws")
-                          ACE_TEXT(" Transport::MiscProblem exception\n")),
-                          -1);
-      }
-      catch (const OpenDDS::DCPS::Transport::NotFound &) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: TransportRegistry::bind_config() throws")
-                          ACE_TEXT(" Transport::NotFound exception\n")),
-                          -1);
-      }
+    try {
+      OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config2, participant2.in());
+    } catch (const OpenDDS::DCPS::Transport::MiscProblem&) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: TransportRegistry::bind_config() throws "
+        "Transport::MiscProblem exception\n"), 1);
+    } catch (const OpenDDS::DCPS::Transport::NotFound&) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: TransportRegistry::bind_config() throws"
+        " Transport::NotFound exception\n"), 1);
+    }
 
-      if (participant1->get_instance_handle () == participant2->get_instance_handle ())
-      {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: participant1 and participant2 do have the same instance handle!\n")),
-                        -1);
-      }
+    if (participant1->get_instance_handle() == participant2->get_instance_handle()) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: "
+        "participant1 and participant2 do have the same instance handle!\n"), 1);
+    }
 
-      // Register TypeSupport (Messenger::Message)
-      Messenger::MessageTypeSupport_var mts =
-        new Messenger::MessageTypeSupportImpl();
+    // Register TypeSupport (Messenger::Message)
+    Messenger::MessageTypeSupport_var mts = new Messenger::MessageTypeSupportImpl();
+    if (mts->register_type(participant1.in(), "") != DDS::RETCODE_OK) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: register_type failed!\n"), 1);
+    }
 
-      if (mts->register_type(participant1.in(), "") != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: register_type failed!\n")),
-                        -1);
-      }
+    // Create Topic
+    CORBA::String_var type_name = mts->get_type_name();
+    DDS::Topic_var topic1 = participant1->create_topic("Movie Discussion List",
+      type_name.in(),
+      TOPIC_QOS_DEFAULT,
+      DDS::TopicListener::_nil(),
+      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!topic1) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: create_topic topic1 failed!\n"), 1);
+    }
 
-      // Create Topic
-      CORBA::String_var type_name = mts->get_type_name();
-      DDS::Topic_var topic =
-        participant1->create_topic("Movie Discussion List",
-                                   type_name.in(),
-                                   TOPIC_QOS_DEFAULT,
-                                   DDS::TopicListener::_nil(),
-                                   OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    // Create Publisher
+    DDS::Publisher_var pub = participant1->create_publisher(
+      PUBLISHER_QOS_DEFAULT, DDS::PublisherListener::_nil(), OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!pub) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: create_publisher failed!\n"), 1);
+    }
 
-      if (CORBA::is_nil(topic.in())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: create_topic failed!\n")),
-                        -1);
-      }
+    // Create DataWriter
+    DDS::DataWriter_var dw = pub->create_datawriter(topic1.in(),
+      DATAWRITER_QOS_DEFAULT,
+      DDS::DataWriterListener::_nil(),
+      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!dw) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: create_datawriter failed!\n"), 1);
+    }
 
-      // Create Publisher
-      DDS::Publisher_var pub =
-        participant1->create_publisher(PUBLISHER_QOS_DEFAULT,
-                                       DDS::PublisherListener::_nil(),
-                                       OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (mts->register_type(participant2.in(), "") != DDS::RETCODE_OK) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: register_type failed!\n"), 1);
+    }
 
-      if (CORBA::is_nil(pub.in())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: create_publisher failed!\n")),
-                        -1);
-      }
+    // Create Topic2
+    DDS::Topic_var topic2 = participant2->create_topic("Movie Discussion List",
+      type_name.in(),
+      TOPIC_QOS_DEFAULT,
+      DDS::TopicListener::_nil(),
+      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!topic2) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: create_topic for topic2 failed!\n"), 1);
+    }
 
-      // Create DataWriter
-      DDS::DataWriter_var dw =
-        pub->create_datawriter(topic.in(),
-                              DATAWRITER_QOS_DEFAULT,
-                              DDS::DataWriterListener::_nil(),
-                              OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    // Create Subscriber
+    DDS::Subscriber_var sub = participant2->create_subscriber(
+      SUBSCRIBER_QOS_DEFAULT, DDS::SubscriberListener::_nil(), OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!sub) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: create_subscriber failed!\n"), 1);
+    }
 
-      if (CORBA::is_nil(dw.in())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: create_datawriter failed!\n")),
-                        -1);
-      }
+    // Create DataReader
+    DDS::DataReader_var dr = sub->create_datareader(topic2.in(),
+      DATAREADER_QOS_DEFAULT,
+      DDS::DataReaderListener::_nil(),
+      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (!dr) {
+      ACE_ERROR_RETURN((LM_ERROR, "%N:%l: main() ERROR: create_datareader failed!\n"), 1);
+    }
 
-      DDS::ReturnCode_t retcode2 = pub->delete_datawriter (dw.in ());
-      if (retcode2 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete datawriter\n")),
-                        -1);
-      }
+    // Try to shutdown, but participant1 and participant2 still exist
+    DDS::ReturnCode_t rc = TheServiceParticipant->shutdown();
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 1st shutdown attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
 
-      DDS::ReturnCode_t retcode5 = dpf->delete_participant(participant1.in ());
-      if (retcode5 != DDS::RETCODE_PRECONDITION_NOT_MET) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should not be able to delete participant1\n")),
-                        -1);
-      }
+    /*
+     * Try to delete participant1, going one entity at a time to check that we
+     * can't delete the participant until every child entity is deleted.
+     */
+    rc = dpf->delete_participant(participant1);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 1st delete participant1 attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
 
-      DDS::ReturnCode_t retcode3 = participant1->delete_publisher (pub.in ());
-      if (retcode3 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete publisher\n")),
-                        -1);
-      }
+    /**
+     * Intentionally try to use the wrong participant to delete the publisher.
+     * This used to cause hard to diagnose errors if the mistake wasn't caught.
+     */
+    rc = participant2->delete_publisher(pub);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 1st delete publisher attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
 
-      DDS::ReturnCode_t retcode4 = participant1->delete_topic (topic.in ());
-      if (retcode4 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete topic\n")),
-                        -1);
-      }
+    rc = participant1->delete_publisher(pub);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) { // dw still exists
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 2nd delete publisher attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
 
-      DDS::ReturnCode_t retcode6 = dpf->delete_participant(participant1.in ());
-      if (retcode6 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete participant1\n")),
-                        -1);
-      }
+    rc = pub->delete_datawriter(dw);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: Failed to delete datawriter: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
 
-//       DDS::ReturnCode_t retcode7 = dpf->delete_participant(participant2.in ());
-//       if (retcode7 != DDS::RETCODE_OK) {
-//         ACE_ERROR_RETURN((LM_ERROR,
-//                           ACE_TEXT("%N:%l: main()")
-//                           ACE_TEXT(" ERROR: should be able to delete participant2\n")),
-//                         -1);
-//       }
+    rc = participant1->delete_publisher(pub);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: 3rd delete publisher attempt failed: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
 
-      ACE_DEBUG ((LM_DEBUG, "Shutting down the service participant with one participant still registered\n"));
-      TheServiceParticipant->shutdown ();
-  }
-  catch (CORBA::Exception& e)
-  {
-    cerr << "dp: Exception caught in main.cpp:" << endl
-         << e << endl;
+    rc = dpf->delete_participant(participant1);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) { // topic1 still exists
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 2nd delete participant1 attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = participant1->delete_topic(topic1);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: failed to delete topic1: %C",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = dpf->delete_participant(participant1);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: 3nd delete participant1 attempt failed: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    // Try to shutdown, but participant2 still exists
+    rc = TheServiceParticipant->shutdown();
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 2nd shutdown attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    /*
+     * Try to delete participant2, going one entity at a time to check that we
+     * can't delete the participant until every child entity is deleted.
+     */
+    rc = dpf->delete_participant(participant2);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 1st delete participant2 attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    /**
+     * Intentionally try to use the wrong participant to delete the subscriber.
+     * This used to cause hard to diagnose errors if the mistake wasn't caught.
+     */
+    rc = participant1->delete_subscriber(sub);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 1st delete subscriber attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = participant2->delete_subscriber(sub);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) { // dr still exists
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 2nd delete subscriber attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = sub->delete_datareader(dr);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: Failed to delete datareader: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = participant2->delete_subscriber(sub);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: 3rd delete subscriber attempt failed: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = dpf->delete_participant(participant2);
+    if (rc != DDS::RETCODE_PRECONDITION_NOT_MET) { // topic2 still exists
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected precondition not met from 2nd delete participant2 attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = participant2->delete_topic(topic2);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: failed to delete topic2: %C",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    rc = dpf->delete_participant(participant2);
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: 3nd delete participant2 attempt failed: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    // Now shutdown should return OK
+    rc = TheServiceParticipant->shutdown();
+    if (rc != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: 3rd shutdown attempt failed: %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+
+    // Calling shutdown again after a successful shutdown should return already deleted
+    rc = TheServiceParticipant->shutdown();
+    if (rc != DDS::RETCODE_ALREADY_DELETED) {
+      ACE_ERROR((LM_ERROR, "%N:%l: ERROR: "
+        "Expected already deleted from 4th shutdown attempt, but got %C\n",
+        OpenDDS::DCPS::retcode_to_string(rc)));
+      return 1;
+    }
+  } catch (CORBA::Exception& e) {
+    cerr << "dp: Exception caught in main.cpp:" << endl << e << endl;
     exit(1);
   }
 

--- a/tests/DCPS/DpShutdown/run_test.pl
+++ b/tests/DCPS/DpShutdown/run_test.pl
@@ -2,52 +2,32 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
      & eval 'exec perl -S $0 $argv:q'
      if 0;
 
-# -*- perl -*-
+use strict;
+use warnings;
 
-use Env (DDS_ROOT);
-use lib "$DDS_ROOT/bin";
-use Env (ACE_ROOT);
-use lib "$ACE_ROOT/bin";
+use lib "$ENV{DDS_ROOT}/bin";
+use lib "$ENV{ACE_ROOT}/bin";
 use PerlDDS::Run_Test;
 
 PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
 
-$status = 0;
-my $debugFile;
-my $debug;
-#$debug = 10;
-$debugFile = "test.log";
-my $debugOpts = "";
-$debugOpts .= "-DCPSDebugLevel $debug " if $debug;
-
-unlink $debugFile;
+my $status = 0;
 
 my $test = new PerlDDS::TestFramework();
 $test->{add_transport_config} = 0;
 
-if ($test->flag('rtps_udp')) {
-    $pub_opts .= " -t rtps_udp";
-}
-elsif ($test->flag('tcp')) {
-    $pub_opts .= " -t tcp";
-}
-elsif ($test->flag('shmem')) {
-    $pub_opts .= " -t shmem";
-}
-elsif ($test->flag('multicast')) {
-    $pub_opts .= " -t multicast";
-}
-elsif ($test->flag('udp')) {
-    $pub_opts .= " -t udp";
+my @args = ();
+my $value;
+if ($test->flag('t', \$value)) {
+  push(@args, '-t', $value);
 }
 
-$test->process("dpshutdown", "dpshutdown", "$debugOpts $pub_opts");
+$test->process("dpshutdown", "dpshutdown", join(' ', @args));
 $test->start_process("dpshutdown");
-$client = $test->finish(30);
-
+my $client = $test->finish(30);
 if ($client != 0) {
-    print STDERR "ERROR: client returned $client\n";
-    $status = 1;
+  print STDERR "ERROR: client returned $client\n";
+  $status = 1;
 }
 
 exit $status;

--- a/tests/DCPS/FindTopic/run_test.pl
+++ b/tests/DCPS/FindTopic/run_test.pl
@@ -20,7 +20,7 @@ my $test = new PerlDDS::TestFramework();
 $test->enable_console_logging();
 $test->{'add_transport_config'} = 0;
 
-if ($test->{'flags'}->{'rtps'}) {
+if ($test->flag('rtps')) {
     $opts .= 'rtps';
 }
 

--- a/tests/DCPS/MultiTopic/run_test.pl
+++ b/tests/DCPS/MultiTopic/run_test.pl
@@ -7,32 +7,29 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 use strict;
 use warnings;
 
-use Env qw(DDS_ROOT ACE_ROOT);
 use lib "$ENV{ACE_ROOT}/bin";
 use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
 
 my $test = new PerlDDS::TestFramework();
 
-my $is_rtps_disc = $test->{'flags'}->{'rtps_disc'} || 0;
-
 my $dir;
-if ($test->{'flags'}->{'cpp11'}) {
-    $dir = 'cpp11';
+if ($test->flag('cpp11')) {
+  $dir = 'cpp11';
 }
-if ($test->{'flags'}->{'classic'}) {
-    $dir = 'classic';
+elsif ($test->flag('classic')) {
+  $dir = 'classic';
 }
 
-if (! $dir) {
-    print "dir not set\n";
-    exit 1;
+if (!defined($dir)) {
+  die("Requires mapping type");
 }
 
 my $args;
-if ($is_rtps_disc) {
+if ($test->flag('rtps_disc')) {
   $args = ' -DCPSConfigFile rtps_disc.ini';
-} else {
+}
+else {
   $test->setup_discovery();
 }
 

--- a/tests/DCPS/Thrasher/run_test.pl
+++ b/tests/DCPS/Thrasher/run_test.pl
@@ -20,29 +20,29 @@ my $debug_level = 0;
 my $opts = "";
 # $opts .= "-DCPSChunks 1 ";
 
-if ($test->{'flags'}->{'low'}) {
+if ($test->flag('low')) {
   $opts .= "-t 8 -s 128 -n 1024";
-} elsif ($test->{'flags'}->{'medium'}) {
+} elsif ($test->flag('medium')) {
   $opts .= "-t 16 -s 64 -n 1024";
-} elsif ($test->{'flags'}->{'high'}) {
+} elsif ($test->flag('high')) {
   $opts .= "-t 32 -s 32 -n 1024";
-} elsif ($test->{'flags'}->{'aggressive'}) {
+} elsif ($test->flag('aggressive')) {
   $opts .= "-t 64 -s 16 -n 1024";
-} elsif ($test->{'flags'}->{'triangle'}) {
+} elsif ($test->flag('triangle')) {
   $opts .= "-t 3 -s 3 -n 9";
-} elsif ($test->{'flags'}->{'double'}) {
+} elsif ($test->flag('double')) {
   $opts .= "-t 2 -s 1 -n 2";
-} elsif ($test->{'flags'}->{'single'}) {
+} elsif ($test->flag('single')) {
   $opts .= "-t 1 -s 1 -n 1";
-} elsif ($test->{'flags'}->{'superlow'}) {
+} elsif ($test->flag('superlow')) {
   $opts .= "-t 4 -s 256 -n 1024";
-} elsif ($test->{'flags'}->{'megalow'}) {
+} elsif ($test->flag('megalow')) {
   $opts .= "-t 2 -s 512 -n 1024";
 } else { # default (i.e. lazy)
   $opts .= "-t 1 -s 1024 -n 1024";
 }
 
-if ($test->{'flags'}->{'durable'}) {
+if ($test->flag('durable')) {
   $opts .= " -d";
 }
 
@@ -52,7 +52,7 @@ if ($debug_level) {
 }
 
 my $ini_file = "thrasher.ini";
-if ($test->{'flags'}->{'rtps'}) {
+if ($test->flag('rtps')) {
   $ini_file = "thrasher_rtps.ini";
 }
 $opts .= " -DCPSConfigFile $ini_file";

--- a/tests/DCPS/ZeroCopyDataReaderListener/run_test.pl
+++ b/tests/DCPS/ZeroCopyDataReaderListener/run_test.pl
@@ -17,7 +17,7 @@ PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
 
 my $test = new PerlDDS::TestFramework();
 
-if ($test->{'flags'}->{'all'}) {
+if ($test->flags('all')) {
     @original_ARGV = grep { $_ ne 'all' } @original_ARGV;
     my @tests = ('', qw/udp multicast default_tcp default_udp default_multicast
                         nobits stack shmem
@@ -36,17 +36,17 @@ $test->{'dcps_transport_debug_level'} = 2;
 my $dbg_lvl = '-ORBDebugLevel 1';
 my $pending_timeout = '-DCPSPendingTimeout 2';
 
-my $thread_per_connection = $test->{'flags'}->{'thread_per'} ? '-p' : '';
+my $thread_per_connection = $test->flag('thread_per') ? '-p' : '';
 
-my $default_tport = ($test->{'flags'}->{'default_tcp'} ||
-                     $test->{'flags'}->{'stack'}) ? '-t tcp' :
-    $test->{'flags'}->{'default_udp'} ? '-t udp' :
-    $test->{'flags'}->{'default_multicast'} ? '-t multicast' : '';
+my $default_tport = ($test->flag('default_tcp') ||
+                     $test->flag('stack')) ? '-t tcp' :
+    $test->flag('default_udp') ? '-t udp' :
+    $test->flag('default_multicast') ? '-t multicast' : '';
 
 $test->{'transport'} = ($PerlDDS::SafetyProfile ? 'rtps_disc' : 'tcp')
     if $default_tport eq '' && $test->{'transport'} eq '';
 
-my $stack_based = $test->{'flags'}->{'stack'} ? 1 : 0;
+my $stack_based = $test->flag('stack') ? 1 : 0;
 
 $test->process('sub', ($stack_based ? 'stack_' : '') . 'subscriber',
                "$dbg_lvl $default_tport $pending_timeout");

--- a/tests/DCPS/ZeroCopyDataReaderListener/run_test.pl
+++ b/tests/DCPS/ZeroCopyDataReaderListener/run_test.pl
@@ -17,7 +17,7 @@ PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
 
 my $test = new PerlDDS::TestFramework();
 
-if ($test->flags('all')) {
+if ($test->flag('all')) {
     @original_ARGV = grep { $_ ne 'all' } @original_ARGV;
     my @tests = ('', qw/udp multicast default_tcp default_udp default_multicast
                         nobits stack shmem

--- a/tests/DCPS/sub_init_loop/run_test.pl
+++ b/tests/DCPS/sub_init_loop/run_test.pl
@@ -30,7 +30,7 @@ $test->enable_console_logging();
 
 $test->process('sub', 'subscriber', '-DCPSConfigFile sub.ini -v');
 
-my $verbose_opt = $test->{'flags'}->{'verbose'} ? '-v ' : '';
+my $verbose_opt = $test->flag('verbose') ? '-v ' : '';
 $test->process('pub', 'publisher', "-DCPSConfigFile pub.ini $verbose_opt");
 
 $test->start_process('sub');

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -54,10 +54,10 @@ tests/DCPS/Inconsistent_Qos/run_test.pl: RTPS XERCES3 !STATIC !DDS_NO_PERSISTENC
 tests/DCPS/InconsistentTopic/run_test.pl rtps_disc: RTPS !NO_BUILT_IN_TOPICS
 tests/DCPS/TopicReuse/run_test.pl: RTPS
 tests/DCPS/DpShutdown/run_test.pl: RTPS
-tests/DCPS/DpShutdown/run_test.pl tcp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/DpShutdown/run_test.pl shmem: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM
-tests/DCPS/DpShutdown/run_test.pl udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/DpShutdown/run_test.pl multicast: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_MCAST
+tests/DCPS/DpShutdown/run_test.pl t=tcp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/DpShutdown/run_test.pl t=shmem: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM
+tests/DCPS/DpShutdown/run_test.pl t=udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/DpShutdown/run_test.pl t=multicast: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_MCAST
 
 tests/DCPS/ContainsEntity/run_test.pl: RTPS
 

--- a/tests/security/ConcurrentAuthLimit/run_test.pl
+++ b/tests/security/ConcurrentAuthLimit/run_test.pl
@@ -11,7 +11,7 @@ my $test = new PerlDDS::TestFramework();
 $test->{dcps_security_debug} = 'auth_debug';
 
 $test->process('ConcurrentAuthLimit', 'ConcurrentAuthLimit', "");
-if ($test->{flags}->{"no_limit"}) {
+if ($test->flag('no_limit')) {
     $ENV{'no_limit'} = 'true';
 }
 $test->start_process('ConcurrentAuthLimit');


### PR DESCRIPTION
- DpShutdown Test
  - Extend to cover shutdown and delete related stuff added in https://github.com/objectcomputing/OpenDDS/pull/3159
  - Reformat to bring in line with the style guidelines
  - Cleanup `run_test.pl`
- PerlDDS
  - Remove unused `value_flag` and `get_value_flag`, add ability to get flag value using an optional argument to `flag`.
  - Add support for `DCPSLogLevel`
  - Put `-ORBLogFile` first to make sure debug level set and other messages are in the log file.
- Fix typos in log messages