### PR TITLE
MultiTopic Test Fix

### DIFF
--- a/dds/DCPS/MultiTopicDataReader_T.cpp
+++ b/dds/DCPS/MultiTopicDataReader_T.cpp
@@ -360,14 +360,14 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::incoming_sample(void* sample,
   }
 
   for (typename std::map<TopicSet, SampleVec>::iterator iterPR =
-      partialResults.begin(); iterPR != partialResults.end(); ++iterPR) {
+       partialResults.begin(); iterPR != partialResults.end(); ++iterPR) {
     for (typename SampleVec::iterator i = iterPR->second.begin();
-        i != iterPR->second.end(); ++i) {
+         i != iterPR->second.end(); ++i) {
       InstanceHandle_t ih = tdr->store_synthetic_data(i->sample_, i->view_);
       if (ih != HANDLE_NIL) {
         typedef std::map<OPENDDS_STRING, InstanceHandle_t>::iterator mapiter_t;
         for (mapiter_t iterMap = i->info_.begin(); iterMap != i->info_.end();
-            ++iterMap) {
+             ++iterMap) {
           query_plans_[iterMap->first].instances_.insert(
             make_pair(iterMap->second, ih));
         }

--- a/dds/DCPS/MultiTopicDataReader_T.cpp
+++ b/dds/DCPS/MultiTopicDataReader_T.cpp
@@ -102,7 +102,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::join(
     if (ih != HANDLE_NIL) {
       GenericData other_data(other_meta, false);
       SampleInfo info;
-      ReturnCode_t ret = other_dri->read_instance_generic(other_data.ptr_,
+      const ReturnCode_t ret = other_dri->read_instance_generic(other_data.ptr_,
         info, ih, READ_SAMPLE_STATE, ANY_VIEW_STATE, ALIVE_INSTANCE_STATE);
       if (ret != RETCODE_OK && ret != RETCODE_NO_DATA) {
         throw std::runtime_error(
@@ -123,7 +123,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::join(
     for (InstanceHandle_t ih = HANDLE_NIL; ret != RETCODE_NO_DATA;) {
       GenericData other_data(other_meta, false);
       SampleInfo info;
-      ret = other_dri->read_next_instance_generic(other_data.ptr_, info, ih,
+      const ReturnCode_t ret = other_dri->read_next_instance_generic(other_data.ptr_, info, ih,
         READ_SAMPLE_STATE, ANY_VIEW_STATE, ALIVE_INSTANCE_STATE);
       if (ret != RETCODE_OK && ret != RETCODE_NO_DATA) {
         std::ostringstream ss;
@@ -243,7 +243,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::process_joins(
             other_meta.assign(other_key.ptr_, keys[j].c_str(),
               &starting[i], keys[j].c_str(), resulting_meta);
           }
-          DDS::ReturnCode_t ret = join(join_result, starting[i], keys,
+          const DDS::ReturnCode_t ret = join(join_result, starting[i], keys,
             other_key.ptr_, other_dr, other_meta);
           if (ret != DDS::RETCODE_OK) {
             return ret;
@@ -252,7 +252,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::process_joins(
 
         if (!join_result.empty() && !seen.count(other_topic)) {
           // recurse
-          DDS::ReturnCode_t ret = process_joins(partialResults, join_result, withJoin, other_qp);
+          const DDS::ReturnCode_t ret = process_joins(partialResults, join_result, withJoin, other_qp);
           if (ret != DDS::RETCODE_OK) {
             return ret;
           }
@@ -293,7 +293,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::cross_join(
       SampleVec resulting;
       for (typename SampleVec::iterator i = iterPR->second.begin();
         i != iterPR->second.end(); ++i) {
-        DDS::ReturnCode_t ret = join(resulting, *i, no_keys, NULL, qp.data_reader_, other_meta);
+        const DDS::ReturnCode_t ret = join(resulting, *i, no_keys, 0, qp.data_reader_, other_meta);
         if (ret != DDS::RETCODE_OK) {
           return ret;
         }
@@ -304,7 +304,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::cross_join(
     withJoin.insert(topicNameFor(qp.data_reader_));
     partialResults[withJoin].swap(partialResults[seen]);
     partialResults.erase(seen);
-    DDS::ReturnCode_t ret = process_joins(partialResults, partialResults[withJoin], withJoin, qp);
+    const DDS::ReturnCode_t ret = process_joins(partialResults, partialResults[withJoin], withJoin, qp);
     if (ret != DDS::RETCODE_OK) {
       partialResults.erase(withJoin);
       return ret;
@@ -331,7 +331,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::incoming_sample(void* sample,
   partialResults[seen].push_back(SampleWithInfo(topic, info));
   assign_fields(sample, partialResults[seen].back().sample_, qp, meta);
 
-  DDS::ReturnCode_t ret = process_joins(partialResults, partialResults[seen], seen, qp);
+  const DDS::ReturnCode_t ret = process_joins(partialResults, partialResults[seen], seen, qp);
   if (ret != DDS::RETCODE_OK) {
     return;
   }
@@ -342,7 +342,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::incoming_sample(void* sample,
       find_if(partialResults.begin(), partialResults.end(),
               Contains(iter->first));
     if (found == partialResults.end()) {
-      DDS::ReturnCode_t cj_ret = cross_join(partialResults, seen, iter->second);
+      const DDS::ReturnCode_t cj_ret = cross_join(partialResults, seen, iter->second);
       if (cj_ret != DDS::RETCODE_OK) {
         return;
       }

--- a/dds/DCPS/MultiTopicDataReader_T.cpp
+++ b/dds/DCPS/MultiTopicDataReader_T.cpp
@@ -337,7 +337,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::incoming_sample(void* sample,
   }
   // Any topic we haven't seen needs to be cross-joined
   for (std::map<OPENDDS_STRING, QueryPlan>::iterator iter = query_plans_.begin();
-      iter != query_plans_.end(); ++iter) {
+       iter != query_plans_.end(); ++iter) {
     typename std::map<TopicSet, SampleVec>::iterator found =
       find_if(partialResults.begin(), partialResults.end(),
               Contains(iter->first));

--- a/dds/DCPS/MultiTopicDataReader_T.cpp
+++ b/dds/DCPS/MultiTopicDataReader_T.cpp
@@ -209,7 +209,7 @@ MultiTopicDataReader_T<Sample, TypedDataReader>::process_joins(
   const MetaStruct& resulting_meta = getResultingMeta();
   OPENDDS_STRING this_topic;
   {
-    // ACE_READ_GUARD(ACE_RW_Thread_Mutex, read_guard, qp_lock_);
+    ACE_GUARD_RETURN(ACE_RW_Thread_Mutex, read_guard, qp_lock_, DDS::RETCODE_OUT_OF_RESOURCES);
     this_topic = topicNameFor(qp.data_reader_);
   }
   typedef multimap<OPENDDS_STRING, OPENDDS_STRING>::const_iterator iter_t;

--- a/dds/DCPS/MultiTopicDataReader_T.h
+++ b/dds/DCPS/MultiTopicDataReader_T.h
@@ -129,22 +129,23 @@ private:
 
   // Process all joins (recursively) in the QueryPlan 'qp'.
   DDS::ReturnCode_t process_joins(OPENDDS_MAP(TopicSet, SampleVec)& partialResults,
-                     SampleVec starting, const TopicSet& seen,
-                     const QueryPlan& qp);
+                                  SampleVec starting, const TopicSet& seen,
+                                  const QueryPlan& qp);
 
   // Starting with a 'prototype' sample, fill a 'resulting' vector with all
   // data from 'other_dr' (with MetaStruct 'other_meta') such that all key
   // fields named in 'key_names' match the values in 'key_data'.  The struct
   // pointed-to by 'key_data' is of the type used by the 'other_dr'.
   DDS::ReturnCode_t join(SampleVec& resulting, const SampleWithInfo& prototype,
-            const std::vector<OPENDDS_STRING>& key_names, const void* key_data,
-            DDS::DataReader_ptr other_dr, const MetaStruct& other_meta);
+                         const std::vector<OPENDDS_STRING>& key_names,
+                         const void* key_data, DDS::DataReader_ptr other_dr,
+                         const MetaStruct& other_meta);
 
   // When no common keys are found, natural join devolves to a cross-join where
   // each instance in the joined-to-topic (qp) is combined with the results so
   // far (partialResults).
   DDS::ReturnCode_t cross_join(OPENDDS_MAP(TopicSet, SampleVec)& partialResults,
-                  const TopicSet& seen, const QueryPlan& qp);
+                               const TopicSet& seen, const QueryPlan& qp);
 
   // Combine two vectors of data, 'resulting' and 'other', with the results of
   // the combination going into 'resulting'.  Use the keys in 'key_names' to

--- a/dds/DCPS/MultiTopicDataReader_T.h
+++ b/dds/DCPS/MultiTopicDataReader_T.h
@@ -128,7 +128,7 @@ private:
                      const MetaStruct& meta);
 
   // Process all joins (recursively) in the QueryPlan 'qp'.
-  void process_joins(OPENDDS_MAP(TopicSet, SampleVec)& partialResults,
+  DDS::ReturnCode_t process_joins(OPENDDS_MAP(TopicSet, SampleVec)& partialResults,
                      SampleVec starting, const TopicSet& seen,
                      const QueryPlan& qp);
 
@@ -136,14 +136,14 @@ private:
   // data from 'other_dr' (with MetaStruct 'other_meta') such that all key
   // fields named in 'key_names' match the values in 'key_data'.  The struct
   // pointed-to by 'key_data' is of the type used by the 'other_dr'.
-  void join(SampleVec& resulting, const SampleWithInfo& prototype,
+  DDS::ReturnCode_t join(SampleVec& resulting, const SampleWithInfo& prototype,
             const std::vector<OPENDDS_STRING>& key_names, const void* key_data,
             DDS::DataReader_ptr other_dr, const MetaStruct& other_meta);
 
   // When no common keys are found, natural join devolves to a cross-join where
   // each instance in the joined-to-topic (qp) is combined with the results so
   // far (partialResults).
-  void cross_join(OPENDDS_MAP(TopicSet, SampleVec)& partialResults,
+  DDS::ReturnCode_t cross_join(OPENDDS_MAP(TopicSet, SampleVec)& partialResults,
                   const TopicSet& seen, const QueryPlan& qp);
 
   // Combine two vectors of data, 'resulting' and 'other', with the results of


### PR DESCRIPTION
The MultiTopic test is experiencing a few failures on the OpenDDS Scoreboard. Among these is one where an improperly joined sample in being inserted using `store_synthetic_data`. This happens if the order of received topics is done in such a way that all keys are known, but not all topics are received. A a topic causing cross join would then need to be received before the other remaining topic, leading to the failure.

Currently still need to resolve how to deal with the `ACE_GUARD` because it is attempting an empty `return` if uncommented.