### PR TITLE
Various CI Fixes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -330,6 +330,7 @@ jobs:
           --no-debug \
           --features=versioned_namespace=1 \
           --tests
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: make OpenDDS
       run: |
         cd OpenDDS
@@ -340,7 +341,6 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: make install OpenDDS
       shell: bash
       run: |
@@ -368,7 +368,7 @@ jobs:
         export LD_LIBRARY_PATH="\$OPENDDS_INSTALL_PREFIX/lib:\$LD_LIBRARY_PATH"
         export PERL5LIB=$(realpath bin):$(realpath $ACE_ROOT/bin)
         EOF
-    - name: make install build messenger
+    - name: build make install messenger
       shell: bash
       run: |
         cd OpenDDS
@@ -377,7 +377,7 @@ jobs:
         git clean -dfx .
         $ACE_ROOT/bin/mwc.pl -type gnuace .
         make
-    - name: make install build cmake
+    - name: build make install cmake
       shell: bash
       run: |
         cd OpenDDS
@@ -388,7 +388,7 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=$DDS_ROOT ..
         cmake --build .
-    - name: make install build java
+    - name: build make install java
       shell: bash
       run: |
         cd OpenDDS
@@ -518,6 +518,7 @@ jobs:
         cd OpenDDS/build/target
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build everything
       run: |
         cd OpenDDS
@@ -608,6 +609,7 @@ jobs:
         cd OpenDDS/build/target
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build everything
       run: |
         cd OpenDDS
@@ -2188,6 +2190,7 @@ jobs:
         cd OpenDDS/build/target
         . setenv.sh
         tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build everything
       run: |
         cd OpenDDS
@@ -4198,13 +4201,14 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - name: build messenger tests
+    - name: configure messenger tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
         cd tests/DCPS/Messenger
         perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0 -features no_cxx11=0
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: make messenger tests
       shell: bash
       run: |
@@ -4212,7 +4216,7 @@ jobs:
         . setenv.sh
         cd tests/DCPS/Messenger
         make
-    - name: build C++11 messenger test
+    - name: configure C++11 messenger test
       shell: bash
       run: |
         cd OpenDDS
@@ -4339,7 +4343,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: bash
       run: |
         cd OpenDDS
@@ -4357,6 +4361,7 @@ jobs:
         rm -rf xcdr
         rm -rf XTypesExtensibility
         perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: make compiler tests
       shell: bash
       run: |
@@ -4477,7 +4482,7 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: bash
       run: |
         cd OpenDDS
@@ -4497,6 +4502,7 @@ jobs:
         rm -rf isolated_types
         rm -rf is_topic_type
         perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: make compiler tests
       shell: bash
       run: |
@@ -4617,13 +4623,14 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - name: build unit tests
+    - name: configure unit tests
       shell: bash
       run: |
         cd OpenDDS
         . setenv.sh
         cd tests/unit-tests
         perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: make unit tests
       shell: bash
       run: |
@@ -4742,6 +4749,7 @@ jobs:
         . setenv.sh
         cd tests/security/attributes
         perl $ACE_ROOT/bin/mwc.pl -type gnuace -static -features no_cxx11=0 -features no_rapidjson=0 -features qt5=1 -features ssl=1 -features java=1 -features openssl11=1 -features xerces3=1 -features no_opendds_security=0
+    - uses: ammaraskar/gcc-problem-matcher@0.1
     - name: build security tests
       shell: bash
       run: |
@@ -5186,7 +5194,6 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ ACE_TAO_w19_p1_stat_js0.tar.xz
         rm -f ACE_TAO_w19_p1_stat_js0.tar.xz
-    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1
     - name: setup gtest
@@ -5211,6 +5218,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -5290,6 +5298,7 @@ jobs:
         rm -f build_w19_p1_stat_js0.tar.xz
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.9.0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: Build CMake Tests
       shell: cmd
       run: |
@@ -5431,13 +5440,14 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build messenger tests
+    - name: configure messenger tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Messenger
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features ssl=1 -features no_cxx11=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make messenger tests
       shell: cmd
       run: |
@@ -5445,7 +5455,7 @@ jobs:
         call setenv.cmd
         cd tests\DCPS\Messenger
         msbuild -p:Configuration=Debug,Platform=x64 -m Messenger.sln
-    - name: build C++11 messenger test
+    - name: configure C++11 messenger test
       shell: cmd
       run: |
         cd OpenDDS
@@ -5578,7 +5588,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: cmd
       run: |
         cd OpenDDS
@@ -5596,6 +5606,7 @@ jobs:
         rm -rf xcdr
         rm -rf XTypesExtensibility
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features no_cxx11=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make compiler tests
       shell: cmd
       run: |
@@ -5723,7 +5734,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: cmd
       run: |
         cd OpenDDS
@@ -5743,6 +5754,7 @@ jobs:
         rm -rf isolated_types
         rm -rf is_topic_type
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features no_cxx11=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make compiler tests
       shell: cmd
       run: |
@@ -5876,13 +5888,14 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build unit tests
+    - name: configure unit tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\unit-tests
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features no_rapidjson=1 -features ipv6=1 -features ssl=1 -features no_cxx11=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make unit tests
       shell: cmd
       run: |
@@ -6061,7 +6074,6 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ ACE_TAO_w19_re_p1_stat_FM-08.tar.xz
         rm -f ACE_TAO_w19_re_p1_stat_FM-08.tar.xz
-    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1
     - name: setup gtest
@@ -6086,6 +6098,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -6165,6 +6178,7 @@ jobs:
         rm -f build_w19_re_p1_stat_FM-08.tar.xz
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1.9.0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: Build CMake Tests
       shell: cmd
       run: |
@@ -6306,13 +6320,14 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build messenger tests
+    - name: configure messenger tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Messenger
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make messenger tests
       shell: cmd
       run: |
@@ -6320,7 +6335,7 @@ jobs:
         call setenv.cmd
         cd tests\DCPS\Messenger
         msbuild -p:Configuration=Release,Platform=x64 -m Messenger.sln
-    - name: build C++11 messenger test
+    - name: configure C++11 messenger test
       shell: cmd
       run: |
         cd OpenDDS
@@ -6453,7 +6468,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: cmd
       run: |
         cd OpenDDS
@@ -6471,6 +6486,7 @@ jobs:
         rm -rf xcdr
         rm -rf XTypesExtensibility
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features no_rapidjson=0 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make compiler tests
       shell: cmd
       run: |
@@ -6597,7 +6613,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: cmd
       run: |
         cd OpenDDS
@@ -6617,6 +6633,7 @@ jobs:
         rm -rf isolated_types
         rm -rf is_topic_type
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features no_rapidjson=0 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make compiler tests
       shell: cmd
       run: |
@@ -6749,13 +6766,14 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build unit tests
+    - name: configure unit tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\unit-tests
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -static -features ipv6=1 -features no_cxx11=0 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features built_in_topics=0 -features ownership_profile=0 -features content_subscription=0 -features object_model_profile=0 -features persistence_profile=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make unit tests
       shell: cmd
       run: |
@@ -6935,7 +6953,6 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ ACE_TAO_w19_re_o1p1_sec.tar.xz
         rm -f ACE_TAO_w19_re_o1p1_sec.tar.xz
-    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1
     - name: setup gtest
@@ -6960,6 +6977,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -7192,13 +7210,14 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: build messenger tests
+    - name: configure messenger tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Messenger
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -features ipv6=1 -features no_cxx11=0 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features no_opendds_security=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make messenger tests
       shell: cmd
       run: |
@@ -7206,7 +7225,7 @@ jobs:
         call setenv.cmd
         cd tests\DCPS\Messenger
         msbuild -p:Configuration=Release,Platform=x64 -m Messenger.sln
-    - name: build C++11 messenger test
+    - name: configure C++11 messenger test
       shell: cmd
       run: |
         cd OpenDDS
@@ -7345,13 +7364,14 @@ jobs:
         mkdir install
         cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON ..
         cmake --build . --target install --config Release
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Compiler
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -features ipv6=1 -features no_cxx11=0 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features no_opendds_security=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make compiler tests
       shell: cmd
       run: |
@@ -7484,13 +7504,14 @@ jobs:
         mkdir install
         cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON ..
         cmake --build . --target install --config Release
-    - name: build unit tests
+    - name: configure unit tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\unit-tests
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -features ipv6=1 -features no_cxx11=0 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features no_opendds_security=0 -value_project macros+=GTEST_LINKED_AS_SHARED_LIBRARY
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make unit tests
       shell: cmd
       run: |
@@ -7753,8 +7774,6 @@ jobs:
         cd OpenDDS/ACE_TAO
         tar xvfJ ACE_TAO_w19_re_j_ws_FM-1f.tar.xz
         rm -f ACE_TAO_w19_re_j_ws_FM-1f.tar.xz
-    - name: set up MSVC problem matcher
-      uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1
     - name: setup gtest
@@ -7779,8 +7798,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
-    - name: set up msvc env
-      uses: ilammy/msvc-dev-cmd@v1
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: build OpenDDS
       shell: cmd
       run: |
@@ -7995,13 +8013,14 @@ jobs:
         mkdir install
         cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON ..
         cmake --build . --target install --config Release
-    - name: build messenger tests
+    - name: configure messenger tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Messenger
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -features no_cxx11=0 -features java=1 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features built_in_topics=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make messenger tests
       shell: cmd
       run: |
@@ -8009,7 +8028,7 @@ jobs:
         call setenv.cmd
         cd tests\DCPS\Messenger
         msbuild -p:Configuration=Release,Platform=x64 -m Messenger.sln
-    - name: build C++11 messenger test
+    - name: configure C++11 messenger test
       shell: cmd
       run: |
         cd OpenDDS
@@ -8148,13 +8167,14 @@ jobs:
         mkdir install
         cmake -DCMAKE_INSTALL_PREFIX=./install -DBUILD_SHARED_LIBS=ON ..
         cmake --build . --target install --config Release
-    - name: build compiler tests
+    - name: configure compiler tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\DCPS\Compiler
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -features no_cxx11=0 -features java=1 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features built_in_topics=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make compiler tests
       shell: cmd
       run: |
@@ -8294,13 +8314,14 @@ jobs:
         dir
         cd lib
         dir
-    - name: build unit tests
+    - name: configure unit tests
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         cd tests\unit-tests
         perl %ACE_ROOT%\bin\mwc.pl -type vs2019 -features no_cxx11=0 -features java=1 -features xerces3=1 -features no_rapidjson=0 -features ssl=1 -features openssl11=1 -features built_in_topics=0 -value_project macros+=GTEST_LINKED_AS_SHARED_LIBRARY
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: make unit tests
       shell: cmd
       run: |
@@ -8493,7 +8514,6 @@ jobs:
       run: |
         mv OpenDDS/ACE_TAO /c/
         mv MPC /c/
-    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1
       with:
@@ -8520,6 +8540,7 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
+    - uses: ammaraskar/msvc-problem-matcher@0.1
     - name: build OpenDDS
       shell: cmd
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -548,7 +548,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_EXTENDED -Config RTPS -Config LINUX -Config OPENDDS_SAFETY_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_EXTENDED -Config OPENDDS_SAFETY_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -638,7 +638,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_BASE -Config RTPS -Config LINUX -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_BASE -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -884,7 +884,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config LINUX -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS -Config NO_UNIT_TESTS --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config NO_UNIT_TESTS --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2458,7 +2458,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config WIRESHARK -Config GH_ACTIONS --java --modeling --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config WIRESHARK --java --modeling --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2706,7 +2706,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security -Config GH_ACTIONS_ASAN"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --security -Config GH_ACTIONS_ASAN"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -2954,7 +2954,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --no-dcps tests/tsan_tests.lst"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/tsan_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -3201,7 +3201,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -3402,7 +3402,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -Config NO_UNIT_TESTS --modeling --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS --modeling --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -3648,7 +3648,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config RTPS -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -Config NO_UNIT_TESTS --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_UNIT_TESTS --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -3849,7 +3849,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config RTPS -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config GH_ACTIONS -Config NO_UNIT_TESTS --java --modeling --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config NO_UNIT_TESTS --java --modeling --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4252,7 +4252,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_MESSENGER -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4390,7 +4390,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_COMPILER -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_COMPILER -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4530,7 +4530,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_COMPILER2 -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_COMPILER2 -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -4657,7 +4657,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_UNIT -Config RTPS -Config STATIC -Config LINUX -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/static_ci_tests.lst -Config STATIC_UNIT -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -5048,7 +5048,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config GH_ACTIONS --modeling --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC --modeling --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -5485,7 +5485,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_MESSENGER -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -5630,7 +5630,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -5777,7 +5777,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER2 -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER2 -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -5916,7 +5916,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_UNIT -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config CXX11 -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_UNIT -Config IPV6 -Config XERCES3 -Config CXX11"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -6360,7 +6360,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC -Config STATIC_MESSENGER -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config CXX11 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC -Config STATIC_MESSENGER -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config CXX11 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -6504,7 +6504,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -6650,7 +6650,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER2 -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER2 -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -6789,7 +6789,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_UNIT -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config RTPS -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_UNIT -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -7246,7 +7246,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_MESSENGER -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -7385,7 +7385,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_COMPILER -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_COMPILER -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -7524,7 +7524,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_UNIT -Config RTPS -Config WIN64 -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_UNIT -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -8049,7 +8049,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_MESSENGER -Config RTPS -Config WIN64 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_MESSENGER -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -8188,7 +8188,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_COMPILER -Config RTPS -Config WIN64 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -Config NO_UNIT_TESTS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_COMPILER -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -8334,7 +8334,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_UNIT -Config RTPS -Config WIN64 -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\static_ci_tests.lst -ExeSubDir Release -Config STATIC_UNIT -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -8658,7 +8658,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config RTPS -Config WIN32 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS -Config GH_ACTIONS_W16 --security"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config GH_ACTIONS_W16 --security"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -9116,7 +9116,7 @@ jobs:
 #        <command name="check_compiler" options="gcc"/>
 #        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS --security"/>
+#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS --security"/>
 #        <command name="log" options="off"/>
 #        <command name="process_logs" options="prettify"/>
 #        </autobuild>
@@ -9311,7 +9311,7 @@ jobs:
 #        <command name="check_compiler" options="gcc"/>
 #        <command name="print_perl_version"/>
 #        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS --java --modeling"/>
+#        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS --java --modeling"/>
 #        <command name="log" options="off"/>
 #        <command name="process_logs" options="prettify"/>
 #        </autobuild>
@@ -9567,7 +9567,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config OSX -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS -Config GH_ACTIONS_M10 --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M10 --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -9849,7 +9849,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RTPS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config GH_ACTIONS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M10 --java --modeling --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M10 --java --modeling --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DDS_ROOT: ${{github.workspace}}
+  DDS_ROOT: ${{github.workspace}}/OpenDDS
   DOC_ROOT: ${{github.workspace}}/ACE_TAO
   ACE_ROOT: ${{github.workspace}}/ACE_TAO/ACE
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,6 @@ jobs:
         install-modules: |
           YAML
     - name: Run lint.pl
-      run: cd OpenDDS ; perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
+      run: cd $DDS_ROOT ; perl tools/scripts/lint.pl --color --ace
     - name: Run lint_build_and_test.pl
       run: perl $DDS_ROOT/.github/workflows/lint_build_and_test.pl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v2
+      with:
+        path: ${{ env.DDS_ROOT }}
     - name: checkout ACE_TAO
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,9 +28,9 @@ jobs:
         ref: ace6tao2
         path: ${{ env.DOC_ROOT }}
     - name: Install Perl Dependencies
-      run: |
-        curl -L https://cpanmin.us | perl - --sudo App::cpanminus
-        cpanm YAML
+      uses: shogo82148/actions-setup-perl@v1
+      install-modules: |
+        YAML
     - name: Run lint.pl
       run: perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
     - name: Run lint_build_and_test.pl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ env:
   ACE_ROOT: ${{github.workspace}}/ACE_TAO/ACE
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - name: checkout OpenDDS
@@ -27,6 +27,11 @@ jobs:
         repository: DOCGroup/ACE_TAO
         ref: ace6tao2
         path: ${{ env.DOC_ROOT }}
-    - name: Run lint.pl
+    - name: Install Perl Dependencies
       run: |
-        perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
+        curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+        cpanm YAML
+    - name: Run lint.pl
+      run: perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
+    - name: Run lint_build_and_test.pl
+      run: perl $DDS_ROOT/.github/workflows/lint_build_and_test.pl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,6 @@ jobs:
         install-modules: |
           YAML
     - name: Run lint.pl
-      run: perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
+      run: cd OpenDDS ; perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
     - name: Run lint_build_and_test.pl
       run: perl $DDS_ROOT/.github/workflows/lint_build_and_test.pl

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,8 +29,9 @@ jobs:
         path: ${{ env.DOC_ROOT }}
     - name: Install Perl Dependencies
       uses: shogo82148/actions-setup-perl@v1
-      install-modules: |
-        YAML
+      with:
+        install-modules: |
+          YAML
     - name: Run lint.pl
       run: perl $DDS_ROOT/tools/scripts/lint.pl --color --ace
     - name: Run lint_build_and_test.pl

--- a/.github/workflows/lint_build_and_test.pl
+++ b/.github/workflows/lint_build_and_test.pl
@@ -1,0 +1,113 @@
+#!/usr/bin/env perl
+
+# Try to find issues with build_and_test.yml
+# It requires the YAML cpan module
+
+use strict;
+use warnings;
+
+use FindBin;
+
+use YAML qw();
+
+my $error_jobs = 0;
+
+my $gha = YAML::LoadFile("$FindBin::Bin/build_and_test.yml");
+for my $job_name (keys(%{$gha->{jobs}})) {
+  my $job = $gha->{jobs}->{$job_name};
+  # print("#### Job $job_name\n");
+  my $expected_matcher;
+  my @expected_build_commands = ();
+  if ($job->{'runs-on'} =~ /^windows/) {
+    $expected_matcher = 'msvc-problem-matcher';
+    push(@expected_build_commands, qr/(?<!\w)msbuild/);
+  }
+  elsif ($job->{'runs-on'} =~ /^ubuntu/ || $job->{'runs-on'} =~ /^macos/) {
+    $expected_matcher = 'gcc-problem-matcher';
+    push(@expected_build_commands, qr/(?<!\w)make(?!( install|include))/);
+  }
+  else {
+    die("Job $job_name has unexpected runs-on: $job->{'runs-on'}");
+  }
+  my $expected_matcher_re = quotemeta($expected_matcher);
+  push(@expected_build_commands, qr/(?<!\w)cmake --build/, qr/docker build/);
+
+  my $job_has_problem_matcher = 0;
+  my $job_has_build_command = 0;
+  my $step_i = 0;
+  my $error_steps = 0;
+  for my $step (@{$job->{steps}}) {
+    $step_i += 1;
+    if (exists($step->{uses})) {
+      if ($step->{uses} =~ $expected_matcher_re) {
+        if ($job_has_problem_matcher) {
+          print STDERR ("Job $job_name has multiple problem matchers\n");
+          $error_steps = 1;
+        }
+        else {
+          $job_has_problem_matcher = 1;
+          if ($job_has_build_command) {
+            print STDERR ("Job $job_name has problem matcher but it's too late! Move it up!\n");
+            $error_steps = 1;
+          }
+        }
+      }
+    }
+    elsif (exists($step->{run})) {
+      die("Expected $job_name step $step_i to have name!") if (!exists($step->{name}));
+      my $what = "Job $job_name step \"$step->{name}\"";
+      # print("---- $what\n");
+
+      my $avoids_problem_matcher = 0;
+      if ($step->{name} =~ /setup gtest/i) {
+        $avoids_problem_matcher = 1;
+      }
+      elsif ($step->{name} =~ /build ace.*tao/i) {
+        $avoids_problem_matcher = 1;
+      }
+
+      if ($avoids_problem_matcher) {
+        if ($job_has_problem_matcher) {
+          print STDERR ("$what shouldn't have problem matcher, remove it or move it down!\n");
+          $error_steps = 1;
+        }
+        next;
+      }
+
+      my $build_command_expected = 0;
+      if ($step->{name} =~ /^build/i) {
+        $build_command_expected = 1;
+      }
+      elsif ($step->{name} =~ /(?<!\w)make(?! install)/i) {
+        $build_command_expected = 1;
+      }
+
+      my $step_has_build_command = 0;
+      for my $expected_build_command (@expected_build_commands) {
+        if ($step->{run} =~ /($expected_build_command)/) {
+          $job_has_build_command = 1;
+          $step_has_build_command = 1;
+          die("$what unexpected build command: based on run string: $1")
+            if (!$build_command_expected);
+          if (!$job_has_problem_matcher) {
+            print STDERR ("$what needs a $expected_matcher problem matcher, based on run string: $1\n");
+            $error_steps += 1;
+          }
+          last;
+        }
+      }
+      die("$what expected to have a build command based on step name")
+        if (!$step_has_build_command && $build_command_expected);
+    }
+    else {
+      die("$job_name step $step_i is confusing me");
+    }
+  }
+
+  $error_jobs += 1 if ($error_steps);
+}
+
+if ($error_jobs) {
+  print STDERR ("ERROR: $error_jobs out of ", scalar(keys(%{$gha->{jobs}})), " have has issues\n");
+  exit(1);
+}

--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -21,6 +21,14 @@ use Getopt::Long;
 
 use constant windows => $^O eq "MSWin32";
 
+my $gh_actions = ($ENV{GITHUB_ACTIONS} // "") eq "true";
+
+my %os_configs = (
+    MSWin32 => 'Win32',
+    darwin => 'macOS',
+    linux => 'Linux',
+);
+
 sub cd {
     my $dir = shift;
     chdir($dir) or die "auto_run_tests.pl: Error: Cannot chdir to $dir: $!";
@@ -107,7 +115,10 @@ sub print_help {
         "<list_file> can be a path or - to use stdin.\n" .
         "\n" .
         "Options:\n" .
-        "    --help | -h              Display this help\n";
+        "    --help | -h              Display this help\n" .
+        "    --no-auto-config         Don't set common options by default. This includes\n" .
+        "                             the RTPS and per-OS configs and the default test\n" .
+        "                             lists below.\n";
 
     my $indent = 29;
     foreach my $list (@builtin_test_lists) {
@@ -163,6 +174,7 @@ my $cmake_tests = "$DDS_ROOT/tests/cmake";
 
 # Parse Options
 my $help = 0;
+my $auto_config = 1;
 my $sandbox = '';
 my $show_configs = 0;
 my $show_all_configs = 0;
@@ -180,6 +192,7 @@ my $ctest_args = '';
 my $python = windows ? 'python' : 'python3';
 my %opts = (
     'help|h' => \$help,
+    'auto-config!' => \$auto_config,
     'sandbox|s=s' => \$sandbox,
     'dry-run|z' => \$dry_run,
     'show-configs' => \$show_configs,
@@ -226,10 +239,22 @@ my $query = $show_configs || $list_configs || $list_tests;
 
 # Determine what test list files to use
 my @file_list = ();
-foreach my $list (@builtin_test_lists) {
-    push(@file_list, "$DDS_ROOT/$list->{file}") if ($query_all || $list->{enabled});
+if ($auto_config) {
+    foreach my $list (@builtin_test_lists) {
+        push(@file_list, "$DDS_ROOT/$list->{file}") if ($query_all || $list->{enabled});
+    }
 }
 push(@file_list, @ARGV);
+
+if ($auto_config) {
+    die("auto_run_tests.pl: Error: unknown perl OS: $^O") if (!exists($os_configs{$^O}));
+    push(@PerlACE::ConfigList::Configs, $os_configs{$^O});
+
+    push(@PerlACE::ConfigList::Configs, "RTPS");
+    if ($gh_actions) {
+        push(@PerlACE::ConfigList::Configs, 'GH_ACTIONS');
+    }
+}
 
 if ($show_configs) {
     foreach my $test_list (@file_list) {

--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -381,7 +381,7 @@ if ($cmake) {
             push(@run_test_cmd, $ctest_args);
         }
         if ($ctest_args !~ /--build-config/ && defined($cmake_build_cfg)) {
-            push(@run_test_cmd, "--build-config $cmake_build_cfg");
+            push(@run_test_cmd, "--build-config", $cmake_build_cfg);
         }
         run_test($fake_name, \@run_test_cmd, verbose => 1);
         mark_test_start($process_name);

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -11,7 +11,7 @@
 # means to run if the build is not a minimal test and RTPS is enabled.
 #
 
-tools/scripts/modules/tests/command_utils.pl: !WIN32 !WIN64
+tools/scripts/modules/tests/command_utils.pl: !Win32
 tools/scripts/modules/tests/ChangeDir.pl
 
 tests/DCPS/Prst_delayed_subscriber/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
- `auto_run_tests.pl`:
  - Two small parts of #2452: Automatically add  `-Config RTPS` and `-Config GH_ACTIONS` if running on GitHub Actions
  - Automatically add an OS `-Config` value according to `$^O`.
  - Try to fix issue with the CTest missing build config on Windows.
- `build_and_test.yml`:
  - Add script to lint workflow that tries to determine when GHA C++ compiler problem matchers are needed.
  - Added, removed, and moved problem matchers entries based on feedback from the script.
  - Remove `-Config` options no longer needed because they are automatically added.