### PR TITLE
Process Logging Options First

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -644,7 +644,7 @@ sub process {
     $file_name =~ s/ /_/g;
     $file_name =~ s/#//g;
 
-    $params = "-ORBLogFile $file_name.log $params";
+    $params .= " -ORBLogFile $file_name.log";
   }
 
   if ($self->{add_transport_config} &&


### PR DESCRIPTION
Undoes a previous change in PerlDDS in https://github.com/objectcomputing/OpenDDS/pull/3270 and instead changes OpenDDS to process `-ORBLogFile` first to make sure as much logging as possible goes to the file.