### PR TITLE
Fix Data Race in DataWriterImpl::participant_liveliness_activity_after

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1232,6 +1232,7 @@ DataWriterImpl::liveliness_check_interval(DDS::LivelinessQosPolicyKind kind)
 bool
 DataWriterImpl::participant_liveliness_activity_after(const MonotonicTimePoint& tv)
 {
+  ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
   if (this->qos_.liveliness.kind == DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS) {
     return last_liveliness_activity_time_ > tv;
   } else {


### PR DESCRIPTION
Problem: TSAN Flagged an intermittent data race issue in LivelinessTest on [this PR build](https://github.com/objectcomputing/OpenDDS/runs/4928749930?check_suite_focus=true). It looks like we don't use the recursive mutex correctly for this small function.

Solution: Use the mutex.