### PR TITLE
ICE::Agent singleton accessed during shutdown

### DIFF
--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -1757,6 +1757,7 @@ protected:
 #endif
 
 #ifdef OPENDDS_SECURITY
+  DCPS::RcHandle<ICE::Agent> ice_agent_;
   RcHandle<PublicationAgentInfoListener> publication_agent_info_listener_;
   RcHandle<SubscriptionAgentInfoListener> subscription_agent_info_listener_;
 #endif

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -732,6 +732,8 @@ private:
 
   DDS::Security::ParticipantSecurityAttributes participant_sec_attr_;
 
+  DCPS::RcHandle<ICE::Agent> ice_agent_;
+
   void start_ice(DCPS::WeakRcHandle<ICE::Endpoint> endpoint, DCPS::RepoId remote, BuiltinEndpointSet_t avail,
                  DDS::Security::ExtendedBuiltinEndpointSet_t extended_avail,
                  const ICE::AgentInfo& agent_info);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -94,6 +94,7 @@ RtpsUdpDataLink::RtpsUdpDataLink(RtpsUdpTransport& transport,
 #ifdef OPENDDS_SECURITY
   , security_config_(Security::SecurityRegistry::instance()->default_config())
   , local_crypto_handle_(DDS::HANDLE_NIL)
+  , ice_agent_(ICE::Agent::instance())
 #endif
 {
 #ifdef OPENDDS_SECURITY
@@ -4701,7 +4702,7 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
 #ifdef OPENDDS_SECURITY
   DCPS::WeakRcHandle<ICE::Endpoint> endpoint = get_ice_endpoint();
   if (endpoint) {
-    ice_addr = ICE::Agent::instance()->get_address(endpoint, local, remote);
+    ice_addr = ice_agent_->get_address(endpoint, local, remote);
   }
 #endif
 
@@ -4727,6 +4728,14 @@ RtpsUdpDataLink::accumulate_addresses(const RepoId& local, const RepoId& remote,
   entry.value().addrs_.insert(normal_addrs.begin(), normal_addrs.end());
   entry.value().expires_ = normal_addrs_expires;
 }
+
+#ifdef OPENDDS_SECURITY
+DCPS::RcHandle<ICE::Agent>
+RtpsUdpDataLink::get_ice_agent() const
+{
+  return ice_agent_;
+}
+#endif
 
 DCPS::WeakRcHandle<ICE::Endpoint>
 RtpsUdpDataLink::get_ice_endpoint() const {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -203,6 +203,9 @@ public:
 
   virtual void pre_stop_i();
 
+#ifdef OPENDDS_SECURITY
+  DCPS::RcHandle<ICE::Agent> get_ice_agent() const;
+#endif
   virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint() const;
 
   virtual bool is_leading(const GUID_t& writer_id,
@@ -917,6 +920,7 @@ private:
   Security::SecurityConfig_rch security_config_;
   Security::HandleRegistry_rch handle_registry_;
   DDS::Security::ParticipantCryptoHandle local_crypto_handle_;
+  RcHandle<ICE::Agent> ice_agent_;
 #endif
 
   void accumulate_addresses(const RepoId& local, const RepoId& remote, AddrSet& addresses, bool prefer_unicast = false) const;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -74,7 +74,10 @@ public:
                                       int n,
                                       const ACE_SOCK_Dgram& socket,
                                       ACE_INET_Addr& remote_address,
+#ifdef OPENDDS_SECURITY
+                                      DCPS::RcHandle<ICE::Agent> agent,
                                       DCPS::WeakRcHandle<ICE::Endpoint> endpoint,
+#endif
                                       RtpsUdpTransport& tport,
                                       bool& stop);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -29,6 +29,9 @@ class OpenDDS_Rtps_Udp_Export RtpsUdpTransport : public TransportImpl {
 public:
   RtpsUdpTransport(RtpsUdpInst& inst);
   RtpsUdpInst& config() const;
+#ifdef OPENDDS_SECURITY
+  DCPS::RcHandle<ICE::Agent> get_ice_agent() const;
+#endif
   virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
   virtual void rtps_relay_only_now(bool flag);
   virtual void use_rtps_relay_now(bool flag);
@@ -187,6 +190,7 @@ private:
   void start_ice();
   void stop_ice();
 
+  RcHandle<ICE::Agent> ice_agent_;
 #endif
 
   InternalTransportStatistics transport_statistics_;


### PR DESCRIPTION
Problem
-------

Programs that exit normally will call the destructor for the
ICE::Agent singleton.  Later in the destruction sequence, the
singleton may be accessed again and re-created.  This leads to
problems since the newly created ICE::Agent cannot perform the desired
actions.

Solution
--------

Save a handle to the ICE::Agent instead of always going through the singleton.