### PR TITLE
[Bench Dashboard] Allow Scenario Name Prefix Overlapping

### DIFF
--- a/performance-tests/bench/dashboard_summarizer/main.cpp
+++ b/performance-tests/bench/dashboard_summarizer/main.cpp
@@ -130,7 +130,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     // Determine Scenario Name
     std::string scn;
     for (auto it = known_scenario_names.begin(); scn.empty() && it != known_scenario_names.end(); ++it) {
-      if (file_names[i].find(*it) == 0) {
+      const std::string with_underscore = *it + '_';
+      if (file_names[i].find(with_underscore) == 0) {
         scn = *it;
       }
     }


### PR DESCRIPTION
Problem: The dashboard summary generator currently will match any scenario with the string "disco" as belonging to the "disco" scenario, and then the results for disco-relay and disco-repo get displayed incorrectly.

Solution: Match against the known string with a trailing underscore in order to avoid the same issue in the future.