### PR TITLE
[Bench] Minor TSAN fix for WorkerDataWriterListener::unset_listener

### DIFF
--- a/etc/tsan-suppr.txt
+++ b/etc/tsan-suppr.txt
@@ -25,4 +25,3 @@ race:^TAO_IIOP_Connection_Handler
 
 race:^OpenDDS::Federator
 race:^OpenDDS::DCPS::DCPS_debug_level
-race:^Builder::BuilderProcess::detach_listeners

--- a/performance-tests/bench/worker/WorkerDataWriterListener.cpp
+++ b/performance-tests/bench/worker/WorkerDataWriterListener.cpp
@@ -95,6 +95,8 @@ WorkerDataWriterListener::set_datawriter(Builder::DataWriter& datawriter)
 void
 WorkerDataWriterListener::unset_datawriter(Builder::DataWriter& datawriter)
 {
+  std::unique_lock<std::mutex> lock(mutex_);
+
   if (datawriter_ == &datawriter) {
     discovery_delta_stat_block_->finalize();
     datawriter_ = nullptr;


### PR DESCRIPTION
Fixing a data race for un-setting listener at the end of test execution.