### PR TITLE
Inconsistent Topic TSAN Fix

### DIFF
--- a/dds/DCPS/TopicImpl.h
+++ b/dds/DCPS/TopicImpl.h
@@ -105,7 +105,7 @@ private:
   /// The id given by discovery.
   RepoId                       id_;
 
-  /// Mutex to protect listener info
+  /// Mutex to protect status info
   ACE_Thread_Mutex             status_mutex_;
   /// Count of discovered (readers/writers using) topics with the same
   /// topic name but different characteristics (typename)

--- a/dds/DCPS/TopicImpl.h
+++ b/dds/DCPS/TopicImpl.h
@@ -105,6 +105,8 @@ private:
   /// The id given by discovery.
   RepoId                       id_;
 
+  /// Mutex to protect listener info
+  ACE_Thread_Mutex             status_mutex_;
   /// Count of discovered (readers/writers using) topics with the same
   /// topic name but different characteristics (typename)
   DDS::InconsistentTopicStatus inconsistent_topic_status_;

--- a/etc/tsan-suppr.txt
+++ b/etc/tsan-suppr.txt
@@ -11,13 +11,13 @@ race_top:^ACE_Proactor::proactor_end_event_loop
 race_top:^ACE_Proactor_Timer_Handler::destroy
 race_top:^ACE_Thread_Manager::wait_task
 race_top:^ACE_TSS<*>::ts_get
-race_top:^ACE_TSS_Singleton<*>::instance
 race_top:^ACE_Timer_Heap_T<*>::is_empty
 race:^ACE_Log_Msg::default_priority_mask_$
 race:^ACE_Sig_Handler::sig_pending_$
 race:^ACE_Proactor::cancel_timer
 race:^ACE_Proactor::schedule_timer
 race:^ACE_Thread_Exit::instance
+race:^ACE_TSS_Singleton<*>::instance
 
 race_top:^TAO_Leader_Follower::wait_for_event
 race_top:^TAO_ORB_Core::*shutdown

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -23,6 +23,9 @@ tests/DCPS/Messenger/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWN
 tests/DCPS/Messenger/run_test.pl rtps_disc_tcp: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl rtps_disc_tcp thread_per: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
+tests/DCPS/XTypes/run_test.pl: !DCPS_MIN
+tests/DCPS/XTypes/run_test.pl --tcp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+
 tests/DCPS/WaitForAck/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/WaitForAck/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/WaitForAck/run_test.pl --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
Problem: TSAN issues in TopicImpl surrounding inconsistent_topic_status_

Solution: Add mutex protection, make copies when required for safe access.

Also, expand TSAN coverage to include XTypes test