### PR TITLE
ReactorTask catches

### DIFF
--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -149,27 +149,16 @@ int ReactorTask::svc()
     condition_.notify_all();
   }
 
-  try {
-    // Tell the reactor to handle events.
-    if (thread_status_manager_->update_thread_status()) {
-      while (state_ == STATE_RUNNING) {
-        ACE_Time_Value t = thread_status_manager_->thread_status_interval().value();
-        ThreadStatusManager::Sleeper sleeper(*thread_status_manager_);
-        reactor_->run_reactor_event_loop(t, 0);
-      }
-
-    } else {
-      reactor_->run_reactor_event_loop();
+  // Tell the reactor to handle events.
+  if (thread_status_manager_->update_thread_status()) {
+    while (state_ == STATE_RUNNING) {
+      ACE_Time_Value t = thread_status_manager_->thread_status_interval().value();
+      ThreadStatusManager::Sleeper sleeper(*thread_status_manager_);
+      reactor_->run_reactor_event_loop(t, 0);
     }
-  } catch (const std::exception& e) {
-    ACE_ERROR((LM_ERROR,
-               "(%P|%t) ERROR: ReactorTask::svc caught exception - %C.\n",
-               e.what()));
-    throw;
-  } catch (...) {
-    ACE_ERROR((LM_ERROR,
-               "(%P|%t) ERROR: ReactorTask::svc caught exception.\n"));
-    throw;
+
+  } else {
+    reactor_->run_reactor_event_loop();
   }
 
   return 0;


### PR DESCRIPTION
Problem
-------

ReactorTask catches exceptions, logs them, and throws them again.  The
stack may be lost so a stack trace does not show the source of the
exception.

Solution
--------

Don't catch the exception.