### PR TITLE
AuthResendPeriod is too granular

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -644,9 +644,9 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
         } else if (name == "AuthResendPeriod") {
           // In seconds.
           const OPENDDS_STRING& string_value = it->second;
-          int int_value;
-          if (DCPS::convertToInteger(string_value, int_value)) {
-            config->auth_resend_period(TimeDuration(int_value));
+          double double_value;
+          if (DCPS::convertToDouble(string_value, double_value)) {
+            config->auth_resend_period(TimeDuration::from_double(double_value));
           } else {
             ACE_ERROR_RETURN((LM_ERROR,
                               ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config(): ")

--- a/dds/DCPS/TimeDuration.h
+++ b/dds/DCPS/TimeDuration.h
@@ -37,6 +37,11 @@ public:
   static TimeDuration from_msec(const ACE_UINT64& ms);
 
   /**
+   * Return a TimeDuration from fractional seconds.
+   */
+  static TimeDuration from_double(double duration);
+
+  /**
    * Initialized to zero
    */
   TimeDuration();

--- a/dds/DCPS/TimeDuration.inl
+++ b/dds/DCPS/TimeDuration.inl
@@ -17,6 +17,15 @@ TimeDuration::from_msec(const ACE_UINT64& ms)
 }
 
 ACE_INLINE
+TimeDuration
+TimeDuration::from_double(double duration)
+{
+  ACE_Time_Value rv;
+  rv.set(duration);
+  return TimeDuration(rv);
+}
+
+ACE_INLINE
 TimeDuration::TimeDuration()
 : value_(zero_value.value())
 {

--- a/tests/unit-tests/dds/DCPS/TimeDuration.cpp
+++ b/tests/unit-tests/dds/DCPS/TimeDuration.cpp
@@ -52,3 +52,10 @@ TEST(dds_DCPS_TimeDuration, str)
   EXPECT_EQ(TimeDuration(100).str(0, true), "100 s");
   EXPECT_EQ(TimeDuration(100).sec_str(0), "100 s");
 }
+
+TEST(dds_DCPS_TimeDuration, double_ctor)
+{
+  const TimeDuration td = TimeDuration::from_double(1.1);
+  EXPECT_EQ(td.value().sec(), 1);
+  EXPECT_EQ(td.value().usec(), 100000);
+}


### PR DESCRIPTION
Problem
-------

AuthResendPeriod is assumed to be in integer seconds.  Sub-second
durations are required.

Solution
--------

Allow AuthResendPeriod to be a decimal.