### PR TITLE
Improve Mutex Contention in NetworkConfigMonitor

### DIFF
--- a/dds/DCPS/LinuxNetworkConfigMonitor.cpp
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.cpp
@@ -238,7 +238,7 @@ void LinuxNetworkConfigMonitor::process_message(const nlmsghdr* header)
       }
 
       remove_interface(msg->ifi_index);
-      add_interface(NetworkInterface(msg->ifi_index, name, msg->ifi_flags & (IFF_MULTICAST | IFF_LOOPBACK)));
+      add_interface(make_rch<NetworkInterface>(msg->ifi_index, name, msg->ifi_flags & (IFF_MULTICAST | IFF_LOOPBACK)));
     }
     break;
   case RTM_DELLINK:

--- a/dds/DCPS/NetworkConfigModifier.cpp
+++ b/dds/DCPS/NetworkConfigModifier.cpp
@@ -64,7 +64,7 @@ bool NetworkConfigModifier::open()
 
         std::pair<Nics::iterator, bool> p = nics.insert(std::make_pair(p_if->ifa_name, make_rch<NetworkInterface>(ACE_OS::if_nametoindex(p_if->ifa_name), p_if->ifa_name, p_if->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK))));
 
-        p.first->second.add_address(address);
+        p.first->second->add_address(address);
       }
     }
 # if defined (ACE_HAS_IPV6)
@@ -77,7 +77,7 @@ bool NetworkConfigModifier::open()
 
         std::pair<Nics::iterator, bool> p = nics.insert(std::make_pair(p_if->ifa_name, make_rch<NetworkInterface>(ACE_OS::if_nametoindex(p_if->ifa_name), p_if->ifa_name, p_if->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK))));
 
-        p.first->second.add_address(address);
+        p.first->second->add_address(address);
       }
     }
 # endif /* ACE_HAS_IPV6 */
@@ -152,9 +152,9 @@ void NetworkConfigModifier::update_interfaces()
   // Add interfaces that are new
   nis = get_interfaces();
   for (Names::iterator iter = names.begin(); iter != names.end(); ++iter) {
-    NetworkInterfaces::iterator pos = std::find_if(nis.begin(), nis.end(), NetworkInterfaceName((*iter)->first));
+    NetworkInterfaces::iterator pos = std::find_if(nis.begin(), nis.end(), NetworkInterfaceName(iter->first));
     if (pos == nis.end()) {
-      ifaddrs* ifa = (*iter)->second;
+      ifaddrs* ifa = iter->second;
       ACE_INET_Addr address;
       const bool can_multicast = ifa->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK);
       if (ifa->ifa_addr->sa_family == AF_INET) {

--- a/dds/DCPS/NetworkConfigMonitor.h
+++ b/dds/DCPS/NetworkConfigMonitor.h
@@ -28,7 +28,7 @@ public:
     : index_(-1)
     , can_multicast_(false)
   {}
-  NetworkInterface(const NetworkInterface& val) { *this = val; }
+  NetworkInterface(const NetworkInterface& val) : RcObject() { *this = val; }
   NetworkInterface(int index,
                    const OPENDDS_STRING& name,
                    bool can_multicast)

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -273,13 +273,13 @@ void AgentImpl::network_change() const
   }
 }
 
-void AgentImpl::add_address(const DCPS::NetworkInterface&,
+void AgentImpl::add_address(const DCPS::NetworkInterface_rch&,
                             const ACE_INET_Addr&)
 {
   network_change();
 }
 
-void AgentImpl::remove_address(const DCPS::NetworkInterface&,
+void AgentImpl::remove_address(const DCPS::NetworkInterface_rch&,
                                const ACE_INET_Addr&)
 {
   network_change();

--- a/dds/DCPS/RTPS/ICE/AgentImpl.h
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.h
@@ -96,9 +96,9 @@ public:
 
 private:
   void network_change() const;
-  void add_address(const DCPS::NetworkInterface& interface,
+  void add_address(const DCPS::NetworkInterface_rch& interface,
                    const ACE_INET_Addr& address);
-  void remove_address(const DCPS::NetworkInterface& interface,
+  void remove_address(const DCPS::NetworkInterface_rch& interface,
                       const ACE_INET_Addr& address);
   void process_deferred();
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -542,12 +542,12 @@ private:
     bool open_unicast_ipv6_socket(u_short port);
 #endif
 
-    void join_multicast_group(const DCPS::NetworkInterface& nic,
+    void join_multicast_group(const DCPS::NetworkInterface_rch& nic,
                               bool all_interfaces = false);
-    void leave_multicast_group(const DCPS::NetworkInterface& nic);
-    void add_address(const DCPS::NetworkInterface& nic,
+    void leave_multicast_group(const DCPS::NetworkInterface_rch& nic);
+    void add_address(const DCPS::NetworkInterface_rch& nic,
                      const ACE_INET_Addr& address);
-    void remove_address(const DCPS::NetworkInterface& nic,
+    void remove_address(const DCPS::NetworkInterface_rch& nic,
                         const ACE_INET_Addr& address);
 
     DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
@@ -622,7 +622,7 @@ private:
     enum CmgAction {CMG_JOIN, CMG_LEAVE};
 
     ChangeMulticastGroup(const DCPS::RcHandle<SpdpTransport>& tport,
-                         const DCPS::NetworkInterface& nic, CmgAction action,
+                         const DCPS::NetworkInterface_rch& nic, CmgAction action,
                          bool all_interfaces = false)
       : tport_(tport)
       , nic_(nic)
@@ -645,7 +645,7 @@ private:
     }
 
     DCPS::WeakRcHandle<SpdpTransport> tport_;
-    DCPS::NetworkInterface nic_;
+    DCPS::NetworkInterface_rch nic_;
     CmgAction action_;
     bool all_interfaces_;
   };

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -415,8 +415,8 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
   if (ncm) {
     ncm->add_listener(*this);
   } else {
-    NetworkInterface nic(0, cfg.multicast_interface_, true);
-    nic.add_default_addrs();
+    NetworkInterface_rch nic = make_rch<NetworkInterface>(0, cfg.multicast_interface_, true);
+    nic->add_default_addrs();
     const bool all = cfg.multicast_interface_.empty();
     join_multicast_group(nic, all);
   }
@@ -425,7 +425,7 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
 }
 
 void
-RtpsUdpDataLink::add_address(const NetworkInterface& nic,
+RtpsUdpDataLink::add_address(const NetworkInterface_rch& nic,
                              const ACE_INET_Addr&)
 {
   job_queue_->enqueue(make_rch<ChangeMulticastGroup>(rchandle_from(this), nic,
@@ -433,7 +433,7 @@ RtpsUdpDataLink::add_address(const NetworkInterface& nic,
 }
 
 void
-RtpsUdpDataLink::remove_address(const NetworkInterface& nic,
+RtpsUdpDataLink::remove_address(const NetworkInterface_rch& nic,
                                 const ACE_INET_Addr&)
 {
   job_queue_->enqueue(make_rch<ChangeMulticastGroup>(rchandle_from(this), nic,
@@ -441,7 +441,7 @@ RtpsUdpDataLink::remove_address(const NetworkInterface& nic,
 }
 
 void
-RtpsUdpDataLink::join_multicast_group(const NetworkInterface& nic,
+RtpsUdpDataLink::join_multicast_group(const NetworkInterface_rch& nic,
                                       bool all_interfaces)
 {
   network_change();
@@ -450,21 +450,21 @@ RtpsUdpDataLink::join_multicast_group(const NetworkInterface& nic,
     return;
   }
 
-  if (nic.exclude_from_multicast(config().multicast_interface_.c_str())) {
+  if (nic->exclude_from_multicast(config().multicast_interface_.c_str())) {
     return;
   }
 
-  if (joined_interfaces_.count(nic.name()) == 0 && nic.has_ipv4()) {
+  if (joined_interfaces_.count(nic->name()) == 0 && nic->has_ipv4()) {
     if (DCPS_debug_level > 3) {
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::join_multicast_group ")
                  ACE_TEXT("joining group %C on %C\n"),
                  DCPS::LogAddr(config().multicast_group_address()).c_str(),
-                 nic.name().c_str()));
+                 nic->name().c_str()));
     }
 
-    if (0 == multicast_socket_.join(config().multicast_group_address(), 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
-      joined_interfaces_.insert(nic.name());
+    if (0 == multicast_socket_.join(config().multicast_group_address(), 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic->name().c_str()))) {
+      joined_interfaces_.insert(nic->name());
 
       if (get_reactor()->register_handler(multicast_socket_.get_handle(),
                                           receive_strategy().in(),
@@ -483,17 +483,17 @@ RtpsUdpDataLink::join_multicast_group(const NetworkInterface& nic,
   }
 
 #ifdef ACE_HAS_IPV6
-  if (ipv6_joined_interfaces_.count(nic.name()) == 0 && nic.has_ipv6()) {
+  if (ipv6_joined_interfaces_.count(nic->name()) == 0 && nic->has_ipv6()) {
     if (DCPS_debug_level > 3) {
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::join_multicast_group ")
                  ACE_TEXT("joining group %C on %C\n"),
                  DCPS::LogAddr(config().ipv6_multicast_group_address()).c_str(),
-                 nic.name().c_str()));
+                 nic->name().c_str()));
     }
 
-    if (0 == ipv6_multicast_socket_.join(config().ipv6_multicast_group_address(), 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
-      ipv6_joined_interfaces_.insert(nic.name());
+    if (0 == ipv6_multicast_socket_.join(config().ipv6_multicast_group_address(), 1, all_interfaces ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nic->name().c_str()))) {
+      ipv6_joined_interfaces_.insert(nic->name());
 
       if (get_reactor()->register_handler(ipv6_multicast_socket_.get_handle(),
                                           receive_strategy().in(),
@@ -514,19 +514,19 @@ RtpsUdpDataLink::join_multicast_group(const NetworkInterface& nic,
 }
 
 void
-RtpsUdpDataLink::leave_multicast_group(const NetworkInterface& nic)
+RtpsUdpDataLink::leave_multicast_group(const NetworkInterface_rch& nic)
 {
-  if (joined_interfaces_.count(nic.name()) != 0 && !nic.has_ipv4()) {
+  if (joined_interfaces_.count(nic->name()) != 0 && !nic->has_ipv4()) {
     if (DCPS_debug_level > 3) {
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::leave_multicast_group ")
                  ACE_TEXT("leaving group %C on %C\n"),
                  DCPS::LogAddr(config().multicast_group_address()).c_str(),
-                 nic.name().c_str()));
+                 nic->name().c_str()));
     }
 
-    if (0 == multicast_socket_.leave(config().multicast_group_address(), ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
-      joined_interfaces_.erase(nic.name());
+    if (0 == multicast_socket_.leave(config().multicast_group_address(), ACE_TEXT_CHAR_TO_TCHAR(nic->name().c_str()))) {
+      joined_interfaces_.erase(nic->name());
     } else {
       if (DCPS_debug_level > 0) {
         ACE_ERROR((LM_ERROR,
@@ -537,17 +537,17 @@ RtpsUdpDataLink::leave_multicast_group(const NetworkInterface& nic)
   }
 
 #ifdef ACE_HAS_IPV6
-  if (ipv6_joined_interfaces_.count(nic.name()) != 0 && !nic.has_ipv6()) {
+  if (ipv6_joined_interfaces_.count(nic->name()) != 0 && !nic->has_ipv6()) {
     if (DCPS_debug_level > 3) {
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("(%P|%t) RtpsUdpDataLink::leave_ipv6_multicast_group ")
                  ACE_TEXT("leaving group %C on %C\n"),
                  DCPS::LogAddr(config().multicast_group_address()).c_str(),
-                 nic.name().c_str()));
+                 nic->name().c_str()));
     }
 
-    if (0 == ipv6_multicast_socket_.leave(config().ipv6_multicast_group_address(), ACE_TEXT_CHAR_TO_TCHAR(nic.name().c_str()))) {
-      ipv6_joined_interfaces_.erase(nic.name());
+    if (0 == ipv6_multicast_socket_.leave(config().ipv6_multicast_group_address(), ACE_TEXT_CHAR_TO_TCHAR(nic->name().c_str()))) {
+      ipv6_joined_interfaces_.erase(nic->name());
     } else {
       if (DCPS_debug_level > 0) {
         ACE_ERROR((LM_ERROR,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -236,12 +236,12 @@ public:
   void disable_response_queue();
 
 private:
-  void join_multicast_group(const NetworkInterface& nic,
+  void join_multicast_group(const NetworkInterface_rch& nic,
                             bool all_interfaces = false);
-  void leave_multicast_group(const NetworkInterface& nic);
-  void add_address(const NetworkInterface& nic,
+  void leave_multicast_group(const NetworkInterface_rch& nic);
+  void add_address(const NetworkInterface_rch& nic,
                    const ACE_INET_Addr& address);
-  void remove_address(const NetworkInterface& nic,
+  void remove_address(const NetworkInterface_rch& nic,
                       const ACE_INET_Addr& address);
 
   // Internal non-locking versions of the above
@@ -929,7 +929,7 @@ private:
     enum CmgAction {CMG_JOIN, CMG_LEAVE};
 
     ChangeMulticastGroup(RcHandle<RtpsUdpDataLink> link,
-                         const NetworkInterface& nic, CmgAction action)
+                         const NetworkInterface_rch& nic, CmgAction action)
       : link_(link)
       , nic_(nic)
       , action_(action)
@@ -945,7 +945,7 @@ private:
     }
 
     RcHandle<RtpsUdpDataLink> link_;
-    NetworkInterface nic_;
+    NetworkInterface_rch nic_;
     CmgAction action_;
   };
 


### PR DESCRIPTION
Problem: On machines with large numbers of network interfaces, holding an internal lock to iterate over the network interfaces and call add_listener is costly.

Solution: Make NetworkInterface inherit from RcObject and prefer the use of RcHandles to make copying lists of interfaces faster / safer, and then iterate over copies of the list rather than holding the lock.