### PR TITLE
Remove boost as an optional dependency

### DIFF
--- a/configure
+++ b/configure
@@ -232,8 +232,6 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'qt:s', 'Qt5 (use QTDIR or system pkg)',
     'qt-include:s', 'Qt include dir (use QT5_INCDIR, QTDIR/include,' .
       $argIndent . 'or sysytem package)',
-    'boost:s', 'Boost (use BOOST_ROOT or system pkg)',
-    'boost-version:s', 'Boost version (only if needed to find headers)',
     'xerces3:s', 'Xerces-C++ 3 for QoS XML handling, DDS Security',
     'openssl:s', 'OpenSSL for DDS Security',
     'cmake:s', 'Path to cmake binary for compiling Google Test' .
@@ -1126,7 +1124,6 @@ my %optdep = (
     mpc => 'no_rapidjson=0',
   },
   'qt' => {env => 'QTDIR', sanity => '', mpc => 'qt5'},
-  'boost' => {env => 'BOOST_ROOT', sanity => 'include/boost/version.hpp', mpc => 'boost'},
   'xerces3' => {
     env => 'XERCESCROOT',
     sanity => 'include/xercesc/dom/DOM.hpp',
@@ -1174,7 +1171,6 @@ if (exists $opts{'java'}) {
 
 my $try_to_use_qt_system_pkg =
   exists $opts{'qt'} && !length($opts{'qt'}) && !exists $opts{'qt-include'};
-$opts{'boost'} = '' if exists $opts{'boost-version'} && !exists $opts{'boost'};
 
 # Default to Wireshark Development Package if installed and a path wasn't
 # supplied.
@@ -1338,10 +1334,9 @@ if (exists $opts{'rapidjson'}) {
   }
 }
 
-my %use_system_pkg = map {$_, 1} qw/ant glib qt boost xerces3 openssl/;
+my %use_system_pkg = map {$_, 1} qw/ant glib qt xerces3 openssl/;
 
 my %use_win_default = (
-    'boost' => 'c:\\Boost',
     'openssl' => system_default_install_dir() . '/OpenSSL',
     'xerces3' => system_default_install_dir() . '/xerces-c');
 
@@ -1452,31 +1447,6 @@ sub env_from_opt {
   my $notdir = shift;
   if ($opts{$key}) {
     setEnv($e, $opts{$key}, $notdir);
-  }
-}
-
-if (exists $opts{'boost'} && !exists $opts{'boost-version'}) {
-  if (!-r $opts{'boost'} . '/' . $optdep{'boost'}->{sanity}
-      && -d $opts{'boost'} . '/include') {
-    opendir DIR, $opts{'boost'} . '/include';
-    my @dirs = sort {$b cmp $a} grep {/boost-/} readdir DIR;
-    closedir DIR;
-    if (scalar @dirs && -r $opts{'boost'} . '/include/' . $dirs[0]
-        . '/boost/version.hpp') {
-      $opts{'boost-version'} = $dirs[0];
-      print "Found boost-version = $dirs[0]\n" if $opts{'verbose'};
-    }
-  }
-}
-
-if (exists $opts{'boost'} && exists $opts{'boost-version'}) {
-  env_from_opt('boost', $optdep{'boost'}->{env});
-  env_from_opt('boost-version', 'BOOST_VERSION', 1);
-  if ($targetEnv{'BOOST_VERSION'}
-      && !-r $targetEnv{'BOOST_ROOT'} . '/' . $optdep{'boost'}->{sanity}
-      && -r $targetEnv{'BOOST_ROOT'} . '/include/' . $targetEnv{'BOOST_VERSION'}
-      . '/boost/version.hpp') {
-    $optdep{'boost'}->{sanity} = ''; # skip sanity check in for-loop below
   }
 }
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -14,7 +14,6 @@
   * [Qt](#qt)
   * [Wireshark](#wireshark)
   * [RapidJSON](#rapidjson)
-  * [Boost](#boost)
   * [Xerces](#xerces)
   * [OpenSSL](#openssl)
   * [Python](#python)
@@ -176,12 +175,6 @@ manually.**
 
 RapidJSON is also available as package, at least in Debian-based Linux
 distributions.
-
-### Boost
-
-Boost, as of writing, is just an optional dependency of the
-[ishapes](../examples/DCPS/ishapes) RTPS demo and only if C++11 is not
-available.
 
 ### Xerces
 

--- a/examples/DCPS/ishapes/Circle.cpp
+++ b/examples/DCPS/ishapes/Circle.cpp
@@ -4,7 +4,7 @@
 
 
 Circle::Circle(const QRect& bounds,
-               shared_ptr<ShapeDynamics> dynamics,
+               std::shared_ptr<ShapeDynamics> dynamics,
                const QPen& pen,
                const QBrush& brush,
                bool targeted)

--- a/examples/DCPS/ishapes/Circle.hpp
+++ b/examples/DCPS/ishapes/Circle.hpp
@@ -8,7 +8,7 @@ class Circle : public Shape {
 public:
 
     Circle(const QRect& bounds,
-           shared_ptr<ShapeDynamics> dynamics,
+           std::shared_ptr<ShapeDynamics> dynamics,
            const QPen& pen,
            const QBrush& brush,
            bool targeted = false);
@@ -23,7 +23,7 @@ private:
     Circle& operator=(Circle&);
 
 private:
-    shared_ptr<ShapeDynamics> dynamics_;
+    std::shared_ptr<ShapeDynamics> dynamics_;
 };
 
 #endif /* _CIRCLE_HPP */

--- a/examples/DCPS/ishapes/DDSShapeDynamics.hpp
+++ b/examples/DCPS/ishapes/DDSShapeDynamics.hpp
@@ -32,7 +32,7 @@ public:
   virtual ~DDSShapeDynamics();
 
 public:
-  void setShape(shared_ptr<Shape> shape) {
+  void setShape(std::shared_ptr<Shape> shape) {
     shape_ = shape;
   }
 
@@ -40,7 +40,7 @@ public:
 private:
   DDSShapeDynamics(const DDSShapeDynamics& orig);
 
-  shared_ptr<Shape> shape_;
+  std::shared_ptr<Shape> shape_;
   int x0_;
   int y0_;
   org::omg::dds::demo::ShapeTypeDataReader_var shapeReader_;

--- a/examples/DCPS/ishapes/Shape.hpp
+++ b/examples/DCPS/ishapes/Shape.hpp
@@ -7,14 +7,7 @@
 
 #include "ace/config-all.h"
 
-#if defined (ACE_HAS_CPP11)
-# include <memory>
-using std::shared_ptr;
-#else
-# include <boost/shared_ptr.hpp>
-using boost::shared_ptr;
-#endif /* ACE_HAS_CPP11 */
-
+#include <memory>
 
 class Shape {
 public:

--- a/examples/DCPS/ishapes/ShapesDialog.cpp
+++ b/examples/DCPS/ishapes/ShapesDialog.cpp
@@ -14,12 +14,10 @@
 #include "ace/config-all.h"
 #include "ShapeTypeTypeSupportImpl.h"
 
-#ifdef ACE_HAS_CPP11
-# include <string>
-# define TO_STRING std::to_string
-#else
-# include <boost/lexical_cast.hpp>
-# define TO_STRING boost::lexical_cast<std::string>
+#include <string>
+
+#ifndef ACE_HAS_CPP11
+#error ishapes requires C++11 or newer
 #endif
 
 using org::omg::dds::demo::ShapeType;
@@ -227,10 +225,10 @@ ShapesDialog::onPublishButtonClicked() {
     ShapeTypeDataWriter_var dw =
       ShapeTypeDataWriter::_narrow(writer);
 
-    shared_ptr<BouncingShapeDynamics>
+    std::shared_ptr<BouncingShapeDynamics>
       dynamics(new BouncingShapeDynamics(x, y, rect, constr, PI/6, speed,
            shape, dw));
-    shared_ptr<Shape>
+    std::shared_ptr<Shape>
       circle(new Circle(rect, dynamics, pen, brush));
     shapesWidget->addShape(circle);
 
@@ -256,10 +254,10 @@ ShapesDialog::onPublishButtonClicked() {
     ShapeTypeDataWriter_var dw =
       ShapeTypeDataWriter::_narrow(writer);
 
-    shared_ptr<BouncingShapeDynamics>
+    std::shared_ptr<BouncingShapeDynamics>
       dynamics(new BouncingShapeDynamics(x, y, rect, constr, PI/6, speed,
            shape, dw));
-    shared_ptr<Shape>
+    std::shared_ptr<Shape>
       square(new Square(rect, dynamics, pen, brush));
     shapesWidget->addShape(square);
     // std::cout << "CREATE SQUARE" << std::endl;
@@ -285,10 +283,10 @@ ShapesDialog::onPublishButtonClicked() {
     ShapeTypeDataWriter_var dw =
       ShapeTypeDataWriter::_narrow(writer);
 
-    shared_ptr<BouncingShapeDynamics>
+    std::shared_ptr<BouncingShapeDynamics>
       dynamics(new BouncingShapeDynamics(x, y, rect, constr, PI/6, speed,
            shape, dw));
-    shared_ptr<Shape>
+    std::shared_ptr<Shape>
       triangle(new Triangle(rect, dynamics, pen, brush));
     shapesWidget->addShape(triangle);
     // std::cout << "CREATE TRIANGLE" << std::endl;
@@ -320,11 +318,11 @@ ShapesDialog::onSubscribeButtonClicked() {
   filterParams_ = DDS::StringSeq();
   if (filterDialog_->isEnabled()) {
     QRect rect =  filterDialog_->getFilterBounds();
-    std::string x0 = TO_STRING(rect.x());
-    std::string x1 = TO_STRING(rect.x() + rect.width());
+    std::string x0 = std::to_string(rect.x());
+    std::string x1 = std::to_string(rect.x() + rect.width());
 
-    std::string y0 = TO_STRING(rect.y());
-    std::string y1 = TO_STRING(rect.y() + rect.height());
+    std::string y0 = std::to_string(rect.y());
+    std::string y1 = std::to_string(rect.y() + rect.height());
     filterParams_.length(4);
     filterParams_[0] = x0.c_str();
     filterParams_[1] = x1.c_str();
@@ -412,9 +410,9 @@ ShapesDialog::onSubscribeButtonClicked() {
   case CIRCLE: {
     for (int i = 0; i < CN; ++i) {
       std::string colorStr(colorString_[i]);
-      shared_ptr<DDSShapeDynamics>
+      std::shared_ptr<DDSShapeDynamics>
         dynamics(new DDSShapeDynamics(x, y, dr, colorStr, i));
-      shared_ptr<Shape>
+      std::shared_ptr<Shape>
         circle(new Circle(rect, dynamics, pen, brush, true));
       dynamics->setShape(circle);
       shapesWidget->addShape(circle);
@@ -425,9 +423,9 @@ ShapesDialog::onSubscribeButtonClicked() {
   case SQUARE: {
     for (int i = 0; i < CN; ++i) {
       std::string colorStr(colorString_[i]);
-      shared_ptr<DDSShapeDynamics>
+      std::shared_ptr<DDSShapeDynamics>
         dynamics(new DDSShapeDynamics(x, y, dr, colorStr, i));
-      shared_ptr<Shape>
+      std::shared_ptr<Shape>
         square(new Square(rect, dynamics, pen, brush, true));
       dynamics->setShape(square);
       shapesWidget->addShape(square);
@@ -437,9 +435,9 @@ ShapesDialog::onSubscribeButtonClicked() {
   case TRIANGLE: {
     for (int i = 0; i < CN; ++i) {
       std::string colorStr(colorString_[i]);
-      shared_ptr<DDSShapeDynamics>
+      std::shared_ptr<DDSShapeDynamics>
         dynamics(new DDSShapeDynamics(x, y, dr, colorStr, i));
-      shared_ptr<Shape>
+      std::shared_ptr<Shape>
         triangle(new Triangle(rect, dynamics, pen, brush, true));
       dynamics->setShape(triangle);
       shapesWidget->addShape(triangle);

--- a/examples/DCPS/ishapes/ShapesWidget.cpp
+++ b/examples/DCPS/ishapes/ShapesWidget.cpp
@@ -28,7 +28,7 @@ ShapesWidget::~ShapesWidget() {
 }
 
 void
-ShapesWidget::addShape(shared_ptr<Shape> shape) {
+ShapesWidget::addShape(std::shared_ptr<Shape> shape) {
     shapeList_.push_back(shape);
 }
 

--- a/examples/DCPS/ishapes/ShapesWidget.hpp
+++ b/examples/DCPS/ishapes/ShapesWidget.hpp
@@ -12,7 +12,7 @@ class ShapesWidget  : public QWidget
 {
   Q_OBJECT
   public:
-  typedef std::vector<shared_ptr<Shape> > ShapeList;
+  typedef std::vector<std::shared_ptr<Shape> > ShapeList;
   typedef std::vector<QRect> FilterList;
 public:
 
@@ -25,7 +25,7 @@ public:
 
 public slots:
   void nextAnimationFrame();
-  void addShape(shared_ptr<Shape> shape);
+  void addShape(std::shared_ptr<Shape> shape);
 
 protected:
   void paintEvent(QPaintEvent *event);

--- a/examples/DCPS/ishapes/Square.cpp
+++ b/examples/DCPS/ishapes/Square.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 Square::Square(const QRect& bounds,
-               shared_ptr<ShapeDynamics> dynamics,
+               std::shared_ptr<ShapeDynamics> dynamics,
                const QPen& pen,
                const QBrush& brush,
                bool targeted)

--- a/examples/DCPS/ishapes/Square.hpp
+++ b/examples/DCPS/ishapes/Square.hpp
@@ -8,7 +8,7 @@
 class Square : public Shape {
 public:
     Square(const QRect& bounds,
-           shared_ptr<ShapeDynamics> dynamics,
+           std::shared_ptr<ShapeDynamics> dynamics,
            const QPen& pen,
            const QBrush& brush,
            bool targeted = false);
@@ -23,7 +23,7 @@ private:
     Square& operator=(const Square&);
 
 private:
-    shared_ptr<ShapeDynamics> dynamics_;
+    std::shared_ptr<ShapeDynamics> dynamics_;
 
 };
 

--- a/examples/DCPS/ishapes/Triangle.cpp
+++ b/examples/DCPS/ishapes/Triangle.cpp
@@ -3,7 +3,7 @@
 #include "Triangle.hpp"
 
 Triangle::Triangle(const QRect& bounds,
-                   shared_ptr<ShapeDynamics> dynamics,
+                   std::shared_ptr<ShapeDynamics> dynamics,
                    const QPen& pen,
                    const QBrush& brush,
                    bool targeted)

--- a/examples/DCPS/ishapes/Triangle.hpp
+++ b/examples/DCPS/ishapes/Triangle.hpp
@@ -7,7 +7,7 @@
 class Triangle : public Shape {
 public:
   Triangle(const QRect& bounds,
-           shared_ptr<ShapeDynamics> dynamics,
+           std::shared_ptr<ShapeDynamics> dynamics,
            const QPen& pen,
            const QBrush& brush,
            bool targeted = false);
@@ -24,7 +24,7 @@ private:
   Triangle& operator=(const Triangle&);
 
 private:
-  shared_ptr<ShapeDynamics> dynamics_;
+  std::shared_ptr<ShapeDynamics> dynamics_;
   QPolygon triangle_;
 };
 

--- a/examples/DCPS/ishapes/boost_or_cxx11.mpb
+++ b/examples/DCPS/ishapes/boost_or_cxx11.mpb
@@ -1,6 +1,0 @@
-feature(boost): boost_base {
-}
-
-feature(no_cxx11) {
-  requires += boost
-}

--- a/examples/DCPS/ishapes/ishapes.mpc
+++ b/examples/DCPS/ishapes/ishapes.mpc
@@ -1,4 +1,4 @@
-project(ishapes): dcpsexe, dcps_tcp, dcps_udp, dcps_multicast, dcps_rtps_udp, qt5_widgets, boost_or_cxx11 {
+project: dcpsexe, dcps_tcp, dcps_udp, dcps_multicast, dcps_rtps_udp, qt5_widgets {
 
   exename = *
   includes += .


### PR DESCRIPTION
It was only used when building examples/DCPS/ishapes with old compilers
Since ishapes also requires Qt5 and is not configured by default, we
will assume a new enough C++ version