### PR TITLE
configure: Ensure `--prefix` is an Absolute Path

### DIFF
--- a/configure
+++ b/configure
@@ -463,6 +463,10 @@ if (exists($opts{'workspace'})) {
   $opts{'workspace'} = Cwd::realpath($opts{'workspace'});
 }
 
+if (exists($opts{'prefix'}) && !File::Spec->file_name_is_absolute($opts{'prefix'})) {
+  die("ERROR: --prefix argument $opts{'prefix'} is not an absolute path, stopped");
+}
+
 # Set initial libpath
 addCurLibPathRef(\%hostEnv);
 addCurLibPathRef(\%targetEnv);


### PR DESCRIPTION
Prompted by a note in this
https://github.com/objectcomputing/OpenDDS/blob/c62aa01c8d97e41f498a3e4b6765531f3a59451e/docs/cmake.md#example-using-installed-opendds-unix-only