### PR TITLE
Improve Sequence Growth Performance

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -32,18 +32,6 @@ using DCPS::operator!=;
 
 namespace {
 
-  void add_param(ParameterList& param_list, const Parameter& param)
-  {
-    const CORBA::ULong length = param_list.length();
-    // Grow by factor of 2 when length is a power of 2 in order to prevent every call to length(+1)
-    // allocating a new buffer & copying previous results. The maximum is kept when length is reduced.
-    if (length && !(length & (length - 1))) {
-      param_list.length(2 * length);
-    }
-    param_list.length(length + 1);
-    param_list[length] = param;
-  }
-
   void extract_type_info_param(const Parameter& param, XTypes::TypeInformation& type_info)
   {
     if (!XTypes::deserialize_type_info(type_info, param.type_information())) {
@@ -66,10 +54,10 @@ namespace {
     }
 
     param.type_information(seq);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
-  void add_param_locator_seq(ParameterList& param_list,
+  void push_back_locator_seq(ParameterList& param_list,
                              const DCPS::LocatorSeq& locator_seq,
                              const ParameterId_t pid)
   {
@@ -78,11 +66,11 @@ namespace {
       Parameter param;
       param.locator(locator_seq[i]);
       param._d(pid);
-      add_param(param_list, param);
+      DCPS::push_back(param_list, param);
     }
   }
 
-  void add_param_rtps_locator(ParameterList& param_list,
+  void push_back_rtps_locator(ParameterList& param_list,
                               const DCPS::TransportLocator& dcps_locator,
                               bool map /*map IPV4 to IPV6 addr*/)
   {
@@ -102,48 +90,32 @@ namespace {
           } else {
             param._d(PID_UNICAST_LOCATOR);
           }
-          add_param(param_list, param);
+          DCPS::push_back(param_list, param);
         }
       }
     } else {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: add_param_rtps_locator - ")
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: push_back_rtps_locator - ")
                            ACE_TEXT("Unable to convert dcps_rtps ")
                            ACE_TEXT("TransportLocator blob to LocatorSeq\n")));
     }
   }
 
-  void add_param_dcps_locator(ParameterList& param_list,
+  void push_back_dcps_locator(ParameterList& param_list,
                               const DCPS::TransportLocator& dcps_locator)
   {
     Parameter param;
     param.opendds_locator(dcps_locator);
     param._d(PID_OPENDDS_LOCATOR);
-    add_param(param_list, param);
-  }
-
-  void append_locator(DCPS::LocatorSeq& list, const DCPS::Locator_t& locator)
-  {
-    const CORBA::ULong length = list.length();
-    list.length(length + 1);
-    list[length] = locator;
-  }
-
-  void append_locator(DCPS::TransportLocatorSeq& list,
-                      const DCPS::TransportLocator& locator)
-  {
-    const CORBA::ULong length = list.length();
-    list.length(length + 1);
-    list[length] = locator;
+    DCPS::push_back(param_list, param);
   }
 
   void append_locators_if_present(DCPS::TransportLocatorSeq& list,
                                   const DCPS::LocatorSeq& rtps_udp_locators)
   {
     if (rtps_udp_locators.length()) {
-      const CORBA::ULong length = list.length();
-      list.length(length + 1);
-      list[length].transport_type = "rtps_udp";
-      locators_to_blob(rtps_udp_locators, list[length].data);
+      DCPS::TransportLocator& tl = list[DCPS::grow(list) - 1];
+      tl.transport_type = "rtps_udp";
+      locators_to_blob(rtps_udp_locators, tl.data);
     }
   }
 
@@ -153,14 +125,6 @@ namespace {
     locator_address_only,
     locator_port_only
   };
-
-  void append_associated_writer(DCPS::DiscoveredReaderData& reader_data,
-                                const Parameter& param)
-  {
-    const CORBA::ULong len = reader_data.readerProxy.associatedWriters.length();
-    reader_data.readerProxy.associatedWriters.length(len + 1);
-    reader_data.readerProxy.associatedWriters[len] = param.guid();
-  }
 
   bool not_default(const DDS::UserDataQosPolicy& qos)
   {
@@ -374,7 +338,7 @@ bool to_param_list(const DDS::ParticipantBuiltinTopicData& pbtd,
   if (not_default(pbtd.user_data)) {
     Parameter param_ud;
     param_ud.user_data(pbtd.user_data);
-    add_param(param_list, param_ud);
+    DCPS::push_back(param_list, param_ud);
   }
 
   return true;
@@ -410,25 +374,25 @@ bool to_param_list(const DDS::Security::ParticipantBuiltinTopicData& pbtd,
 
   Parameter param_it;
   param_it.identity_token(pbtd.identity_token);
-  add_param(param_list, param_it);
+  DCPS::push_back(param_list, param_it);
 
   Parameter param_pt;
   param_pt.permissions_token(pbtd.permissions_token);
-  add_param(param_list, param_pt);
+  DCPS::push_back(param_list, param_pt);
 
   if (not_default(pbtd.property)) {
     Parameter param_p;
     param_p.property(pbtd.property);
-    add_param(param_list, param_p);
+    DCPS::push_back(param_list, param_p);
   }
 
   Parameter param_psi;
   param_psi.participant_security_info(pbtd.security_info);
-  add_param(param_list, param_psi);
+  DCPS::push_back(param_list, param_psi);
 
   Parameter param_ebe;
   param_ebe.extended_builtin_endpoints(pbtd.extended_builtin_endpoints);
-  add_param(param_list, param_ebe);
+  DCPS::push_back(param_list, param_ebe);
 
   return true;
 }
@@ -478,7 +442,7 @@ bool to_param_list(const DDS::Security::ParticipantBuiltinTopicDataSecure& pbtds
 
   Parameter param_ist;
   param_ist.identity_status_token(pbtds.identity_status_token);
-  add_param(param_list, param_ist);
+  DCPS::push_back(param_list, param_ist);
 
   return true;
 }
@@ -513,35 +477,35 @@ bool to_param_list(const ParticipantProxy_t& proxy,
 {
   Parameter beq_param;
   beq_param.builtinEndpointQos(proxy.builtinEndpointQos);
-  add_param(param_list, beq_param);
+  DCPS::push_back(param_list, beq_param);
 
   Parameter pd_param;
   pd_param.domainId(proxy.domainId);
-  add_param(param_list, pd_param);
+  DCPS::push_back(param_list, pd_param);
 
   Parameter pv_param;
   pv_param.version(proxy.protocolVersion);
-  add_param(param_list, pv_param);
+  DCPS::push_back(param_list, pv_param);
 
   Parameter gp_param;
   gp_param.guid(DCPS::make_part_guid(proxy.guidPrefix));
   gp_param._d(PID_PARTICIPANT_GUID);
-  add_param(param_list, gp_param);
+  DCPS::push_back(param_list, gp_param);
 
   Parameter vid_param;
   vid_param.vendor(proxy.vendorId);
-  add_param(param_list, vid_param);
+  DCPS::push_back(param_list, vid_param);
 
   if (proxy.expectsInlineQos) {
     Parameter eiq_param; // Default is false
     eiq_param.expects_inline_qos(proxy.expectsInlineQos);
-    add_param(param_list, eiq_param);
+    DCPS::push_back(param_list, eiq_param);
   }
 
   Parameter abe_param;
   abe_param.participant_builtin_endpoints(
     proxy.availableBuiltinEndpoints);
-  add_param(param_list, abe_param);
+  DCPS::push_back(param_list, abe_param);
 
   // Interoperability note:
   // For interoperability with other DDS implemenations, we'll encode the
@@ -550,56 +514,56 @@ bool to_param_list(const ParticipantProxy_t& proxy,
   Parameter be_param;
   be_param.builtin_endpoints(
     proxy.availableBuiltinEndpoints);
-  add_param(param_list, be_param);
+  DCPS::push_back(param_list, be_param);
 
 #ifdef OPENDDS_SECURITY
   Parameter ebe_param;
   ebe_param.extended_builtin_endpoints(
     proxy.availableExtendedBuiltinEndpoints);
-  add_param(param_list, ebe_param);
+  DCPS::push_back(param_list, ebe_param);
 #endif
 
   // Each locator
-  add_param_locator_seq(
+  push_back_locator_seq(
       param_list,
       proxy.metatrafficUnicastLocatorList,
       PID_METATRAFFIC_UNICAST_LOCATOR);
 
-  add_param_locator_seq(
+  push_back_locator_seq(
       param_list,
       proxy.metatrafficMulticastLocatorList,
       PID_METATRAFFIC_MULTICAST_LOCATOR);
 
-  add_param_locator_seq(
+  push_back_locator_seq(
       param_list,
       proxy.defaultUnicastLocatorList,
       PID_DEFAULT_UNICAST_LOCATOR);
 
-  add_param_locator_seq(
+  push_back_locator_seq(
       param_list,
       proxy.defaultMulticastLocatorList,
       PID_DEFAULT_MULTICAST_LOCATOR);
 
   Parameter ml_param;
   ml_param.count(proxy.manualLivelinessCount);
-  add_param(param_list, ml_param);
+  DCPS::push_back(param_list, ml_param);
 
   if (not_default(proxy.property)) {
     Parameter param_p;
     param_p.property(proxy.property);
-    add_param(param_list, param_p);
+    DCPS::push_back(param_list, param_p);
   }
 
   if (not_default(proxy.opendds_participant_flags)) {
     Parameter param_opf;
     param_opf.participant_flags(proxy.opendds_participant_flags);
-    add_param(param_list, param_opf);
+    DCPS::push_back(param_list, param_opf);
   }
 
   if (proxy.opendds_rtps_relay_application_participant) {
     Parameter param;
     param.opendds_rtps_relay_application_participant(proxy.opendds_rtps_relay_application_participant);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   return true;
@@ -661,22 +625,22 @@ bool from_param_list(const ParameterList& param_list,
         break;
 #endif
       case PID_METATRAFFIC_UNICAST_LOCATOR:
-        append_locator(
+        DCPS::push_back(
             proxy.metatrafficUnicastLocatorList,
             param.locator());
         break;
       case PID_METATRAFFIC_MULTICAST_LOCATOR:
-        append_locator(
+        DCPS::push_back(
             proxy.metatrafficMulticastLocatorList,
             param.locator());
         break;
       case PID_DEFAULT_UNICAST_LOCATOR:
-        append_locator(
+        DCPS::push_back(
             proxy.defaultUnicastLocatorList,
             param.locator());
         break;
       case PID_DEFAULT_MULTICAST_LOCATOR:
-        append_locator(
+        DCPS::push_back(
             proxy.defaultMulticastLocatorList,
             param.locator());
         break;
@@ -717,7 +681,7 @@ bool to_param_list(const Duration_t& duration,
       (duration.fraction != 0)) {
     Parameter ld_param;
     ld_param.duration(duration);
-    add_param(param_list, ld_param);
+    DCPS::push_back(param_list, ld_param);
   }
 
   return true;
@@ -833,7 +797,7 @@ void add_DataRepresentationQos(ParameterList& param_list, const DDS::DataReprese
   if (dr_qos.value.length() != 1 || dr_qos.value[0] != DDS::XCDR_DATA_REPRESENTATION) {
     Parameter param;
     param.representation(dr_qos);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 }
 
@@ -849,14 +813,14 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
     Parameter param;
     param.string_data(writer_data.ddsPublicationData.topic_name);
     param._d(PID_TOPIC_NAME);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   {
     Parameter param;
     param.string_data(writer_data.ddsPublicationData.type_name);
     param._d(PID_TYPE_NAME);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (use_xtypes) {
@@ -866,31 +830,31 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
   if (not_default(writer_data.ddsPublicationData.durability)) {
     Parameter param;
     param.durability(writer_data.ddsPublicationData.durability);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.durability_service)) {
     Parameter param;
     param.durability_service(writer_data.ddsPublicationData.durability_service);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.deadline)) {
     Parameter param;
     param.deadline(writer_data.ddsPublicationData.deadline);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.latency_budget)) {
     Parameter param;
     param.latency_budget(writer_data.ddsPublicationData.latency_budget);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.liveliness)) {
     Parameter param;
     param.liveliness(writer_data.ddsPublicationData.liveliness);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   // Interoperability note:
@@ -907,61 +871,61 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
     }
 
     param.reliability(reliability);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.lifespan)) {
     Parameter param;
     param.lifespan(writer_data.ddsPublicationData.lifespan);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.user_data)) {
     Parameter param;
     param.user_data(writer_data.ddsPublicationData.user_data);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.ownership)) {
     Parameter param;
     param.ownership(writer_data.ddsPublicationData.ownership);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.ownership_strength)) {
     Parameter param;
     param.ownership_strength(writer_data.ddsPublicationData.ownership_strength);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.destination_order)) {
     Parameter param;
     param.destination_order(writer_data.ddsPublicationData.destination_order);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.presentation)) {
     Parameter param;
     param.presentation(writer_data.ddsPublicationData.presentation);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.partition)) {
     Parameter param;
     param.partition(writer_data.ddsPublicationData.partition);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.topic_data)) {
     Parameter param;
     param.topic_data(writer_data.ddsPublicationData.topic_data);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.group_data)) {
     Parameter param;
     param.group_data(writer_data.ddsPublicationData.group_data);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   add_DataRepresentationQos(param_list, writer_data.ddsPublicationData.representation.value);
@@ -970,7 +934,7 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
     Parameter param;
     param.guid(writer_data.writerProxy.remoteWriterGuid);
     param._d(PID_ENDPOINT_GUID);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
   const CORBA::ULong locator_len = writer_data.writerProxy.allLocators.length();
 
@@ -983,11 +947,11 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
     // If this is an rtps udp transport
     if (!std::strcmp(tl.transport_type, "rtps_udp")) {
       // Append the locator's deserialized locator and an RTPS PID
-      add_param_rtps_locator(param_list, tl, map);
+      push_back_rtps_locator(param_list, tl, map);
       // Otherwise, this is an OpenDDS, custom transport
     } else {
       // Append the blob and a custom PID
-      add_param_dcps_locator(param_list, tl);
+      push_back_dcps_locator(param_list, tl);
       if (!std::strcmp(tl.transport_type, "multicast")) {
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) to_param_list(dwd) - ")
@@ -1133,17 +1097,17 @@ bool from_param_list(const ParameterList& param_list,
         writer_data.writerProxy.remoteWriterGuid = param.guid();
         break;
       case PID_UNICAST_LOCATOR:
-        append_locator(rtps_udp_locators, param.locator());
+        DCPS::push_back(rtps_udp_locators, param.locator());
         break;
       case PID_MULTICAST_LOCATOR:
-        append_locator(rtps_udp_locators, param.locator());
+        DCPS::push_back(rtps_udp_locators, param.locator());
         break;
       case PID_OPENDDS_LOCATOR:
         // Append the rtps_udp_locators, if any, first, to preserve order
         append_locators_if_present(writer_data.writerProxy.allLocators,
                                    rtps_udp_locators);
         rtps_udp_locators.length(0);
-        append_locator(writer_data.writerProxy.allLocators,
+        DCPS::push_back(writer_data.writerProxy.allLocators,
                        param.opendds_locator());
         break;
       case PID_SENTINEL:
@@ -1181,7 +1145,7 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     Parameter param;
     param.string_data(reader_data.ddsSubscriptionData.topic_name);
     param._d(PID_TOPIC_NAME);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (use_xtypes) {
@@ -1192,31 +1156,31 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     Parameter param;
     param.string_data(reader_data.ddsSubscriptionData.type_name);
     param._d(PID_TYPE_NAME);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.durability)) {
     Parameter param;
     param.durability(reader_data.ddsSubscriptionData.durability);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.deadline)) {
     Parameter param;
     param.deadline(reader_data.ddsSubscriptionData.deadline);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.latency_budget)) {
     Parameter param;
     param.latency_budget(reader_data.ddsSubscriptionData.latency_budget);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.liveliness)) {
     Parameter param;
     param.liveliness(reader_data.ddsSubscriptionData.liveliness);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   // Interoperability note:
@@ -1234,55 +1198,55 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     }
 
     param.reliability(reliability);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.ownership)) {
     Parameter param;
     param.ownership(reader_data.ddsSubscriptionData.ownership);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.destination_order)) {
     Parameter param;
     param.destination_order(reader_data.ddsSubscriptionData.destination_order);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.user_data)) {
     Parameter param;
     param.user_data(reader_data.ddsSubscriptionData.user_data);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.time_based_filter)) {
     Parameter param;
     param.time_based_filter(reader_data.ddsSubscriptionData.time_based_filter);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.presentation)) {
     Parameter param;
     param.presentation(reader_data.ddsSubscriptionData.presentation);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.partition)) {
     Parameter param;
     param.partition(reader_data.ddsSubscriptionData.partition);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.topic_data)) {
     Parameter param;
     param.topic_data(reader_data.ddsSubscriptionData.topic_data);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.group_data)) {
     Parameter param;
     param.group_data(reader_data.ddsSubscriptionData.group_data);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   add_DataRepresentationQos(param_list, reader_data.ddsSubscriptionData.representation.value);
@@ -1290,14 +1254,14 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
   if (not_default(reader_data.ddsSubscriptionData.type_consistency)) {
     Parameter param;
     param.type_consistency(reader_data.ddsSubscriptionData.type_consistency);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   {
     Parameter param;
     param.guid(reader_data.readerProxy.remoteReaderGuid);
     param._d(PID_ENDPOINT_GUID);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.contentFilterProperty)) {
@@ -1307,7 +1271,7 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
       cfprop_copy.filterClassName = "DDSSQL";
     }
     param.content_filter_property(cfprop_copy);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
 
   CORBA::ULong i;
@@ -1321,11 +1285,11 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     // If this is an rtps udp transport
     if (!std::strcmp(tl.transport_type, "rtps_udp")) {
       // Append the locator's deserialized locator and an RTPS PID
-      add_param_rtps_locator(param_list, tl, map);
+      push_back_rtps_locator(param_list, tl, map);
       // Otherwise, this is an OpenDDS, custom transport
     } else {
       // Append the blob and a custom PID
-      add_param_dcps_locator(param_list, tl);
+      push_back_dcps_locator(param_list, tl);
       if (!std::strcmp(tl.transport_type, "multicast")) {
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) to_param_list(drd) - ")
@@ -1340,7 +1304,7 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     Parameter param;
     param.guid(reader_data.readerProxy.associatedWriters[i]);
     param._d(PID_OPENDDS_ASSOCIATED_WRITER);
-    add_param(param_list, param);
+    DCPS::push_back(param_list, param);
   }
   return true;
 }
@@ -1473,10 +1437,10 @@ bool from_param_list(const ParameterList& param_list,
         reader_data.readerProxy.remoteReaderGuid = param.guid();
         break;
       case PID_UNICAST_LOCATOR:
-        append_locator(rtps_udp_locators, param.locator());
+        DCPS::push_back(rtps_udp_locators, param.locator());
         break;
       case PID_MULTICAST_LOCATOR:
-        append_locator(rtps_udp_locators, param.locator());
+        DCPS::push_back(rtps_udp_locators, param.locator());
         break;
       case PID_CONTENT_FILTER_PROPERTY:
         reader_data.contentFilterProperty = param.content_filter_property();
@@ -1486,11 +1450,11 @@ bool from_param_list(const ParameterList& param_list,
         append_locators_if_present(reader_data.readerProxy.allLocators,
                                    rtps_udp_locators);
         rtps_udp_locators.length(0);
-        append_locator(reader_data.readerProxy.allLocators,
+        DCPS::push_back(reader_data.readerProxy.allLocators,
                        param.opendds_locator());
         break;
       case PID_OPENDDS_ASSOCIATED_WRITER:
-        append_associated_writer(reader_data, param);
+        DCPS::push_back(reader_data.readerProxy.associatedWriters, param.guid());
         break;
       case PID_SENTINEL:
       case PID_PAD:
@@ -1520,7 +1484,7 @@ bool to_param_list(const DDS::Security::EndpointSecurityInfo& info,
 {
   Parameter param;
   param.endpoint_security_info(info);
-  add_param(param_list, param);
+  DCPS::push_back(param_list, param);
   return true;
 }
 
@@ -1552,7 +1516,7 @@ bool to_param_list(const DDS::Security::DataTags& tags,
 {
   Parameter param;
   param.data_tags(tags);
-  add_param(param_list, param);
+  DCPS::push_back(param_list, param);
   return true;
 }
 
@@ -1643,7 +1607,7 @@ bool to_param_list(const ICE::AgentInfoMap& ai_map,
 
     Parameter param_general;
     param_general.ice_general(ice_general);
-    add_param(param_list, param_general);
+    DCPS::push_back(param_list, param_general);
 
     for (ICE::AgentInfo::CandidatesType::const_iterator pos = agent_info.candidates.begin(),
            limit = agent_info.candidates.end(); pos != limit; ++pos) {
@@ -1656,7 +1620,7 @@ bool to_param_list(const ICE::AgentInfoMap& ai_map,
 
       Parameter param;
       param.ice_candidate(ice_candidate);
-      add_param(param_list, param);
+      DCPS::push_back(param_list, param);
     }
   }
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -5204,9 +5204,7 @@ Sedp::set_inline_qos(DCPS::TransportLocatorSeq& locators)
   const OPENDDS_STRING rtps_udp = "rtps_udp";
   for (CORBA::ULong i = 0; i < locators.length(); ++i) {
     if (locators[i].transport_type.in() == rtps_udp) {
-      const CORBA::ULong len = locators[i].data.length();
-      locators[i].data.length(len + 1);
-      locators[i].data[len] = CORBA::Octet(1);
+      DCPS::push_back(locators[i].data, CORBA::Octet(1));
     }
   }
 }

--- a/dds/DCPS/SequenceIterator.h
+++ b/dds/DCPS/SequenceIterator.h
@@ -6,10 +6,10 @@
 #ifndef OPENDDS_DCPS_SEQUENCEITERATOR_H
 #define OPENDDS_DCPS_SEQUENCEITERATOR_H
 
+#include "Util.h"
 #include "dds/Versioned_Namespace.h"
 
 #include "tao/Unbounded_Value_Sequence_T.h"
-
 #include <iterator>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -31,9 +31,7 @@ public:
 
   SequenceBackInsertIterator& operator=(const typename Sequence::value_type& value)
   {
-    const unsigned int len = seq_->length();
-    seq_->length(len + 1);
-    (*seq_)[len] = value;
+    push_back(*seq_, value);
     return *this;
   }
 

--- a/dds/DCPS/Util.h
+++ b/dds/DCPS/Util.h
@@ -136,8 +136,26 @@ template <typename Seq>
 void push_back(Seq& seq, const typename Seq::value_type& val)
 {
   const CORBA::ULong len = seq.length();
+  // Grow by factor of 2 when length is a power of 2 in order to prevent every call to length(+1)
+  // allocating a new buffer & copying previous results. The maximum is kept when length is reduced.
+  if (len && !(len & (len - 1))) {
+    seq.length(2 * len);
+  }
   seq.length(len + 1);
   seq[len] = val;
+}
+
+template <typename Seq>
+typename Seq::size_type grow(Seq& seq)
+{
+  const CORBA::ULong len = seq.length();
+  // Grow by factor of 2 when length is a power of 2 in order to prevent every call to length(+1)
+  // allocating a new buffer & copying previous results. The maximum is kept when length is reduced.
+  if (len && !(len & (len - 1))) {
+    seq.length(2 * len);
+  }
+  seq.length(len + 1);
+  return len + 1;
 }
 
 // Constructs a sorted intersect of the given two sorted ranges [a,aEnd) and [b,bEnd).

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -182,9 +182,8 @@ TransportClient::populate_connection_info()
     if (check_transport_qos(*inst)) {
       TransportImpl_rch impl = inst->impl();
       if (impl) {
-        const CORBA::ULong len = conn_info_.length();
-        conn_info_.length(len + 1);
-        impl->connection_info(conn_info_[len], CONNINFO_ALL);
+        const CORBA::ULong idx = DCPS::grow(conn_info_) - 1;
+        impl->connection_info(conn_info_[idx], CONNINFO_ALL);
       }
     }
   }

--- a/dds/DCPS/transport/framework/TransportConfig.cpp
+++ b/dds/DCPS/transport/framework/TransportConfig.cpp
@@ -44,8 +44,7 @@ TransportConfig::populate_locators(TransportLocatorSeq& trans_info) const
   for (InstancesType::const_iterator pos = instances_.begin(), limit = instances_.end();
        pos != limit;
        ++pos) {
-    const CORBA::ULong idx = trans_info.length();
-    trans_info.length(idx + 1);
+    const CORBA::ULong idx = DCPS::grow(trans_info) - 1;
     if ((*pos)->populate_locator(trans_info[idx], CONNINFO_ALL) == 0) {
       trans_info.length(idx);
     }

--- a/dds/DCPS/transport/framework/TransportStatistics.h
+++ b/dds/DCPS/transport/framework/TransportStatistics.h
@@ -105,8 +105,7 @@ struct InternalTransportStatistics {
 
 inline void append(TransportStatisticsSequence& seq, const InternalTransportStatistics& istats)
 {
-  const ACE_CDR::ULong idx = seq.length();
-  seq.length(idx + 1);
+  const ACE_CDR::ULong idx = grow(seq) - 1;
   TransportStatistics& stats = seq[idx];
   stats.transport = istats.transport.c_str();
   for (InternalTransportStatistics::MessageCountMap::const_iterator pos = istats.message_count.begin(),

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1608,9 +1608,8 @@ RtpsUdpDataLink::RtpsWriter::add_gap_submsg_i(RTPS::SubmessageSeq& msg,
   gap.smHeader.submessageLength =
       static_cast<CORBA::UShort>(size) - SMHDR_SZ;
 
-  const CORBA::ULong i = msg.length();
-  msg.length(i + 1);
-  msg[i].gap_sm(gap);
+  const CORBA::ULong idx = grow(msg) - 1;
+  msg[idx].gap_sm(gap);
 }
 
 void RtpsUdpDataLink::update_last_recv_addr(const RepoId& src, const ACE_INET_Addr& addr)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -197,70 +197,66 @@ RtpsUdpInst::populate_locator(TransportLocator& info, ConnectionInfoFlags flags)
 
   // multicast first so it's preferred by remote peers
   if ((flags & CONNINFO_MULTICAST) && use_multicast_ && multicast_group_address_ != ACE_INET_Addr()) {
-    idx = locators.length();
-    locators.length(idx + 1);
-    address_to_locator(locators[idx], this->multicast_group_address_);
+    grow(locators);
+    address_to_locator(locators[idx++], this->multicast_group_address_);
   }
 #ifdef ACE_HAS_IPV6
   if ((flags & CONNINFO_MULTICAST) && use_multicast_ && ipv6_multicast_group_address_ != ACE_INET_Addr()) {
-    idx = locators.length();
-    locators.length(idx + 1);
-    address_to_locator(locators[idx], this->ipv6_multicast_group_address_);
+    grow(locators);
+    address_to_locator(locators[idx++], this->ipv6_multicast_group_address_);
   }
 #endif
 
   if (flags & CONNINFO_UNICAST) {
     if (local_address() != ACE_INET_Addr()) {
       if (advertised_address() != ACE_INET_Addr()) {
-        idx = locators.length();
-        locators.length(idx + 1);
+        grow(locators);
         address_to_locator(locators[idx], advertised_address());
         if (locators[idx].port == 0) {
           locators[idx].port = local_address().get_port_number();
         }
+        ++idx;
       } else if (local_address().is_any()) {
         typedef OPENDDS_VECTOR(ACE_INET_Addr) AddrVector;
         AddrVector addrs;
         get_interface_addrs(addrs);
         for (AddrVector::iterator adr_it = addrs.begin(); adr_it != addrs.end(); ++adr_it) {
           if (*adr_it != ACE_INET_Addr() && adr_it->get_type() == AF_INET) {
-            idx = locators.length();
-            locators.length(idx + 1);
+            grow(locators);
             address_to_locator(locators[idx], *adr_it);
             locators[idx].port = local_address().get_port_number();
+            ++idx;
           }
         }
       } else {
-        idx = locators.length();
-        locators.length(idx + 1);
-        address_to_locator(locators[idx], local_address());
+        grow(locators);
+        address_to_locator(locators[idx++], local_address());
       }
     }
 #ifdef ACE_HAS_IPV6
     if (ipv6_local_address() != ACE_INET_Addr()) {
       if (ipv6_advertised_address() != ACE_INET_Addr()) {
-        idx = locators.length();
-        locators.length(idx + 1);
+        grow(locators);
         address_to_locator(locators[idx], ipv6_advertised_address());
         if (locators[idx].port == 0) {
           locators[idx].port = ipv6_local_address().get_port_number();
         }
+        ++idx;
       } else if (ipv6_local_address().is_any()) {
         typedef OPENDDS_VECTOR(ACE_INET_Addr) AddrVector;
         AddrVector addrs;
         get_interface_addrs(addrs);
         for (AddrVector::iterator adr_it = addrs.begin(); adr_it != addrs.end(); ++adr_it) {
           if (*adr_it != ACE_INET_Addr() && adr_it->get_type() == AF_INET6) {
-            idx = locators.length();
-            locators.length(idx + 1);
+            grow(locators);
             address_to_locator(locators[idx], *adr_it);
             locators[idx].port = ipv6_local_address().get_port_number();
+            ++idx;
           }
         }
       } else {
-        idx = locators.length();
-        locators.length(idx + 1);
-        address_to_locator(locators[idx], ipv6_local_address());
+        grow(locators);
+        address_to_locator(locators[idx++], ipv6_local_address());
       }
     }
 #endif

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -642,17 +642,12 @@ namespace {
       extraction.endArgs();
       be_global->impl_ <<
         "  while (true) {\n"
-        "    const CORBA::ULong len = seq.length();\n"
-        "    // Improves growth behavior. See note in ParameterListConverter's add_param()\n"
-        "    if (len && !(len & (len - 1))) {\n"
-        "      seq.length(2 * len);\n"
-        "    }\n"
-        "    seq.length(len + 1);\n"
-        "    if (!(strm >> seq[len])) {\n"
+        "    const CORBA::ULong idx = OpenDDS::DCPS::grow(seq) - 1;\n"
+        "    if (!(strm >> seq[idx])) {\n"
         "      return false;\n"
         "    }\n"
-        "    if (seq[len]._d() == OpenDDS::RTPS::PID_SENTINEL) {\n"
-        "      seq.length(len);\n"
+        "    if (seq[idx]._d() == OpenDDS::RTPS::PID_SENTINEL) {\n"
+        "      seq.length(idx);\n"
         "      return true;\n"
         "    }\n"
         "  }\n";
@@ -782,6 +777,7 @@ namespace {
   void gen_sequence_i(
     UTL_ScopedName* tdname, AST_Sequence* seq, bool nested_key_only, const FieldInfo* anonymous = 0)
   {
+    be_global->add_include("dds/DCPS/Util.h");
     be_global->add_include("dds/DCPS/Serializer.h");
     if (anonymous) {
       seq = dynamic_cast<AST_Sequence*>(anonymous->type_);

--- a/dds/idl/value_reader_generator.cpp
+++ b/dds/idl/value_reader_generator.cpp
@@ -116,7 +116,7 @@ namespace {
     if (use_cxx11) {
       be_global->impl_ << indent << "  " << expression << ".resize(" << expression << ".size() + 1);\n";
     } else {
-      be_global->impl_ << indent << "  " << expression << ".length(" << expression << ".length() + 1);\n";
+      be_global->impl_ << indent << "  OpenDDS::DCPS::grow(" << expression << ");\n";
     }
     be_global->impl_ <<
       indent << "  if (!value_reader.begin_element()) return false;\n";
@@ -215,6 +215,7 @@ bool value_reader_generator::gen_enum(AST_Enum*,
                                       const std::vector<AST_EnumVal*>& contents,
                                       const char*)
 {
+  be_global->add_include("dds/DCPS/Util.h", BE_GlobalData::STREAM_H);
   be_global->add_include("dds/DCPS/ValueReader.h", BE_GlobalData::STREAM_H);
 
   const std::string type_name = scoped(name);
@@ -261,6 +262,7 @@ bool value_reader_generator::gen_struct(AST_Structure*,
                                         AST_Type::SIZE_TYPE,
                                         const char*)
 {
+  be_global->add_include("dds/DCPS/Util.h", BE_GlobalData::STREAM_H);
   be_global->add_include("dds/DCPS/ValueReader.h", BE_GlobalData::STREAM_H);
 
   const std::string type_name = scoped(name);
@@ -326,6 +328,7 @@ bool value_reader_generator::gen_union(AST_Union* u,
                                        AST_Type* discriminator,
                                        const char*)
 {
+  be_global->add_include("dds/DCPS/Util.h", BE_GlobalData::STREAM_H);
   be_global->add_include("dds/DCPS/ValueReader.h", BE_GlobalData::STREAM_H);
 
   const std::string type_name = scoped(name);

--- a/performance-tests/bench/test_controller/AllocationHelper.cpp
+++ b/performance-tests/bench/test_controller/AllocationHelper.cpp
@@ -34,7 +34,7 @@ void AllocationHelper::alloc_exclusive_node_configs(AllocatedScenario& allocated
 
             // Update the allocated scenario to add a config for this node controller
             CORBA::ULong old_len = allocated_scenario.configs.length();
-            allocated_scenario.configs.length(old_len + 1);
+            OpenDDS::DCPS::grow(allocated_scenario.configs);
             allocated_scenario.configs[old_len].node_id = top.id;
             allocated_scenario.configs[old_len].timeout = scenario_prototype.timeout;
             allocated_scenario.configs[old_len].spawned_processes.length(0);
@@ -74,7 +74,7 @@ void AllocationHelper::alloc_nonexclusive_node_configs(AllocatedScenario& alloca
             my_ncs.insert(std::make_pair(id, nonexclusive_ncs[id]));
           } else {
             unsigned next_idx = allocated_scenario.configs.length();
-            allocated_scenario.configs.length(next_idx + 1);
+            OpenDDS::DCPS::grow(allocated_scenario.configs);
             allocated_scenario.configs[next_idx].node_id = id;
             allocated_scenario.configs[next_idx].timeout = scenario_prototype.timeout;
             allocated_scenario.configs[next_idx].spawned_processes.length(0);
@@ -193,9 +193,8 @@ void AllocationHelper::add_single_worker_to_node(const WorkerPrototype& protowor
   const std::map<std::string, std::string>& worker_configs,
   NodeController::Config& node)
 {
-  unsigned worker_i = node.spawned_processes.length();
+  unsigned worker_i = OpenDDS::DCPS::grow(node.spawned_processes) - 1;
   NodeController::SpawnedProcessId spawned_process_id = worker_i ? (node.spawned_processes[worker_i - 1].spawned_process_id + node.spawned_processes[worker_i - 1].count) : 1;
-  node.spawned_processes.length(node.spawned_processes.length() + 1);
   auto& process = node.spawned_processes[worker_i];
   process.executable = protoworker.executable.in();
   process.command = protoworker.command.in();

--- a/performance-tests/bench/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench/test_controller/ScenarioManager.cpp
@@ -340,13 +340,13 @@ void ScenarioManager::execute(const Bench::TestController::AllocatedScenario& al
 
     for (CORBA::ULong r = 0; r < reports.length(); r++) {
       if (info[r].valid_data) {
-        report.node_reports.length(report.node_reports.length() + 1);
-        Bench::TestController::NodeReport& node_report = report.node_reports[report.node_reports.length() - 1];
+        const CORBA::ULong nr_idx = OpenDDS::DCPS::grow(report.node_reports) - 1;
+        Bench::TestController::NodeReport& node_report = report.node_reports[nr_idx];
         const NodeController::SpawnedProcessReports& spawned_process_reports = reports[r].spawned_process_reports;
         for (CORBA::ULong wr = 0; wr < spawned_process_reports.length(); wr++) {
           ++process_report_count;
-          node_report.spawned_process_ids.length(node_report.spawned_process_ids.length() + 1);
-          node_report.spawned_process_ids[node_report.spawned_process_ids.length() - 1] = spawned_process_reports[wr].spawned_process_id;
+          const CORBA::ULong spi_idx = OpenDDS::DCPS::grow(node_report.spawned_process_ids) - 1;
+          node_report.spawned_process_ids[spi_idx] = spawned_process_reports[wr].spawned_process_id;
           if (spawned_process_reports[wr].failed) {
             ++worker_failures;
             std::stringstream ss;
@@ -360,8 +360,8 @@ void ScenarioManager::execute(const Bench::TestController::AllocatedScenario& al
             ss << spawned_process_reports[wr].details << std::flush;
             if (!ss.str().empty()) {
               if (json_2_idl(ss, worker_report)) {
-                node_report.worker_reports.length(node_report.worker_reports.length() + 1);
-                node_report.worker_reports[node_report.worker_reports.length() - 1] = worker_report;
+                const CORBA::ULong wr_idx = OpenDDS::DCPS::grow(node_report.worker_reports) - 1;
+                node_report.worker_reports[wr_idx] = worker_report;
                 ++parsed_worker_report_count;
               } else {
                 ++parse_failures;
@@ -372,8 +372,8 @@ void ScenarioManager::execute(const Bench::TestController::AllocatedScenario& al
               }
             }
             if (spawned_process_reports[wr].log.in() && spawned_process_reports[wr].log.in()[0]) {
-              node_report.spawned_process_logs.length(node_report.spawned_process_logs.length() + 1);
-              node_report.spawned_process_logs[node_report.spawned_process_logs.length() - 1] = spawned_process_reports[wr].log;
+              const CORBA::ULong spl_idx = OpenDDS::DCPS::grow(node_report.spawned_process_logs) - 1;
+              node_report.spawned_process_logs[spl_idx] = spawned_process_reports[wr].log;
             }
           }
           std::stringstream ss;


### PR DESCRIPTION
Expand `dds/DCPS/Util.h` helper utilities for managing TAO's sequence growth performance issues (reallocates for every "larger" length) and use them more consistently throughout the code to improve allocation performance.