### PR TITLE
Patch: CMake: Block Messenger_Space test on VS2010

### DIFF
--- a/tests/cmake/Messenger/CMakeLists.txt
+++ b/tests/cmake/Messenger/CMakeLists.txt
@@ -4,7 +4,7 @@ project(opendds_messenger_tests)
 
 add_subdirectory(Messenger_1)
 add_subdirectory(Messenger_2)
-if (NOT CMAKE_GENERATOR STREQUAL "Visual Studio 10 2010")
+if (NOT CMAKE_GENERATOR STREQUAL "Visual Studio 10 2010 Win64")
   add_subdirectory(Messenger_Space)
 endif()
 if(OPENDDS_CXX11)

--- a/tests/cmake/Messenger/CMakeLists.txt
+++ b/tests/cmake/Messenger/CMakeLists.txt
@@ -4,7 +4,7 @@ project(opendds_messenger_tests)
 
 add_subdirectory(Messenger_1)
 add_subdirectory(Messenger_2)
-if (NOT CMAKE_GENERATOR STREQUAL "Visual Studio 10 2010 Win64")
+if (NOT CMAKE_GENERATOR MATCHES "Visual Studio 10.*")
   add_subdirectory(Messenger_Space)
 endif()
 if(OPENDDS_CXX11)

--- a/tests/cmake/Messenger/Messenger_Space/CMakeLists.txt
+++ b/tests/cmake/Messenger/Messenger_Space/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(OpenDDS REQUIRED)
 if (NOT OPENDDS_OWNERSHIP_PROFILE)
   message(FATAL_ERROR "This test requires OpenDDS to be built with Ownership Profile enabled")
 endif()
-if (CMAKE_GENERATOR STREQUAL "Visual Studio 10 2010")
+if (CMAKE_GENERATOR STREQUAL "Visual Studio 10 2010 Win64")
   message(FATAL_ERROR "This test does not support Visual Studio 2010")
 endif()
 

--- a/tests/cmake/Messenger/Messenger_Space/CMakeLists.txt
+++ b/tests/cmake/Messenger/Messenger_Space/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(OpenDDS REQUIRED)
 if (NOT OPENDDS_OWNERSHIP_PROFILE)
   message(FATAL_ERROR "This test requires OpenDDS to be built with Ownership Profile enabled")
 endif()
-if (CMAKE_GENERATOR STREQUAL "Visual Studio 10 2010 Win64")
+if (CMAKE_GENERATOR MATCHES "Visual Studio 10.*")
   message(FATAL_ERROR "This test does not support Visual Studio 2010")
 endif()
 


### PR DESCRIPTION
The previous PR #3327 did not catch the Visual Studio 2010 on the scoreboard build machine. Digging further, it appears CMake has changed how it formats CMAKE_GENERATOR over time. As a result, we should switch to using a regex string of `Visual Studio 10.*`.