### PR TITLE
DataReaderImpl_T allocator is not thread safe

### DIFF
--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -86,7 +86,7 @@ namespace OpenDDS {
       ACE_New_Allocator* allocator_;
     };
 
-    typedef OpenDDS::DCPS::Cached_Allocator_With_Overflow<MessageTypeMemoryBlock, ACE_Null_Mutex>  DataAllocator;
+    typedef OpenDDS::DCPS::Cached_Allocator_With_Overflow<MessageTypeMemoryBlock, ACE_Thread_Mutex>  DataAllocator;
 
     typedef typename TraitsType::DataReaderType Interface;
 


### PR DESCRIPTION
Problem
-------

Allocations from `data_allocator_` in DataReaderImpl_T are
synchronized on the `sample_lock_`.  However, not all deallocations
are not synchronized.  For example, taking samples will place the
samples in a sequence and destroying the sequence may cause a
deallocation.

Solution
--------

Use a mutex in the relevant part of the allocator.