### PR TITLE
Fix Locking in RtpsDiscovery::remove_domain_participant

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -1265,7 +1265,7 @@ bool RtpsDiscovery::remove_domain_participant(
   // Use reference counting to ensure participant
   // does not get deleted until lock as been released.
   ParticipantHandle participant;
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, participants_lock_, false);
   DomainParticipantMap::iterator domain = participants_.find(domain_id);
   if (domain == participants_.end()) {
     return false;


### PR DESCRIPTION
Problem: #3313 Introduced a TSAN issue by neglecting to switch the mutex used in remove_domain_participant to the participants_lock_

Solution: Use the correct lock.