### PR TITLE
Fix TSAN data race in GuardCondition

### DIFF
--- a/dds/DCPS/GuardCondition.cpp
+++ b/dds/DCPS/GuardCondition.cpp
@@ -14,7 +14,7 @@ namespace DDS {
 
 CORBA::Boolean GuardCondition::get_trigger_value()
 {
-  return trigger_value_;
+  return trigger_value_.value();
 }
 
 ReturnCode_t GuardCondition::set_trigger_value(CORBA::Boolean value)

--- a/dds/DCPS/GuardCondition.h
+++ b/dds/DCPS/GuardCondition.h
@@ -45,7 +45,7 @@ public:
   static GuardCondition_ptr _narrow(CORBA::Object_ptr obj);
 
 private:
-  CORBA::Boolean trigger_value_;
+  ACE_Atomic_Op<ACE_Thread_Mutex, CORBA::Boolean> trigger_value_;
 };
 
 } // namespace DDS


### PR DESCRIPTION
Problem: TSAN complains about data races surrounding GuardCondition's trigger_value_.

Solution: Use some kind of thread safety mechanism.