### PR TITLE
TransportRegistry has load data race

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -105,7 +105,7 @@ sub wait_kill {
   my $result = $process->WaitKill($wait_time);
   my $time_str = formatted_time();
   if ($result != 0) {
-      my $ext = ($verbose ? "" : "(started at $start_time)");
+      my $ext = ($verbose ? "" : "(started waiting for termination at $start_time)");
       print STDERR "$time_str: ERROR: $desc returned $result $ext\n";
       $ret_status = 1;
   } elsif ($verbose) {
@@ -774,7 +774,8 @@ sub start_process {
 
   print $process->CommandLine() . "\n";
   $process->Spawn();
-  print "$name PID: " . _getpid($process) . "\n";
+  my $start_time = PerlDDS::formatted_time();
+  print "$name PID: " . _getpid($process) . " started at $start_time\n";
 }
 
 sub stop_process {

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -15,6 +15,10 @@
 #include "dds/DCPS/ConfigUtils.h"
 #include "dds/DCPS/DCPS_Utils.h"
 
+#include "dds/DCPS/transport/framework/TransportRegistry.h"
+#include "dds/DCPS/transport/framework/TransportType.h"
+#include "dds/DCPS/transport/framework/TransportType_rch.h"
+
 #include "tao/ORB_Core.h"
 #include "tao/BiDir_GIOP/BiDirGIOP.h"
 #include "ace/Reactor.h"
@@ -24,7 +28,6 @@
 #include "dds/DCPS/BuiltInTopicUtils.h"
 #include "dds/DCPS/Marked_Default_Qos.h"
 
-#include "dds/DCPS/transport/framework/TransportRegistry.h"
 #include "dds/DCPS/transport/framework/TransportExceptions.h"
 
 #include "dds/DCPS/transport/tcp/TcpInst.h"
@@ -1047,9 +1050,20 @@ InfoRepoDiscovery::OrbRunner::svc()
   return 0;
 }
 
+class InfoRepoType : public TransportType {
+public:
+  const char* name() { return "repository"; }
+
+  TransportInst_rch new_inst(const std::string&)
+  {
+    return TransportInst_rch();
+  }
+};
 
 InfoRepoDiscovery::StaticInitializer::StaticInitializer()
 {
+  TransportRegistry* registry = TheTransportRegistry;
+  registry->register_type(make_rch<InfoRepoType>());
   TheServiceParticipant->register_discovery_type("repository", new Config);
 }
 

--- a/dds/DCPS/transport/multicast/MulticastLoader.cpp
+++ b/dds/DCPS/transport/multicast/MulticastLoader.cpp
@@ -38,7 +38,10 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   if (initialized) return 0;  // already initialized
 
   TransportRegistry* registry = TheTransportRegistry;
-  registry->register_type(make_rch<MulticastType>());
+  if (!registry->register_type(make_rch<MulticastType>())) {
+    return 0;
+  }
+
   TransportConfig_rch cfg =
     registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
@@ -41,11 +41,10 @@ void RtpsUdpLoader::load()
 {
   TransportRegistry* registry = TheTransportRegistry;
   TransportType_rch type = make_rch<RtpsUdpType>();
-  if (registry->has_type(type)) {
+  if (!registry->register_type(type)) {
     return;
   }
 
-  registry->register_type(type);
   // Don't create a default for RTPS.  At least for the initial implementation,
   // the user needs to explicitly configure it...
 #ifdef OPENDDS_SAFETY_PROFILE

--- a/dds/DCPS/transport/shmem/ShmemLoader.cpp
+++ b/dds/DCPS/transport/shmem/ShmemLoader.cpp
@@ -38,7 +38,9 @@ ShmemLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   if (initialized) return 0;  // already initialized
 
   TransportRegistry* registry = TheTransportRegistry;
-  registry->register_type(make_rch<ShmemType>());
+  if (!registry->register_type(make_rch<ShmemType>())) {
+    return 0;
+  }
 
   //FUTURE: when we're ready, add a ShmemInst to the default config, like so:
   /*

--- a/dds/DCPS/transport/tcp/TcpLoader.cpp
+++ b/dds/DCPS/transport/tcp/TcpLoader.cpp
@@ -57,7 +57,10 @@ TcpLoader::init(int, ACE_TCHAR*[])
     return 0;
 
   TransportRegistry* registry = TheTransportRegistry;
-  registry->register_type(make_rch<TcpType>());
+  if (!registry->register_type(make_rch<TcpType>())) {
+    return 0;
+  }
+
   TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           std::string("0500_TCP"), TCP_NAME, false);

--- a/dds/DCPS/transport/udp/UdpLoader.cpp
+++ b/dds/DCPS/transport/udp/UdpLoader.cpp
@@ -38,7 +38,10 @@ UdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   if (initialized) return 0;  // already initialized
 
   TransportRegistry* registry = TheTransportRegistry;
-  registry->register_type(make_rch<UdpType>());
+  if (!registry->register_type(make_rch<UdpType>())) {
+    return 0;
+  }
+
   TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           std::string("0300_UDP"), UDP_NAME, false);


### PR DESCRIPTION
Problem
-------

A thread calling `create_inst` only waits if a load is pending.  For a
static build, there is no guarantee that the thread loading the
static libraries will have started the load.  Thus, `create_inst`
fails since it doesn't wait and then can't find the transport type.

Solution
--------

If desired, wait for the transport to be loaded by checking
`type_map_`.