### PR TITLE
Sample lock is held too long

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2143,8 +2143,8 @@ DataReaderImpl::writer_removed(WriterInfo& info)
     }
 
     liveliness_changed_status_.last_publication_handle = info.handle();
-    instances_liveliness_update(info_writer_id);
   }
+  instances_liveliness_update(info_writer_id);
 
   if (liveliness_changed) {
     set_status_changed_flag(DDS::LIVELINESS_CHANGED_STATUS, true);
@@ -2324,7 +2324,6 @@ DataReaderImpl::instances_liveliness_update(const PublicationId& writer)
     }
   }
 
-  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
   for (InstanceSet::iterator iter = localinsts.begin(); iter != localinsts.end(); ++iter) {
     set_instance_state(*iter, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, SystemTimePoint::now(), writer);
   }


### PR DESCRIPTION
Problem
-------

Setting the instance state may lead to invoking the listener.  To
allow the user to read samples, the sample lock is unlocked with a
reverse lock.  The reverse lock only works if the sample lock is
locked once.  (It is a recursive lock which is a problem in and of
itself.)  Some code paths that set the instance state lock the sample
lock multiple times so the reverse lock doesn't release the lock.

The problem is that the transport thread can be storing a sample and
then invoking the listener.  At this point the sample lock is not
locked.  Another thread, i.e., discovery or the service participant,
can then update the instance state due to liveliness.  This thread
will acquire and retain the sample lock when invoking the listener.
If the transport thread does a read or take, which it probably will,
it will deadlock.

Solution
--------

Remove the extra locks.