### PR TITLE
Delay Access To ReactorTask Members Until Thread Is Started

### DIFF
--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -142,7 +142,7 @@ int ReactorTask::svc()
     }
     reactor_owner_ = ACE_Thread_Manager::instance()->thr_self();
 
-    interceptor_ = make_rch<Interceptor>(this);
+    interceptor_ = make_rch<Interceptor>(this, reactor_, reactor_owner_);
 
     // Advance the state.
     state_ = STATE_RUNNING;

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -36,6 +36,7 @@ ReactorTask::ReactorTask(bool useAsyncSend)
 #ifdef OPENDDS_REACTOR_TASK_ASYNC
   , use_async_send_(useAsyncSend)
 #endif
+  , timer_queue_(0)
   , thread_status_manager_(0)
 {
   ACE_UNUSED_ARG(useAsyncSend);
@@ -60,6 +61,8 @@ void ReactorTask::cleanup()
 
   delete reactor_;
   reactor_ = 0;
+  delete timer_queue_;
+  timer_queue_ = 0;
 }
 
 int ReactorTask::open_reactor_task(void*,
@@ -88,6 +91,11 @@ int ReactorTask::open_reactor_task(void*,
   if (!reactor_) {
     reactor_ = new ACE_Reactor(new ACE_Select_Reactor, true);
     proactor_ = 0;
+  }
+
+  if (!timer_queue_) {
+    timer_queue_ = new TimerQueueType();
+    reactor_->timer_queue(timer_queue_);
   }
 
   state_ = STATE_OPENING;

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -12,6 +12,8 @@
 #include "ReactorTask.inl"
 #endif /* __ACE_INLINE__ */
 
+#include "Service_Participant.h"
+
 #include <ace/Select_Reactor.h>
 #include <ace/WFMO_Reactor.h>
 #include <ace/Proactor.h>
@@ -45,6 +47,15 @@ ReactorTask::ReactorTask(bool useAsyncSend)
 ReactorTask::~ReactorTask()
 {
   cleanup();
+}
+
+void ReactorTask::wait_for_startup_i() const
+{
+  while (state_ == STATE_UNINITIALIZED || state_ == STATE_OPENING) {
+    condition_.wait(thread_status_manager_ ?
+                      *thread_status_manager_ :
+                      TheServiceParticipant->get_thread_status_manager());
+  }
 }
 
 void ReactorTask::cleanup()

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -228,7 +228,7 @@ void ReactorTask::stop()
 
     // In the future, we will likely want to replace this assert with a new "SHUTTING_DOWN" state
     // which can be used to delay any potential new calls to open_reactor_task()
-    OPENDDS_ASSERT(state_ = STATE_SHUT_DOWN);
+    OPENDDS_ASSERT(state_ == STATE_SHUT_DOWN);
 
     // Let's wait for the reactor task's thread to complete before we
     // leave this stop method.

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -28,8 +28,8 @@ namespace OpenDDS {
 namespace DCPS {
 
 ReactorTask::ReactorTask(bool useAsyncSend)
-  : state_(STATE_NOT_RUNNING)
-  , condition_(lock_)
+  : condition_(lock_)
+  , state_(STATE_NOT_RUNNING)
   , reactor_(0)
   , reactor_owner_(ACE_OS::NULL_thread)
   , proactor_(0)

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -59,22 +59,18 @@ public:
   ACE_Proactor* get_proactor();
   const ACE_Proactor* get_proactor() const;
 
-  void wait_for_startup()
-  {
-    while (state_ != STATE_RUNNING) {
-      condition_.wait(*thread_status_manager_);
-    }
-  }
+  void wait_for_startup() const;
 
-  bool is_shut_down() const { return state_ == STATE_NOT_RUNNING; }
+  bool is_shut_down() const;
 
-  ReactorInterceptor_rch interceptor() const { return interceptor_; }
+  ReactorInterceptor_rch interceptor() const;
 
   OPENDDS_POOL_ALLOCATION_FWD
 
 private:
 
   void cleanup();
+  void wait_for_startup_i() const;
 
   typedef ACE_SYNCH_MUTEX LockType;
   typedef ACE_Guard<LockType> GuardType;
@@ -100,11 +96,11 @@ private:
     DCPS::ReactorTask* const task_;
   };
 
-  LockType      lock_;
-  State         state_;
-  ConditionVariableType condition_;
-  ACE_Reactor*  reactor_;
-  ACE_thread_t  reactor_owner_;
+  mutable LockType lock_;
+  mutable ConditionVariableType condition_;
+  State state_;
+  ACE_Reactor* reactor_;
+  ACE_thread_t reactor_owner_;
   ACE_Proactor* proactor_;
 
 #if defined ACE_WIN32 && defined ACE_HAS_WIN32_OVERLAPPED_IO

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -79,7 +79,7 @@ private:
     ACE_Event_Handler*, ACE_Event_Handler_Handle_Timeout_Upcall,
     ACE_SYNCH_RECURSIVE_MUTEX, MonotonicClock> TimerQueueType;
 
-  enum State { STATE_NOT_RUNNING, STATE_OPENING, STATE_RUNNING };
+  enum State { STATE_UNINITIALIZED, STATE_OPENING, STATE_RUNNING, STATE_SHUT_DOWN };
 
   class Interceptor : public DCPS::ReactorInterceptor {
   public:
@@ -107,8 +107,6 @@ private:
 #define OPENDDS_REACTOR_TASK_ASYNC
   bool use_async_send_;
 #endif
-
-  TimerQueueType* timer_queue_;
 
   // thread status reporting
   String name_;

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -108,6 +108,8 @@ private:
   bool use_async_send_;
 #endif
 
+  TimerQueueType* timer_queue_;
+
   // thread status reporting
   String name_;
 

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -83,8 +83,8 @@ private:
 
   class Interceptor : public DCPS::ReactorInterceptor {
   public:
-    explicit Interceptor(DCPS::ReactorTask* task)
-     : ReactorInterceptor(task->get_reactor(), task->get_reactor_owner())
+    Interceptor(DCPS::ReactorTask* task, ACE_Reactor* reactor, ACE_thread_t owner)
+     : ReactorInterceptor(reactor, owner)
      , task_(task)
      {}
     bool reactor_is_shut_down() const

--- a/dds/DCPS/ReactorTask.inl
+++ b/dds/DCPS/ReactorTask.inl
@@ -19,25 +19,60 @@ ACE_Reactor* ReactorTask::get_reactor()
 ACE_INLINE
 const ACE_Reactor* ReactorTask::get_reactor() const
 {
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
   return reactor_;
 }
 
 ACE_INLINE
 ACE_thread_t ReactorTask::get_reactor_owner() const
 {
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
+  wait_for_startup_i();
   return reactor_owner_;
 }
 
 ACE_INLINE
 ACE_Proactor* ReactorTask::get_proactor()
 {
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
   return proactor_;
 }
 
 ACE_INLINE
 const ACE_Proactor* ReactorTask::get_proactor() const
 {
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
   return proactor_;
+}
+
+ACE_INLINE
+void ReactorTask::wait_for_startup() const
+{
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
+  wait_for_startup_i();
+}
+
+ACE_INLINE
+void ReactorTask::wait_for_startup_i() const
+{
+  while (state_ != STATE_RUNNING) {
+    condition_.wait(*thread_status_manager_);
+  }
+}
+
+ACE_INLINE
+bool ReactorTask::is_shut_down() const
+{
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
+  return state_ == STATE_NOT_RUNNING;
+}
+
+ACE_INLINE
+ReactorInterceptor_rch ReactorTask::interceptor() const
+{
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
+  wait_for_startup_i();
+  return interceptor_;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/ReactorTask.inl
+++ b/dds/DCPS/ReactorTask.inl
@@ -27,7 +27,6 @@ ACE_INLINE
 ACE_thread_t ReactorTask::get_reactor_owner() const
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
-  wait_for_startup_i();
   return reactor_owner_;
 }
 
@@ -50,14 +49,6 @@ void ReactorTask::wait_for_startup() const
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
   wait_for_startup_i();
-}
-
-ACE_INLINE
-void ReactorTask::wait_for_startup_i() const
-{
-  while (state_ == STATE_UNINITIALIZED || state_ == STATE_OPENING) {
-    condition_.wait(*thread_status_manager_);
-  }
 }
 
 ACE_INLINE

--- a/dds/DCPS/ReactorTask.inl
+++ b/dds/DCPS/ReactorTask.inl
@@ -55,7 +55,7 @@ void ReactorTask::wait_for_startup() const
 ACE_INLINE
 void ReactorTask::wait_for_startup_i() const
 {
-  while (state_ != STATE_RUNNING) {
+  while (state_ == STATE_UNINITIALIZED || state_ == STATE_OPENING) {
     condition_.wait(*thread_status_manager_);
   }
 }
@@ -64,7 +64,7 @@ ACE_INLINE
 bool ReactorTask::is_shut_down() const
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
-  return state_ == STATE_NOT_RUNNING;
+  return state_ == STATE_SHUT_DOWN;
 }
 
 ACE_INLINE

--- a/dds/DCPS/ReactorTask.inl
+++ b/dds/DCPS/ReactorTask.inl
@@ -13,6 +13,7 @@ namespace DCPS {
 ACE_INLINE
 ACE_Reactor* ReactorTask::get_reactor()
 {
+  ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
   return reactor_;
 }
 
@@ -27,6 +28,7 @@ ACE_INLINE
 ACE_thread_t ReactorTask::get_reactor_owner() const
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
+  wait_for_startup_i();
   return reactor_owner_;
 }
 

--- a/tests/transport/error_handling/main.cpp
+++ b/tests/transport/error_handling/main.cpp
@@ -47,6 +47,8 @@ bool testConnectionErrorHandling()
 
   TheTransportRegistry->global_config(cfg);
 
+  DDS::DomainParticipantFactory_var dpf = TheServiceParticipant->get_domain_participant_factory();
+
   SimpleTransportClient transportClient;
   transportClient.exceptionThrown = false;
   transportClient.enable();

--- a/tests/transport/rtps_reliability/rtps_reliability.cpp
+++ b/tests/transport/rtps_reliability/rtps_reliability.cpp
@@ -993,10 +993,9 @@ bool run_test()
 
 int ACE_TMAIN(int /*argc*/, ACE_TCHAR* /*argv*/[])
 {
-  try
-  {
-    ::DDS::DomainParticipantFactory_var dpf =
-      TheServiceParticipant->get_domain_participant_factory();
+  DDS::DomainParticipantFactory_var dpf;
+  try {
+    dpf = TheServiceParticipant->get_domain_participant_factory();
   }
   catch (const CORBA::BAD_PARAM& ex)
   {

--- a/tests/transport/simple/SimpleDataReader.cpp
+++ b/tests/transport/simple/SimpleDataReader.cpp
@@ -53,6 +53,9 @@ SimpleDataReader::data_received(const OpenDDS::DCPS::ReceivedDataSample& sample)
   DBG_ENTRY("SimpleDataReader","data_received");
 
   ACE_DEBUG((LM_DEBUG, "(%P|%t) Data has been received:\n"));
+
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+
   if (sample.sample_->length() < 25) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Message: [%C]\n", sample.sample_->rd_ptr()));
   }
@@ -82,12 +85,14 @@ SimpleDataReader::transport_lost()
 int
 SimpleDataReader::received_test_message() const
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   return (this->num_messages_received_ == this->num_messages_expected_) ? 1 : 0;
 }
 
 void
 SimpleDataReader::print_time()
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   ACE_Time_Value total = finished_recvd_ - begin_recvd_;
   ACE_DEBUG((LM_INFO,
     "(%P|%t) Total time required is %d.%d seconds.\n",

--- a/tests/transport/simple/SimpleDataReader.h
+++ b/tests/transport/simple/SimpleDataReader.h
@@ -54,6 +54,7 @@ class SimpleDataReader
 
   private:
 
+    mutable ACE_Thread_Mutex mutex_;
     const OpenDDS::DCPS::RepoId& sub_id_;
     int num_messages_expected_;
     int num_messages_received_;

--- a/tests/transport/simple/SimpleDataWriter.cpp
+++ b/tests/transport/simple/SimpleDataWriter.cpp
@@ -103,6 +103,7 @@ SimpleDataWriter::data_delivered(const OpenDDS::DCPS::DataSampleElement* sample)
   // Delete the element
   //delete sample;
 
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   ++this->num_messages_delivered_;
 }
 
@@ -127,6 +128,7 @@ SimpleDataWriter::data_dropped(const OpenDDS::DCPS::DataSampleElement* sample,
   // Delete the element
   //delete sample;
 
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   ++this->num_messages_delivered_;
 }
 
@@ -134,6 +136,7 @@ SimpleDataWriter::data_dropped(const OpenDDS::DCPS::DataSampleElement* sample,
 int
 SimpleDataWriter::delivered_test_message()
 {
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   return (this->num_messages_delivered_ == this->num_messages_sent_) ? 1 : 0;
 }
 
@@ -260,5 +263,6 @@ SimpleDataWriter::transport_assoc_done(int flags, const OpenDDS::DCPS::RepoId& r
 {
   ACE_DEBUG((LM_INFO,
              "(%P|%t) DataWriter association with %C is done flags=%d.\n", OpenDDS::DCPS::LogGuid(remote).c_str(), flags));
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   associated_ = true;
 }

--- a/tests/transport/simple/SimpleDataWriter.h
+++ b/tests/transport/simple/SimpleDataWriter.h
@@ -59,7 +59,11 @@ class SimpleDataWriter
       { return 0; }
     void transport_assoc_done(int flags, const OpenDDS::DCPS::RepoId& remote);
 
-    bool associated() const { return associated_; }
+    bool associated() const
+    {
+      ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+      return associated_;
+    }
 
     int delivered_test_message();
 
@@ -68,6 +72,7 @@ class SimpleDataWriter
 
   protected:
 
+    mutable ACE_Thread_Mutex mutex_;
     const OpenDDS::DCPS::RepoId& pub_id_;
     int num_messages_sent_;
     int num_messages_delivered_;

--- a/tests/transport/simple/pub_main.cpp
+++ b/tests/transport/simple/pub_main.cpp
@@ -30,9 +30,10 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     }
   }
 
+  DDS::DomainParticipantFactory_var dpf;
   try
   {
-    DDS::DomainParticipantFactory_var dpf = TheServiceParticipant->get_domain_participant_factory();
+    dpf = TheServiceParticipant->get_domain_participant_factory();
   }
   catch (const CORBA::BAD_PARAM& ex) {
     ex._tao_print_exception("Exception caught in pub_main.cpp:");

--- a/tests/transport/simple/sub_main.cpp
+++ b/tests/transport/simple/sub_main.cpp
@@ -30,9 +30,10 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
     }
   }
 
+  DDS::DomainParticipantFactory_var dpf;
   try
   {
-    DDS::DomainParticipantFactory_var dpf = TheServiceParticipant->get_domain_participant_factory();
+    dpf = TheServiceParticipant->get_domain_participant_factory();
   }
   catch (const CORBA::BAD_PARAM& ex) {
     ex._tao_print_exception("Exception caught in sub_main.cpp:");

--- a/tests/transport/spdp/spdp_transport.cpp
+++ b/tests/transport/spdp/spdp_transport.cpp
@@ -531,9 +531,9 @@ bool run_test()
 
 int ACE_TMAIN(int, ACE_TCHAR*[])
 {
+  DDS::DomainParticipantFactory_var dpf;
   try {
-    ::DDS::DomainParticipantFactory_var dpf =
-        TheServiceParticipant->get_domain_participant_factory();
+    dpf = TheServiceParticipant->get_domain_participant_factory();
     set_DCPS_debug_level(1);
   } catch (const CORBA::BAD_PARAM& ex) {
     ex._tao_print_exception("Exception caught in spdp_transport.cpp:");

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -14,6 +14,20 @@
 tests/unit-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS
 tests/stress-tests/dds/DCPS/run_test.pl: !DCPS_MIN
 
+tests/transport/simple/run_test.pl bp: !NO_DDS_TRANSPORT !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/transport/simple/run_test.pl n: !NO_DDS_TRANSPORT !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/transport/simple/run_test.pl: !NO_DDS_TRANSPORT !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+
+tests/transport/simple/run_test.pl shmem bp: !NO_DDS_TRANSPORT !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE
+tests/transport/simple/run_test.pl shmem n: !NO_DDS_TRANSPORT !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE
+tests/transport/simple/run_test.pl shmem: !NO_DDS_TRANSPORT !DCPS_MIN !NO_SHMEM !OPENDDS_SAFETY_PROFILE
+
+tests/DCPS/DpShutdown/run_test.pl: RTPS
+tests/DCPS/DpShutdown/run_test.pl t=tcp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/DpShutdown/run_test.pl t=shmem: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM
+tests/DCPS/DpShutdown/run_test.pl t=udp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/DpShutdown/run_test.pl t=multicast: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_MCAST
+
 tests/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl default_tcp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl thread_per: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE


### PR DESCRIPTION
Problem: "Early" access to ReactorTask's `interceptor` or `reactor_owner' members will result in use of incorrect values.

Solution: Delay accessor requests for these values until thread startup has been signaled.