### PR TITLE
Improve DataReader Lookup Speeds For Large Numbers of Instances

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2058,6 +2058,11 @@ DataReaderImpl::release_instance(DDS::InstanceHandle_t handle)
   }
 }
 
+void
+DataReaderImpl::state_updated(DDS::InstanceHandle_t handle)
+{
+  state_updated_i(handle);
+}
 
 OpenDDS::DCPS::WriterStats::WriterStats(
     int amount,

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3590,7 +3590,7 @@ void DataReaderImpl::initialize_lookup_maps()
   combined_state_lookup_[0] = HandleSet();
 }
 
-void DataReaderImpl::update_lookup_maps(const typename SubscriptionInstanceMapType::iterator& input)
+void DataReaderImpl::update_lookup_maps(const SubscriptionInstanceMapType::iterator& input)
 {
   for (LookupMap::iterator it = combined_state_lookup_.begin(); it != combined_state_lookup_.end(); ++it) {
     if (it->first == 0) continue;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -434,6 +434,9 @@ public:
   /// Release the instance with the handle.
   void release_instance(DDS::InstanceHandle_t handle);
 
+  // Take appropriate actions upon learning instance or view state has been updated
+  void state_updated(DDS::InstanceHandle_t handle);
+
   /// Release all instances held by the reader.
   virtual void release_all_instances() = 0;
 
@@ -635,6 +638,7 @@ protected:
   virtual void purge_data(SubscriptionInstance_rch instance) = 0;
 
   virtual void release_instance_i(DDS::InstanceHandle_t handle) = 0;
+  virtual void state_updated_i(DDS::InstanceHandle_t handle) = 0;
 
   bool has_readcondition(DDS::ReadCondition_ptr a_condition);
 

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -640,7 +640,7 @@ protected:
   }
 
   void initialize_lookup_maps();
-  void update_lookup_maps(const typename SubscriptionInstanceMapType::iterator& input);
+  void update_lookup_maps(const SubscriptionInstanceMapType::iterator& input);
   void remove_from_lookup_maps(DDS::InstanceHandle_t handle);
   const HandleSet& lookup_matching_instances(CORBA::ULong sample_states, CORBA::ULong view_states, CORBA::ULong instance_states) const;
 

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -617,7 +617,6 @@ protected:
   // These may need to be updated if the spec ever changes
   static const CORBA::ULong COMBINED_VIEW_STATE_SHIFT = MAX_INSTANCE_STATE_BITS;
   static const CORBA::ULong COMBINED_SAMPLE_STATE_SHIFT = COMBINED_VIEW_STATE_SHIFT + MAX_VIEW_STATE_BITS;
-  static const CORBA::ULong MAX_COMBINED_STATE_MASK = (MAX_SAMPLE_STATE_FLAG << (COMBINED_SAMPLE_STATE_SHIFT + MAX_SAMPLE_STATE_BITS)) - 1;
 
   typedef OPENDDS_SET(DDS::InstanceHandle_t) HandleSet;
   typedef OPENDDS_MAP(CORBA::ULong, HandleSet) LookupMap;

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -639,49 +639,10 @@ protected:
     instance_states = combined & MAX_INSTANCE_STATE_MASK;
   }
 
-  void initialize_lookup_maps()
-  {
-    // These all start at 1 (0 mask is bogus) and include the full mask (any)
-    for (CORBA::ULong is = 1; is <= MAX_SAMPLE_STATE_MASK; ++is) {
-      for (CORBA::ULong iv = 1; iv <= MAX_VIEW_STATE_MASK; ++iv) {
-        for (CORBA::ULong ii = 1; ii <= MAX_INSTANCE_STATE_MASK; ++ii) {
-          combined_state_lookup_[to_combined_states(is, iv, ii)] = HandleSet();
-        }
-      }
-    }
-    // catch-all for "bogus" lookups
-    combined_state_lookup_[0] = HandleSet();
-  }
-
-  void update_lookup_maps(const typename SubscriptionInstanceMapType::iterator& input)
-  {
-    for (LookupMap::iterator it = combined_state_lookup_.begin(); it != combined_state_lookup_.end(); ++it) {
-      if (it->first == 0) continue;
-      CORBA::ULong sample_states, view_states, instance_states;
-      split_combined_states(it->first, sample_states, view_states, instance_states);
-      if (input->second->matches(sample_states, view_states, instance_states)) {
-        it->second.insert(input->first);
-      } else {
-        it->second.erase(input->first);
-      }
-    }
-  }
-
-  void remove_from_lookup_maps(DDS::InstanceHandle_t handle)
-  {
-    for (LookupMap::iterator it = combined_state_lookup_.begin(), the_end = combined_state_lookup_.end(); it != the_end; ++it) {
-      if (it->first == 0) continue;
-      it->second.erase(handle);
-    }
-  }
-
-  const HandleSet& lookup_matching_instances(CORBA::ULong sample_states, CORBA::ULong view_states, CORBA::ULong instance_states) const
-  {
-    const CORBA::ULong combined_states = to_combined_states(sample_states, view_states, instance_states);
-    LookupMap::const_iterator ci = combined_state_lookup_.find(combined_states);
-    OPENDDS_ASSERT(ci != combined_state_lookup_.end());
-    return ci->second;
-  }
+  void initialize_lookup_maps();
+  void update_lookup_maps(const typename SubscriptionInstanceMapType::iterator& input);
+  void remove_from_lookup_maps(DDS::InstanceHandle_t handle);
+  const HandleSet& lookup_matching_instances(CORBA::ULong sample_states, CORBA::ULong view_states, CORBA::ULong instance_states) const;
 
   LookupMap combined_state_lookup_;
 

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -405,10 +405,12 @@ public:
   void process_latency(const ReceivedDataSample& sample);
   void notify_latency(PublicationId writer);
 
-  CORBA::Long get_depth() const {
-    return depth_;
+  size_t get_depth() const
+  {
+    return static_cast<size_t>(depth_);
   }
-  size_t get_n_chunks() const {
+  size_t get_n_chunks() const
+  {
     return n_chunks_;
   }
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1078,20 +1078,20 @@ namespace OpenDDS {
 protected:
 
   // Update max flag if the spec ever changes
-  const CORBA::ULong MAX_VIEW_STATE_FLAG = DDS::NOT_NEW_VIEW_STATE;
-  const CORBA::ULong MAX_VIEW_STATE_MASK = (MAX_VIEW_STATE_FLAG << 1) - 1;
+  static const CORBA::ULong MAX_VIEW_STATE_FLAG = DDS::NOT_NEW_VIEW_STATE;
+  static const CORBA::ULong MAX_VIEW_STATE_MASK = (MAX_VIEW_STATE_FLAG << 1) - 1;
 
   // Update max flag if the spec ever changes
-  const CORBA::ULong MAX_INSTANCE_STATE_FLAG = DDS::ALIVE_INSTANCE_STATE;
-  const CORBA::ULong MAX_INSTANCE_STATE_MASK = (MAX_INSTANCE_STATE_FLAG << 1) - 1;
+  static const CORBA::ULong MAX_INSTANCE_STATE_FLAG = DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE;
+  static const CORBA::ULong MAX_INSTANCE_STATE_MASK = (MAX_INSTANCE_STATE_FLAG << 1) - 1;
 
   void initialize_lookup_maps()
   {
-    for (CORBA::ULong i = 0; i < MAX_VIEW_STATE_MASK; ++i) {
+    for (CORBA::ULong i = 0; i <= MAX_VIEW_STATE_MASK; ++i) {
       view_state_lookup_[i] = HandleSet();
     }
 
-    for (CORBA::ULong i = 0; i < MAX_INSTANCE_STATE_MASK; ++i) {
+    for (CORBA::ULong i = 0; i <= MAX_INSTANCE_STATE_MASK; ++i) {
       instance_state_lookup_[i] = HandleSet();
     }
   }

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1841,7 +1841,7 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
   if ((qos_.resource_limits.max_samples_per_instance !=
         DDS::LENGTH_UNLIMITED) &&
       (instance_ptr->rcvd_samples_.size() >=
-        qos_.resource_limits.max_samples_per_instance)) {
+        static_cast<size_t>(qos_.resource_limits.max_samples_per_instance))) {
 
     // According to spec 1.2, Samples that contain no data do not
     // count towards the limits imposed by the RESOURCE_LIMITS QoS policy

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1656,6 +1656,7 @@ DDS::ReturnCode_t read_next_instance_i(MessageSequenceType& received_data,
     const typename ReverseInstanceMap::const_iterator pos = reverse_instance_map_.find(a_handle);
     if (pos != reverse_instance_map_.end()) {
       it = pos->second;
+      ++it;
     } else {
       it = the_end;
     }
@@ -1703,6 +1704,7 @@ DDS::ReturnCode_t take_next_instance_i(MessageSequenceType& received_data,
     const typename ReverseInstanceMap::const_iterator pos = reverse_instance_map_.find(a_handle);
     if (pos != reverse_instance_map_.end()) {
       it = pos->second;
+      ++it;
     } else {
       it = the_end;
     }

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1370,7 +1370,7 @@ DDS::ReturnCode_t take_i(MessageSequenceType& received_data,
         const ValueWriterDispatcher* vwd = get_value_writer_dispatcher();
         if (observer && item->registered_data_ && vwd) {
           Observer::Sample s(handle, inst->instance_state_->instance_state(), *item, *vwd);
-          observer->on_sample_read(this, s);
+          observer->on_sample_taken(this, s);
         }
       }
     }

--- a/dds/DCPS/GroupRakeData.cpp
+++ b/dds/DCPS/GroupRakeData.cpp
@@ -22,6 +22,7 @@ GroupRakeData::GroupRakeData()
 
 
 bool GroupRakeData::insert_sample(ReceivedDataElement* sample,
+                                  ReceivedDataElementList* rdel,
                                   SubscriptionInstance_rch instance,
                                   size_t index_in_instance)
 {
@@ -31,7 +32,7 @@ bool GroupRakeData::insert_sample(ReceivedDataElement* sample,
     return false;
   }
 
-  RakeData rd = {sample, instance, index_in_instance};
+  RakeData rd = {sample, rdel, instance, index_in_instance};
   this->sorted_.insert(rd);
 
   this->current_sample_ = this->sorted_.begin();

--- a/dds/DCPS/GroupRakeData.h
+++ b/dds/DCPS/GroupRakeData.h
@@ -37,7 +37,9 @@ public:
   /// Returns false if the sample will definitely not be part of the
   /// resulting dataset, however if this returns true it still may be
   /// excluded (due to sorting and max_samples).
-  bool insert_sample(ReceivedDataElement* sample, SubscriptionInstance_rch i,
+  bool insert_sample(ReceivedDataElement* sample,
+                     ReceivedDataElementList* rdel,
+                     SubscriptionInstance_rch i,
                      size_t index_in_instance);
 
   void get_datareaders (DDS::DataReaderSeq & readers);

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -135,6 +135,7 @@ bool InstanceState::dispose_was_received(const PublicationId& writer_id)
         || (owner_manager && owner_manager->is_owner (handle_, writer_id))) {
 #endif
         instance_state_ = DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
+        state_updated();
         schedule_release();
         return true;
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
@@ -172,6 +173,7 @@ bool InstanceState::unregister_was_received(const PublicationId& writer_id)
 
   if (writers_.empty() && (instance_state_ & DDS::ALIVE_INSTANCE_STATE)) {
     instance_state_ = DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE;
+    state_updated();
     schedule_release();
     return true;
   }
@@ -182,6 +184,14 @@ bool InstanceState::unregister_was_received(const PublicationId& writer_id)
 void InstanceState::schedule_pending()
 {
   release_pending_ = true;
+}
+
+void OpenDDS::DCPS::InstanceState::state_updated() const
+{
+  RcHandle<DataReaderImpl> reader = reader_.lock();
+  if (reader) {
+    reader->state_updated(handle_);
+  }
 }
 
 void InstanceState::schedule_release()

--- a/dds/DCPS/InstanceState.h
+++ b/dds/DCPS/InstanceState.h
@@ -123,6 +123,7 @@ public:
   }
 
   WeakRcHandle<DataReaderImpl> data_reader() const;
+  void state_updated() const;
 
   virtual int handle_timeout(const ACE_Time_Value& current_time,
                              const void* arg);

--- a/dds/DCPS/InstanceState.inl
+++ b/dds/DCPS/InstanceState.inl
@@ -27,6 +27,7 @@ OpenDDS::DCPS::InstanceState::accessed()
   //
   if (view_state_ & DDS::ANY_VIEW_STATE) {
     view_state_ = DDS::NOT_NEW_VIEW_STATE;
+    state_updated();
   }
 }
 
@@ -83,11 +84,13 @@ OpenDDS::DCPS::InstanceState::data_was_received(const PublicationId& writer_id)
   case DDS::NOT_NEW_VIEW_STATE:
     if (instance_state_ & DDS::NOT_ALIVE_INSTANCE_STATE) {
       view_state_ = DDS::NEW_VIEW_STATE;
+      state_updated();
     }
     break;
 
   default:
     view_state_ = DDS::NEW_VIEW_STATE;
+    state_updated();
     break;
   }
 
@@ -105,6 +108,7 @@ OpenDDS::DCPS::InstanceState::data_was_received(const PublicationId& writer_id)
   }
 
   instance_state_ = DDS::ALIVE_INSTANCE_STATE;
+  state_updated();
 }
 
 ACE_INLINE
@@ -124,6 +128,7 @@ OpenDDS::DCPS::InstanceState::lively(const PublicationId& writer_id)
 
     ++no_writers_generation_count_;
     instance_state_ = DDS::ALIVE_INSTANCE_STATE;
+    state_updated();
   }
 }
 

--- a/dds/DCPS/RakeData.h
+++ b/dds/DCPS/RakeData.h
@@ -26,6 +26,7 @@ namespace DCPS {
 /// data used by the data structures in RakeResults<T>.
 struct OpenDDS_Dcps_Export RakeData {
   ReceivedDataElement* rde_;
+  ReceivedDataElementList* rdel_;
   SubscriptionInstance_rch si_;
   size_t index_in_instance_;
 };

--- a/dds/DCPS/RakeResults_T.h
+++ b/dds/DCPS/RakeResults_T.h
@@ -45,7 +45,9 @@ public:
   /// Returns false if the sample will definitely not be part of the
   /// resulting dataset, however if this returns true it still may be
   /// excluded (due to sorting and max_samples).
-  bool insert_sample(ReceivedDataElement* sample, SubscriptionInstance_rch i,
+  bool insert_sample(ReceivedDataElement* sample,
+                     ReceivedDataElementList* rdel,
+                     SubscriptionInstance_rch instance,
                      size_t index_in_instance);
 
   bool copy_to_user();

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -78,7 +78,6 @@ OpenDDS::DCPS::ReceivedDataElementList::apply_all(
       op(it);
     }
   }
-  OPENDDS_ASSERT(sanity_check());
 }
 
 bool
@@ -139,7 +138,6 @@ OpenDDS::DCPS::ReceivedDataElementList::remove(
     }
   }
 
-  OPENDDS_ASSERT(sanity_check());
   return released;
 }
 
@@ -171,7 +169,6 @@ OpenDDS::DCPS::ReceivedDataElement*
 OpenDDS::DCPS::ReceivedDataElementList::get_next_match(CORBA::ULong sample_states, ReceivedDataElement* prev)
 {
   OPENDDS_ASSERT(sanity_check(prev));
-  OPENDDS_ASSERT(sanity_check());
   if (prev == tail_) {
     return NULL;
   }
@@ -187,11 +184,9 @@ OpenDDS::DCPS::ReceivedDataElementList::get_next_match(CORBA::ULong sample_state
       && !item->coherent_change_
 #endif
       ) {
-      OPENDDS_ASSERT(sanity_check());
       return item;
     }
   }
-  OPENDDS_ASSERT(sanity_check());
   return NULL;
 }
 
@@ -199,7 +194,6 @@ void
 OpenDDS::DCPS::ReceivedDataElementList::mark_read(ReceivedDataElement* item)
 {
   OPENDDS_ASSERT(sanity_check(item));
-  OPENDDS_ASSERT(sanity_check());
   if (item->sample_state_ & DDS::NOT_READ_SAMPLE_STATE) {
     item->sample_state_ = DDS::READ_SAMPLE_STATE;
     decrement_not_read_count();
@@ -212,7 +206,6 @@ void
 OpenDDS::DCPS::ReceivedDataElementList::accept_coherent_change(OpenDDS::DCPS::ReceivedDataElement* item)
 {
   OPENDDS_ASSERT(sanity_check(item));
-  OPENDDS_ASSERT(sanity_check());
   if (item->coherent_change_) {
     item->coherent_change_ = false;
     increment_not_read_count();

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -152,7 +152,11 @@ bool
 OpenDDS::DCPS::ReceivedDataElementList::has_zero_copies() const
 {
   for (ReceivedDataElement* item = head_; item != 0; item = item->next_data_sample_) {
+#ifdef ACE_HAS_CPP11
     if (item->zero_copy_cnt_) {
+#else
+    if (item->zero_copy_cnt_.value()) {
+#endif
       return true;
     }
   }

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -95,7 +95,10 @@ OpenDDS::DCPS::ReceivedDataElementList::remove(
        item = item->next_data_sample_) {
     if (match(item)) {
       size_-- ;
-      if (!item->coherent_change_) {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+      if (!item->coherent_change_)
+#endif
+      {
         if (item->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
           decrement_not_read_count();
         } else {
@@ -200,7 +203,10 @@ void
 OpenDDS::DCPS::ReceivedDataElementList::mark_read(ReceivedDataElement* item)
 {
   OPENDDS_ASSERT(sanity_check(item));
-  if (!item->coherent_change_) {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+  if (!item->coherent_change_)
+#endif
+  {
     if (item->sample_state_ & DDS::NOT_READ_SAMPLE_STATE) {
       item->sample_state_ = DDS::READ_SAMPLE_STATE;
       decrement_not_read_count();

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -233,6 +233,9 @@ public:
   ReceivedDataElement* get_next_match(CORBA::ULong sample_states, ReceivedDataElement* prev);
 
   void mark_read(ReceivedDataElement* item);
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+  void accept_coherent_change(ReceivedDataElement* item);
+#endif
 
 private:
   DataReaderImpl* reader_;
@@ -254,9 +257,10 @@ private:
   void decrement_read_count();
   void increment_not_read_count();
   void decrement_not_read_count();
-
   InstanceState_rch instance_state_;
 
+  bool sanity_check();
+  bool sanity_check(ReceivedDataElement* item);
 }; // ReceivedDataElementList
 
 } // namespace DCPS

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -205,7 +205,7 @@ public:
 
 class OpenDDS_Dcps_Export ReceivedDataElementList {
 public:
-  explicit ReceivedDataElementList(InstanceState_rch instance_state = InstanceState_rch());
+  explicit ReceivedDataElementList(DataReaderImpl*, InstanceState_rch instance_state = InstanceState_rch());
 
   ~ReceivedDataElementList();
 
@@ -213,6 +213,7 @@ public:
 
   // adds a data sample to the end of the list
   void add(ReceivedDataElement* data_sample);
+  void add_by_timestamp(ReceivedDataElement* data_sample);
 
   // returns true if the instance was released
   bool remove(ReceivedDataElement* data_sample);
@@ -220,8 +221,21 @@ public:
   // returns true if the instance was released
   bool remove(ReceivedDataFilter& match, bool eval_all);
 
+  const ReceivedDataElement* const peek_tail() { return tail_; }
+
   ReceivedDataElement* remove_head();
   ReceivedDataElement* remove_tail();
+
+  size_t size() const { return size_; }
+
+  bool has_zero_copies() const;
+  bool matches(CORBA::ULong sample_states) const;
+  ReceivedDataElement* get_next_match(CORBA::ULong sample_states, ReceivedDataElement* prev);
+
+  void mark_read(ReceivedDataElement* item);
+
+private:
+  DataReaderImpl* reader_;
 
   /// The first element of the list.
   ReceivedDataElement* head_;
@@ -230,10 +244,19 @@ public:
   ReceivedDataElement* tail_;
 
   /// Number of elements in the list.
-  ssize_t size_;
+  size_t size_;
 
-private:
+  CORBA::ULong read_sample_count_;
+  CORBA::ULong not_read_sample_count_;
+  CORBA::ULong sample_states_;
+
+  void increment_read_count();
+  void decrement_read_count();
+  void increment_not_read_count();
+  void decrement_not_read_count();
+
   InstanceState_rch instance_state_;
+
 }; // ReceivedDataElementList
 
 } // namespace DCPS

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -221,7 +221,7 @@ public:
   // returns true if the instance was released
   bool remove(ReceivedDataFilter& match, bool eval_all);
 
-  const ReceivedDataElement* const peek_tail() { return tail_; }
+  const ReceivedDataElement* peek_tail() { return tail_; }
 
   ReceivedDataElement* remove_head();
   ReceivedDataElement* remove_tail();

--- a/dds/DCPS/ReceivedDataElementList.inl
+++ b/dds/DCPS/ReceivedDataElementList.inl
@@ -50,45 +50,6 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
 }
 
 ACE_INLINE
-void
-OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *data_sample)
-{
-  data_sample->previous_data_sample_ = 0;
-  data_sample->next_data_sample_ = 0;
-
-  for (ReceivedDataElement* it = head_; it != 0; it = it->next_data_sample_) {
-    if (data_sample->source_timestamp_ < it->source_timestamp_) {
-      data_sample->previous_data_sample_ = it->previous_data_sample_;
-      data_sample->next_data_sample_ = it;
-
-      // Are we replacing the head?
-      if (it->previous_data_sample_ == 0) {
-        head_ = data_sample;
-      } else {
-        it->previous_data_sample_->next_data_sample_ = data_sample;
-      }
-      it->previous_data_sample_ = data_sample;
-
-      ++size_;
-#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
-      if (!data_sample->coherent_change_)
-#endif
-      {
-        if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
-          increment_not_read_count();
-        } else {
-          increment_read_count();
-        }
-      }
-
-      return;
-    }
-  }
-
-  add(data_sample);
-}
-
-ACE_INLINE
 OpenDDS::DCPS::ReceivedDataElement*
 OpenDDS::DCPS::ReceivedDataElementList::remove_head()
 {

--- a/dds/DCPS/ReceivedDataElementList.inl
+++ b/dds/DCPS/ReceivedDataElementList.inl
@@ -22,7 +22,10 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
 
   ++size_;
 
-  if (!data_sample->coherent_change_) {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+  if (!data_sample->coherent_change_)
+#endif
+  {
     if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
       increment_not_read_count();
     } else {
@@ -67,7 +70,10 @@ OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *da
       it->previous_data_sample_ = data_sample;
 
       ++size_;
-      if (!data_sample->coherent_change_) {
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+      if (!data_sample->coherent_change_)
+#endif
+      {
         if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
           increment_not_read_count();
         } else {

--- a/dds/DCPS/ReceivedDataElementList.inl
+++ b/dds/DCPS/ReceivedDataElementList.inl
@@ -42,7 +42,6 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
   if (instance_state_) {
     instance_state_->empty(false);
   }
-  OPENDDS_ASSERT(sanity_check());
 }
 
 ACE_INLINE
@@ -72,7 +71,6 @@ OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *da
         increment_read_count();
       }
 
-      OPENDDS_ASSERT(sanity_check());
       return;
     }
   }

--- a/dds/DCPS/ReceivedDataElementList.inl
+++ b/dds/DCPS/ReceivedDataElementList.inl
@@ -20,7 +20,7 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
   data_sample->previous_data_sample_ = 0;
   data_sample->next_data_sample_ = 0;
 
-  ++size_ ;
+  ++size_;
 
   if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
     increment_not_read_count();
@@ -30,11 +30,11 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
 
   if (!head_) {
     // First sample in the list.
-    head_ = tail_ = data_sample ;
+    head_ = tail_ = data_sample;
 
   } else {
     // Add to existing list.
-    tail_->next_data_sample_ = data_sample ;
+    tail_->next_data_sample_ = data_sample;
     data_sample->previous_data_sample_ = tail_;
     tail_ = data_sample;
   }
@@ -42,12 +42,16 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
   if (instance_state_) {
     instance_state_->empty(false);
   }
+  OPENDDS_ASSERT(sanity_check());
 }
 
 ACE_INLINE
 void
 OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *data_sample)
 {
+  data_sample->previous_data_sample_ = 0;
+  data_sample->next_data_sample_ = 0;
+
   for (ReceivedDataElement* it = head_; it != 0; it = it->next_data_sample_) {
     if (data_sample->source_timestamp_ < it->source_timestamp_) {
       data_sample->previous_data_sample_ = it->previous_data_sample_;
@@ -68,6 +72,7 @@ OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *da
         increment_read_count();
       }
 
+      OPENDDS_ASSERT(sanity_check());
       return;
     }
   }
@@ -76,31 +81,27 @@ OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *da
 }
 
 ACE_INLINE
-OpenDDS::DCPS::ReceivedDataElement *
+OpenDDS::DCPS::ReceivedDataElement*
 OpenDDS::DCPS::ReceivedDataElementList::remove_head()
 {
   if (!size_) {
-    return 0 ;
+    return 0;
   }
 
-  OpenDDS::DCPS::ReceivedDataElement *ptr = head_ ;
-
-  remove(head_) ;
-
-  return ptr ;
+  OpenDDS::DCPS::ReceivedDataElement *ptr = head_;
+  remove(head_);
+  return ptr;
 }
 
 ACE_INLINE
-OpenDDS::DCPS::ReceivedDataElement *
+OpenDDS::DCPS::ReceivedDataElement*
 OpenDDS::DCPS::ReceivedDataElementList::remove_tail()
 {
   if (!size_) {
-    return 0 ;
+    return 0;
   }
 
-  OpenDDS::DCPS::ReceivedDataElement *ptr = tail_ ;
-
-  remove(tail_) ;
-
-  return ptr ;
+  OpenDDS::DCPS::ReceivedDataElement* ptr = tail_;
+  remove(tail_);
+  return ptr;
 }

--- a/dds/DCPS/ReceivedDataElementList.inl
+++ b/dds/DCPS/ReceivedDataElementList.inl
@@ -22,10 +22,12 @@ OpenDDS::DCPS::ReceivedDataElementList::add(ReceivedDataElement *data_sample)
 
   ++size_;
 
-  if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
-    increment_not_read_count();
-  } else {
-    increment_read_count();
+  if (!data_sample->coherent_change_) {
+    if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
+      increment_not_read_count();
+    } else {
+      increment_read_count();
+    }
   }
 
   if (!head_) {
@@ -65,10 +67,12 @@ OpenDDS::DCPS::ReceivedDataElementList::add_by_timestamp(ReceivedDataElement *da
       it->previous_data_sample_ = data_sample;
 
       ++size_;
-      if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
-        increment_not_read_count();
-      } else {
-        increment_read_count();
+      if (!data_sample->coherent_change_) {
+        if (data_sample->sample_state_ == DDS::NOT_READ_SAMPLE_STATE) {
+          increment_not_read_count();
+        } else {
+          increment_read_count();
+        }
       }
 
       return;

--- a/dds/DCPS/ReceivedDataStrategy.cpp
+++ b/dds/DCPS/ReceivedDataStrategy.cpp
@@ -136,29 +136,7 @@ SourceDataStrategy::~SourceDataStrategy()
 void
 SourceDataStrategy::add(ReceivedDataElement* data_sample)
 {
-  for (ReceivedDataElement* it = this->rcvd_samples_.head_;
-       it != 0; it = it->next_data_sample_) {
-    if (data_sample->source_timestamp_ < it->source_timestamp_) {
-      data_sample->previous_data_sample_ = it->previous_data_sample_;
-      data_sample->next_data_sample_ = it;
-
-      // Are we replacing the head?
-      if (it->previous_data_sample_ == 0) {
-        this->rcvd_samples_.head_ = data_sample;
-
-      } else {
-        it->previous_data_sample_->next_data_sample_ = data_sample;
-      }
-
-      it->previous_data_sample_ = data_sample;
-
-      ++this->rcvd_samples_.size_;
-
-      return;
-    }
-  }
-
-  this->rcvd_samples_.add(data_sample);
+  rcvd_samples_.add_by_timestamp(data_sample);
 }
 
 } // namespace DCPS

--- a/dds/DCPS/SubscriptionInstance.cpp
+++ b/dds/DCPS/SubscriptionInstance.cpp
@@ -20,7 +20,9 @@ SubscriptionInstance::SubscriptionInstance(DataReaderImpl* reader,
                                            DDS::InstanceHandle_t handle,
                                            bool owns_handle)
   : instance_state_(make_rch<InstanceState>(reader, ref(lock), handle))
-  , rcvd_samples_(instance_state_)
+  , rcvd_samples_(reader, instance_state_)
+  , read_sample_count_(0)
+  , not_read_sample_count_(0)
   , instance_handle_(handle)
   , owns_handle_(owns_handle)
   , deadline_timer_id_(-1)
@@ -50,6 +52,11 @@ SubscriptionInstance::~SubscriptionInstance()
       reader->return_handle(instance_handle_);
     }
   }
+}
+
+bool SubscriptionInstance::matches(CORBA::ULong sample_states, CORBA::ULong view_states, CORBA::ULong instance_states) const
+{
+  return instance_state_->match(view_states, instance_states) && rcvd_samples_.matches(sample_states);
 }
 
 }

--- a/dds/DCPS/SubscriptionInstance.h
+++ b/dds/DCPS/SubscriptionInstance.h
@@ -43,6 +43,8 @@ public:
 
   ~SubscriptionInstance();
 
+  bool matches(CORBA::ULong sample_states, CORBA::ULong view_states, CORBA::ULong instance_states) const;
+
   /// Instance state for this instance
   const InstanceState_rch instance_state_;
 
@@ -51,6 +53,10 @@ public:
 
   /// Data sample(s) in this instance
   ReceivedDataElementList rcvd_samples_;
+
+  CORBA::ULong read_sample_count_;
+  CORBA::ULong not_read_sample_count_;
+  CORBA::ULong sample_states_;
 
   /// ReceivedDataElementList strategy
   unique_ptr<ReceivedDataStrategy> rcvd_strategy_;

--- a/tests/DCPS/MockedTypeSupport/MyTypeSupportImpl.h
+++ b/tests/DCPS/MockedTypeSupport/MyTypeSupportImpl.h
@@ -84,7 +84,7 @@ public:
 
   virtual void purge_data(OpenDDS::DCPS::SubscriptionInstance_rch) {}
   virtual void release_instance_i(DDS::InstanceHandle_t) {}
-  virtual void state_updated_i(DDS::InstanceHandle_t handle) {}
+  virtual void state_updated_i(DDS::InstanceHandle_t) {}
   void release_all_instances() {}
   virtual OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::MessageHolder>
   dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample&,

--- a/tests/DCPS/MockedTypeSupport/MyTypeSupportImpl.h
+++ b/tests/DCPS/MockedTypeSupport/MyTypeSupportImpl.h
@@ -84,6 +84,7 @@ public:
 
   virtual void purge_data(OpenDDS::DCPS::SubscriptionInstance_rch) {}
   virtual void release_instance_i(DDS::InstanceHandle_t) {}
+  virtual void state_updated_i(DDS::InstanceHandle_t handle) {}
   void release_all_instances() {}
   virtual OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::MessageHolder>
   dds_demarshal(const OpenDDS::DCPS::ReceivedDataSample&,


### PR DESCRIPTION
Problem: For large numbers of instances and instances, several lookups within DataReaderImpl_T are non-performant, opting to loop over the entire list of instances looking for appropriate samples, and then potentially looping over many samples to find matching samples.

Solution: Maintain separate lookup maps based on instance, view, and sample states, and keep them up to date as these values get updated.