### PR TITLE
Tweak NetworkAddress Unit Test To Avoid set_addr() Issue

### DIFF
--- a/tests/unit-tests/dds/DCPS/NetworkAddress.cpp
+++ b/tests/unit-tests/dds/DCPS/NetworkAddress.cpp
@@ -33,7 +33,12 @@ TEST(dds_DCPS_NetworkAddress, AddrConstructorPortStrIpFour)
   const NetworkAddress sa(ia);
   EXPECT_EQ(sa.get_type(), AF_INET);
   EXPECT_EQ(sa.get_port_number(), 1234);
-  EXPECT_EQ(sa.to_addr(), ia);
+
+  // This is necessary because of a deficiency in ACE_INET_Addr where calling set_addr will not copy / set
+  // the bytes of 'sin_zero' (reserved for system use), but the 2 argument constructor might, depending on the system
+  ACE_INET_Addr ia2;
+  ia2.set_addr(ia.get_addr(), ia.get_addr_size());
+  EXPECT_EQ(sa.to_addr(), ia2);
 }
 
 TEST(dds_DCPS_NetworkAddress, AddrConstructorStrIpFour)
@@ -42,7 +47,12 @@ TEST(dds_DCPS_NetworkAddress, AddrConstructorStrIpFour)
   const NetworkAddress sa(ia);
   EXPECT_EQ(sa.get_type(), AF_INET);
   EXPECT_EQ(sa.get_port_number(), 4321);
-  EXPECT_EQ(sa.to_addr(), ia);
+
+  // This is necessary because of a deficiency in ACE_INET_Addr where calling set_addr will not copy / set
+  // the bytes of 'sin_zero' (reserved for system use), but the 2 argument constructor might, depending on the system
+  ACE_INET_Addr ia2;
+  ia2.set_addr(ia.get_addr(), ia.get_addr_size());
+  EXPECT_EQ(sa.to_addr(), ia2);
 }
 
 #if defined (ACE_HAS_IPV6)
@@ -72,7 +82,14 @@ TEST(dds_DCPS_NetworkAddress, PortStrConstructorIpFour)
   const NetworkAddress sa(1234, "127.0.10.13");
   EXPECT_EQ(sa.get_type(), AF_INET);
   EXPECT_EQ(sa.get_port_number(), 1234);
-  EXPECT_EQ(sa.to_addr(), ACE_INET_Addr(1234, "127.0.10.13"));
+
+  // This is necessary because of a deficiency in ACE_INET_Addr where calling set_addr will not copy / set
+  // the bytes of 'sin_zero' (reserved for system use), but the 2 argument constructor might, depending on the system
+  ACE_INET_Addr ia(1234, "127.0.10.13");
+  ACE_INET_Addr ia2;
+  ia2.set_addr(ia.get_addr(), ia.get_addr_size());
+  EXPECT_EQ(sa.to_addr(), ia2);
+
   EXPECT_EQ(sa, NetworkAddress(1234, "127.0.10.13"));
 }
 
@@ -81,7 +98,14 @@ TEST(dds_DCPS_NetworkAddress, StrConstructorIpFour)
   const NetworkAddress sa("127.0.10.13:4321");
   EXPECT_EQ(sa.get_type(), AF_INET);
   EXPECT_EQ(sa.get_port_number(), 4321);
-  EXPECT_EQ(sa.to_addr(), ACE_INET_Addr(4321, "127.0.10.13"));
+
+  // This is necessary because of a deficiency in ACE_INET_Addr where calling set_addr will not copy / set
+  // the bytes of 'sin_zero' (reserved for system use), but the 2 argument constructor might, depending on the system
+  ACE_INET_Addr ia(4321, "127.0.10.13");
+  ACE_INET_Addr ia2;
+  ia2.set_addr(ia.get_addr(), ia.get_addr_size());
+  EXPECT_EQ(sa.to_addr(), ia2);
+
   EXPECT_EQ(sa, NetworkAddress(4321, "127.0.10.13"));
 }
 


### PR DESCRIPTION
Problem: NetworkAddress unit test is failing on windows builds because for IPv4 addresses, ACE_INET_Addr's 2-argmument constructor will set sockaddr_in.sin_zero bytes (reserved for system use) but ACE_INET_Addr's set_addr() does not copy them. So even if we wanted to copy / use them in NetworkAddress (doubtful), compatibility with set_addr() would still be a problem.

Solution: There are a number of ways to potentially resolve this, but given ACE_INET_Addr's current implementation of set_addr(), I would argue the best approach is to leave both ACE and NetworkAddress the way they are (NetworkAddress's primary benefit is being able to directly memcmp the entire structure and guarantee strict ordering... sin_zero bytes would break that guarantee), but to change the test to only test NetworkAddress::to_addr() equivalence with "clean" IPv4 ACE_INET_Addr objects (those which have been created using set_addr, and not the constructor directly). The tests which were previously failing have comments explaining the issue.