### PR TITLE
Fix safety profile TimeBasedFilter test.

### DIFF
--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -72,7 +72,9 @@ public:
   , condition_(lock_)
   , num_samples_(0)
   , expected_num_samples_(expected_num_samples)
+#ifdef OPENDDS_SAFETY_PROFILE
   , first_sample_(true)
+#endif
   {
   }
 
@@ -99,11 +101,13 @@ public:
       DDS::ReturnCode_t error = message_dr->take(foos, info, DDS::LENGTH_UNLIMITED,
         DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
+#ifdef OPENDDS_SAFETY_PROFILE
       // discard the first sample. necessary for reliable safety profile.
       if (first_sample_) {
         first_sample_ = false;
         return;
       }
+#endif
 
       ACE_Time_Value now(ACE_OS::gettimeofday());
 
@@ -212,7 +216,9 @@ private:
   ACE_Condition<ACE_SYNCH_MUTEX> condition_;
   size_t num_samples_;
   const size_t expected_num_samples_;
+#ifdef OPENDDS_SAFETY_PROFILE
   bool first_sample_;
+#endif
 };
 
 void validate(const float expected_x, const float actual_x,
@@ -586,6 +592,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     SampleMap send_map;
 
+#ifdef OPENDDS_SAFETY_PROFILE
     // receiving the first safety profile sample takes longer than
     // subsequent samples, so write a throwaway
     Foo f = { 0, 0, 0, 0 };
@@ -598,6 +605,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     // and sleep so that the the first sample doesn't
     // affect the timing of the several time-based samples
     ACE_OS::sleep(2 * minimum_separation.sec + 1);
+#endif
 
     // We expect to receive up to one sample per
     // cycle (all others should be filtered).

--- a/tests/DCPS/TimeBasedFilter/main.cpp
+++ b/tests/DCPS/TimeBasedFilter/main.cpp
@@ -72,6 +72,7 @@ public:
   , condition_(lock_)
   , num_samples_(0)
   , expected_num_samples_(expected_num_samples)
+  , first_sample_(true)
   {
   }
 
@@ -97,6 +98,13 @@ public:
 
       DDS::ReturnCode_t error = message_dr->take(foos, info, DDS::LENGTH_UNLIMITED,
         DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+
+      // discard the first sample. necessary for reliable safety profile.
+      if (first_sample_) {
+        first_sample_ = false;
+        return;
+      }
+
       ACE_Time_Value now(ACE_OS::gettimeofday());
 
       ACE_GUARD(ACE_SYNCH_MUTEX, g, this->lock_);
@@ -204,6 +212,7 @@ private:
   ACE_Condition<ACE_SYNCH_MUTEX> condition_;
   size_t num_samples_;
   const size_t expected_num_samples_;
+  bool first_sample_;
 };
 
 void validate(const float expected_x, const float actual_x,
@@ -215,14 +224,13 @@ void validate(const float expected_x, const float actual_x,
     ACE_ERROR((LM_ERROR,
       ACE_TEXT("%N:%l validate()")
       ACE_TEXT(" ERROR: for key %d received sample x=%f y=%f")
-      ACE_TEXT("but expected x=%f y=%f!\n"),
+      ACE_TEXT(" but expected x=%f y=%f!\n"),
       key, actual_x, actual_y, expected_x, expected_y));
   }
   else {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l validate() - ")
-      ACE_TEXT("received message with key %d received sample x=%f y=%f")
-      ACE_TEXT("but expected x=%f y=%f!\n"),
-      key, actual_x, actual_y, expected_x, expected_y));
+      ACE_TEXT("received message with key %d received sample x=%f y=%f\n"),
+      key, actual_x, actual_y));
   }
 }
 
@@ -542,6 +550,8 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
     DDS::WaitSet_var ws = new DDS::WaitSet;
     ws->attach_condition(cond);
 
+    ACE_Time_Value start = ACE_OS::gettimeofday();
+
     DDS::Duration_t timeout = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
 
     DDS::ConditionSeq conditions;
@@ -576,6 +586,19 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
 
     SampleMap send_map;
 
+    // receiving the first safety profile sample takes longer than
+    // subsequent samples, so write a throwaway
+    Foo f = { 0, 0, 0, 0 };
+    if (writer_i->write(f, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+      ACE_ERROR_RETURN((LM_ERROR,
+        ACE_TEXT("%N:%l main()")
+        ACE_TEXT(" ERROR: Unable to write sample!\n")), -1);
+    }
+
+    // and sleep so that the the first sample doesn't
+    // affect the timing of the several time-based samples
+    ACE_OS::sleep(2 * minimum_separation.sec + 1);
+
     // We expect to receive up to one sample per
     // cycle (all others should be filtered).
     size_t global_sent_msg_counter = 0;
@@ -593,7 +616,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
           }
           else {
             ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l main() - ")
-              ACE_TEXT("wrote sample with key: %d and x: %f y: %f\n"), foo.key, foo.x, foo.y));
+              ACE_TEXT("wrote sample @ %d msecs with key: %d and x: %f y: %f\n"), (ACE_OS::gettimeofday() - start).msec(), foo.key, foo.x, foo.y));
           }
         }
 
@@ -612,7 +635,7 @@ ACE_TMAIN(int argc, ACE_TCHAR** argv)
             }
             else {
               ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l main() - ")
-                ACE_TEXT("wrote sample with key: %d and x: %f y: %f\n"), foo.key, foo.x, foo.y));
+                ACE_TEXT("wrote sample @ %d msecs with key: %d and x: %f y: %f\n"), (ACE_OS::gettimeofday() - start).msec(), foo.key, foo.x, foo.y));
             }
           }
         }


### PR DESCRIPTION
The first sample is received after a delay in
safety profile builds. Discard the first sample
to avoid timing issues that cause test failures.
Update log messages.