### PR TITLE
Fix Intermittent Shutdown Order Issues In TransientLocalMultiInstance Test

### DIFF
--- a/tests/DCPS/TransientLocalMultiInstanceTest/publisher.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/publisher.cpp
@@ -276,23 +276,20 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       }
     }
 
-    int ten = 0;
     while (true) {
-      ++ten;
       DDS::PublicationMatchedStatus pubmatched, pubmatched2;
       if (dw1->get_publication_matched_status(pubmatched) != DDS::RETCODE_OK || dw2->get_publication_matched_status(pubmatched2) != DDS::RETCODE_OK) {
         ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: get_publication_matched_status\n")));
         break;
       }
-      else if (pubmatched.current_count == 4 && pubmatched.total_count == 4 && pubmatched2.current_count == 4 && pubmatched2.total_count == 4) {
+      else if (pubmatched.current_count == 2 && pubmatched.total_count == 4 && pubmatched2.current_count == 2 && pubmatched2.total_count == 4) {
         // subscriber has come and gone
         break;
       }
-      if (ten % 100000 == 0) {
-        ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) pubmatched current_count : %d total_count : %d pubmatched2 current_count : %d total_count : %d\n"),
-          pubmatched.current_count, pubmatched.total_count, pubmatched2.current_count, pubmatched2.total_count));
-      }
+      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) pubmatched current_count : %d total_count : %d pubmatched2 current_count : %d total_count : %d\n"),
+        pubmatched.current_count, pubmatched.total_count, pubmatched2.current_count, pubmatched2.total_count));
+      ACE_OS::sleep(ACE_Time_Value(0, 200000));
     }
     participant->delete_contained_entities();
     dpf->delete_participant(participant);

--- a/tests/DCPS/TransientLocalMultiInstanceTest/subscriber.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/subscriber.cpp
@@ -113,21 +113,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         ACE_TEXT("(%P|%t) ERROR: failed to receive expected number of samples\n")));
     }
 
-    while (true) {
-      DDS::SubscriptionMatchedStatus submatched;
-      if (dr2->get_subscription_matched_status(submatched) != DDS::RETCODE_OK) {
-        ACE_ERROR((LM_ERROR,
-          ACE_TEXT("(%P|%t) ERROR: get_subscription_matched_status\n")));
-        break;
-      }
-      else if (submatched.current_count == 0) {
-        // publisher has come and gone
-        break;
-      }
-      ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) submatched current_count: %d total_count: %d\n"), submatched.current_count, submatched.total_count));
-      ACE_OS::sleep(1);
-    }
-
     if (!CORBA::is_nil(participant)) {
       participant->delete_contained_entities();
     }


### PR DESCRIPTION
Problem: TransientLocalMultiInstance Test will occassionally hang when the publisher exits before the subscriber processes have received all their data.

Solution: Use the publisher's DataReaderListeners (yes, you read that right) to see if the local datareaders have received their data. Then monitor both the current and total publication matches to see when all 4 total matches have been seen but only 2 remain (the 2 subscribers have exited). Then it's safe for the publisher to exit. The subscriber applications should exist as soon as they have their data.