### PR TITLE
Quickstart/docker: users don't need to write rtps.ini

### DIFF
--- a/quickstart/GettingStartedDocker.html
+++ b/quickstart/GettingStartedDocker.html
@@ -52,16 +52,6 @@ make</pre>
       <pre>cd Messenger</pre>
     </li>
     <li>
-      <p>Create an <i>rtps.ini</i> file to control discovery with the following content</p>
-      <pre>
-[common]
-DCPSGlobalTransportConfig=$file
-DCPSDefaultDiscovery=DEFAULT_RTPS
-
-[transport/the_rtps_transport]
-transport_type=rtps_udp</pre>
-    </li>
-    <li>
       <p>Run the Messenger example with RTPS</p>
       <pre>docker-compose up</pre>
     </li>


### PR DESCRIPTION
It's already in the repo