### PR TITLE
DpShutdown test fails for t=tcp on static builds

### DIFF
--- a/tests/DCPS/DpShutdown/dpshutdown.cpp
+++ b/tests/DCPS/DpShutdown/dpshutdown.cpp
@@ -17,6 +17,7 @@
 #  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #  include <dds/DCPS/transport/shmem/Shmem.h>
 #  include <dds/DCPS/transport/udp/Udp.h>
+#  include <dds/DCPS/transport/tcp/Tcp.h>
 #  include <dds/DCPS/transport/multicast/Multicast.h>
 #  include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #endif


### PR DESCRIPTION
Problem
-------

DpShutdown test fails for t=tcp on static builds.

Solution
--------

Add missing include to register the transport.