### PR TITLE
Fix #3268 opendds_idl Segfault

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -509,7 +509,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ github.job }}.tar.xz
-        key: c05_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c06_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
@@ -776,7 +776,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ github.job }}.tar.xz
-        key: c05_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c06_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2
@@ -2587,7 +2587,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ github.job }}.tar.xz
-        key: c05_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c06_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: checkout MPC
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v2

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -2584,7 +2584,7 @@ namespace {
       const Classification fld_cls = classify(type);
       if (fld_cls & CL_SEQUENCE) {
         AST_Sequence* const seq = dynamic_cast<AST_Sequence*>(type);
-        AST_Type* const base = seq->base_type();
+        AST_Type* const base = resolveActualType(seq->base_type());
         if (classify(base) & CL_PRIMITIVE) {
           AST_PredefinedType* const pt = dynamic_cast<AST_PredefinedType*>(base);
           if (pt->pt() == AST_PredefinedType::PT_octet) {

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -111,6 +111,12 @@ module Xyz {
   typedef char MyChar;
   typedef sequence<MyChar, 5> AMyCharSeq;
 
+  // Test for https://github.com/objectcomputing/OpenDDS/issues/3268
+  @topic
+  struct OnlyASeqOfTypedefChar {
+    sequence<MyChar, 5> anon_seq;
+  };
+
   typedef string<100> BoundedString;
   typedef sequence<BoundedString> UnboundedSeqOfBoundedString;
   typedef sequence<BoundedString, 10> BoundedSeqOfBoundedString;

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -113,8 +113,8 @@ module Xyz {
 
   // Test for https://github.com/objectcomputing/OpenDDS/issues/3268
   @topic
-  struct OnlyASeqOfTypedefChar {
-    sequence<MyChar, 5> anon_seq;
+  struct OnlyAMyCharSeq {
+    AMyCharSeq only_member;
   };
 
   typedef string<100> BoundedString;


### PR DESCRIPTION
Fixes https://github.com/objectcomputing/OpenDDS/issues/3268. The check for a struct with just a octet sequence member added to support ROS didn't resolve the sequence base type. Fixed this and added a compiler test for this.