### PR TITLE
Last Received Address Hinting Using Discovery Info

### DIFF
--- a/dds/DCPS/AssociationData.h
+++ b/dds/DCPS/AssociationData.h
@@ -23,6 +23,7 @@ namespace DCPS {
 struct AssociationData {
   RepoId               remote_id_;
   TransportLocatorSeq  remote_data_;
+  TransportLocator     discovery_locator_;
   MonotonicTime_t      participant_discovered_at_;
   ACE_CDR::ULong       remote_transport_context_;
   Priority             publication_transport_priority_;
@@ -30,6 +31,7 @@ struct AssociationData {
 
   AssociationData()
     : remote_id_(GUID_UNKNOWN)
+    , discovery_locator_()
     , participant_discovered_at_(monotonic_time_zero())
     , remote_transport_context_(0)
     , publication_transport_priority_(0)

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -253,7 +253,7 @@ DataReaderImpl::add_association(const RepoId& yourId,
     }
   }
 
-  //Why do we need the publication_handle_lock_ here?  No access to id_to_handle_map_...
+  // Why do we need the publication_handle_lock_ here?  No access to id_to_handle_map_...
   ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, publication_handle_lock_);
 
 
@@ -322,6 +322,7 @@ DataReaderImpl::add_association(const RepoId& yourId,
   AssociationData data;
   data.remote_id_ = writer.writerId;
   data.remote_data_ = writer.writerTransInfo;
+  data.discovery_locator_ = writer.writerDiscInfo;
   data.participant_discovered_at_ = writer.participantDiscoveredAt;
   data.remote_transport_context_ = writer.transportContext;
   data.publication_transport_priority_ =

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -246,6 +246,7 @@ DataWriterImpl::add_association(const RepoId& yourId,
   AssociationData data;
   data.remote_id_ = reader.readerId;
   data.remote_data_ = reader.readerTransInfo;
+  data.discovery_locator_ = reader.readerDiscInfo;
   data.participant_discovered_at_ = reader.participantDiscoveredAt;
   data.remote_transport_context_ = reader.transportContext;
   data.remote_reliable_ =

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -315,7 +315,7 @@ struct DiscoveredParticipant {
   DCPS::ParticipantLocationBuiltinTopicData location_data_;
   DDS::InstanceHandle_t location_ih_;
 
-  ACE_INET_Addr local_address_;
+  ACE_INET_Addr last_recv_address_;
   MonotonicTimePoint discovered_at_;
   MonotonicTimePoint lease_expiration_;
   DDS::InstanceHandle_t bit_ih_;
@@ -469,6 +469,8 @@ private:
   typedef OPENDDS_MAP_CMP(GUID_t, DiscoveredPublication,
                           GUID_tKeyLessThan) DiscoveredPublicationMap;
   typedef DiscoveredPublicationMap::iterator DiscoveredPublicationIter;
+
+  void populate_origination_locator(const GUID_t& id, DCPS::TransportLocator& tl);
 
 public:
   Sedp(const DCPS::RepoId& participant_id,

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -802,7 +802,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     update_rtps_relay_application_participant_i(iter, p.second);
 
     if (!from_relay && from != ACE_INET_Addr()) {
-      iter->second.local_address_ = from;
+      iter->second.last_recv_address_ = from;
     }
 
     if (DCPS::transport_debug.log_progress) {
@@ -825,7 +825,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     // own announcement, so they don't have to wait.
     if (from != ACE_INET_Addr()) {
       if (from_relay) {
-        tport_->write_i(guid, iter->second.local_address_, SpdpTransport::SEND_RELAY);
+        tport_->write_i(guid, iter->second.last_recv_address_, SpdpTransport::SEND_RELAY);
       } else {
         tport_->shorten_local_sender_delay_i();
       }
@@ -854,7 +854,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         iter->second.extended_builtin_endpoints_ = pdata.ddsParticipantDataSecure.base.extended_builtin_endpoints;
 
         // The remote needs to see our SPDP before attempting authentication.
-        tport_->write_i(guid, iter->second.local_address_, from_relay ? SpdpTransport::SEND_RELAY : SpdpTransport::SEND_DIRECT);
+        tport_->write_i(guid, iter->second.last_recv_address_, from_relay ? SpdpTransport::SEND_RELAY : SpdpTransport::SEND_DIRECT);
 
         attempt_authentication(iter, true);
 
@@ -901,7 +901,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
     if (is_security_enabled() && iter->second.auth_state_ == AUTH_STATE_AUTHENTICATED && !from_sedp) {
       update_lease_expiration_i(iter, now);
       if (!from_relay && from != ACE_INET_Addr()) {
-        iter->second.local_address_ = from;
+        iter->second.last_recv_address_ = from;
       }
 #ifndef DDS_HAS_MINIMUM_BIT
       process_location_updates_i(iter);
@@ -965,7 +965,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       update_lease_expiration_i(iter, now);
       update_rtps_relay_application_participant_i(iter, false);
       if (!from_relay && from != ACE_INET_Addr()) {
-        iter->second.local_address_ = from;
+        iter->second.last_recv_address_ = from;
       }
 
 #ifndef DDS_HAS_MINIMUM_BIT
@@ -1771,7 +1771,7 @@ Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
       // Send the auth req first to reset the remote if necessary.
       if (pit->second.have_auth_req_msg_) {
         // Send the SPDP announcement in case it got lost.
-        tport_->write_i(pit->first, pit->second.local_address_, SpdpTransport::SEND_RELAY | SpdpTransport::SEND_DIRECT);
+        tport_->write_i(pit->first, pit->second.last_recv_address_, SpdpTransport::SEND_RELAY | SpdpTransport::SEND_DIRECT);
         if (sedp_->transport_inst()->count_messages()) {
           ++tport_->transport_statistics_.writer_resend_count[make_id(guid_, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER)];
         }
@@ -3672,6 +3672,20 @@ Spdp::get_default_locators(const RepoId& part_id, DCPS::LocatorSeq& target,
 }
 
 bool
+Spdp::get_last_recv_locator(const RepoId& part_id, DCPS::LocatorSeq& target,
+                            bool& inlineQos)
+{
+  DiscoveredParticipantIter pos = participants_.find(part_id);
+  if (pos != participants_.end() && pos->second.last_recv_address_ != ACE_INET_Addr()) {
+    inlineQos = pos->second.pdata_.participantProxy.expectsInlineQos;
+    target.length(1);
+    DCPS::address_to_locator(target[0], pos->second.last_recv_address_);
+    return true;
+  }
+  return false;
+}
+
+bool
 Spdp::associated() const
 {
   return !participants_.empty();
@@ -4267,7 +4281,7 @@ void Spdp::SpdpTransport::send_directed(const DCPS::MonotonicTimePoint& /*now*/)
       continue;
     }
 
-    write_i(id, pos->second.local_address_, SEND_DIRECT | SEND_RELAY);
+    write_i(id, pos->second.last_recv_address_, SEND_DIRECT | SEND_RELAY);
     directed_guids_.push_back(id);
     directed_send_task_->schedule(outer->config_->resend_period() * (1.0 / directed_guids_.size()));
     break;

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -107,6 +107,10 @@ public:
                             DCPS::LocatorSeq& target,
                             bool& inlineQos);
 
+  bool get_last_recv_locator(const DCPS::RepoId& part_id,
+                             DCPS::LocatorSeq& target,
+                             bool& inlineQos);
+
   // Managing reader/writer associations
   void signal_liveliness(DDS::LivelinessQosPolicyKind kind);
 

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -338,6 +338,7 @@ RecorderImpl::add_association(const RepoId&            yourId,
     AssociationData data;
     data.remote_id_ = writer.writerId;
     data.remote_data_ = writer.writerTransInfo;
+    data.discovery_locator_ = writer.writerDiscInfo;
     data.remote_transport_context_ = writer.transportContext;
     data.publication_transport_priority_ =
       writer.writerQos.transport_priority.value;

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -448,6 +448,7 @@ ReplayerImpl::add_association(const RepoId&            yourId,
   AssociationData data;
   data.remote_id_ = reader.readerId;
   data.remote_data_ = reader.readerTransInfo;
+  data.discovery_locator_ = reader.readerDiscInfo;
   data.remote_transport_context_ = reader.transportContext;
   data.remote_reliable_ =
     (reader.readerQos.reliability.kind == DDS::RELIABLE_RELIABILITY_QOS);

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -339,7 +339,7 @@ StaticEndpointManager::add_publication_i(const RepoId& writerid,
     ra.exprParams = 0;
 #else
     const ReaderAssociation ra =
-      {reader.trans_info, 0, readerid, reader.subscriber_qos, reader.qos, "", "", 0, 0, {0, 0}};
+      {reader.trans_info, TransportLocator(), 0, readerid, reader.subscriber_qos, reader.qos, "", "", 0, 0, {0, 0}};
 #endif
     DataWriterCallbacks_rch pl = pub.publication_.lock();
     if (pl) {
@@ -411,7 +411,7 @@ StaticEndpointManager::add_subscription_i(const RepoId& readerid,
 
     DDS::OctetSeq type_info;
     const WriterAssociation wa = {
-      writer.trans_info, 0, writerid, writer.publisher_qos, writer.qos, type_info, {0, 0}
+      writer.trans_info, TransportLocator(), 0, writerid, writer.publisher_qos, writer.qos, type_info, {0, 0}
     };
     DataReaderCallbacks_rch sl = sub.subscription_.lock();
     if (sl) {
@@ -505,7 +505,7 @@ StaticEndpointManager::reader_exists(const RepoId& readerid, const RepoId& write
     DataWriterCallbacks_rch dwr = lp_pos->second.publication_.lock();
     if (dwr) {
       const ReaderAssociation ra =
-        {reader_pos->second.trans_info, 0, readerid, reader_pos->second.subscriber_qos, reader_pos->second.qos,
+        {reader_pos->second.trans_info, TransportLocator(), 0, readerid, reader_pos->second.subscriber_qos, reader_pos->second.qos,
          "", "", DDS::StringSeq(), DDS::OctetSeq(), {0, 0}};
       dwr->add_association(writerid, ra, true);
     }
@@ -541,7 +541,7 @@ StaticEndpointManager::writer_exists(const RepoId& writerid, const RepoId& reade
     DataReaderCallbacks_rch drr = ls_pos->second.subscription_.lock();
     if (drr) {
       const WriterAssociation wa =
-        {writer_pos->second.trans_info, 0, writerid, writer_pos->second.publisher_qos, writer_pos->second.qos, DDS::OctetSeq(), {0,0}};
+        {writer_pos->second.trans_info, TransportLocator(), 0, writerid, writer_pos->second.publisher_qos, writer_pos->second.qos, DDS::OctetSeq(), {0,0}};
       drr->add_association(readerid, wa, false);
     }
   }
@@ -1375,7 +1375,7 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
     DDS::OctetSeq octet_seq_type_info_reader;
     XTypes::serialize_type_info(*reader_type_info, octet_seq_type_info_reader);
     const ReaderAssociation ra = {
-      *rTls, rTransportContext, reader, *subQos, *drQos,
+      *rTls, TransportLocator(), rTransportContext, reader, *subQos, *drQos,
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
       cfProp->filterClassName, cfProp->filterExpression,
 #else
@@ -1389,7 +1389,7 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
     DDS::OctetSeq octet_seq_type_info_writer;
     XTypes::serialize_type_info(*writer_type_info, octet_seq_type_info_writer);
     const WriterAssociation wa = {
-      *wTls, wTransportContext, writer, *pubQos, *dwQos,
+      *wTls, TransportLocator(), wTransportContext, writer, *pubQos, *dwQos,
       octet_seq_type_info_writer,
       writer_participant_discovered_at
     };

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -538,12 +538,12 @@ SubscriberImpl::get_datareaders(
       GroupRakeData data;
       for (DataReaderSet::const_iterator pos = localreaders.begin();
            pos != localreaders.end(); ++pos) {
-        (*pos)->get_ordered_data (data, sample_states, view_states, instance_states);
+        (*pos)->get_ordered_data(data, sample_states, view_states, instance_states);
       }
 
       // Return list of readers in the order of the source timestamp of the received
       // samples from readers.
-      data.get_datareaders (readers);
+      data.get_datareaders(readers);
       return DDS::RETCODE_OK;
     }
   }

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -290,7 +290,7 @@ TransportClient::associate(const AssociationData& data, bool active)
       for (CORBA::ULong j = 0; j < data.remote_data_.length(); ++j) {
         if (data.remote_data_[j].transport_type.in() == type) {
           const TransportImpl::RemoteTransport remote = {
-            data.remote_id_, data.remote_data_[j].data, data.participant_discovered_at_, data.remote_transport_context_,
+            data.remote_id_, data.remote_data_[j].data, data.discovery_locator_.data, data.participant_discovered_at_, data.remote_transport_context_,
             data.publication_transport_priority_,
             data.remote_reliable_, data.remote_durable_};
 
@@ -443,7 +443,7 @@ TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
     for (; blob_index_ < data_.remote_data_.length(); ++blob_index_) {
       if (data_.remote_data_[blob_index_].transport_type.in() == type) {
         const TransportImpl::RemoteTransport remote = {
-          data_.remote_id_, data_.remote_data_[blob_index_].data, data_.participant_discovered_at_, data_.remote_transport_context_,
+          data_.remote_id_, data_.remote_data_[blob_index_].data, data_.discovery_locator_.data, data_.participant_discovered_at_, data_.remote_transport_context_,
           data_.publication_transport_priority_,
           data_.remote_reliable_, data_.remote_durable_};
 

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -105,6 +105,9 @@ public:
   virtual void update_locators(const RepoId& /*remote*/,
                                const TransportLocatorSeq& /*locators*/) { }
 
+  virtual void get_last_recv_locator(const RepoId& /*remote_id*/,
+                                     TransportLocator& /*locators*/) {}
+
   virtual void rtps_relay_address_change() {}
   virtual void append_transport_statistics(TransportStatisticsSequence& /*seq*/) {}
 
@@ -143,6 +146,7 @@ public:
   struct RemoteTransport {
     RepoId repo_id_;
     TransportBLOB blob_;
+    TransportBLOB discovery_blob_;
     MonotonicTime_t participant_discovered_at_;
     ACE_CDR::ULong context_;
     Priority publication_transport_priority_;

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -136,6 +136,9 @@ public:
   virtual void update_locators(const RepoId& /*remote_id*/,
                                const TransportLocatorSeq& /*locators*/) {}
 
+  virtual void get_last_recv_locator(const RepoId& /*remote_id*/,
+                                     TransportLocator& /*locators*/) {}
+
   virtual void rtps_relay_address_change() {}
 
   ReactorTask_rch reactor_task();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -154,6 +154,8 @@ public:
 
   void remove_locator_and_bundling_cache(const RepoId& remote_id);
 
+  NetworkAddress get_last_recv_address(const RepoId& remote_id);
+
   void update_locators(const RepoId& remote_id,
                        AddrSet& unicast_addresses,
                        AddrSet& multicast_addresses,
@@ -182,6 +184,7 @@ public:
                   const TransportClient_rch& client,
                   AddrSet& unicast_addresses,
                   AddrSet& multicast_addresses,
+                  const NetworkAddress& last_addr_hint,
                   bool requires_inline_qos);
 
   void disassociated(const RepoId& local, const RepoId& remote);
@@ -238,6 +241,8 @@ public:
   void enable_response_queue();
   void disable_response_queue();
 
+  bool requires_inline_qos(const GUIDSeq_var& peers);
+
 private:
   void on_data_available(RcHandle<InternalDataReader<NetworkInterfaceAddress> > reader);
 
@@ -256,7 +261,6 @@ private:
   friend class ::DDS_TEST;
   /// static member used by testing code to force inline qos
   static bool force_inline_qos_;
-  bool requires_inline_qos(const GUIDSeq_var & peers);
 
   ReactorTask_rch reactor_task_;
   RcHandle<JobQueue> job_queue_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -291,6 +291,17 @@ RtpsUdpInst::update_locators(const RepoId& remote_id,
 }
 
 void
+RtpsUdpInst::get_last_recv_locator(const RepoId& remote_id,
+                                   TransportLocator& locator)
+{
+  TransportImpl_rch imp = impl();
+  if (imp) {
+    RtpsUdpTransport_rch rtps_impl = static_rchandle_cast<RtpsUdpTransport>(imp);
+    rtps_impl->get_last_recv_locator(remote_id, locator);
+  }
+}
+
+void
 RtpsUdpInst::rtps_relay_address_change()
 {
   TransportImpl_rch imp = impl();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -137,6 +137,9 @@ public:
   void update_locators(const RepoId& remote_id,
                        const TransportLocatorSeq& locators);
 
+  void get_last_recv_locator(const RepoId& /*remote_id*/,
+                             TransportLocator& /*locators*/);
+
   void rtps_relay_address_change();
   void append_transport_statistics(TransportStatisticsSequence& seq);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -10,6 +10,8 @@
 #include "RtpsUdpSendStrategy.h"
 #include "RtpsUdpReceiveStrategy.h"
 
+#include <dds/OpenddsDcpsExtTypeSupportImpl.h>
+
 #include <dds/DCPS/AssociationData.h>
 #include <dds/DCPS/BuiltInTopicUtils.h>
 #include <dds/DCPS/LogAddr.h>
@@ -17,7 +19,6 @@
 #include <dds/DCPS/transport/framework/TransportClient.h>
 #include <dds/DCPS/transport/framework/TransportExceptions.h>
 #include <dds/DCPS/RTPS/BaseMessageUtils.h>
-
 #include <dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.h>
 
 #include <ace/CDR_Base.h>

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -45,6 +45,9 @@ public:
   virtual void update_locators(const RepoId& /*remote*/,
                                const TransportLocatorSeq& /*locators*/);
 
+  virtual void get_last_recv_locator(const RepoId& /*remote_id*/,
+                                     TransportLocator& /*locators*/);
+
   void rtps_relay_address_change();
   void append_transport_statistics(TransportStatisticsSequence& seq);
 
@@ -105,6 +108,7 @@ private:
   bool use_datalink(const RepoId& local_id,
                     const RepoId& remote_id,
                     const TransportBLOB& remote_data,
+                    const TransportBLOB& discovery_locator,
                     const MonotonicTime_t& participant_discovered_at,
                     ACE_CDR::ULong participant_flags,
                     bool local_reliable, bool remote_reliable,

--- a/dds/DdsDcpsInfoUtils.idl
+++ b/dds/DdsDcpsInfoUtils.idl
@@ -64,6 +64,7 @@ module OpenDDS
 
     struct WriterAssociation {
       TransportLocatorSeq writerTransInfo;
+      TransportLocator writerDiscInfo;
       unsigned long transportContext;
       RepoId writerId;
       ::DDS::PublisherQos pubQos;
@@ -74,6 +75,7 @@ module OpenDDS
 
     struct ReaderAssociation {
       TransportLocatorSeq readerTransInfo;
+      TransportLocator readerDiscInfo;
       unsigned long transportContext;
       RepoId readerId;
       ::DDS::SubscriberQos subQos;


### PR DESCRIPTION
Problem: For newly associated RTPS readers and writers, excess traffic may be generated until inbound traffic is received to determine a viable "last received" address. For readers and writers with many locators, the amount of redundant traffic can be significant.

Solution: When possible, use addresses / locators from discovery to "hint" at the last received address on association and cut down the amount of initially-generated traffic.