### PR TITLE
Protect Against Null Reactor In Spdp::SpdpTransport::on_data_available

### DIFF
--- a/dds/DCPS/MulticastManager.cpp
+++ b/dds/DCPS/MulticastManager.cpp
@@ -61,9 +61,9 @@ bool MulticastManager::process(InternalDataReader<NetworkInterfaceAddress>::Samp
           joined_interfaces_.insert(nia.name);
           any_joined = true;
 
-          if (reactor->register_handler(multicast_socket.get_handle(),
-                                        event_handler,
-                                        ACE_Event_Handler::READ_MASK) != 0) {
+          if (reactor && reactor->register_handler(multicast_socket.get_handle(),
+                                                   event_handler,
+                                                   ACE_Event_Handler::READ_MASK) != 0) {
             if (log_level >= LogLevel::Error) {
               ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: failed to register multicast input handler\n"));
             }

--- a/dds/DCPS/MulticastManager.cpp
+++ b/dds/DCPS/MulticastManager.cpp
@@ -61,11 +61,17 @@ bool MulticastManager::process(InternalDataReader<NetworkInterfaceAddress>::Samp
           joined_interfaces_.insert(nia.name);
           any_joined = true;
 
-          if (reactor && reactor->register_handler(multicast_socket.get_handle(),
+          if (reactor) {
+            if (reactor->register_handler(multicast_socket.get_handle(),
                                                    event_handler,
                                                    ACE_Event_Handler::READ_MASK) != 0) {
+              if (log_level >= LogLevel::Error) {
+                ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: failed to register multicast input handler\n"));
+              }
+            }
+          } else {
             if (log_level >= LogLevel::Error) {
-              ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: failed to register multicast input handler\n"));
+              ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: reactor is NULL\n"));
             }
           }
         } else {
@@ -93,17 +99,23 @@ bool MulticastManager::process(InternalDataReader<NetworkInterfaceAddress>::Samp
           ipv6_joined_interfaces_.insert(nia.name);
           any_joined = true;
 
-          if (reactor->register_handler(ipv6_multicast_socket.get_handle(),
-                                        event_handler,
-                                        ACE_Event_Handler::READ_MASK) != 0) {
+          if (reactor) {
+            if (reactor->register_handler(ipv6_multicast_socket.get_handle(),
+                                          event_handler,
+                                          ACE_Event_Handler::READ_MASK) != 0) {
+              if (log_level >= LogLevel::Error) {
+                ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: ipv6 failed to register multicast input handler\n"));
+              }
+            }
+          } else {
             if (log_level >= LogLevel::Error) {
-              ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: failed to register multicast input handler\n"));
+              ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: MulticastManager::process: ipv6 reactor is NULL\n"));
             }
           }
         } else {
           if (log_level >= LogLevel::Error) {
             ACE_ERROR((LM_ERROR,
-                       "(%P|%t) ERROR: MulticastManager::process: ACE_SOCK_Dgram_Mcast::join failed: %m\n"));
+                       "(%P|%t) ERROR: MulticastManager::process: ipv6 ACE_SOCK_Dgram_Mcast::join failed: %m\n"));
           }
         }
       }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3626,13 +3626,10 @@ void Spdp::SpdpTransport::on_data_available(DCPS::RcHandle<DCPS::InternalDataRea
 
   network_interface_address_reader_->take(samples, infos);
 
-  ACE_Reactor* reactor_ptr = reactor();
-  if (!reactor_ptr) return;
-
   if (multicast_manager_.process(samples,
                                  infos,
                                  multicast_interface_,
-                                 reactor_ptr,
+                                 reactor(),
                                  this,
                                  DCPS::NetworkAddress(multicast_address_),
                                  multicast_socket_

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3626,13 +3626,13 @@ void Spdp::SpdpTransport::on_data_available(DCPS::RcHandle<DCPS::InternalDataRea
 
   network_interface_address_reader_->take(samples, infos);
 
-  ACE_Reactor* reactor = reactor();
-  if (!reactor) return;
+  ACE_Reactor* reactor_ptr = reactor();
+  if (!reactor_ptr) return;
 
   if (multicast_manager_.process(samples,
                                  infos,
                                  multicast_interface_,
-                                 reactor,
+                                 reactor_ptr,
                                  this,
                                  DCPS::NetworkAddress(multicast_address_),
                                  multicast_socket_

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3626,10 +3626,13 @@ void Spdp::SpdpTransport::on_data_available(DCPS::RcHandle<DCPS::InternalDataRea
 
   network_interface_address_reader_->take(samples, infos);
 
+  ACE_Reactor* reactor = reactor();
+  if (!reactor) return;
+
   if (multicast_manager_.process(samples,
                                  infos,
                                  multicast_interface_,
-                                 reactor(),
+                                 reactor,
                                  this,
                                  DCPS::NetworkAddress(multicast_address_),
                                  multicast_socket_

--- a/dds/DCPS/ReactorTask.inl
+++ b/dds/DCPS/ReactorTask.inl
@@ -21,6 +21,7 @@ ACE_INLINE
 const ACE_Reactor* ReactorTask::get_reactor() const
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(lock_);
+  wait_for_startup_i();
   return reactor_;
 }
 


### PR DESCRIPTION
Ubuntu 18 Thrasher Test SEGV:

```
(gdb) where
#0  0x00007fb157fa6f34 in ACE_Reactor::implementation (this=0x0) at /home/tsimpson/code/OpenDDS/ACE_wrappers/ace/Reactor.inl:126
#1  0x00007fb156600980 in ACE_Reactor::register_handler (this=0x0, io_handle=46, event_handler=0x7fb130009070, mask=1) at /home/tsimpson/code/OpenDDS/ACE_wrappers/ace/Reactor.cpp:347
#2  0x00007fb157220139 in OpenDDS::DCPS::MulticastManager::process (this=0x7fb130008ca8, samples=std::vector of length 4, capacity 4 = {...}, infos=std::vector of length 4, capacity 4 = {...}, 
    multicast_interface="", reactor=0x0, event_handler=0x7fb130009070, multicast_group_address=..., multicast_socket=...) at /home/tsimpson/code/OpenDDS/dds/DCPS/MulticastManager.cpp:64
#3  0x00007fb157f9e859 in OpenDDS::RTPS::Spdp::SpdpTransport::on_data_available (this=0x7fb130008b80) at /home/tsimpson/code/OpenDDS/dds/DCPS/RTPS/Spdp.cpp:3629
#4  0x00007fb157dc5d88 in OpenDDS::DCPS::InternalDataReaderListener<OpenDDS::DCPS::NetworkInterfaceAddress>::execute (this=0x7fb1300090b8) at ../../../dds/DCPS/InternalDataReaderListener.h:104
#5  0x00007fb157dc5c0b in OpenDDS::DCPS::InternalDataReaderListener<OpenDDS::DCPS::NetworkInterfaceAddress>::Job::execute (this=0x7fb130008710) at ../../../dds/DCPS/InternalDataReaderListener.h:75
#6  0x00007fb157208943 in OpenDDS::DCPS::JobQueue::handle_exception (this=0x7fb13005a790) at /home/tsimpson/code/OpenDDS/dds/DCPS/JobQueue.cpp:35
#7  0x00007fb15660e7be in ACE_Select_Reactor_Notify::dispatch_notify (this=0x7fb130033de0, buffer=...) at /home/tsimpson/code/OpenDDS/ACE_wrappers/ace/Select_Reactor_Base.cpp:850
#8  0x00007fb15660ea4d in ACE_Select_Reactor_Notify::handle_input (this=0x7fb130033de0, handle=31) at /home/tsimpson/code/OpenDDS/ACE_wrappers/ace/Select_Reactor_Base.cpp:951
#9  0x00007fb15660e608 in ACE_Select_Reactor_Notify::dispatch_notifications (this=0x7fb130033de0, number_of_active_handles=@0x7fb1137fdb94: 0, rd_mask=...)
```