### PR TITLE
Defer ReactorInterceptor Execution If Queue Is Non-Empty

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2434,7 +2434,7 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task,
   }
 #endif
 
-  reactor(reactor_task->reactor());
+  reactor(reactor_task->get_reactor());
   reactor_task->interceptor()->execute_or_enqueue(DCPS::make_rch<RegisterHandlers>(rchandle_from(this), reactor_task));
 
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -21,7 +21,6 @@ namespace DCPS {
 
 ReactorInterceptor::Command::Command()
   : executed_(false)
-  , on_queue_(false)
   , condition_(mutex_)
   , reactor_(0)
 {}
@@ -47,49 +46,65 @@ ReactorInterceptor::~ReactorInterceptor()
 {
 }
 
-bool ReactorInterceptor::should_execute_immediately()
+ReactorInterceptor::CommandPtr ReactorInterceptor::execute_or_enqueue(CommandPtr command)
 {
-  bool is_safe_to_execute = false;
+  OPENDDS_ASSERT(command);
 
-  {
-    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
 
-    // Only allow immediate execution if running on the reactor thread, otherwise we risk deadlock
-    // when calling into the reactor object.
-    const bool is_owner = ACE_OS::thr_equal(owner_, ACE_Thread::self());
-    // If state is set to processing, the conents of command_queue_ have been swapped out
-    // so immediate execution may run jobs out of the expected order.
-    const bool is_not_processing = state_ != PROCESSING;
-    // If the command_queue_ is not empty, allowing execution will potentially run unexpected code
-    // which is problematic since we may be holding locks used by the unexpected code.
-    const bool is_empty = command_queue_.empty();
+  // Only allow immediate execution if running on the reactor thread, otherwise we risk deadlock
+  // when calling into the reactor object.
+  const bool is_owner = ACE_OS::thr_equal(owner_, ACE_Thread::self());
 
-    is_safe_to_execute = is_owner && is_not_processing && is_empty;
+  // If state is set to processing, the conents of command_queue_ have been swapped out
+  // so immediate execution may run jobs out of the expected order.
+  const bool is_not_processing = state_ != PROCESSING;
+
+  // If the command_queue_ is not empty, allowing execution will potentially run unexpected code
+  // which is problematic since we may be holding locks used by the unexpected code.
+  const bool is_empty = command_queue_.empty();
+
+  // If all three of these conditions are met, it should be safe to execute
+  const bool is_safe_to_execute = is_owner && is_not_processing && is_empty;
+
+  // Even if it's not normally safe to execute, allow immediate execution if the reactor is shut down
+  const bool immediate = is_safe_to_execute || reactor_is_shut_down();
+
+  // Always set reactor and push to the queue
+  ACE_Reactor* local_reactor = ACE_Event_Handler::reactor();
+  command->set_reactor(local_reactor);
+  command_queue_.push_back(command);
+
+  // But depending on whether we're running it immediately or not, we either process or notify
+  if (immediate) {
+    process_command_queue_i(guard);
+  } else if (state_ == NONE) {
+    state_ = NOTIFIED;
+    guard.release();
+    local_reactor->notify(this);
   }
-
-  return is_safe_to_execute || reactor_is_shut_down();
+  return command;
 }
 
 int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)
 {
   ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
 
-  process_command_queue_i();
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  process_command_queue_i(guard);
   return 0;
 }
 
-void ReactorInterceptor::process_command_queue_i()
+void ReactorInterceptor::process_command_queue_i(ACE_Guard<ACE_Thread_Mutex>& guard)
 {
   Queue cq;
   ACE_Reverse_Lock<ACE_Thread_Mutex> rev_lock(mutex_);
 
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   state_ = PROCESSING;
   if (!command_queue_.empty()) {
     cq.swap(command_queue_);
     ACE_Guard<ACE_Reverse_Lock<ACE_Thread_Mutex> > rev_guard(rev_lock);
     for (Queue::const_iterator pos = cq.begin(), limit = cq.end(); pos != limit; ++pos) {
-      (*pos)->dequeue();
       (*pos)->execute();
       (*pos)->executed();
     }

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -49,8 +49,15 @@ ReactorInterceptor::~ReactorInterceptor()
 
 bool ReactorInterceptor::should_execute_immediately()
 {
-  return ACE_OS::thr_equal(owner_, ACE_Thread::self()) ||
-    reactor_is_shut_down();
+  bool is_owner_and_empty = false;
+
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    const bool is_owner = ACE_OS::thr_equal(owner_, ACE_Thread::self());
+    is_owner_and_empty = is_owner && command_queue_.empty();
+  }
+
+  return is_owner_and_empty || reactor_is_shut_down();
 }
 
 int ReactorInterceptor::handle_exception(ACE_HANDLE /*fd*/)

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -242,6 +242,16 @@ void ReactorTask::stop()
   }
 }
 
+void ReactorTask::reactor(ACE_Reactor* reactor)
+{
+  ACE_Event_Handler::reactor(reactor);
+}
+
+ACE_Reactor* ReactorTask::reactor() const
+{
+  return ACE_Event_Handler::reactor();
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/ReactorTask.h
+++ b/dds/DCPS/ReactorTask.h
@@ -69,6 +69,9 @@ public:
 
 private:
 
+  virtual void reactor(ACE_Reactor* reactor);
+  virtual ACE_Reactor* reactor() const;
+
   void cleanup();
   void wait_for_startup_i() const;
 


### PR DESCRIPTION
Problem: ReactorInterceptor::execute_or_enqueue may currently wind up executing "unplanned" code if commands already exist in the command queue. As a result, any code that may even have a remote chance of calling execute_or_enqueue needs to release all held mutexes, or else the "unplanned" code may double-lock a held mutex.

Solution: Since this isn't really practical, one simple solution is to dis-allow "immediate" execution by the reactor thread when commands already exist in the command queue. This prevents running "unknown" code in-situ, and so hopefully the calling context knows enough about what will get called in order to release all mutexes which might cause deadlock.