### PR TITLE
Remove show_build_config.pl from GHA Job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -446,12 +446,6 @@ jobs:
       run: |
         cd OpenDDS
         tar xvfJ build_u18_o1d0v1_xer0_j12.tar.xz
-    - name: check build configuration
-      shell: bash
-      run: |
-        cd OpenDDS
-        . setenv.sh
-        tools/scripts/show_build_config.pl
     - name: test make install messenger
       shell: bash
       run: |


### PR DESCRIPTION
After https://github.com/objectcomputing/OpenDDS/pull/3392 the script
can fail if it can't show some files. Removing it here because it wasn't
designed to work with installations.