### PR TITLE
GitHub Actions: default.features needed in ACE_TAO_u18_stat_qt_ws_sec

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4587,7 +4587,6 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
         find . -iname "*\.o" | xargs rm
         tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
         git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4558,7 +4558,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ github.job }}.tar.xz
-        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c02_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev


### PR DESCRIPTION
OpenDDS's configure when given an already-configured ACE+TAO will not
edit the default.features.  We need default.features to have the expected
features in order to generate makefiles for specific tests later on.

This means that the generated ACE_TAO artifact is biased for how we're
going to use it in OpenDDS, but it's only used once so this should be fine.