### PR TITLE
DataReaderImpl allocator is not thread safe

### DIFF
--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -72,7 +72,7 @@ class Monitor;
 class DataReaderImpl;
 class FilterEvaluator;
 
-typedef Cached_Allocator_With_Overflow<ReceivedDataElementMemoryBlock, ACE_Null_Mutex>
+typedef Cached_Allocator_With_Overflow<ReceivedDataElementMemoryBlock, ACE_Thread_Mutex>
 ReceivedDataAllocator;
 
 enum MarshalingType {


### PR DESCRIPTION
Problem
-------

Allocations from rd_allocator_ in DataReaderImpl_T are synchronized on
the sample_lock_. However, not all deallocations are synchronized. For
example, taking samples will place the samples in a sequence and
destroying the sequence may cause a deallocation.

Solution
--------

Use a mutex in the relevant part of the allocator.

Note
----

This was the desired fix for #3335.