### PR TITLE
OpenSSL 3: portability, warnings, style

### DIFF
--- a/dds/DCPS/security/SSL/Certificate.cpp
+++ b/dds/DCPS/security/SSL/Certificate.cpp
@@ -398,7 +398,7 @@ struct cache_dsign_algo_impl
       return 0;
     }
 #else
-    int ptype = EVP_PKEY_id (pkey_);
+    const int ptype = EVP_PKEY_id (pkey_);
     if (ptype == EVP_PKEY_RSA || ptype == EVP_PKEY_RSA_PSS) {
       dst = "RSASSA-PSS-SHA256";
       return 0;

--- a/dds/DCPS/security/SSL/PrivateKey.cpp
+++ b/dds/DCPS/security/SSL/PrivateKey.cpp
@@ -232,9 +232,9 @@ bool operator==(const PrivateKey& lhs, const PrivateKey& rhs)
 {
   if (lhs.k_ && rhs.k_) {
 #ifdef OPENSSL_V_3_0
-    return (1 == EVP_PKEY_eq(lhs.k_, rhs.k_));
+    return 1 == EVP_PKEY_eq(lhs.k_, rhs.k_);
 #else
-    return (1 == EVP_PKEY_cmp(lhs.k_, rhs.k_));
+    return 1 == EVP_PKEY_cmp(lhs.k_, rhs.k_);
 #endif
   }
   return lhs.k_ == rhs.k_;


### PR DESCRIPTION
Most important is that strcasecmp is not in std C or C++, so we need ACE
Other than that I tried to clean up some style/warnings kind of things

We could also consider if case-insensitive is really required here, but
I didn't take the time to research it