### PR TITLE
Add Inspect Tool README

### DIFF
--- a/tools/inspect/README
+++ b/tools/inspect/README
@@ -1,6 +1,6 @@
-The inspect tool is a way to monitor traffic occuring on a given topic, typename and domain when 
-using OpenDDS XTypes. It creates a recorder that will associate with any compatible discovered
-readers. Any message received by the recorder will be printed to cout.
+The inspect tool is a way to monitor samples from OpenDDS XTypes writers with a matching topic,
+typename and domain. It creates a recorder that will associate with any compatible discovered
+readers. Any sample received by the recorder will be printed to cout.
 
 Positional Arguments:
   TOPIC_NAME              The name of the topic to listen for.

--- a/tools/inspect/README
+++ b/tools/inspect/README
@@ -1,0 +1,5 @@
+Run inspect with --help for additional usage information.
+
+The inspect tool is a way to monitor traffic occuring on a given topic, typename and domain.
+It creates a recorder that will associate with any compatible discovered readers. Any message
+received by the recorder will be printed to cout.

--- a/tools/inspect/README
+++ b/tools/inspect/README
@@ -1,5 +1,19 @@
-Run inspect with --help for additional usage information.
+The inspect tool is a way to monitor traffic occuring on a given topic, typename and domain when 
+using OpenDDS XTypes. It creates a recorder that will associate with any compatible discovered
+readers. Any message received by the recorder will be printed to cout.
 
-The inspect tool is a way to monitor traffic occuring on a given topic, typename and domain.
-It creates a recorder that will associate with any compatible discovered readers. Any message
-received by the recorder will be printed to cout.
+Positional Arguments:
+  TOPIC_NAME              The name of the topic to listen for.
+  TYPE_NAME               The full name (including any modules) of the topic
+                          type.
+  DOMAIN_ID               The DDS Domain to participant in.
+
+Options
+  -h | --help             Displays this message.
+  -w | --writer-count     Print number of associated writers when they change.
+                          Default is not to.
+  --samples COUNT         Wait for at least this number of samples and exit.
+                          May actually print more. Default is to print samples
+                          forever.
+  --time SECONDS          Print samples for an ammount of seconds and exit.
+                          Default to print samples forever.


### PR DESCRIPTION
The inspect tool was lacking a readme. I added on with the intent of quickly communicating the point of the tool, as well as provide usage instructions.