### PR TITLE
Json parsing requires "end of document"

### DIFF
--- a/dds/DCPS/JsonValueReader.h
+++ b/dds/DCPS/JsonValueReader.h
@@ -140,7 +140,7 @@ private:
       return token_type_;
     }
 
-    if (!reader_.IterativeParseNext<rapidjson::kParseDefaultFlags>(input_stream_, *this)) {
+    if (!reader_.IterativeParseNext<rapidjson::kParseStopWhenDoneFlag>(input_stream_, *this)) {
       token_type_ = kError;
     }
 


### PR DESCRIPTION
Problem
-------

JsonValueReader can be used to load data.  The format of such an input
file should be a sequence of JSON Objects.  Currently, this doesn't
parse correctly as rapidjson expects there to be exactly one object in
the stream.

Solution
--------

Update the parse flags to stop after one object and not check for end
of document.