### PR TITLE
Fix 2 Anon. `sequence<string>` in the same `struct`

### DIFF
--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -385,7 +385,7 @@ namespace AstTypeClassification {
 
   inline Classification classify(AST_Type* type)
   {
-    type = AstTypeClassification::resolveActualType(type);
+    type = resolveActualType(type);
     switch (type->node_type()) {
     case AST_Decl::NT_pre_defined: {
       AST_PredefinedType* p = dynamic_cast<AST_PredefinedType*>(type);
@@ -1179,6 +1179,34 @@ ACE_CDR::ULong array_element_count(AST_Array* arr)
     count *= arr->dims()[i]->ev()->u.ulval;
   }
   return count;
+}
+
+inline
+ACE_CDR::ULong container_element_limit(AST_Type* type)
+{
+  AST_Type* const act = AstTypeClassification::resolveActualType(type);
+  AST_Sequence* const seq = dynamic_cast<AST_Sequence*>(act);
+  AST_Array* const arr = dynamic_cast<AST_Array*>(act);
+  if (seq && !seq->unbounded()) {
+    return seq->max_size()->ev()->u.ulval;
+  } else if (arr) {
+    return array_element_count(arr);
+  }
+  return 0;
+}
+
+inline
+AST_Type* container_base_type(AST_Type* type)
+{
+  AST_Type* const act = AstTypeClassification::resolveActualType(type);
+  AST_Sequence* const seq = dynamic_cast<AST_Sequence*>(act);
+  AST_Array* const arr = dynamic_cast<AST_Array*>(act);
+  if (seq) {
+    return seq->base_type();
+  } else if (arr) {
+    return arr->base_type();
+  }
+  return 0;
 }
 
 #endif

--- a/dds/idl/field_info.cpp
+++ b/dds/idl/field_info.cpp
@@ -8,28 +8,41 @@
 #include "field_info.h"
 
 #include <sstream>
+#include <cstring>
 
 using namespace AstTypeClassification;
 
-FieldInfo::EleLen::EleLen(const FieldInfo& af)
-  : cls_(af.cls_)
-  , len_(af.n_elems_)
+FieldInfo::EleLen::EleLen(AST_Type* type)
+  : cls_(classify(type))
+  , len_(container_element_limit(type))
 {
-  AST_Type* const base = resolveActualType(af.as_base_);
-  base_cls_ = classify(base);
+  AST_Type* const base = resolveActualType(container_base_type(type));
+  const Classification base_cls = classify(base);
+  base_cls_ = base_cls;
   base_name_ = base->full_name();
+  if (base_cls & (CL_ARRAY | CL_SEQUENCE)) {
+    base_container_ = Container(new EleLen(base));
+  }
 }
 
 bool FieldInfo::EleLen::operator<(const EleLen& o) const
 {
-  if (cls_ == o.cls_) {
-    if (base_cls_ == o.base_cls_) {
-      const int compared = base_name_.compare(o.base_name_);
-      return compared < 0 || (compared == 0 && len_ < o.len_);
-    }
+  if (cls_ != o.cls_) {
+    return cls_ < o.cls_;
+  }
+  if (len_ != o.len_) {
+    return len_ < o.len_;
+  }
+  if (bool(base_container_.get()) != bool(o.base_container_.get())) {
+    return bool(base_container_.get()) < bool(o.base_container_.get());
+  }
+  if (base_container_.get()) {
+    return *base_container_ < *o.base_container_;
+  }
+  if (base_cls_ != o.base_cls_) {
     return base_cls_ < o.base_cls_;
   }
-  return cls_ < o.cls_;
+  return std::strcmp(base_name_, o.base_name_) < 0;
 }
 
 const std::string FieldInfo::scope_op = "::";
@@ -82,25 +95,21 @@ FieldInfo::FieldInfo(AST_Field& field)
   , cls_(classify(act_))
   , arr_(dynamic_cast<AST_Array*>(type_))
   , seq_(dynamic_cast<AST_Sequence*>(type_))
-  , as_base_(arr_ ? arr_->base_type() : (seq_ ? seq_->base_type() : 0))
+  , as_base_(container_base_type(type_))
   , as_act_(as_base_ ? resolveActualType(as_base_) : 0)
   , as_cls_(as_act_ ? classify(as_act_) : CL_UNKNOWN)
   , scoped_elem_(as_base_ ? scoped(as_base_->name()) : "")
   , underscored_elem_(as_base_ ? underscore(scoped_elem_) : "")
   , elem_ref_(as_base_ ? ref(scoped_elem_, "") : "")
   , elem_const_ref_(as_base_ ? ref(scoped_elem_) : "")
+  , n_elems_(container_element_limit(type_))
 {
-  n_elems_ = 1;
   if (arr_) {
-    for (size_t i = 0; i < arr_->n_dims(); ++i) {
-      n_elems_ *= arr_->dims()[i]->ev()->u.ulval;
-    }
     std::ostringstream os;
     os << n_elems_;
     length_ = os.str();
     arg_ = "arr";
   } else if (seq_) {
-    n_elems_ = !seq_->unbounded() ? seq_->max_size()->ev()->u.ulval : 0;
     length_ = "length";
     arg_ = "seq";
   }
@@ -122,7 +131,7 @@ FieldInfo::FieldInfo(AST_Field& field)
 
 bool FieldInfo::is_new(EleLenSet& el_set) const
 {
-  return cxx11() || el_set.insert(EleLen(*this)).second;
+  return cxx11() || el_set.insert(EleLen(type_)).second;
 }
 
 bool FieldInfo::anonymous() const

--- a/dds/idl/field_info.cpp
+++ b/dds/idl/field_info.cpp
@@ -12,14 +12,24 @@
 using namespace AstTypeClassification;
 
 FieldInfo::EleLen::EleLen(const FieldInfo& af)
-  : ele_(af.as_base_)
+  : cls_(af.cls_)
   , len_(af.n_elems_)
 {
+  AST_Type* const base = resolveActualType(af.as_base_);
+  base_cls_ = classify(base);
+  base_name_ = base->full_name();
 }
 
 bool FieldInfo::EleLen::operator<(const EleLen& o) const
 {
-  return ele_ < o.ele_ || (ele_ == o.ele_ && len_ < o.len_);
+  if (cls_ == o.cls_) {
+    if (base_cls_ == o.base_cls_) {
+      const int compared = base_name_.compare(o.base_name_);
+      return compared < 0 || (compared == 0 && len_ < o.len_);
+    }
+    return base_cls_ < o.base_cls_;
+  }
+  return cls_ < o.cls_;
 }
 
 const std::string FieldInfo::scope_op = "::";

--- a/dds/idl/field_info.h
+++ b/dds/idl/field_info.h
@@ -17,7 +17,9 @@
 
 struct FieldInfo {
   struct EleLen {
-    AST_Type* ele_;
+    AstTypeClassification::Classification cls_;
+    AstTypeClassification::Classification base_cls_;
+    std::string base_name_;
     std::size_t len_;
     explicit EleLen(const FieldInfo& af);
     bool operator<(const EleLen& o) const;

--- a/dds/idl/field_info.h
+++ b/dds/idl/field_info.h
@@ -13,15 +13,19 @@
 #include <utl_scoped_name.h>
 #include <ast.h>
 
+#include <ace/Bound_Ptr.h>
+
 #include <string>
 
 struct FieldInfo {
   struct EleLen {
     AstTypeClassification::Classification cls_;
+    const char* base_name_;
     AstTypeClassification::Classification base_cls_;
-    std::string base_name_;
+    typedef ACE_Strong_Bound_Ptr<const EleLen, ACE_Null_Mutex> Container;
+    Container base_container_;
     std::size_t len_;
-    explicit EleLen(const FieldInfo& af);
+    explicit EleLen(AST_Type* type);
     bool operator<(const EleLen& o) const;
   };
   typedef std::set<EleLen> EleLenSet;

--- a/tests/DCPS/Compiler/anonymous_types/test.idl
+++ b/tests/DCPS/Compiler/anonymous_types/test.idl
@@ -60,6 +60,9 @@ struct TopicA {
   BoundedString bstr;
   string<20> bstr20;
   sequence<string> strs;
+  sequence<string> strs_2nd;
+  string str_arr[4];
+  string str_arr_2nd[4];
   //sequence<string<30>> str30s;
   sequence<BoundedString> bstrs;
 


### PR DESCRIPTION
Defining two anonymous `sequence<string>` members in the same struct causes a redefinition compile error in the type support. This happens because the anonymous type code relies on the pointer to the `AST_Decl` of the base type to tell if the type has already been used. The problem with that is apparently there can be multiple objects for string types.

This replaces the pointer with the classification of the container type and the classification and name of the base type.