### PR TITLE
Update NEWS, Reverse missing-news-prs.py Output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,8 +27,10 @@ OpenDDS 3.20.0 is currently in development, so this list might change.
 - Updated the RapidJSON submodule (#3284)
 
 ### Fixes:
+- Fixed issue preventing 2 `sequence<string>` anonymous types in the same struct (#3415)
 - Fixed issues with entity association when using the multicast transport (#3377)
 - Fixed issue #3268, a segfault in `opendds_idl` (#3374)
+- Fixed thread safety of `DataReaderImpl_T`'s allocator (#3335, #3403)
 - Improvements to how data representation is handled (#3233)
 - Fixed instance lifetime issue with `assert_liveliness` (#3241)
 - RTPS:

--- a/tools/scripts/release_notes/missing-news-prs.py
+++ b/tools/scripts/release_notes/missing-news-prs.py
@@ -38,7 +38,7 @@ with open(sys.argv[1]) as f:
             prs.append((m.group(1), row[2], row[8]))
 
 # Print Missing PRs
-for pr in reversed(prs):
+for pr in prs:
     num = pr[0]
     if num not in news_prs:
         what = pr[1]


### PR DESCRIPTION
- One NEWS item is new and another one appears to be missing.
- Reversed missing-news-prs.py output as it appears to be going from
  newest to oldest, when it should probably be the other way around.
  Current order isn't going to be changed, as this isn't a big deal.