### PR TITLE
New NetworkConfigModifier interface breaks existing clients

### DIFF
--- a/dds/DCPS/DefaultNetworkConfigMonitor.h
+++ b/dds/DCPS/DefaultNetworkConfigMonitor.h
@@ -24,16 +24,16 @@ public:
   {
     const NetworkAddress sp_default = TheServiceParticipant->default_address();
     if (sp_default != NetworkAddress()) {
-      set(NetworkInterfaceAddress(0, "", true, sp_default));
+      set(NetworkInterfaceAddress("", true, sp_default));
       return true;
     }
 
     static const u_short port_zero = 0;
     ACE_INET_Addr addr(port_zero, "0.0.0.0");
-    set(NetworkInterfaceAddress(0, "", true, NetworkAddress(addr)));
+    set(NetworkInterfaceAddress("", true, NetworkAddress(addr)));
 #ifdef ACE_HAS_IPV6
     ACE_INET_Addr addr2(port_zero, "::");
-    set(NetworkInterfaceAddress(0, "", true, NetworkAddress(addr2)));
+    set(NetworkInterfaceAddress("", true, NetworkAddress(addr2)));
 #endif
 
     return true;

--- a/dds/DCPS/NetworkConfigModifier.cpp
+++ b/dds/DCPS/NetworkConfigModifier.cpp
@@ -76,7 +76,7 @@ void NetworkConfigModifier::update_interfaces()
         ACE_INET_Addr address;
         address.set((u_short) 0, addr->sin_addr.s_addr, 0);
 
-        nia_list.push_back(NetworkInterfaceAddress(ACE_OS::if_nametoindex(p_if->ifa_name), p_if->ifa_name, p_if->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK), NetworkAddress(address)));
+        nia_list.push_back(NetworkInterfaceAddress(p_if->ifa_name, p_if->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK), NetworkAddress(address)));
       }
     }
 # if defined (ACE_HAS_IPV6)
@@ -97,6 +97,28 @@ void NetworkConfigModifier::update_interfaces()
   ::freeifaddrs (p_ifa);
 
   NetworkConfigMonitor::set(nia_list);
+}
+
+void NetworkConfigModifier::add_interface(const OPENDDS_STRING&)
+{
+  // This is a no-op.
+}
+
+void NetworkConfigModifier::remove_interface(const OPENDDS_STRING& name)
+{
+  NetworkConfigMonitor::remove_interface(name);
+}
+
+void NetworkConfigModifier::add_address(const OPENDDS_STRING& name,
+                                        bool can_multicast,
+                                        const ACE_INET_Addr& addr)
+{
+  NetworkConfigMonitor::set(NetworkInterfaceAddress(name, can_multicast, NetworkAddress(addr)));
+}
+
+void NetworkConfigModifier::remove_address(const OPENDDS_STRING& name, const ACE_INET_Addr& addr)
+{
+  NetworkConfigMonitor::remove_address(name, NetworkAddress(addr));
 }
 
 } // DCPS

--- a/dds/DCPS/NetworkConfigModifier.h
+++ b/dds/DCPS/NetworkConfigModifier.h
@@ -28,6 +28,13 @@ public:
   bool open();
   bool close();
   void update_interfaces();
+
+  void add_interface(const OPENDDS_STRING& name);
+  void remove_interface(const OPENDDS_STRING& name);
+  void add_address(const OPENDDS_STRING& name,
+                   bool can_multicast,
+                   const ACE_INET_Addr& addr);
+  void remove_address(const OPENDDS_STRING& name, const ACE_INET_Addr& addr);
 };
 typedef RcHandle<NetworkConfigModifier> NetworkConfigModifier_rch;
 

--- a/dds/DCPS/NetworkConfigMonitor.cpp
+++ b/dds/DCPS/NetworkConfigMonitor.cpp
@@ -105,40 +105,12 @@ void NetworkConfigMonitor::set(const NetworkInterfaceAddress& nia)
   }
 }
 
-void NetworkConfigMonitor::remove_interface(int index)
-{
-  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
-
-  for (List::iterator pos = list_.begin(), limit = list_.end(); pos != limit;) {
-    if (pos->index == index) {
-      writer_->dispose(*pos);
-      list_.erase(pos++);
-    } else {
-      ++pos;
-    }
-  }
-}
-
 void NetworkConfigMonitor::remove_interface(const OPENDDS_STRING& name)
 {
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
   for (List::iterator pos = list_.begin(), limit = list_.end(); pos != limit;) {
     if (pos->name == name) {
-      writer_->dispose(*pos);
-      list_.erase(pos++);
-    } else {
-      ++pos;
-    }
-  }
-}
-
-void NetworkConfigMonitor::remove_address(int index, const NetworkAddress& address)
-{
-  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
-
-  for (List::iterator pos = list_.begin(), limit = list_.end(); pos != limit;) {
-    if (pos->index == index && pos->address == address) {
       writer_->dispose(*pos);
       list_.erase(pos++);
     } else {

--- a/dds/DCPS/NetworkConfigMonitor.h
+++ b/dds/DCPS/NetworkConfigMonitor.h
@@ -22,15 +22,12 @@ namespace DCPS {
 
 struct OpenDDS_Dcps_Export NetworkInterfaceAddress {
   NetworkInterfaceAddress()
-    : index(-1)
-    , can_multicast(false)
+    : can_multicast(false)
   {}
-  NetworkInterfaceAddress(int a_index,
-                          const OPENDDS_STRING& a_name,
+  NetworkInterfaceAddress(const OPENDDS_STRING& a_name,
                           bool a_can_multicast,
                           const NetworkAddress& a_address)
-    : index(a_index)
-    , name(a_name)
+    : name(a_name)
     , can_multicast(a_can_multicast)
     , address(a_address)
   {}
@@ -41,8 +38,7 @@ struct OpenDDS_Dcps_Export NetworkInterfaceAddress {
 
   bool operator==(const NetworkInterfaceAddress& other) const
   {
-    return index == other.index &&
-      name == other.name &&
+    return name == other.name &&
       can_multicast == other.can_multicast &&
       address == other.address;
   }
@@ -61,32 +57,9 @@ struct OpenDDS_Dcps_Export NetworkInterfaceAddress {
     return address < other.address;
   }
 
-  int index;
   OPENDDS_STRING name;
   bool can_multicast;
   NetworkAddress address;
-};
-
-struct NetworkInterfaceIndex {
-  explicit NetworkInterfaceIndex(int index) : index_(index) {}
-
-  bool operator()(const NetworkInterfaceAddress& nic) const
-  {
-    return index_ == nic.index;
-  }
-
-  const int index_;
-};
-
-struct NetworkInterfaceName {
-  explicit NetworkInterfaceName(const OPENDDS_STRING& name) : name_(name) {}
-
-  bool operator()(const NetworkInterfaceAddress& nic)
-  {
-    return name_ == nic.name;
-  }
-
-  const OPENDDS_STRING name_;
 };
 
 struct NetworkInterfaceAddressKeyEqual {
@@ -118,9 +91,7 @@ public:
   void clear();
 
   void set(const NetworkInterfaceAddress& nia);
-  void remove_interface(int index);
   void remove_interface(const OPENDDS_STRING& name);
-  void remove_address(int index, const NetworkAddress& address);
   void remove_address(const OPENDDS_STRING& name, const NetworkAddress& address);
 
 private:


### PR DESCRIPTION
Problem
-------

Recent changes to the NetworkConfigModifier break existing clients.

Solution
--------

Restore the old interface as much as possible.  The only remaining
incompatibility is that `add_address` now takes a flag indicating if
the interface can multicast.

Notes
-----

The `index` member of NetworkInterfaceAddress was removed.
Implementations must use names.