### PR TITLE
Lock SPDP During Shutdown Checks To Avoid NULL Transport SEGV in process_participant_ice()

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1080,7 +1080,10 @@ Spdp::data_received(const DataSubmessage& data,
   const bool relay_in_use = (config_->rtps_relay_only() || config_->use_rtps_relay());
   const bool from_relay = relay_in_use && (from == config_->spdp_rtps_relay_address());
 
-  if (config_->check_source_ip() && msg_id == DCPS::SAMPLE_DATA && !from_relay && !ip_in_locator_list(from, pdata.participantProxy.metatrafficUnicastLocatorList)) {
+  const bool check_source_ip = config_->check_source_ip();
+  guard.release();
+
+  if (check_source_ip && msg_id == DCPS::SAMPLE_DATA && !from_relay && !ip_in_locator_list(from, pdata.participantProxy.metatrafficUnicastLocatorList)) {
     if (DCPS::DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) Spdp::data_received - IP not in locator list: %C\n"), DCPS::LogAddr(from).c_str()));
     }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1089,6 +1089,8 @@ Spdp::data_received(const DataSubmessage& data,
     }
     return;
   }
+#else
+  guard.release();
 #endif
 
   handle_participant_data(msg_id, pdata, to_opendds_seqnum(data.writerSN), from, false);


### PR DESCRIPTION
Problem: Shutdown is clearing the `tport_` member of spdp in the middle of process_participant_ice() because we're not guaranteeing mutual exclusion during / after checking shutdown flags.

Solution: Don't do that. Lock to check, and recheck when we release / reacquire the lock.