### PR TITLE
Modify SPDP Sequence Reset Counting To Track Max SN

### DIFF
--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -253,7 +253,7 @@ struct DiscoveredParticipant {
     : pdata_(p)
     , location_ih_(DDS::HANDLE_NIL)
     , bit_ih_(DDS::HANDLE_NIL)
-    , last_seq_(seq)
+    , max_seq_(seq)
     , seq_reset_count_(0)
 #ifdef OPENDDS_SECURITY
     , have_spdp_info_(false)
@@ -319,7 +319,7 @@ struct DiscoveredParticipant {
   MonotonicTimePoint discovered_at_;
   MonotonicTimePoint lease_expiration_;
   DDS::InstanceHandle_t bit_ih_;
-  SequenceNumber last_seq_;
+  SequenceNumber max_seq_;
   ACE_UINT16 seq_reset_count_;
   typedef OPENDDS_LIST(BuiltinAssociationRecord) BuiltinAssociationRecords;
   BuiltinAssociationRecords builtin_pending_records_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -1001,10 +1001,11 @@ Spdp::handle_participant_data(DCPS::MessageId id,
 bool
 Spdp::validateSequenceNumber(const DCPS::MonotonicTimePoint& now, const DCPS::SequenceNumber& seq, DiscoveredParticipantIter& iter)
 {
-  if (seq.getValue() != 0 && iter->second.last_seq_ != DCPS::SequenceNumber::MAX_VALUE) {
-    if (seq < iter->second.last_seq_) {
+  if (seq.getValue() != 0 && iter->second.max_seq_ != DCPS::SequenceNumber::MAX_VALUE) {
+    if (seq < iter->second.max_seq_) {
       const bool honeymoon_period = now < iter->second.discovered_at_ + config_->min_resend_delay();
       if (!honeymoon_period) {
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) Spdp::validateSequenceNumber() - %C sees %C seq %q and max_seq_ was %q\n", DCPS::LogGuid(guid_).c_str(), DCPS::LogGuid(iter->first).c_str(), seq.getValue(), iter->second.max_seq_.getValue()));
         ++iter->second.seq_reset_count_;
       }
       return false;
@@ -1012,7 +1013,7 @@ Spdp::validateSequenceNumber(const DCPS::MonotonicTimePoint& now, const DCPS::Se
       --iter->second.seq_reset_count_;
     }
   }
-  iter->second.last_seq_ = seq;
+  iter->second.max_seq_ = std::max(iter->second.max_seq_, seq);
   return true;
 }
 

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -837,7 +837,7 @@ private:
     MonotonicTimePoint discovered_at_;
     MonotonicTimePoint lease_expiration_;
     DDS::InstanceHandle_t bit_ih_;
-    SequenceNumber last_seq_;
+    SequenceNumber max_seq_;
     ACE_UINT16 seq_reset_count_;
   };
 


### PR DESCRIPTION
Problem: For local RTPS discovery using both ipv4 and ipv6, participant announcements received on different sockets may be processed slightly offset from one another. This causes troubles with the sequence counting reset method, since the sequence number is only ever compared to the last sequence number received and so it can bounce up and down.

Solution: Since we're considering these sequence counts to reset the whole discovered participant, only compare against the maximum sequence number received from that participant.