### PR TITLE
Windows Thrasher Test Cleanup

### DIFF
--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -92,10 +92,12 @@ Publisher::Publisher(const long domain_id, std::size_t samples_per_thread, bool 
 
 int Publisher::publish()
 {
+  OpenDDS::DCPS::DataWriterImpl* p = dynamic_cast<OpenDDS::DCPS::DataWriterImpl*>(writer_.in());
+  OPENDDS_ASSERT(p);
   if (!durable_) {
-    ACE_DEBUG((LM_INFO, (pfx_ + "->wait_match() before write\n").c_str()));
+    ACE_DEBUG((LM_INFO, (pfx_ + "->wait_match() before write for %C\n").c_str(), OpenDDS::DCPS::LogGuid(p->get_repo_id()).c_str()));
     Utils::wait_match(dw_, 1);
-    ACE_DEBUG((LM_INFO, (pfx_ + "<-match found! before write\n").c_str()));
+    ACE_DEBUG((LM_INFO, (pfx_ + "<-match found! before write for %C\n").c_str(), OpenDDS::DCPS::LogGuid(p->get_repo_id()).c_str()));
   }
 
   // Intentionally inefficient to stress various pathways related to publication:
@@ -116,9 +118,9 @@ int Publisher::publish()
   }
 
   if (durable_) {
-    ACE_DEBUG((LM_INFO, (pfx_ + "->wait_match()\n").c_str()));
+    ACE_DEBUG((LM_INFO, (pfx_ + "->wait_match() before write for %C\n").c_str(), OpenDDS::DCPS::LogGuid(p->get_repo_id()).c_str()));
     Utils::wait_match(dw_, 1);
-    ACE_DEBUG((LM_INFO, (pfx_ + "<-match found!\n").c_str()));
+    ACE_DEBUG((LM_INFO, (pfx_ + "<-match found! before write for %C\n").c_str(), OpenDDS::DCPS::LogGuid(p->get_repo_id()).c_str()));
   }
 
   DDS::Duration_t interval = {300, 0};

--- a/tests/DCPS/Thrasher/thrasher_rtps.ini
+++ b/tests/DCPS/Thrasher/thrasher_rtps.ini
@@ -8,6 +8,7 @@ DiscoveryConfig=uni_rtps
 [rtps_discovery/uni_rtps]
 SedpMulticast=0
 ResendPeriod=2
+SedpPassiveConnectDuration=600000
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp


### PR DESCRIPTION
Problem: On windows, for the very large Thrasher tests, SEDP connections are failing due the pending association timeout (60 seconds).

Solution: Increase SedpPassiveConnectDuration for RTPS Thrasher tests.