### PR TITLE
More Thrasher Cleanup, CI Coverage Expansion

### DIFF
--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -9,7 +9,11 @@ DataReaderListenerImpl::DataReaderListenerImpl(const std::size_t expected_sample
 #else
   , condition_(mutex_)
 #endif
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+  , expected_samples_(1)
+#else
   , expected_samples_(expected_samples)
+#endif
   , received_samples_(0)
   , task_samples_map_()
   , progress_(progress_fmt, expected_samples_)

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -2,21 +2,26 @@
 #include "FooTypeTypeSupportC.h"
 #include <dds/DCPS/Service_Participant.h>
 
-DataReaderListenerImpl::DataReaderListenerImpl(const std::size_t expected_samples, const char* progress_fmt)
+DataReaderListenerImpl::DataReaderListenerImpl(size_t publisher_count, size_t samples_per_publisher, const char* progress_fmt)
   : mutex_()
 #ifdef ACE_HAS_CPP11
   , condition_()
 #else
   , condition_(mutex_)
 #endif
+  , publisher_count_(publisher_count)
+  , samples_per_publisher_(samples_per_publisher)
+  , maximum_possible_samples_(publisher_count_ * samples_per_publisher_)
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
-  , expected_samples_(1)
+  , expected_total_samples_(maximum_possible_samples_)
+  , expected_samples_per_publisher_(samples_per_publisher_)
 #else
-  , expected_samples_(expected_samples)
+  , expected_total_samples_(publisher_count_)
+  , expected_samples_per_publisher_(1)
 #endif
-  , received_samples_(0)
-  , task_samples_map_()
-  , progress_(progress_fmt, expected_samples_)
+  , received_total_samples_(0)
+  , received_samples_map_()
+  , progress_(progress_fmt, maximum_possible_samples_)
 {}
 
 DataReaderListenerImpl::~DataReaderListenerImpl()
@@ -25,8 +30,8 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 void DataReaderListenerImpl::wait_received() const
 {
   Lock lock(mutex_);
-  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub wait_received %d:%d\n"), received_samples_, expected_samples_));
-  while (received_samples_ < expected_samples_) {
+  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub wait_received %d:%d\n"), received_total_samples_, expected_total_samples_));
+  while (!received_all()) {
 #ifdef ACE_HAS_CPP11
     condition_.wait(lock);
 #else
@@ -37,28 +42,40 @@ void DataReaderListenerImpl::wait_received() const
   }
 }
 
-int DataReaderListenerImpl::check_received(const size_t n_publishers) const
+int DataReaderListenerImpl::check_received() const
 {
+  Lock lock(mutex_);
   ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub check_received\n")));
   int ret = 0;
-  const size_t samples_per_publisher = expected_samples_ / n_publishers;
-  for (size_t p = 0; p < n_publishers; ++p) {
-    TaskSamplesMap::const_iterator i = task_samples_map_.find(p);
-    if (i != task_samples_map_.end()) {
-      for (size_t s = 0; s < samples_per_publisher; ++s) {
+  for (size_t p = 0; p < publisher_count_; ++p) {
+    ReceivedSamplesMap::const_iterator i = received_samples_map_.find(p);
+    if (i != received_samples_map_.end()) {
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+      for (size_t s = 0; s < expected_samples_per_publisher_; ++s) {
         if (i->second.count(s) == 0) {
           ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing pub%d sample%d\n"), p, s));
           ++ret;
         }
       }
+#else
+      if (i->second.size() == 0) {
+        // Theoretically this should never happen, since the only reason to have a map entry is receiving a sample
+        ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing any sample from pub%d\n"), p));
+        ++ret;
+      }
+#endif
     } else {
       ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing pub%d samples\n"), p));
       ++ret;
     }
   }
-  if (received_samples_ != expected_samples_) {
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+  if (received_total_samples_ != expected_total_samples_) {
+#else
+  if (received_total_samples_ < expected_total_samples_) {
+#endif
     ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: sub received %d of expected %d samples.\n"),
-      received_samples_, expected_samples_));
+      received_total_samples_, expected_total_samples_));
     ++ret;
   }
   ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub check_received returns %d\n"), ret));
@@ -79,7 +96,8 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
   DDS::SampleInfo si;
   while (reader_i->take_next_sample(foo, si) == DDS::RETCODE_OK) {
     if (si.valid_data) {
-      if (received_all((size_t) foo.x, (size_t) foo.y)) {
+      Lock lock(mutex_);
+      if (update_and_check(static_cast<size_t>(foo.x), static_cast<size_t>(foo.y))) {
         ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t)  sub condition_.notify_all\n")));
         condition_.notify_all();
       }
@@ -87,11 +105,27 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
   }
 }
 
-bool DataReaderListenerImpl::received_all(const size_t x, const size_t y)
+bool DataReaderListenerImpl::received_all() const
 {
-  Lock lock(mutex_);
-  ++received_samples_;
-  ++progress_;
-  task_samples_map_[x].insert(y);
-  return received_samples_ >= expected_samples_;
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+  return received_total_samples_ >= expected_total_samples_;
+#else
+  ReceivedSamplesMap::const_iterator i = received_samples_map_.begin();
+  for (size_t p = 0; p < publisher_count_; ++p) {
+    if (i == received_samples_map_.end() || i->first != p || i->second.size() == 0) {
+      return false;
+    }
+  }
+  return true;
+#endif
+}
+
+bool DataReaderListenerImpl::update_and_check(size_t x, size_t y)
+{
+  if (received_samples_map_[x].insert(y).second) {
+    ++received_total_samples_;
+    ++progress_;
+    return received_all();
+  }
+  return false;
 }

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -115,6 +115,7 @@ bool DataReaderListenerImpl::received_all() const
     if (i == received_samples_map_.end() || i->first != p || i->second.size() == 0) {
       return false;
     }
+    ++i;
   }
   return true;
 #endif

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.cpp
@@ -30,7 +30,7 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 void DataReaderListenerImpl::wait_received() const
 {
   Lock lock(mutex_);
-  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub wait_received %d:%d\n"), received_total_samples_, expected_total_samples_));
+  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub wait_received %B:%B\n"), received_total_samples_, expected_total_samples_));
   while (!received_all()) {
 #ifdef ACE_HAS_CPP11
     condition_.wait(lock);
@@ -53,19 +53,19 @@ int DataReaderListenerImpl::check_received() const
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
       for (size_t s = 0; s < expected_samples_per_publisher_; ++s) {
         if (i->second.count(s) == 0) {
-          ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing pub%d sample%d\n"), p, s));
+          ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing pub%B sample%B\n"), p, s));
           ++ret;
         }
       }
 #else
       if (i->second.size() == 0) {
         // Theoretically this should never happen, since the only reason to have a map entry is receiving a sample
-        ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing any sample from pub%d\n"), p));
+        ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing any sample from pub%B\n"), p));
         ++ret;
       }
 #endif
     } else {
-      ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing pub%d samples\n"), p));
+      ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: missing pub%B samples\n"), p));
       ++ret;
     }
   }
@@ -74,7 +74,7 @@ int DataReaderListenerImpl::check_received() const
 #else
   if (received_total_samples_ < expected_total_samples_) {
 #endif
-    ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: sub received %d of expected %d samples.\n"),
+    ACE_DEBUG((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: sub received %B of expected %B samples.\n"),
       received_total_samples_, expected_total_samples_));
     ++ret;
   }
@@ -86,7 +86,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 {
   FooDataReader_var reader_i = FooDataReader::_narrow(reader);
   if (!reader_i) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("%N:%l: on_data_available() _narrow failed!\n")));
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_data_available() _narrow failed!\n")));
     return;
   }
 
@@ -98,7 +98,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     if (si.valid_data) {
       Lock lock(mutex_);
       if (update_and_check(static_cast<size_t>(foo.x), static_cast<size_t>(foo.y))) {
-        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t)  sub condition_.notify_all\n")));
+        ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) sub condition_.notify_all\n")));
         condition_.notify_all();
       }
     }

--- a/tests/DCPS/Thrasher/DataReaderListenerImpl.h
+++ b/tests/DCPS/Thrasher/DataReaderListenerImpl.h
@@ -18,23 +18,24 @@
 class DataReaderListenerImpl : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener>
 {
 public:
-  DataReaderListenerImpl(const std::size_t expected_samples, const char* progress_fmt);
+  DataReaderListenerImpl(size_t publisher_count, size_t samples_per_publisher, const char* progress_fmt);
   virtual ~DataReaderListenerImpl();
 
   void wait_received() const;
-  int check_received(const size_t n_publishers) const;
+  int check_received() const;
   virtual void on_data_available(DDS::DataReader_ptr reader);
 
-  virtual void on_requested_deadline_missed(DDS::DataReader_ptr, const DDS::RequestedDeadlineMissedStatus&){}
-  virtual void on_requested_incompatible_qos(DDS::DataReader_ptr, const DDS::RequestedIncompatibleQosStatus&){}
-  virtual void on_liveliness_changed(DDS::DataReader_ptr, const DDS::LivelinessChangedStatus&){}
-  virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&){}
-  virtual void on_sample_rejected(DDS::DataReader_ptr, const DDS::SampleRejectedStatus&){}
-  virtual void on_sample_lost(DDS::DataReader_ptr, const DDS::SampleLostStatus&){}
+  virtual void on_requested_deadline_missed(DDS::DataReader_ptr, const DDS::RequestedDeadlineMissedStatus&) {}
+  virtual void on_requested_incompatible_qos(DDS::DataReader_ptr, const DDS::RequestedIncompatibleQosStatus&) {}
+  virtual void on_liveliness_changed(DDS::DataReader_ptr, const DDS::LivelinessChangedStatus&) {}
+  virtual void on_subscription_matched(DDS::DataReader_ptr, const DDS::SubscriptionMatchedStatus&) {}
+  virtual void on_sample_rejected(DDS::DataReader_ptr, const DDS::SampleRejectedStatus&) {}
+  virtual void on_sample_lost(DDS::DataReader_ptr, const DDS::SampleLostStatus&) {}
 
 private:
-  typedef OPENDDS_MAP(size_t, OPENDDS_SET(size_t)) TaskSamplesMap;
-  bool received_all(const size_t x, const size_t y);
+  typedef OPENDDS_MAP(size_t, OPENDDS_SET(size_t)) ReceivedSamplesMap;
+  bool received_all() const;
+  bool update_and_check(size_t x, size_t y);
 #ifdef ACE_HAS_CPP11
   typedef std::mutex Mutex;
   typedef std::condition_variable Condition;
@@ -46,9 +47,13 @@ private:
 #endif
   mutable Mutex mutex_;
   mutable Condition condition_;
-  const size_t expected_samples_;
-  size_t received_samples_;
-  TaskSamplesMap task_samples_map_;
+  const size_t publisher_count_;
+  const size_t samples_per_publisher_;
+  const size_t maximum_possible_samples_;
+  const size_t expected_total_samples_;
+  const size_t expected_samples_per_publisher_;
+  size_t received_total_samples_;
+  ReceivedSamplesMap received_samples_map_;
   ProgressIndicator progress_;
 };
 

--- a/tests/DCPS/Thrasher/ProgressIndicator.cpp
+++ b/tests/DCPS/Thrasher/ProgressIndicator.cpp
@@ -2,7 +2,7 @@
 #include <ace/Log_Msg.h>
 #include <iostream>
 
-ProgressIndicator::ProgressIndicator(const char* format, const std::size_t max, const std::size_t grad)
+ProgressIndicator::ProgressIndicator(const char* format, size_t max, size_t grad)
   : format_(format)
   , max_(max)
   , grad_(grad)
@@ -16,7 +16,7 @@ ProgressIndicator::~ProgressIndicator()
 ProgressIndicator& ProgressIndicator::operator++()
 {
   ++curr_;
-  std::size_t pct = std::size_t(curr_ / double(max_) * 100);
+  size_t pct = static_cast<size_t>(curr_ / static_cast<double>(max_) * 100.0);
   if (pct > last_) {
     ACE_DEBUG((LM_INFO, format_, pct, curr_));
     last_ += grad_;

--- a/tests/DCPS/Thrasher/ProgressIndicator.h
+++ b/tests/DCPS/Thrasher/ProgressIndicator.h
@@ -6,16 +6,16 @@
 class ProgressIndicator
 {
 public:
-  ProgressIndicator(const char* format, const std::size_t max, const std::size_t grad = 10);
+  ProgressIndicator(const char* format, size_t max, size_t grad = 10);
   ~ProgressIndicator();
   ProgressIndicator& operator++();
 
 private:
   const char* format_;
-  const std::size_t max_;
-  const std::size_t grad_;
-  std::size_t last_;
-  std::size_t curr_;
+  const size_t max_;
+  const size_t grad_;
+  size_t last_;
+  size_t curr_;
 };
 
 #endif /* DCPS_THRASHER_PROGRESSINDICATOR_H */

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -58,7 +58,9 @@ Publisher::Publisher(const long domain_id, std::size_t samples_per_thread, bool 
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
     qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
-    qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_ * 2);
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+  qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_ * 2);
+#endif
 
     dw_ = pub->create_datawriter(topic.in(), qos, 0, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (!dw_) {

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -57,9 +57,9 @@ Publisher::Publisher(const long domain_id, std::size_t samples_per_thread, bool 
     if (durable_) {
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
-#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
-    qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_);
-#endif
+    qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+    qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_ * 2);
+
     dw_ = pub->create_datawriter(topic.in(), qos, 0, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (!dw_) {
       throw std::runtime_error("create_datawriter failed!\n");
@@ -182,6 +182,7 @@ void Publisher::configure_transport()
     ach.set_string_value(sect_key, ACE_TEXT("heartbeat_period"), ACE_TEXT("200"));
     ach.set_string_value(sect_key, ACE_TEXT("heartbeat_response_delay"), ACE_TEXT("100"));
     inst->load(ach, sect_key);
+    config->passive_connect_duration_ = 600000;
     config->instances_.push_back(inst);
     TheTransportRegistry->bind_config(config_name, dp_);
   }

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -57,9 +57,9 @@ Publisher::Publisher(const long domain_id, std::size_t samples_per_thread, bool 
     if (durable_) {
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
-    qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
-  qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_ * 2);
+    qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+    qos.history.depth = static_cast<CORBA::Long>(samples_per_thread_ * 2);
 #endif
 
     dw_ = pub->create_datawriter(topic.in(), qos, 0, OpenDDS::DCPS::DEFAULT_STATUS_MASK);

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -59,7 +59,9 @@ Subscriber::Subscriber(const DDS::DomainId_t domainId, const std::size_t n_pub_t
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
     qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
     qos.history.depth = static_cast<CORBA::Long>(expected_samples * 2);
+#endif
 
     reader_ = sub->create_datareader(topic.in(), qos, listener_.in(), OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (!reader_) {

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -16,7 +16,7 @@
 
 #include <stdexcept>
 
-Subscriber::Subscriber(const DDS::DomainId_t domainId, const std::size_t n_pub_threads, const std::size_t expected_samples, const bool durable)
+Subscriber::Subscriber(DDS::DomainId_t domainId, size_t n_pub_threads, size_t expected_samples, bool durable)
   : domainId_(domainId)
   , n_pub_threads_(n_pub_threads)
   , expected_samples_(expected_samples)
@@ -47,7 +47,7 @@ Subscriber::Subscriber(const DDS::DomainId_t domainId, const std::size_t n_pub_t
       throw std::runtime_error("create_subscriber failed.");
     }
     // Create DataReader
-    listener_i_ = new DataReaderListenerImpl(expected_samples_, "(%P|%t)  sub %d%% (%d samples received)\n");
+    listener_i_ = new DataReaderListenerImpl(n_pub_threads, expected_samples_ / n_pub_threads, "(%P|%t)  sub %d%% (%d samples received)\n");
     listener_ = listener_i_;
     if (!listener_) {
       throw std::runtime_error("DataReaderListenerImpl creation failed.");
@@ -107,5 +107,5 @@ void Subscriber::cleanup()
 int Subscriber::wait_and_check_received() const
 {
   listener_i_->wait_received();
-  return listener_i_->check_received(n_pub_threads_);
+  return listener_i_->check_received();
 }

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -58,8 +58,8 @@ Subscriber::Subscriber(const DDS::DomainId_t domainId, const std::size_t n_pub_t
     if (durable_) {
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
-    qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
 #ifndef OPENDDS_NO_OWNERSHIP_PROFILE
+    qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
     qos.history.depth = static_cast<CORBA::Long>(expected_samples * 2);
 #endif
 

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -58,9 +58,9 @@ Subscriber::Subscriber(const DDS::DomainId_t domainId, const std::size_t n_pub_t
     if (durable_) {
       qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
     }
-#ifndef OPENDDS_NO_OWNERSHIP_PROFILE
     qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
-#endif
+    qos.history.depth = static_cast<CORBA::Long>(expected_samples * 2);
+
     reader_ = sub->create_datareader(topic.in(), qos, listener_.in(), OpenDDS::DCPS::DEFAULT_STATUS_MASK);
     if (!reader_) {
       throw std::runtime_error("create_datareader failed.");

--- a/tests/DCPS/Thrasher/Subscriber.cpp
+++ b/tests/DCPS/Thrasher/Subscriber.cpp
@@ -18,7 +18,6 @@
 
 Subscriber::Subscriber(DDS::DomainId_t domainId, size_t n_pub_threads, size_t expected_samples, bool durable)
   : domainId_(domainId)
-  , n_pub_threads_(n_pub_threads)
   , expected_samples_(expected_samples)
   , durable_(durable)
 {

--- a/tests/DCPS/Thrasher/Subscriber.h
+++ b/tests/DCPS/Thrasher/Subscriber.h
@@ -14,7 +14,6 @@ public:
 private:
   void cleanup();
   const DDS::DomainId_t domainId_;
-  const size_t n_pub_threads_;
   const size_t expected_samples_;
   const bool durable_;
   DDS::DomainParticipantFactory_var dpf_;

--- a/tests/DCPS/Thrasher/Subscriber.h
+++ b/tests/DCPS/Thrasher/Subscriber.h
@@ -8,14 +8,14 @@
 class Subscriber
 {
 public:
-  Subscriber(const DDS::DomainId_t domainId, const std::size_t n_pub_threads, const std::size_t expected_samples, const bool durable);
+  Subscriber(DDS::DomainId_t domainId, size_t n_pub_threads, size_t expected_samples, bool durable);
   ~Subscriber();
   int wait_and_check_received() const;
 private:
   void cleanup();
   const DDS::DomainId_t domainId_;
-  const std::size_t n_pub_threads_;
-  const std::size_t expected_samples_;
+  const size_t n_pub_threads_;
+  const size_t expected_samples_;
   const bool durable_;
   DDS::DomainParticipantFactory_var dpf_;
   DDS::DomainParticipant_var dp_;

--- a/tests/DCPS/Thrasher/thrasher_rtps.ini
+++ b/tests/DCPS/Thrasher/thrasher_rtps.ini
@@ -1,9 +1,13 @@
 [common]
 pool_size=900000000
-DCPSGlobalTransportConfig=$file
+DCPSGlobalTransportConfig=myconfig
 
 [domain/42]
 DiscoveryConfig=uni_rtps
+
+[config/myconfig]
+transports=the_rtps_transport
+passive_connect_duration=600000
 
 [rtps_discovery/uni_rtps]
 SedpMulticast=0

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -331,32 +331,32 @@ tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROF
 tests/DCPS/Thrasher/run_test.pl default: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl low: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl medium: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl high: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
-tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
-tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN
-tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
-tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS_ASAN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -339,24 +339,24 @@ tests/DCPS/Thrasher/run_test.pl triangle rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS
-tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high rtps: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive rtps: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl single durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl double durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl triangle durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl default durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl low durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl medium durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl high durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/Thrasher/run_test.pl aggressive durable: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl double rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl triangle rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl default rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl low rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS
-tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS
+tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
+tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
 tests/DCPS/DPFactoryQos/run_test.pl: !DCPS_MIN
 tests/DCPS/DPFactoryQos/run_test.pl rtps_disc: !DCPS_MIN RTPS
 tests/DCPS/ManualAssertLiveliness/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
This PR expands some of the test coverage for Thrasher to more builds and makes the test able to run (with different assumptions) under the no ownership profile builds. It also makes the test resilient against association timeout errors which are problematic when association times start to exceed 30 seconds (expected when the VM is overloaded).