### PR TITLE
Test & Fixes For Durable WaitForAck

### DIFF
--- a/dds/DCPS/DataSampleElement.h
+++ b/dds/DCPS/DataSampleElement.h
@@ -76,12 +76,12 @@ public:
 
   CORBA::ULong get_num_subs() const;
 
-  void set_num_subs(int num_subs);
+  void set_num_subs(CORBA::ULong num_subs);
 
   const OpenDDS::DCPS::RepoId* get_sub_ids() const;
-  OpenDDS::DCPS::RepoId  get_sub_id(int index) const;
+  OpenDDS::DCPS::RepoId get_sub_id(CORBA::ULong index) const;
 
-  void set_sub_id(int index, OpenDDS::DCPS::RepoId id);
+  void set_sub_id(CORBA::ULong index, OpenDDS::DCPS::RepoId id);
 
   TransportSendListener* get_send_listener() const;
   TransportSendListener* get_send_listener();

--- a/dds/DCPS/DataSampleElement.inl
+++ b/dds/DCPS/DataSampleElement.inl
@@ -24,7 +24,7 @@ ACE_INLINE
 void
 DataSampleElement::set_next_send_sample(DataSampleElement* next_send_sample)
 {
-  this->next_send_sample_ = next_send_sample;
+  next_send_sample_ = next_send_sample;
 }
 
 ACE_INLINE
@@ -60,7 +60,7 @@ ACE_INLINE
 void
 DataSampleElement::set_sample(Message_Block_Ptr sample)
 {
-  this->sample_.reset(sample.release());
+  sample_.reset(sample.release());
 }
 
 ACE_INLINE
@@ -79,9 +79,9 @@ DataSampleElement::get_num_subs() const
 
 ACE_INLINE
 void
-DataSampleElement::set_num_subs(int num_subs)
+DataSampleElement::set_num_subs(CORBA::ULong num_subs)
 {
-  this->num_subs_ = num_subs;
+  num_subs_ = num_subs;
 }
 
 ACE_INLINE
@@ -93,16 +93,16 @@ DataSampleElement::get_sub_ids() const
 
 ACE_INLINE
 OpenDDS::DCPS::RepoId
-DataSampleElement::get_sub_id(int index) const
+DataSampleElement::get_sub_id(CORBA::ULong index) const
 {
   return subscription_ids_[index];
 }
 
 ACE_INLINE
 void
-DataSampleElement::set_sub_id(int index, OpenDDS::DCPS::RepoId id)
+DataSampleElement::set_sub_id(CORBA::ULong index, OpenDDS::DCPS::RepoId id)
 {
-  this->subscription_ids_[index] = id;
+  subscription_ids_[index] = id;
 }
 
 ACE_INLINE

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -421,6 +421,8 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
     if (!participant)
       return;
 
+    data_container_->add_reader_acks(remote_id);
+
     const DDS::InstanceHandle_t handle = participant->assign_handle(remote_id);
 
     {
@@ -608,6 +610,8 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
         rds.length(rds_len);
         rds [rds_len - 1] = readers[i];
       }
+
+      data_container_->remove_reader_acks(readers[i]);
 
       ACE_GUARD(ACE_Thread_Mutex, reader_info_guard, this->reader_info_lock_);
       reader_info_.erase(readers[i]);

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -421,7 +421,7 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
     if (!participant)
       return;
 
-    data_container_->add_reader_acks(remote_id);
+    data_container_->add_reader_acks(remote_id, get_max_sn());
 
     const DDS::InstanceHandle_t handle = participant->assign_handle(remote_id);
 

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -172,10 +172,15 @@ WriteDataContainer::~WriteDataContainer()
 }
 
 void
-WriteDataContainer::add_reader_acks(const RepoId& reader)
+WriteDataContainer::add_reader_acks(const RepoId& reader, const SequenceNumber& base)
 {
   ACE_Guard<ACE_Thread_Mutex> guard(wfa_lock_);
   acked_sequences_[reader].reset();
+  if (base == SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
+    acked_sequences_[reader].insert(SequenceNumber::ZERO());
+  } else {
+    acked_sequences_[reader].insert(SequenceRange(SequenceNumber(), base));
+  }
 }
 
 void
@@ -1554,7 +1559,7 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& deadline,
 }
 
 bool
-WriteDataContainer::sequence_acknowledged(SequenceNumber sequence)
+WriteDataContainer::sequence_acknowledged(const SequenceNumber& sequence)
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(wfa_lock_);
   return sequence_acknowledged_i(sequence);

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -183,8 +183,8 @@ WriteDataContainer::remove_reader_acks(const RepoId& reader)
 {
   ACE_Guard<ACE_Thread_Mutex> guard(wfa_lock_);
 
-  SequenceNumber prev_cum_ack = get_cumulative_ack();
-  AckedSequenceMap::iterator it = acked_sequences_.find(reader);
+  const SequenceNumber prev_cum_ack = get_cumulative_ack();
+  const AckedSequenceMap::iterator it = acked_sequences_.find(reader);
   if (it != acked_sequences_.end()) {
     acked_sequences_.erase(it);
     if (prev_cum_ack != get_cumulative_ack()) {
@@ -312,7 +312,6 @@ WriteDataContainer::reenqueue_all(const RepoId& reader_id,
                    lock_,
                    DDS::RETCODE_ERROR);
 
-
   ssize_t total_size = 0;
   for (PublicationInstanceMapType::iterator it = instances_.begin();
        it != instances_.end(); ++it) {
@@ -322,7 +321,6 @@ WriteDataContainer::reenqueue_all(const RepoId& reader_id,
     it->second->durable_samples_remaining_ = durable;
   }
 
-  const ssize_t start_total_size = total_size;
   copy_and_prepend(resend_data_,
                    sending_data_,
                    reader_id,
@@ -701,7 +699,8 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       } else if (!containing_list) {
         // samples that were retrieved from get_resend_data()
         ACE_Guard<ACE_SYNCH_MUTEX> guard(wfa_lock_);
-        for (int i = 0; i < stale->get_num_subs(); ++i) {
+        const int num_subs = static_cast<int>(stale->get_num_subs());
+        for (int i = 0; i < num_subs; ++i) {
           update_acked(stale->get_header().sequence_, stale->get_sub_id(i));
         }
         guard.release();
@@ -1555,14 +1554,14 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& deadline,
 }
 
 bool
-WriteDataContainer::sequence_acknowledged(const SequenceNumber sequence)
+WriteDataContainer::sequence_acknowledged(SequenceNumber sequence)
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(wfa_lock_);
   return sequence_acknowledged_i(sequence);
 }
 
 bool
-WriteDataContainer::sequence_acknowledged_i(const SequenceNumber sequence)
+WriteDataContainer::sequence_acknowledged_i(const SequenceNumber& sequence)
 {
   if (sequence == SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
     //return true here so that wait_for_acknowledgments doesn't block

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -716,8 +716,8 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       } else if (!containing_list) {
         // samples that were retrieved from get_resend_data()
         ACE_Guard<ACE_SYNCH_MUTEX> guard(wfa_lock_);
-        const int num_subs = static_cast<int>(stale->get_num_subs());
-        for (int i = 0; i < num_subs; ++i) {
+        const CORBA::ULong num_subs = stale->get_num_subs();
+        for (CORBA::ULong i = 0; i < num_subs; ++i) {
           update_acked(stale->get_header().sequence_, stale->get_sub_id(i));
         }
         guard.release();

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -420,6 +420,8 @@ private:
   typedef OPENDDS_MAP_CMP(RepoId, DisjointSequence, GUID_tKeyLessThan) AckedSequenceMap;
 #endif
   AckedSequenceMap acked_sequences_;
+  SequenceNumber cached_cumulative_ack_;
+  bool cached_cumulative_ack_valid_;
 
   SequenceNumber get_cumulative_ack();
   SequenceNumber get_last_ack();

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -343,7 +343,7 @@ public:
                                     bool deadline_is_infinite,
                                     const SequenceNumber& sequence);
 
-  bool sequence_acknowledged(const SequenceNumber sequence);
+  bool sequence_acknowledged(const SequenceNumber& sequence);
 
 private:
 
@@ -407,7 +407,7 @@ private:
    */
   void wakeup_blocking_writers (DataSampleElement* stale);
 
-  void add_reader_acks(const RepoId& reader);
+  void add_reader_acks(const RepoId& reader, const SequenceNumber& base);
   void remove_reader_acks(const RepoId& reader);
 
 private:

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -424,7 +424,7 @@ private:
   SequenceNumber get_cumulative_ack();
   SequenceNumber get_last_ack();
   void update_acked(const SequenceNumber& seq, const RepoId& id = GUID_UNKNOWN);
-  bool sequence_acknowledged_i(const SequenceNumber sequence);
+  bool sequence_acknowledged_i(const SequenceNumber& sequence);
 
   /// List of data that has not been sent yet.
   SendStateDataSampleList   unsent_data_;

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -407,11 +407,24 @@ private:
    */
   void wakeup_blocking_writers (DataSampleElement* stale);
 
+  void add_reader_acks(const RepoId& reader);
+  void remove_reader_acks(const RepoId& reader);
+
 private:
 
   void log_send_state_lists (OPENDDS_STRING description);
 
-  DisjointSequence acked_sequences_;
+#ifdef ACE_HAS_CPP11
+  typedef OPENDDS_UNORDERED_MAP(RepoId, DisjointSequence) AckedSequenceMap;
+#else
+  typedef OPENDDS_MAP_CMP(RepoId, DisjointSequence, GUID_tKeyLessThan) AckedSequenceMap;
+#endif
+  AckedSequenceMap acked_sequences_;
+
+  SequenceNumber get_cumulative_ack();
+  SequenceNumber get_last_ack();
+  void update_acked(const SequenceNumber& seq, const RepoId& id = GUID_UNKNOWN);
+  bool sequence_acknowledged_i(const SequenceNumber sequence);
 
   /// List of data that has not been sent yet.
   SendStateDataSampleList   unsent_data_;

--- a/dds/DCPS/transport/framework/TransportQueueElement.inl
+++ b/dds/DCPS/transport/framework/TransportQueueElement.inl
@@ -48,7 +48,11 @@ TransportQueueElement::decision_made(bool dropped_by_transport)
 {
   DBG_ENTRY_LVL("TransportQueueElement", "decision_made", 6);
 
+#ifdef ACE_HAS_CPP11
   OPENDDS_ASSERT(sub_loan_count_);
+#else
+  OPENDDS_ASSERT(sub_loan_count_.value());
+#endif
   const unsigned long new_count = --sub_loan_count_;
   if (new_count == 0) {
     // All interested subscriptions have been satisfied.

--- a/dds/DCPS/transport/framework/TransportQueueElement.inl
+++ b/dds/DCPS/transport/framework/TransportQueueElement.inl
@@ -48,6 +48,7 @@ TransportQueueElement::decision_made(bool dropped_by_transport)
 {
   DBG_ENTRY_LVL("TransportQueueElement", "decision_made", 6);
 
+  OPENDDS_ASSERT(sub_loan_count_);
   const unsigned long new_count = --sub_loan_count_;
   if (new_count == 0) {
     // All interested subscriptions have been satisfied.
@@ -63,12 +64,6 @@ TransportQueueElement::decision_made(bool dropped_by_transport)
     return true;
   }
 
-  // ciju: The sub_loan_count_ has been observed to drop below zero.
-  // Since it isn't exactly a ref count and the object is created in
-  // allocater memory (user space) we *probably* can disregard the
-  // count for now. Ideally we would like to prevent the count from
-  // falling below 0 and opening up this assert.
-  // assert (new_count > 0);
   return false;
 }
 

--- a/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
+++ b/tests/DCPS/ContentFilteredTopic/ContentFilteredTopicTest.cpp
@@ -248,7 +248,7 @@ bool run_filtering_test(const DomainParticipant_var& dp,
     return false;
   }
 
-  // To set up a more difficult wait_for_acknowledgements() scenario,
+  // To set up a more difficult wait_for_acknowledgments() scenario,
   // make sure the sub2 datalink's two readers have different "latest"
   // sequence numbers, and the sub datalink needs no customization.
   sample.key = 2;

--- a/tests/DCPS/ManualAssertLiveliness/Writer.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/Writer.cpp
@@ -129,7 +129,7 @@ Write_Samples::post_loop()
   const DDS::ReturnCode_t ret =  message_dw_->wait_for_acknowledgments(timeout);
   if (ret != ::DDS::RETCODE_OK) {
     ACE_ERROR ((LM_ERROR,
-                ACE_TEXT("(%P|%t) ERROR: wait_for_acknowledgements: ")
+                ACE_TEXT("(%P|%t) ERROR: wait_for_acknowledgments: ")
                 ACE_TEXT("%C returned %d\n"),
                 name_, ret));
   }

--- a/tests/DCPS/WaitForAck/rtps.ini
+++ b/tests/DCPS/WaitForAck/rtps.ini
@@ -1,6 +1,6 @@
 [common]
 DCPSGlobalTransportConfig=$file
-pool_size=500000000
+pool_size=600000000
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp

--- a/tests/DCPS/WaitForAckRace/.gitignore
+++ b/tests/DCPS/WaitForAckRace/.gitignore
@@ -1,0 +1,2 @@
+/publisher
+/subscriber

--- a/tests/DCPS/WaitForAckRace/WaitForAckRace.mpc
+++ b/tests/DCPS/WaitForAckRace/WaitForAckRace.mpc
@@ -1,0 +1,15 @@
+project(*Publisher) : dcpsexe, dcps_test, dcps_cm, dcps_transports_for_test {
+  exename = publisher
+
+  Source_Files {
+    publisher.cpp
+  }
+}
+
+project(*Subscriber) : dcpsexe, dcps_test, dcps_cm, dcps_transports_for_test {
+  exename = subscriber
+
+  Source_Files {
+    subscriber.cpp
+  }
+}

--- a/tests/DCPS/WaitForAckRace/publisher.cpp
+++ b/tests/DCPS/WaitForAckRace/publisher.cpp
@@ -74,7 +74,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
   bool large_samples = false;
   bool sub_delayed_exit = false;
-  for (int i = 0; i < argc; ++i) {
+  for (int i = 1; i < argc; ++i) {
     if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-l") {
       large_samples = true;
     }
@@ -97,8 +97,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     DDS::DomainParticipant_var participant =
       dpf->create_participant(31,
                               PARTICIPANT_QOS_DEFAULT,
-                              DDS::DomainParticipantListener::_nil(),
-                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                              0,
+                              0);
     if (CORBA::is_nil(participant.in())) {
       cerr << "create_participant failed." << endl;
       return 1;
@@ -119,8 +119,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       participant->create_topic("Movie Discussion List",
                                 type_name.in(),
                                 topic_qos,
-                                DDS::TopicListener::_nil(),
-                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                                0,
+                                0);
 
     if (CORBA::is_nil(topic.in())) {
       cerr << "create_topic failed." << endl;
@@ -131,8 +131,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     participant->get_default_publisher_qos(pub_qos);
 
     DDS::Publisher_var pub =
-      participant->create_publisher(pub_qos, DDS::PublisherListener::_nil(),
-                                    ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+      participant->create_publisher(pub_qos,
+                                    0,
+                                    0);
     if (CORBA::is_nil(pub.in())) {
       cerr << "create_publisher failed." << endl;
       exit(1);
@@ -145,9 +146,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     DDS::DataWriter_var dw =
       pub->create_datawriter(topic.in(),
-                              dw_qos,
-                              DDS::DataWriterListener::_nil(),
-                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                             dw_qos,
+                             0,
+                             0);
 
     if (CORBA::is_nil(dw.in())) {
       cerr << "create_datawriter failed." << endl;

--- a/tests/DCPS/WaitForAckRace/publisher.cpp
+++ b/tests/DCPS/WaitForAckRace/publisher.cpp
@@ -99,14 +99,14 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                               PARTICIPANT_QOS_DEFAULT,
                               0,
                               0);
-    if (CORBA::is_nil(participant.in())) {
+    if (!participant) {
       cerr << "create_participant failed." << endl;
       return 1;
     }
 
     MessageTypeSupportImpl::_var_type servant = new MessageTypeSupportImpl();
 
-    if (DDS::RETCODE_OK != servant->register_type(participant.in(), "")) {
+    if (DDS::RETCODE_OK != servant->register_type(participant, "")) {
       cerr << "register_type failed." << endl;
       exit(1);
     }
@@ -117,12 +117,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     participant->get_default_topic_qos(topic_qos);
     DDS::Topic_var topic =
       participant->create_topic("Movie Discussion List",
-                                type_name.in(),
+                                type_name,
                                 topic_qos,
                                 0,
                                 0);
 
-    if (CORBA::is_nil(topic.in())) {
+    if (!topic) {
       cerr << "create_topic failed." << endl;
       exit(1);
     }
@@ -134,7 +134,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       participant->create_publisher(pub_qos,
                                     0,
                                     0);
-    if (CORBA::is_nil(pub.in())) {
+    if (!pub) {
       cerr << "create_publisher failed." << endl;
       exit(1);
     }
@@ -145,20 +145,20 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     dw_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
 
     DDS::DataWriter_var dw =
-      pub->create_datawriter(topic.in(),
+      pub->create_datawriter(topic,
                              dw_qos,
                              0,
                              0);
 
-    if (CORBA::is_nil(dw.in())) {
+    if (!dw) {
       cerr << "create_datawriter failed." << endl;
       exit(1);
     }
 
     Messenger::MessageDataWriter_var message_dw =
-      Messenger::MessageDataWriter::_narrow(dw.in());
+      Messenger::MessageDataWriter::_narrow(dw);
 
-    if (CORBA::is_nil(message_dw.in())) {
+    if (!message_dw) {
       cerr << "Messenger::MessageDataWriter::_narrow() failed." << endl;
       exit(1);
     }
@@ -243,7 +243,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
 
     participant->delete_contained_entities();
-    dpf->delete_participant(participant.in());
+    dpf->delete_participant(participant);
   }
   catch (const CORBA::Exception& e)
   {

--- a/tests/DCPS/WaitForAckRace/publisher.cpp
+++ b/tests/DCPS/WaitForAckRace/publisher.cpp
@@ -1,0 +1,256 @@
+#include "MessengerTypeSupportImpl.h"
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/PublisherImpl.h>
+#include <dds/DCPS/Qos_Helper.h>
+#include <dds/DCPS/StaticIncludes.h>
+#include <dds/DCPS/unique_ptr.h>
+
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+#include <tests/Utils/ExceptionStreams.h>
+#include <tests/Utils/StatusMatching.h>
+
+#include <ace/streams.h>
+#include <ace/Get_Opt.h>
+#include <ace/OS_NS_unistd.h>
+
+#include <memory>
+#include <sstream>
+
+using namespace Messenger;
+using namespace std;
+
+int wait_match(const DDS::DataWriter_var& writer, unsigned int current_readers, unsigned int total_readers)
+{
+  int ret = -1;
+  DDS::StatusCondition_var condition = writer->get_statuscondition();
+  condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
+  DDS::WaitSet_var ws(new DDS::WaitSet);
+  DDS::ReturnCode_t a = ws->attach_condition(condition);
+  if (a != DDS::RETCODE_OK) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() - attach_condition returned %d\n"), a));
+    return ret;
+  }
+
+  const CORBA::Long n_current_readers = static_cast<CORBA::Long>(current_readers);
+  const CORBA::Long n_total_readers = static_cast<CORBA::Long>(total_readers);
+  const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+  DDS::PublicationMatchedStatus ms = { 0, 0, 0, 0, 0 };
+  DDS::ConditionSeq conditions;
+  while (ret != 0) {
+    if (writer->get_publication_matched_status(ms) == DDS::RETCODE_OK) {
+      if (ms.current_count == n_current_readers && ms.total_count == n_total_readers) {
+        ret = 0;
+      } else { // wait for a change
+        DDS::ReturnCode_t w = ws->wait(conditions, forever);
+        if ((w != DDS::RETCODE_OK) && (w != DDS::RETCODE_TIMEOUT)) {
+          ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() - wait returned %d\n"), w));
+          break;
+        }
+      }
+    } else {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %N:%l: wait_match() - get_publication_matched_status failed!\n")));
+      break;
+    }
+  }
+
+  ws->detach_condition(condition);
+  return ret;
+}
+
+int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  sigset_t mask, prev;
+  ACE_OS::sigemptyset(&mask);
+  ACE_OS::sigaddset(&mask, SIGPIPE);
+  ACE_OS::sigprocmask(SIG_BLOCK, &mask, &prev);
+
+  int total_readers = 1;
+
+  bool large_samples = false;
+  bool sub_delayed_exit = false;
+  for (int i = 0; i < argc; ++i) {
+    if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-l") {
+      large_samples = true;
+    }
+    if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-d") {
+      sub_delayed_exit = true;
+    }
+    if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-r") {
+      ++i;
+      if (i < argc) {
+        total_readers = ACE_OS::atoi(argv[i]);
+      }
+    }
+  }
+
+  try
+  {
+    DDS::DomainParticipantFactory_var dpf =
+      TheParticipantFactoryWithArgs(argc, argv);
+
+    DDS::DomainParticipant_var participant =
+      dpf->create_participant(31,
+                              PARTICIPANT_QOS_DEFAULT,
+                              DDS::DomainParticipantListener::_nil(),
+                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (CORBA::is_nil(participant.in())) {
+      cerr << "create_participant failed." << endl;
+      return 1;
+    }
+
+    MessageTypeSupportImpl::_var_type servant = new MessageTypeSupportImpl();
+
+    if (DDS::RETCODE_OK != servant->register_type(participant.in(), "")) {
+      cerr << "register_type failed." << endl;
+      exit(1);
+    }
+
+    CORBA::String_var type_name = servant->get_type_name();
+
+    DDS::TopicQos topic_qos;
+    participant->get_default_topic_qos(topic_qos);
+    DDS::Topic_var topic =
+      participant->create_topic("Movie Discussion List",
+                                type_name.in(),
+                                topic_qos,
+                                DDS::TopicListener::_nil(),
+                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(topic.in())) {
+      cerr << "create_topic failed." << endl;
+      exit(1);
+    }
+
+    DDS::PublisherQos pub_qos;
+    participant->get_default_publisher_qos(pub_qos);
+
+    DDS::Publisher_var pub =
+      participant->create_publisher(pub_qos, DDS::PublisherListener::_nil(),
+                                    ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (CORBA::is_nil(pub.in())) {
+      cerr << "create_publisher failed." << endl;
+      exit(1);
+    }
+
+    DDS::DataWriterQos dw_qos;
+    pub->get_default_datawriter_qos(dw_qos);
+
+    dw_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+
+    DDS::DataWriter_var dw =
+      pub->create_datawriter(topic.in(),
+                              dw_qos,
+                              DDS::DataWriterListener::_nil(),
+                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(dw.in())) {
+      cerr << "create_datawriter failed." << endl;
+      exit(1);
+    }
+
+    Messenger::MessageDataWriter_var message_dw =
+      Messenger::MessageDataWriter::_narrow(dw.in());
+
+    if (CORBA::is_nil(message_dw.in())) {
+      cerr << "Messenger::MessageDataWriter::_narrow() failed." << endl;
+      exit(1);
+    }
+
+    Messenger::Message message;
+
+    {
+      stringstream ss;
+      ss << ACE_OS::getpid() << flush;
+
+      message.from       = ss.str().c_str();
+      message.subject    = "Review";
+      message.text       = large_samples ? std::string(4000, 'Z').c_str() : "Wash. Rinse. Repeat.";
+    }
+
+    const ACE_Time_Value delay(large_samples ? 2 : 0, large_samples ? 0 : 10000);
+
+    const size_t count = large_samples ? 4u : 20u;
+    for (size_t i = 0; i < count; ++i) {
+      message.subject_id = i;
+      message.count = i;
+      DDS::ReturnCode_t error = message_dw->write(message, DDS::HANDLE_NIL);
+
+      if (error != DDS::RETCODE_OK) {
+        cerr << "Messenger::MessageDataWriter::write() failed." << endl;
+        exit(1);
+      }
+    }
+
+    const ::DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+    for (int current_readers = 1; current_readers <= total_readers; ++current_readers) {
+
+      {
+        stringstream ss;
+        ss << "Publisher " << ACE_OS::getpid() << " is waiting for " << current_readers << " readers." << endl;
+
+        cout << ss.str() << flush;
+      }
+      if (sub_delayed_exit) {
+        wait_match(dw, current_readers, current_readers);
+      } else {
+        wait_match(dw, 1, current_readers);
+      }
+      {
+        stringstream ss;
+        ss << "Publisher " << ACE_OS::getpid() << " is done waiting for " << current_readers << " readers." << endl;
+
+        cout << ss.str() << flush;
+      }
+
+      {
+        stringstream ss;
+        ss << "Publisher " << ACE_OS::getpid() << " is waiting for acknowledgments." << endl;
+
+        cout << ss.str() << flush;
+      }
+      if (dw->wait_for_acknowledgments(forever) != DDS::RETCODE_OK) {
+        cerr << "wait_for_acknowledgments() failed." << endl;
+        exit(1);
+      }
+      {
+        stringstream ss;
+        ss << "Publisher " << ACE_OS::getpid() << " is done waiting for acknowledgments." << endl;
+
+        cout << ss.str() << flush;
+      }
+    }
+
+    {
+      stringstream ss;
+      ss << "Publisher " << ACE_OS::getpid() << " is done. Exiting." << endl;
+
+      cout << ss.str() << flush;
+    }
+
+    // Semi-arbitrary change to clean-up approach
+    if (ACE_OS::getpid() % 3) {
+      message_dw = 0;
+
+      pub->delete_datawriter(dw);
+      participant->delete_publisher(pub);
+    }
+
+    participant->delete_contained_entities();
+    dpf->delete_participant(participant.in());
+  }
+  catch (const CORBA::Exception& e)
+  {
+    cerr << "PUB: Exception caught in main.cpp:" << endl
+         << e << endl;
+    exit(1);
+  }
+  TheServiceParticipant->shutdown();
+
+  return 0;
+}

--- a/tests/DCPS/WaitForAckRace/rtps.ini
+++ b/tests/DCPS/WaitForAckRace/rtps.ini
@@ -1,0 +1,6 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[transport/the_rtps_transport]
+transport_type=rtps_udp
+max_message_size=1300

--- a/tests/DCPS/WaitForAckRace/rtps_disc.ini
+++ b/tests/DCPS/WaitForAckRace/rtps_disc.ini
@@ -1,0 +1,16 @@
+[common]
+DCPSGlobalTransportConfig=$file
+DCPSPendingTimeout=3
+
+[domain/31]
+DiscoveryConfig=uni_rtps
+
+[rtps_discovery/uni_rtps]
+InteropMulticastOverride=239.255.1.0
+SedpMulticast=1
+ResendPeriod=2
+
+[transport/the_rtps_transport]
+transport_type=rtps_udp
+multicast_group_address=239.255.2.0
+max_message_size=1300

--- a/tests/DCPS/WaitForAckRace/rtps_disc_tcp.ini
+++ b/tests/DCPS/WaitForAckRace/rtps_disc_tcp.ini
@@ -1,0 +1,12 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[domain/31]
+DiscoveryConfig=fast_rtps
+
+[rtps_discovery/fast_rtps]
+SedpMulticast=0
+ResendPeriod=2
+
+[transport/t1]
+transport_type=tcp

--- a/tests/DCPS/WaitForAckRace/run_test.pl
+++ b/tests/DCPS/WaitForAckRace/run_test.pl
@@ -1,0 +1,97 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+use Env (DDS_ROOT);
+use lib "$DDS_ROOT/bin";
+use Env (ACE_ROOT);
+use lib "$ACE_ROOT/bin";
+use PerlDDS::Run_Test;
+use strict;
+
+PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
+
+my $test = new PerlDDS::TestFramework();
+
+my $pub_count = 0;
+my $sub_count = 0;
+my $rtps_disc = 0;
+my $large_samples = 0;
+my $sub_delay = 0;
+
+my $ai = 0;
+foreach $a(@ARGV) {
+  if ($a eq "rtps_disc") {
+    $rtps_disc = 1;
+  }
+  if ($a eq "rtps_disc_tcp") {
+    $rtps_disc = 1;
+  }
+  if ($a eq "large_samples") {
+    $large_samples = 1;
+  }
+  if ($a eq "sub_delay") {
+    $sub_delay = 1;
+  }
+#  if ($a eq "publishers") {
+#    $pub_count = @ARGV[$ai + 1];
+#  }
+  if ($a eq "subscribers") {
+    $sub_count = @ARGV[$ai + 1];
+  }
+  $ai++;
+}
+
+$test->{'dcps_debug_level'} = 0;
+$test->{'dcps_transport_debug_level'} = 0;
+$test->setup_discovery() unless $rtps_disc;
+
+if ($pub_count == 0) {
+  $pub_count = 1;
+}
+
+if ($sub_count == 0) {
+  $sub_count = 3;
+}
+
+my $pub_index = 1;
+my $sub_index = 1;
+
+my $pub_args = "";
+my $sub_args = "";
+
+if ($large_samples) {
+  $pub_args = $pub_args . " -l";
+  $sub_args = $sub_args . " -l";
+}
+if ($sub_delay) {
+  $pub_args = $pub_args . " -d";
+  $sub_args = $sub_args . " -d";
+}
+$pub_args = $pub_args . " -r $sub_count" . " -DCPSPendingTimeout 3 -ORBVerboseLogging 1";
+
+$sub_args = $sub_args . " -DCPSPendingTimeout 3 -ORBVerboseLogging 1";
+
+for (my $i = 0; $i < $pub_count; $i++) {
+  $test->process("pub_" . $pub_index++, "publisher", $pub_args);
+}
+
+for (my $i = 0; $i < $sub_count; $i++) {
+  $test->process("sub_" . $sub_index++, "subscriber", $sub_args);
+}
+
+$pub_index = 1;
+$sub_index = 1;
+
+for (my $i = 0; $i < $pub_count; $i++) {
+  $test->start_process("pub_" . $pub_index++);
+}
+
+for (my $i = 0; $i < $sub_count; $i++) {
+  sleep(3);
+  $test->start_process("sub_" . $sub_index++);
+}
+
+exit $test->finish(30);

--- a/tests/DCPS/WaitForAckRace/subscriber.cpp
+++ b/tests/DCPS/WaitForAckRace/subscriber.cpp
@@ -1,0 +1,281 @@
+#include "MessengerTypeSupportImpl.h"
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/PublisherImpl.h>
+#include <dds/DCPS/Qos_Helper.h>
+#include <dds/DCPS/StaticIncludes.h>
+#include <dds/DCPS/unique_ptr.h>
+#ifndef ACE_HAS_CPP11
+#  include <dds/DCPS/ConditionVariable.h>
+#endif
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+#include <tests/Utils/ExceptionStreams.h>
+#include <tests/Utils/StatusMatching.h>
+
+#include <ace/streams.h>
+#include <ace/Get_Opt.h>
+#include <ace/OS_NS_unistd.h>
+
+#include <memory>
+#include <sstream>
+#ifdef ACE_HAS_CPP11
+#  include <condition_variable>
+#  include <mutex>
+#  include <thread>
+#endif
+
+using namespace Messenger;
+using namespace std;
+
+struct DataReaderListenerImpl : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener>
+{
+  DataReaderListenerImpl()
+   : mutex_()
+#ifdef ACE_HAS_CPP11
+   , cv_()
+#else
+   , cv_(mutex_)
+#endif
+   , valid_data_seen_(0) {}
+
+  virtual ~DataReaderListenerImpl() {}
+
+  virtual void on_requested_deadline_missed(
+    DDS::DataReader*,
+    const DDS::RequestedDeadlineMissedStatus&) {}
+  virtual void on_requested_incompatible_qos(
+    DDS::DataReader*,
+    const DDS::RequestedIncompatibleQosStatus&) {}
+  virtual void on_liveliness_changed(
+    DDS::DataReader*,
+    const DDS::LivelinessChangedStatus&) {}
+  virtual void on_subscription_matched(
+    DDS::DataReader*,
+    const DDS::SubscriptionMatchedStatus&) {}
+  virtual void on_sample_rejected(
+    DDS::DataReader*,
+    const DDS::SampleRejectedStatus&) {}
+  virtual void on_sample_lost(
+    DDS::DataReader*,
+    const DDS::SampleLostStatus&) {}
+
+  virtual void on_data_available(DDS::DataReader* reader)
+  {
+    Messenger::MessageDataReader_var message_dr =
+      Messenger::MessageDataReader::_narrow(reader);
+    if (0 == message_dr) {
+      return;
+    }
+
+    Messenger::Message message;
+    DDS::SampleInfo si;
+
+    if (message_dr->take_next_sample(message, si) == DDS::RETCODE_OK) {
+      if (si.valid_data) {
+
+        stringstream ss;
+        ss << "Subscriber " << ACE_OS::getpid() << " got new message data:" << endl;
+        ss << " - From  : " << message.from << endl;
+        ss << " - Count : " << message.count << endl;
+        cout << ss.str() << flush;
+
+#ifdef ACE_HAS_CPP11
+        std::unique_lock<std::mutex> lock(mutex_);
+#else
+        ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+#endif
+        ++valid_data_seen_;
+        cv_.notify_all();
+      }
+    }
+  }
+
+  bool wait_valid_data(size_t expected, const OpenDDS::DCPS::MonotonicTimePoint& deadline) {
+#ifdef ACE_HAS_CPP11
+    std::chrono::milliseconds ms((deadline - OpenDDS::DCPS::MonotonicTimePoint::now()).value().get_msec());
+    std::unique_lock<std::mutex> lock(mutex_);
+#else
+    ACE_Guard<ACE_Thread_Mutex> g(mutex_);
+#endif
+#ifdef ACE_HAS_CPP11
+    auto wait_result = cv_.wait_for(lock, ms);
+    while (valid_data_seen_ < expected && wait_result != cv_status::timeout) {
+      wait_result = cv_.wait_for(lock, ms);
+    }
+    return wait_result != cv_status::timeout;
+#else
+    OpenDDS::DCPS::ThreadStatusManager& thread_status_manager = TheServiceParticipant->get_thread_status_manager();
+    OpenDDS::DCPS::CvStatus wait_result = cv_.wait_until(deadline, thread_status_manager);
+    while (valid_data_seen_ < expected && wait_result != OpenDDS::DCPS::CvStatus_Timeout) {
+      wait_result = cv_.wait_until(deadline, thread_status_manager);
+    }
+    return wait_result != OpenDDS::DCPS::CvStatus_Timeout;
+#endif
+  }
+
+private:
+#ifdef ACE_HAS_CPP11
+  std::mutex mutex_;
+  std::condition_variable cv_;
+#else
+  ACE_Thread_Mutex mutex_;
+  OpenDDS::DCPS::ConditionVariable<ACE_Thread_Mutex> cv_;
+#endif
+  size_t valid_data_seen_;
+};
+
+int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  bool large_samples = false;
+  bool delay_exit = false;
+  for (int i = 0; i < argc; ++i) {
+    if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-l") {
+      large_samples = true;
+    }
+    if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-d") {
+      delay_exit = true;
+    }
+  }
+
+  bool got_all_data = false;
+  try
+  {
+    DDS::DomainParticipantFactory_var dpf =
+      TheParticipantFactoryWithArgs(argc, argv);
+
+    DDS::DomainParticipant_var participant =
+      dpf->create_participant(31,
+                              PARTICIPANT_QOS_DEFAULT,
+                              DDS::DomainParticipantListener::_nil(),
+                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (CORBA::is_nil(participant.in())) {
+      cerr << "create_participant failed." << endl;
+      return 1;
+    }
+
+    MessageTypeSupportImpl::_var_type servant = new MessageTypeSupportImpl();
+
+    if (DDS::RETCODE_OK != servant->register_type(participant.in(), "")) {
+      cerr << "register_type failed." << endl;
+      exit(1);
+    }
+
+    CORBA::String_var type_name = servant->get_type_name();
+
+    DDS::TopicQos topic_qos;
+    participant->get_default_topic_qos(topic_qos);
+    DDS::Topic_var topic =
+      participant->create_topic("Movie Discussion List",
+                                type_name.in(),
+                                topic_qos,
+                                DDS::TopicListener::_nil(),
+                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(topic.in())) {
+      cerr << "create_topic failed." << endl;
+      exit(1);
+    }
+
+    DDS::SubscriberQos sub_qos;
+    participant->get_default_subscriber_qos(sub_qos);
+
+    DDS::Subscriber_var sub =
+      participant->create_subscriber(sub_qos, DDS::SubscriberListener::_nil(),
+                                    ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+    if (CORBA::is_nil(sub.in())) {
+      cerr << "create_subscriber failed." << endl;
+      exit(1);
+    }
+
+    DDS::DataReaderQos dr_qos;
+    sub->get_default_datareader_qos(dr_qos);
+
+    dr_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    dr_qos.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+
+    DataReaderListenerImpl* drli = new DataReaderListenerImpl();
+    DDS::DataReaderListener_var drl = drli;
+
+    DDS::DataReader_var dr =
+      sub->create_datareader(topic.in(),
+                              dr_qos,
+                              drl.in(),
+                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+    if (CORBA::is_nil(dr.in())) {
+      cerr << "create_datareader failed." << endl;
+      exit(1);
+    }
+
+    Messenger::MessageDataReader_var message_dr =
+      Messenger::MessageDataReader::_narrow(dr.in());
+
+    if (CORBA::is_nil(message_dr.in())) {
+      cerr << "Messenger::MessageDataReader::_narrow() failed." << endl;
+      exit(1);
+    }
+
+    const size_t count = large_samples ? 4u : 20u;
+    const OpenDDS::DCPS::MonotonicTimePoint deadline = OpenDDS::DCPS::MonotonicTimePoint::now() + OpenDDS::DCPS::TimeDuration(30, 0);
+
+    got_all_data = drli->wait_valid_data(count, deadline);
+
+    if (delay_exit) {
+      Utils::wait_match(dr, 0);
+    }
+
+    {
+      stringstream ss;
+      if (!got_all_data) {
+        ss << "Subscriber " << ACE_OS::getpid() << " is missing data. Exiting." << endl;
+      } else {
+        ss << "Subscriber " << ACE_OS::getpid() << " is done. Exiting." << endl;
+      }
+
+      cout << ss.str() << flush;
+    }
+
+    // Semi-arbitrary change to clean-up approach
+    if (ACE_OS::getpid() % 3) {
+      message_dr = 0;
+
+      sub->delete_datareader(dr);
+      participant->delete_subscriber(sub);
+    }
+
+#ifdef ACE_HAS_CPP11
+    std::atomic<bool> still_cleaning(true);
+    thread t([&](){
+      this_thread::sleep_for(chrono::seconds(3));
+      while (still_cleaning) {
+        stringstream ss;
+        ss << "Subscriber " << ACE_OS::getpid() << " is taking a long time to clean up." << endl;
+        cout << ss.str() << flush;
+        this_thread::sleep_for(chrono::seconds(1));
+      }
+    });
+#endif
+
+    participant->delete_contained_entities();
+    dpf->delete_participant(participant.in());
+
+#ifdef ACE_HAS_CPP11
+    still_cleaning = false;
+    t.join();
+#endif
+  }
+  catch (const CORBA::Exception& e)
+  {
+     cerr << "PUB: Exception caught in main.cpp:" << endl
+       << e << endl;
+     exit(1);
+  }
+  TheServiceParticipant->shutdown();
+
+  return got_all_data ? 0 : 1;
+}

--- a/tests/DCPS/WaitForAckRace/subscriber.cpp
+++ b/tests/DCPS/WaitForAckRace/subscriber.cpp
@@ -133,7 +133,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
   bool large_samples = false;
   bool delay_exit = false;
-  for (int i = 0; i < argc; ++i) {
+  for (int i = 1; i < argc; ++i) {
     if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-l") {
       large_samples = true;
     }
@@ -151,8 +151,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     DDS::DomainParticipant_var participant =
       dpf->create_participant(31,
                               PARTICIPANT_QOS_DEFAULT,
-                              DDS::DomainParticipantListener::_nil(),
-                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                              0,
+                              0);
     if (CORBA::is_nil(participant.in())) {
       cerr << "create_participant failed." << endl;
       return 1;
@@ -173,8 +173,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       participant->create_topic("Movie Discussion List",
                                 type_name.in(),
                                 topic_qos,
-                                DDS::TopicListener::_nil(),
-                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                                0,
+                                0);
 
     if (CORBA::is_nil(topic.in())) {
       cerr << "create_topic failed." << endl;
@@ -185,8 +185,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     participant->get_default_subscriber_qos(sub_qos);
 
     DDS::Subscriber_var sub =
-      participant->create_subscriber(sub_qos, DDS::SubscriberListener::_nil(),
-                                    ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+      participant->create_subscriber(sub_qos,
+                                     0,
+                                     0);
     if (CORBA::is_nil(sub.in())) {
       cerr << "create_subscriber failed." << endl;
       exit(1);
@@ -203,9 +204,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     DDS::DataReader_var dr =
       sub->create_datareader(topic.in(),
-                              dr_qos,
-                              drl.in(),
-                              ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+                             dr_qos,
+                             drl.in(),
+                             ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
     if (CORBA::is_nil(dr.in())) {
       cerr << "create_datareader failed." << endl;

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -314,9 +314,17 @@ tests/DCPS/Priority/run_test.pl --instances: !DCPS_MIN !QNX !OPENDDS_SAFETY_PROF
 tests/DCPS/LatencyBudget/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/LatencyBudget/run_test.pl late: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/WaitForAck/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
-tests/DCPS/WaitForAck/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/WaitForAck/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/WaitForAck/run_test.pl --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
-tests/DCPS/WaitForAck/run_test.pl rtps --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/WaitForAck/run_test.pl rtps --publisher: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3 large_samples: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3 sub_delay: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3 sub_delay large_samples: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3 large_samples: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3 sub_delay: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3 sub_delay large_samples: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl single: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl double: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/Thrasher/run_test.pl triangle: !DCPS_MIN !LYNXOS !OPENDDS_SAFETY_PROFILE

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -44,6 +44,14 @@ tests/DCPS/WaitForAck/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_
 tests/DCPS/WaitForAck/run_test.pl rtps: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/WaitForAck/run_test.pl --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/WaitForAck/run_test.pl rtps --publisher: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3 large_samples: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3 sub_delay: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl subscribers 3 sub_delay large_samples: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3 large_samples: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3 sub_delay: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
+tests/DCPS/WaitForAckRace/run_test.pl rtps_disc subscribers 3 sub_delay large_samples: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 
 tests/DCPS/LivelinessTest/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE
 tests/DCPS/LivelinessTest/run_test.pl take: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE !OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
Problem: Previous `wait_for_acknowledgments` behavior was poorly defined, since any acknowledgment would be applied universally across all readers.

Solution: In general, wait_for_acknowledgments should delay until every currently associated reader has acknowledged the current sequence number at the time of the call to wait_for_acknowledgments.
