### PR TITLE
key information not passed to `begin_struct_member`

### DIFF
--- a/dds/DCPS/JsonValueWriter.h
+++ b/dds/DCPS/JsonValueWriter.h
@@ -45,7 +45,7 @@ public:
 
   void begin_struct();
   void end_struct();
-  void begin_struct_member(const char* name);
+  void begin_struct_member(const XTypes::MemberDescriptor& /*descriptor*/);
   void end_struct_member();
 
   void begin_union();
@@ -101,9 +101,9 @@ void JsonValueWriter<Writer>::end_struct()
 }
 
 template <typename Writer>
-void JsonValueWriter<Writer>::begin_struct_member(const char* name)
+void JsonValueWriter<Writer>::begin_struct_member(const XTypes::MemberDescriptor& descriptor)
 {
-  writer_.Key(name);
+  writer_.Key(descriptor.name.c_str());
 }
 
 template <typename Writer>
@@ -338,22 +338,22 @@ std::string to_json(const DDS::TopicDescription_ptr topic,
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   JsonValueWriter<rapidjson::Writer<rapidjson::StringBuffer> > jvw(writer);
   jvw.begin_struct();
-  jvw.begin_struct_member("topic");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("topic", false));
   jvw.begin_struct();
-  jvw.begin_struct_member("name");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("name", false));
   CORBA::String_var topic_name = topic->get_name();
   static_cast<ValueWriter&>(jvw).write_string(topic_name);
   jvw.end_struct_member();
-  jvw.begin_struct_member("type_name");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("type_name", false));
   CORBA::String_var type_name = topic->get_type_name();
   static_cast<ValueWriter&>(jvw).write_string(type_name);
   jvw.end_struct_member();
   jvw.end_struct();
   jvw.end_struct_member();
-  jvw.begin_struct_member("sample");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("sample", false));
   vwrite(jvw, sample);
   jvw.end_struct_member();
-  jvw.begin_struct_member("sample_info");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("sample_info", false));
   vwrite(jvw, sample_info);
   jvw.end_struct_member();
   jvw.end_struct();

--- a/dds/DCPS/Observer.cpp
+++ b/dds/DCPS/Observer.cpp
@@ -49,19 +49,19 @@ void
 vwrite(ValueWriter& vw, const Observer::Sample& sample)
 {
   vw.begin_struct();
-  vw.begin_struct_member("instance");
+  vw.begin_struct_member(XTypes::MemberDescriptor("instance", false));
   vw.write_int32(sample.instance);
   vw.end_struct_member();
-  vw.begin_struct_member("instance_state");
+  vw.begin_struct_member(XTypes::MemberDescriptor("instance_state", false));
   vw.write_uint32(sample.instance_state);
   vw.end_struct_member();
-  vw.begin_struct_member("timestamp");
+  vw.begin_struct_member(XTypes::MemberDescriptor("timestamp", false));
   vwrite(vw, sample.timestamp);
   vw.end_struct_member();
-  vw.begin_struct_member("sequence_number");
+  vw.begin_struct_member(XTypes::MemberDescriptor("sequence_number", false));
   vw.write_int64(sample.sequence_number.getValue());
   vw.end_struct_member();
-  vw.begin_struct_member("data");
+  vw.begin_struct_member(XTypes::MemberDescriptor("data", false));
   sample.data_dispatcher.write(vw, sample.data);
   vw.end_struct_member();
   vw.end_struct();

--- a/dds/DCPS/RTPS/Logging.cpp
+++ b/dds/DCPS/RTPS/Logging.cpp
@@ -41,13 +41,13 @@ void log_message(const char* format,
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   DCPS::JsonValueWriter<rapidjson::Writer<rapidjson::StringBuffer> > jvw(writer);
   jvw.begin_struct();
-  jvw.begin_struct_member("guidPrefix");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("guidPrefix", false));
   vwrite(jvw, prefix);
   jvw.end_struct_member();
-  jvw.begin_struct_member("send");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("send", false));
   jvw.write_boolean(send);
   jvw.end_struct_member();
-  jvw.begin_struct_member("message");
+  jvw.begin_struct_member(XTypes::MemberDescriptor("message", false));
   vwrite(jvw, message);
   jvw.end_struct_member();
   jvw.end_struct();

--- a/dds/DCPS/ValueWriter.h
+++ b/dds/DCPS/ValueWriter.h
@@ -7,6 +7,7 @@
 #define OPENDDS_DCPS_VALUE_WRITER_H
 
 #include "Definitions.h"
+#include "XTypes/MemberDescriptor.h"
 
 #include <dds/Versioned_Namespace.h>
 #include <FACE/Fixed.h>
@@ -41,7 +42,7 @@ public:
 
   virtual void begin_struct() {}
   virtual void end_struct() {}
-  virtual void begin_struct_member(const char* /*name*/) {}
+  virtual void begin_struct_member(const XTypes::MemberDescriptor& /*descriptor*/) {}
   virtual void end_struct_member() {}
 
   virtual void begin_union() {}

--- a/dds/DCPS/XTypes/MemberDescriptor.h
+++ b/dds/DCPS/XTypes/MemberDescriptor.h
@@ -30,6 +30,17 @@ class OpenDDS_Dcps_Export MemberDescriptor {
 public:
   MemberDescriptor();
   ~MemberDescriptor();
+  MemberDescriptor(const char* a_name, bool a_is_key)
+    : name(a_name)
+    , id(0)
+    , index(0)
+    , try_construct_kind(USE_DEFAULT)
+    , is_key(a_is_key)
+    , is_optional(false)
+    , is_must_understand(false)
+    , is_shared(false)
+    , is_default_label(false)
+  {}
 
   DynamicType_rch get_type() const;
   bool equals(const MemberDescriptor& other) const;

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -269,7 +269,8 @@ bool value_writer_generator::gen_struct(AST_Structure*,
       AST_Field* const field = *pos;
       const std::string field_name = field->local_name()->get_string();
       be_global->impl_ <<
-        "  value_writer.begin_struct_member(\"" << field_name << "\");\n";
+        "  value_writer.begin_struct_member(XTypes::MemberDescriptor(\"" << field_name << "\", "
+                                                                         << (be_global->is_key(field) ? "true" : "false") <<  "));\n";
       generate_write("value." + field_name + accessor_suffix, field->field_type(), "i");
       be_global->impl_ <<
         "  value_writer.end_struct_member();\n";

--- a/tests/unit-tests/dds/DCPS/JsonValueWriter.cpp
+++ b/tests/unit-tests/dds/DCPS/JsonValueWriter.cpp
@@ -54,7 +54,7 @@ TEST(dds_DCPS_JsonValueWriter, begin_struct_member)
   Writer writer(buffer);
   JsonValueWriter<Writer> jvw(writer);
   jvw.begin_struct();
-  jvw.begin_struct_member("aField");
+  jvw.begin_struct_member(OpenDDS::XTypes::MemberDescriptor("aField", false));
   EXPECT_STREQ(buffer.GetString(), "{\"aField\"");
 }
 
@@ -64,7 +64,7 @@ TEST(dds_DCPS_JsonValueWriter, end_struct_member)
   Writer writer(buffer);
   JsonValueWriter<Writer> jvw(writer);
   jvw.begin_struct();
-  jvw.begin_struct_member("aField");
+  jvw.begin_struct_member(OpenDDS::XTypes::MemberDescriptor("aField", false));
   jvw.write_int16(5);
   jvw.end_struct_member();
   EXPECT_STREQ(buffer.GetString(), "{\"aField\":5");
@@ -140,10 +140,10 @@ TEST(dds_DCPS_JsonValueWriter, complete_struct)
   Writer writer(buffer);
   JsonValueWriter<Writer> jvw(writer);
   jvw.begin_struct();
-  jvw.begin_struct_member("aField");
+  jvw.begin_struct_member(OpenDDS::XTypes::MemberDescriptor("aField", false));
   jvw.write_int16(5);
   jvw.end_struct_member();
-  jvw.begin_struct_member("bField");
+  jvw.begin_struct_member(OpenDDS::XTypes::MemberDescriptor("bField", false));
   jvw.write_int16(6);
   jvw.end_struct_member();
   jvw.end_struct();
@@ -275,7 +275,7 @@ TEST(dds_DCPS_JsonValueWriter, complete_struct_with_complete_array)
   Writer writer(buffer);
   TestWriter jvw(writer);
   jvw.begin_struct();
-  jvw.begin_struct_member("a");
+  jvw.begin_struct_member(OpenDDS::XTypes::MemberDescriptor("a", false));
   jvw.begin_array();
   jvw.begin_element(0);
   jvw.write_int16(5);


### PR DESCRIPTION
Problem
-------

ValueWriter implementations may treat members that are keys
differently.  As a concrete example, consider a ValueWriter that
prepares a SQL INSERT statement for a received sample.  Most likely,
this will be an UPSERT which often requires a list of keys and a list
of non-keys.

Solution
--------

Change `begin_struct_member` to take an XTypes::MemberDescriptor which
contains the member name and a bool for key status.  This PR only sets
these two members.