### PR TITLE
Fix One of the Install Test Configure Commands

### DIFF
--- a/tests/cmake/install/CMakeLists.txt
+++ b/tests/cmake/install/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 set(dest_install_prefix "${CMAKE_CURRENT_BINARY_DIR}/the-install-prefix")
 set(common_cmake_args
   "-DCMAKE_INSTALL_PREFIX:PATH=${dest_install_prefix}"
-  "-DCMAKE_PREFIX_PATH:PATH=${OPENDDS_ROOT};${dest_install_prefix}"
+  "-DCMAKE_PREFIX_PATH:PATH=${OPENDDS_ROOT}$<SEMICOLON>${dest_install_prefix}"
   "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
   "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 )


### PR DESCRIPTION
A warning added in CMake 3.23 warns when there's an unused argument to CMake. This is the case here where this argument is supposed to be a list being passed to a child CMake command. It's getting interpreted as a separate argument instead. The solution is, apparently, to replace it with this generator expression.