### PR TITLE
Fix TSAN Issue In ConditionImpl.cpp

### DIFF
--- a/dds/DCPS/ConditionImpl.cpp
+++ b/dds/DCPS/ConditionImpl.cpp
@@ -31,8 +31,7 @@ void ConditionImpl::signal_all()
   if (DCPS_debug_level > 9) {
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ConditionImpl::signal_all() - ")
-               ACE_TEXT("number of sets: %d, locally: %d.\n"),
-               this->waitsets_.size(),
+               ACE_TEXT("number of sets: %d\n"),
                local_ws.size()));
   }
 

--- a/dds/DCPS/ConditionImpl.cpp
+++ b/dds/DCPS/ConditionImpl.cpp
@@ -31,7 +31,7 @@ void ConditionImpl::signal_all()
   if (DCPS_debug_level > 9) {
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ConditionImpl::signal_all() - ")
-               ACE_TEXT("number of sets: %d\n"),
+               ACE_TEXT("number of sets: %B\n"),
                local_ws.size()));
   }
 


### PR DESCRIPTION
Problem: Code was accessing protected data structure without mutex.

Solution: Don't do that. Just use the local copy.