### PR TITLE
Fix Coverity Issue In WaitForAckRace Test

### DIFF
--- a/tests/DCPS/WaitForAckRace/publisher.cpp
+++ b/tests/DCPS/WaitForAckRace/publisher.cpp
@@ -84,7 +84,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     if (std::string(ACE_TEXT_ALWAYS_CHAR(argv[i])) == "-r") {
       ++i;
       if (i < argc) {
-        total_readers = ACE_OS::atoi(argv[i]);
+        const int temp = ACE_OS::atoi(argv[i]);
+        if (temp > 0 && temp < 100) {
+          total_readers = temp;
+        }
       }
     }
   }


### PR DESCRIPTION
Problem: Coverity doesn't like that WaitForAckRace's publisher is using an atoi from a command line variable as a loop boundary.

Solution: Add additional bounds checking so Coverity can sleep at night knowing no fewer than 1 and no more than 99 readers can be specified.