### PR TITLE
Fix Another Potential Ownership SEGV Issue

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2648,6 +2648,7 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   if (this->is_exclusive_ownership_) {
 
+    ACE_Guard<ACE_RW_Thread_Mutex> write_guard(writers_lock_);
     WriterMapType::iterator iter = writers_.find(pubid);
 
     if (iter == writers_.end()) {

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2648,7 +2648,7 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   if (this->is_exclusive_ownership_) {
 
-    ACE_Guard<ACE_RW_Thread_Mutex> write_guard(writers_lock_);
+    ACE_WRITE_GUARD(ACE_RW_Thread_Mutex, write_guard, writers_lock_);
     WriterMapType::iterator iter = writers_.find(pubid);
 
     if (iter == writers_.end()) {

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2648,7 +2648,7 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   if (this->is_exclusive_ownership_) {
 
-    ACE_WRITE_GUARD(ACE_RW_Thread_Mutex, write_guard, writers_lock_);
+    ACE_WRITE_GUARD_RETURN(ACE_RW_Thread_Mutex, write_guard, writers_lock_, true);
     WriterMapType::iterator iter = writers_.find(pubid);
 
     if (iter == writers_.end()) {


### PR DESCRIPTION
Problem: Captured another core file from SEGV in ownership code.

Solution: Pretty sure this function just needs to hold the mutex to prevent other threads from corrupting / invalidating map access.