### PR TITLE
Fix Shutdown Leak In DCPSInfoRepo Under Load

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1070,11 +1070,13 @@ DataWriterImpl::send_request_ack()
       element->get_header(),
       move(blk),
       SystemTimePoint::now().to_dds_time()));
+
   element->set_sample(move(sample));
 
   ret = this->data_container_->enqueue_control(element);
 
   if (ret != DDS::RETCODE_OK) {
+    data_container_->release_buffer(element);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::send_request_ack: ")
@@ -1642,7 +1644,9 @@ DataWriterImpl::register_instance_i(DDS::InstanceHandle_t& handle,
   element->set_sample(move(sample));
 
   ret = this->data_container_->enqueue_control(element);
+
   if (ret != DDS::RETCODE_OK) {
+    data_container_->release_buffer(element);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::register_instance_i: ")
@@ -1730,9 +1734,11 @@ DataWriterImpl::unregister_instance_i(DDS::InstanceHandle_t handle,
                                                   move(unregistered_sample_data),
                                                   source_timestamp));
   element->set_sample(move(sample));
+
   ret = this->data_container_->enqueue_control(element);
 
   if (ret != DDS::RETCODE_OK) {
+    data_container_->release_buffer(element);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::unregister_instance_i: ")
@@ -1791,9 +1797,11 @@ DataWriterImpl::dispose_and_unregister(DDS::InstanceHandle_t handle,
                                                   move(data_sample),
                                                   source_timestamp));
   element->set_sample(move(sample));
+
   ret = this->data_container_->enqueue_control(element);
 
   if (ret != DDS::RETCODE_OK) {
+    data_container_->release_buffer(element);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::dispose_and_unregister: ")
@@ -1877,7 +1885,7 @@ DataWriterImpl::write(Message_Block_Ptr data,
   element->set_sample(move(temp));
 
   if (ret != DDS::RETCODE_OK) {
-    delete element;
+    data_container_->release_buffer(element);
     return ret;
   }
 
@@ -1886,6 +1894,7 @@ DataWriterImpl::write(Message_Block_Ptr data,
   ret = this->data_container_->enqueue(element, handle);
 
   if (ret != DDS::RETCODE_OK) {
+    data_container_->release_buffer(element);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::write: ")
@@ -2030,9 +2039,11 @@ DataWriterImpl::dispose(DDS::InstanceHandle_t handle,
                                                   move(registered_sample_data),
                                                   source_timestamp));
   element->set_sample(move(sample));
+
   ret = this->data_container_->enqueue_control(element);
 
   if (ret != DDS::RETCODE_OK) {
+    data_container_->release_buffer(element);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ")
                       ACE_TEXT("DataWriterImpl::dispose: ")

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1877,6 +1877,7 @@ DataWriterImpl::write(Message_Block_Ptr data,
   element->set_sample(move(temp));
 
   if (ret != DDS::RETCODE_OK) {
+    delete element;
     return ret;
   }
 
@@ -2179,8 +2180,9 @@ DataWriterImpl::create_sample_data_message(Message_Block_Ptr data,
 
   RcHandle<PublisherImpl> publisher = this->publisher_servant_.lock();
 
-  if (!publisher)
+  if (!publisher) {
     return DDS::RETCODE_ERROR;
+  }
 
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
   header_data.group_coherent_ =

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -469,6 +469,8 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
     }
 
     notify_status_condition();
+  } else {
+    data_container_->add_reader_acks(remote_id, get_max_sn());
   }
 
   // Support DURABILITY QoS

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -176,6 +176,7 @@ void
 WriteDataContainer::add_reader_acks(const RepoId& reader, const SequenceNumber& base)
 {
   ACE_Guard<ACE_Thread_Mutex> guard(wfa_lock_);
+
   DisjointSequence& ds = acked_sequences_[reader];
   ds.reset();
   if (base == SequenceNumber::SEQUENCENUMBER_UNKNOWN()) {
@@ -715,12 +716,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
 
       } else if (!containing_list) {
         // samples that were retrieved from get_resend_data()
-        ACE_Guard<ACE_SYNCH_MUTEX> guard(wfa_lock_);
+        ACE_Guard<ACE_SYNCH_MUTEX> wfa_guard(wfa_lock_);
         const CORBA::ULong num_subs = stale->get_num_subs();
         for (CORBA::ULong i = 0; i < num_subs; ++i) {
           update_acked(stale->get_header().sequence_, stale->get_sub_id(i));
         }
-        guard.release();
+        wfa_guard.release();
         SendStateDataSampleList::remove(stale);
         release_buffer(stale);
       }
@@ -857,7 +858,12 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
     // called from reenqueue_all() which supports the TRANSIENT_LOCAL
     // qos. The samples that are sending by transport are dropped from
     // transport and will be moved to the unsent list for resend.
-    unsent_data_.enqueue_tail(sample);
+    if (InstanceDataSampleList::on_some_list(sample)) {
+      unsent_data_.enqueue_tail(sample);
+    } else {
+      SendStateDataSampleList::remove(stale);
+      release_buffer(stale);
+    }
 
   } else {
     //
@@ -1545,7 +1551,6 @@ WriteDataContainer::wait_ack_of_seq(const MonotonicTimePoint& deadline,
                                     const SequenceNumber& sequence)
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(wfa_lock_);
-
   ThreadStatusManager& thread_status_manager = TheServiceParticipant->get_thread_status_manager();
   while ((deadline_is_infinite || MonotonicTimePoint::now() < deadline) && !sequence_acknowledged_i(sequence)) {
     switch (deadline_is_infinite ? wfa_condition_.wait(thread_status_manager) : wfa_condition_.wait_until(deadline, thread_status_manager)) {

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -96,7 +96,6 @@ DataLink::send(TransportQueueElement* element)
   DBG_ENTRY_LVL("DataLink","send",6);
 
   if (element->is_request_ack() && handle_send_request_ack(element)) {
-    element->data_dropped(true);
     return;
   }
 

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -95,8 +95,8 @@ DataLink::send(TransportQueueElement* element)
 {
   DBG_ENTRY_LVL("DataLink","send",6);
 
-  if (element->is_request_ack() &&
-      this->handle_send_request_ack(element)) {
+  if (element->is_request_ack() && handle_send_request_ack(element)) {
+    element->data_dropped(true);
     return;
   }
 

--- a/dds/DCPS/transport/tcp/TcpConnection.cpp
+++ b/dds/DCPS/transport/tcp/TcpConnection.cpp
@@ -635,7 +635,6 @@ OpenDDS::DCPS::TcpConnection::active_reconnect_i()
 void
 OpenDDS::DCPS::TcpConnection::notify_connection_lost()
 {
-  ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpConnection::notify_connection_lost()\n"));
   if (link_) {
     link_->drop_pending_request_acks();
     link_->notify(DataLink::LOST);

--- a/dds/DCPS/transport/tcp/TcpConnection.cpp
+++ b/dds/DCPS/transport/tcp/TcpConnection.cpp
@@ -351,8 +351,9 @@ OpenDDS::DCPS::TcpConnection::close(u_long)
     }
   } else {
     TcpSendStrategy_rch send_strategy = this->send_strategy();
-    if (send_strategy)
+    if (send_strategy) {
       send_strategy->terminate_send();
+    }
 
     this->disconnect();
   }
@@ -618,8 +619,7 @@ OpenDDS::DCPS::TcpConnection::active_reconnect_i()
           ACE_DEBUG((LM_DEBUG, "(%P|%t) DBG:   TcpConnection::"
                                "active_reconnect_i() socket operation is already in progress, wait another second to initiate the connect\n"));
         }
-      }
-      else {
+      } else {
         ACE_ERROR((LM_ERROR, "(%P|%t) TcpConnection::active_reconnect_i error %m.\n"));
       }
       this->reconnect_state_ = ACTIVE_WAITING_STATE;
@@ -627,8 +627,7 @@ OpenDDS::DCPS::TcpConnection::active_reconnect_i()
 
     this->reactor()->schedule_timer(this, 0, timeout);
     this->conn_retry_counter_ ++;
-  }
-  else {
+  } else {
     this->handle_stop_reconnecting();
   }
 }
@@ -636,11 +635,14 @@ OpenDDS::DCPS::TcpConnection::active_reconnect_i()
 void
 OpenDDS::DCPS::TcpConnection::notify_connection_lost()
 {
-  if (this->link_) {
-    this->link_->notify(DataLink::LOST);
+  ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpConnection::notify_connection_lost()\n"));
+  if (link_) {
+    link_->drop_pending_request_acks();
+    link_->notify(DataLink::LOST);
     TcpSendStrategy_rch send_strategy = link_->send_strategy();
-    if (send_strategy)
+    if (send_strategy) {
       send_strategy->terminate_send();
+    }
   }
 }
 
@@ -652,8 +654,7 @@ OpenDDS::DCPS::TcpConnection::handle_stop_reconnecting()
   if (this->tcp_config_->conn_retry_attempts_ > 0) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) we tried and failed to re-establish connection on transport: %C to %C.\n",
       config_name().c_str(), LogAddr(remote_address_).c_str()));
-  }
-  else {
+  } else {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) we did not try to re-establish connection on transport: %C to %C.\n",
       config_name().c_str(), LogAddr(remote_address_).c_str()));
   }
@@ -668,7 +669,7 @@ OpenDDS::DCPS::TcpConnection::handle_timeout(const ACE_Time_Value &,
   ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
 
   DBG_ENTRY_LVL("TcpConnection","handle_timeout",6);
-  ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpConnection::handle_timeout, this->reconnect_state_=%C\n",reconnect_state_string() ));
+  ACE_DEBUG((LM_DEBUG, "(%P|%t) TcpConnection::handle_timeout, this->reconnect_state_ = %C\n", reconnect_state_string()));
   GuardType guard(this->reconnect_lock_);
 
   switch (this->reconnect_state_) {
@@ -723,7 +724,7 @@ OpenDDS::DCPS::TcpConnection::handle_timeout(const ACE_Time_Value &,
   default :
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: TcpConnection::handle_timeout, ")
-               ACE_TEXT(" unknown state or it should not be in state=%d\n"),
+               ACE_TEXT(" unknown state or it should not be in state = %d\n"),
                reconnect_state_));
     break;
   }

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -396,13 +396,16 @@ OpenDDS::DCPS::TcpDataLink::handle_send_request_ack(TransportQueueElement* eleme
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::handle_send_request_ack(%@) sequence number %q, publication_id=%C\n"),
       element, element->sequence().getValue(), OPENDDS_STRING(converter).c_str()));
   }
+  bool result = false;
   TcpConnection_rch connection(connection_.lock());
   if (connection) {
     ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
     pending_request_acks_.push_back(element);
-    return false;
+  } else {
+    element->data_dropped(true);
+    result = true;
   }
-  return true;
+  return result;
 }
 
 void

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -396,12 +396,14 @@ OpenDDS::DCPS::TcpDataLink::handle_send_request_ack(TransportQueueElement* eleme
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::handle_send_request_ack(%@) sequence number %q, publication_id=%C\n"),
       element, element->sequence().getValue(), OPENDDS_STRING(converter).c_str()));
   }
-
-  ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
-  pending_request_acks_.push_back(element);
-  return false;
+  TcpConnection_rch connection(connection_.lock());
+  if (connection) {
+    ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
+    pending_request_acks_.push_back(element);
+    return false;
+  }
+  return true;
 }
-
 
 void
 OpenDDS::DCPS::TcpDataLink::ack_received(const ReceivedDataSample& sample)
@@ -423,7 +425,7 @@ OpenDDS::DCPS::TcpDataLink::ack_received(const ReceivedDataSample& sample)
     // find the pending request with the same sequence number.
     ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
     PendingRequestAcks::iterator it;
-    for (it = pending_request_acks_.begin(); it != pending_request_acks_.end(); ++it){
+    for (it = pending_request_acks_.begin(); it != pending_request_acks_.end(); ++it) {
       if ((*it)->sequence() == sequence && (*it)->publication_id() == sample.header_.publication_id_) {
         elem = *it;
         pending_request_acks_.erase(it);
@@ -564,7 +566,7 @@ OpenDDS::DCPS::TcpDataLink::drop_pending_request_acks()
 {
   ACE_Guard<ACE_SYNCH_MUTEX> guard(pending_request_acks_lock_);
   PendingRequestAcks::iterator it;
-  for (it = pending_request_acks_.begin(); it != pending_request_acks_.end(); ++it){
+  for (it = pending_request_acks_.begin(); it != pending_request_acks_.end(); ++it) {
     (*it)->data_dropped(true);
   }
   pending_request_acks_.clear();

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -855,7 +855,8 @@ int DCPS_IR_Domain::init_built_in_topics_transport(bool persistent)
 int DCPS_IR_Domain::cleanup_built_in_topics()
 {
 #ifndef DDS_HAS_MINIMUM_BIT
-  if (useBIT_ && bitParticipant_) {
+  if (useBIT_.value() && bitParticipant_) {
+    useBIT_ = false;
     using OpenDDS::DCPS::retcode_to_string;
 
     // clean up the Built-in Topic objects
@@ -1015,7 +1016,7 @@ void DCPS_IR_Domain::publish_participant_bit(DCPS_IR_Participant* participant)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_ && !participant->isBitPublisher()) {
+  if (useBIT_.value() && !participant->isBitPublisher()) {
     try {
       const DDS::DomainParticipantQos* participantQos = participant->get_qos();
 
@@ -1051,7 +1052,7 @@ void DCPS_IR_Domain::publish_topic_bit(DCPS_IR_Topic* topic)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
     DCPS_IR_Topic_Description* desc =
       topic->get_topic_description();
     const char* name = desc->get_name();
@@ -1112,7 +1113,7 @@ void DCPS_IR_Domain::publish_subscription_bit(DCPS_IR_Subscription* subscription
 
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
     DCPS_IR_Topic_Description* desc =
       subscription->get_topic_description();
     const char* name = desc->get_name();
@@ -1179,7 +1180,7 @@ void DCPS_IR_Domain::publish_publication_bit(DCPS_IR_Publication* publication)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
 
     DCPS_IR_Topic_Description* desc =
       publication->get_topic_description();
@@ -1259,7 +1260,7 @@ void DCPS_IR_Domain::dispose_participant_bit(DCPS_IR_Participant* participant)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
     if (!participant->isBitPublisher()) {
       try {
         DDS::ParticipantBuiltinTopicData key_data;
@@ -1295,6 +1296,9 @@ void DCPS_IR_Domain::dispose_participant_bit(DCPS_IR_Participant* participant)
         ex._tao_print_exception(
           "ERROR: Exception caught in DCPS_IR_Domain::dispose_participant_bit:");
       }
+    } else {
+      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+      bitParticipantDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1307,7 +1311,7 @@ void DCPS_IR_Domain::dispose_topic_bit(DCPS_IR_Topic* topic)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
     if (!topic->is_bit()) {
       try {
         DDS::TopicBuiltinTopicData key_data;
@@ -1345,6 +1349,9 @@ void DCPS_IR_Domain::dispose_topic_bit(DCPS_IR_Topic* topic)
         ex._tao_print_exception(
           "(%P|%t) ERROR: Exception caught in DCPS_IR_Domain::dispose_topic_bit:");
       }
+    } else {
+      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+      bitTopicDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1357,7 +1364,7 @@ void DCPS_IR_Domain::dispose_subscription_bit(DCPS_IR_Subscription* subscription
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
     if (!subscription->is_bit()) {
       try {
         DDS::SubscriptionBuiltinTopicData key_data;
@@ -1395,6 +1402,9 @@ void DCPS_IR_Domain::dispose_subscription_bit(DCPS_IR_Subscription* subscription
         ex._tao_print_exception(
           "(%P|%t) ERROR: Exception caught in DCPS_IR_Domain::dispose_subscription_bit:");
       }
+    } else {
+      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+      bitSubscriptionDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1407,7 +1417,7 @@ void DCPS_IR_Domain::dispose_publication_bit(DCPS_IR_Publication* publication)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_) {
+  if (useBIT_.value()) {
     if (!publication->is_bit()) {
       try {
         DDS::PublicationBuiltinTopicData key_data;
@@ -1444,6 +1454,9 @@ void DCPS_IR_Domain::dispose_publication_bit(DCPS_IR_Publication* publication)
         ex._tao_print_exception(
           "(%P|%t) ERROR: Exception caught in DCPS_IR_Domain::dispose_publication_bit:");
       }
+    } else {
+      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+      bitPublicationDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1469,7 +1482,7 @@ std::string DCPS_IR_Domain::dump_to_string(const std::string& prefix, int depth)
   std::ostringstream os;
   os << "DCPS_IR_Domain[" << id_ << "]";
   str += os.str();
-  if (useBIT_)
+  if (useBIT_.value())
     str += " BITS";
   str += "\n";
 

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -1296,9 +1296,6 @@ void DCPS_IR_Domain::dispose_participant_bit(DCPS_IR_Participant* participant)
         ex._tao_print_exception(
           "ERROR: Exception caught in DCPS_IR_Domain::dispose_participant_bit:");
       }
-    } else {
-      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
-      bitParticipantDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1349,9 +1346,6 @@ void DCPS_IR_Domain::dispose_topic_bit(DCPS_IR_Topic* topic)
         ex._tao_print_exception(
           "(%P|%t) ERROR: Exception caught in DCPS_IR_Domain::dispose_topic_bit:");
       }
-    } else {
-      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
-      bitTopicDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1402,9 +1396,6 @@ void DCPS_IR_Domain::dispose_subscription_bit(DCPS_IR_Subscription* subscription
         ex._tao_print_exception(
           "(%P|%t) ERROR: Exception caught in DCPS_IR_Domain::dispose_subscription_bit:");
       }
-    } else {
-      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
-      bitSubscriptionDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 
@@ -1454,9 +1445,6 @@ void DCPS_IR_Domain::dispose_publication_bit(DCPS_IR_Publication* publication)
         ex._tao_print_exception(
           "(%P|%t) ERROR: Exception caught in DCPS_IR_Domain::dispose_publication_bit:");
       }
-    } else {
-      const DDS::Duration_t forever = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
-      bitPublicationDataWriter_->wait_for_acknowledgments(forever);
     }
   }
 

--- a/dds/InfoRepo/DCPS_IR_Domain.h
+++ b/dds/InfoRepo/DCPS_IR_Domain.h
@@ -175,7 +175,7 @@ public:
 
   std::string dump_to_string(const std::string& prefix, int depth) const;
 
-  bool useBIT() const { return useBIT_; }
+  bool useBIT() const { return useBIT_.value(); }
 
 private:
   OpenDDS::DCPS::TopicStatus add_topic_i(OpenDDS::DCPS::RepoId& topicId,
@@ -239,7 +239,7 @@ private:
   IdToTopicMap idToTopicMap_;
 
   /// indicates if the BuiltIn Topics are enabled
-  bool useBIT_;
+  ACE_Atomic_Op<ACE_Thread_Mutex, bool> useBIT_;
 
   ///@{
   /// Built-in Topic variables


### PR DESCRIPTION
Problem: Under load, DCPSInfoRepo leaks some buffers from BIT writes.

Solution: prevent reinsertion of dropped / delivered buffers during shutdown & after disposal to avoid leaks