### PR TITLE
Java Messenger Test Fixes

### DIFF
--- a/java/tests/messenger/publisher/run_test.pl
+++ b/java/tests/messenger/publisher/run_test.pl
@@ -39,7 +39,7 @@ my $sub_opts = $opts;
 if ($debug ne '0') {
     my $debug_opt = "-ORBDebugLevel $debug -DCPSDebugLevel $debug " .
                     "-DCPSTransportDebugLevel $debug";
-    $pub_opts .= " $debug_opt -ORBLogFile pub.log";
+    $pub_opts .= " $debug_opt -ORBLogFile pub.log -DCPSPendingTimeout 3";
     $sub_opts .= " $debug_opt -ORBLogFile sub.log";
 }
 

--- a/java/tests/messenger/run_test.pl
+++ b/java/tests/messenger/run_test.pl
@@ -46,7 +46,7 @@ my $sub_opts = $opts;
 if ($debug ne '0') {
     my $debug_opt = "-ORBDebugLevel $debug -DCPSDebugLevel $debug " .
                     "-DCPSTransportDebugLevel $debug";
-    $pub_opts .= " $debug_opt -ORBLogFile pub.log";
+    $pub_opts .= " $debug_opt -ORBLogFile pub.log -DCPSPendingTimeout 3";
     $sub_opts .= " $debug_opt -ORBLogFile sub.log";
 }
 

--- a/java/tests/messenger/subscriber/TestSubscriber.java
+++ b/java/tests/messenger/subscriber/TestSubscriber.java
@@ -105,6 +105,12 @@ public class TestSubscriber {
         qosh.value.history.kind = HistoryQosPolicyKind.KEEP_ALL_HISTORY_QOS;
 
         DataReaderListenerImpl listener = new DataReaderListenerImpl();
+
+        GuardCondition gc = new GuardCondition();
+        WaitSet ws = new WaitSet();
+        ws.attach_condition(gc);
+        listener.set_guard_condition(gc);
+
         DataReader dr = sub.create_datareader(top,
                                               qosh.value,
                                               listener,
@@ -117,10 +123,6 @@ public class TestSubscriber {
             System.err.println("ERROR: DataReader creation failed");
             return;
         }
-        GuardCondition gc = new GuardCondition();
-        listener.set_guard_condition(gc);
-        WaitSet ws = new WaitSet();
-        ws.attach_condition(gc);
         Duration_t timeout = new Duration_t(DURATION_INFINITE_SEC.value,
                                             DURATION_INFINITE_NSEC.value);
 

--- a/java/tests/messenger/subscriber/run_test.pl
+++ b/java/tests/messenger/subscriber/run_test.pl
@@ -39,7 +39,7 @@ my $sub_opts = "$opts $reliable";
 if ($debug ne '0') {
     my $debug_opt = "-ORBDebugLevel $debug -DCPSDebugLevel $debug " .
                     "-DCPSTransportDebugLevel $debug";
-    $pub_opts .= " $debug_opt -ORBLogFile pub.log";
+    $pub_opts .= " $debug_opt -ORBLogFile pub.log -DCPSPendingTimeout 3";
     $sub_opts .= " $debug_opt -ORBLogFile sub.log";
 }
 


### PR DESCRIPTION
Messenger has multiple java errors on the scoreboard.

The first is due to a timeout with pending data.
The second is due to the guard condition being declared after the datareader.

This PR fixes those errors.