### PR TITLE
TSAN Fix and Minor Cleanup for Ownership Test DataReaderListener

### DIFF
--- a/tests/DCPS/Ownership/DataReaderListener.cpp
+++ b/tests/DCPS/Ownership/DataReaderListener.cpp
@@ -36,7 +36,6 @@ DataReaderListenerImpl::~DataReaderListenerImpl()
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   try {
     Messenger::MessageDataReader_var message_dr =
       Messenger::MessageDataReader::_narrow(reader);
@@ -50,7 +49,6 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     DDS::ReturnCode_t status = DDS::RETCODE_OK;
     while (status == DDS::RETCODE_OK) {
-      ++num_reads_;
       Messenger::Message message;
       DDS::SampleInfo si;
 
@@ -58,6 +56,8 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
       if (status == DDS::RETCODE_OK) {
         if (si.valid_data) {
+          ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+          ++num_reads_;
           ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) %C->%C subject_id: %d ")
             ACE_TEXT("count: %d strength: %d\n"),
             message.from.in(), reader_id_, message.subject_id,

--- a/tests/DCPS/Ownership/DataReaderListener.h
+++ b/tests/DCPS/Ownership/DataReaderListener.h
@@ -61,12 +61,13 @@ public:
     return num_reads_;
   }
 
-  bool verify_result ();
+  bool verify_result();
 
 private:
 
-  bool verify (const Messenger::Message& msg);
+  bool verify(const Messenger::Message& msg);
 
+  ACE_Thread_Mutex     mutex_;
   DDS::DataReader_var  reader_;
   long                 num_reads_;
   const char*          reader_id_;


### PR DESCRIPTION
Problem: Different threads can call the Ownership DataReaderListener's on_data_available method, causing a TSAN complaint.

Solution: Add a mutex to the DataReaderListener to avoid TSAN complaints