### PR TITLE
Avoid non-id version of canceling reactor timers where possible

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -229,7 +229,7 @@ private:
     PendingAssocTimer(ACE_Reactor* reactor,
                       ACE_thread_t owner)
       : ReactorInterceptor(reactor, owner)
-      , timer_id_(0)
+      , timer_id_(-1)
     { }
 
     void schedule_timer(TransportClient_rch transport_client, const PendingAssoc_rch& pend)
@@ -282,7 +282,7 @@ private:
             long id = timer_->reactor()->schedule_timer(assoc_.in(),
                                                         client.in(),
                                                         client->passive_connect_duration_.value());
-            if (id > 0) {
+            if (id != -1) {
               timer_->set_id(id);
             }
           }
@@ -300,7 +300,7 @@ private:
         if (timer_->reactor() && timer_->get_id()) {
           ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
           timer_->reactor()->cancel_timer(timer_->get_id());
-          timer_->set_id(0);
+          timer_->set_id(-1);
           assoc_->scheduled_ = false;
         }
       }

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -229,6 +229,7 @@ private:
     PendingAssocTimer(ACE_Reactor* reactor,
                       ACE_thread_t owner)
       : ReactorInterceptor(reactor, owner)
+      , timer_id_(0)
     { }
 
     void schedule_timer(TransportClient_rch transport_client, const PendingAssoc_rch& pend)
@@ -240,6 +241,9 @@ private:
     {
       return execute_or_enqueue(make_rch<CancelCommand>(this, pend));
     }
+
+    void set_id(long id) { timer_id_ = id; }
+    long get_id() const { return timer_id_; }
 
     virtual bool reactor_is_shut_down() const
     {
@@ -275,9 +279,12 @@ private:
           if (client) {
             ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
             assoc_->scheduled_ = true;
-            timer_->reactor()->schedule_timer(assoc_.in(),
-                                              client.in(),
-                                              client->passive_connect_duration_.value());
+            long id = timer_->reactor()->schedule_timer(assoc_.in(),
+                                                        client.in(),
+                                                        client->passive_connect_duration_.value());
+            if (id > 0) {
+              timer_->set_id(id);
+            }
           }
         }
       }
@@ -290,13 +297,15 @@ private:
       { }
       virtual void execute()
       {
-        if (timer_->reactor()) {
+        if (timer_->reactor() && timer_->get_id()) {
           ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
-          timer_->reactor()->cancel_timer(assoc_.in());
+          timer_->reactor()->cancel_timer(timer_->get_id());
+          timer_->set_id(0);
           assoc_->scheduled_ = false;
         }
       }
     };
+    long timer_id_;
   };
   RcHandle<PendingAssocTimer> pending_assoc_timer_;
 

--- a/tests/unit-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/unit-tests/dds/DCPS/SporadicTask.cpp
@@ -25,7 +25,7 @@ namespace {
   class MyReactor : public ACE_Reactor {
   public:
     MOCK_METHOD4(schedule_timer, long(ACE_Event_Handler*, const void*, const ACE_Time_Value&, const ACE_Time_Value&));
-    MOCK_METHOD2(cancel_timer, int(ACE_Event_Handler*, int));
+    MOCK_METHOD3(cancel_timer, int(long, const void**, int));
   };
 
   class MyReactorInterceptor : public ReactorInterceptor {
@@ -43,6 +43,7 @@ namespace {
                    RcHandle<ReactorInterceptor> interceptor)
       : SporadicTask(time_source, interceptor)
     {}
+    long timer_id() { return get_timer_id(); }
 
     MOCK_METHOD1(execute, void(const MonotonicTimePoint&));
   };
@@ -172,12 +173,13 @@ TEST(dds_DCPS_SporadicTask, schedule_earlier)
 
   EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, two_seconds.value(), ACE_Time_Value::zero))
     .WillOnce(testing::Return(1));
+  sporadic_task->schedule(two_seconds);
+
+  EXPECT_CALL(reactor, cancel_timer(sporadic_task->timer_id(), 0, 1))
+    .WillOnce(testing::Return(1));
   EXPECT_CALL(reactor, schedule_timer(sporadic_task.get(), 0, one_second.value(), ACE_Time_Value::zero))
     .WillOnce(testing::Return(1));
-  EXPECT_CALL(reactor, cancel_timer(sporadic_task.get(), 1))
-    .WillOnce(testing::Return(0));
 
-  sporadic_task->schedule(two_seconds);
   sporadic_task->schedule(one_second);
 }
 
@@ -246,10 +248,11 @@ TEST(dds_DCPS_SporadicTask, cancel_scheduled)
     .Times(1)
     .WillOnce(testing::Return(1));
 
-  EXPECT_CALL(reactor, cancel_timer(sporadic_task.get(), 1))
-    .WillOnce(testing::Return(0));
-
   sporadic_task->schedule(two_seconds);
+
+  EXPECT_CALL(reactor, cancel_timer(sporadic_task->timer_id(), 0, 1))
+    .WillOnce(testing::Return(1));
+
   sporadic_task->cancel();
 }
 


### PR DESCRIPTION
Problem: The non-id version of ACE_Timer_Heap_T has linear performance over all registered timers. For small numbers of timers, it's not a big deal, but generally good to avoid when possible by using the id version, which does an O(log(n)) lookup.

Solution: Store timer id when it makes sense to do so for faster cancels.