### PR TITLE
Duplicate samples are received in reflective mode

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3143,8 +3143,6 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
           ACE_DEBUG((LM_DEBUG, "(%P|%t) {transport_debug.log_dropped_messages} RtpsUdpDataLink::RtpsWriter::process_acknack - %C -> %C stale message (reflect %d < %d)\n", LogGuid(id_).c_str(), LogGuid(reader->id_).c_str(), acknack.count.value, reader->required_acknack_count_));
         }
         dont_schedule_nack_response = true;
-      } else {
-        reader->required_acknack_count_ = heartbeat_count_;
       }
     }
   }
@@ -3668,6 +3666,7 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
        pos != limit; ++pos) {
     const ReaderInfo_rch& reader = *pos;
     gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
+    reader->required_acknack_count_ = heartbeat_count_;
   }
   readers_expecting_heartbeat_.clear();
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -212,6 +212,7 @@ RtpsUdpInst::populate_locator(TransportLocator& info, ConnectionInfoFlags flags)
     if (local_address() != NetworkAddress()) {
       if (advertised_address() != NetworkAddress()) {
         grow(locators);
+        address_to_locator(locators[idx], advertised_address().to_addr());
         if (locators[idx].port == 0) {
           locators[idx].port = local_address().get_port_number();
         }
@@ -237,6 +238,7 @@ RtpsUdpInst::populate_locator(TransportLocator& info, ConnectionInfoFlags flags)
     if (ipv6_local_address() != NetworkAddress()) {
       if (ipv6_advertised_address() != NetworkAddress()) {
         grow(locators);
+        address_to_locator(locators[idx], ipv6_advertised_address().to_addr());
         if (locators[idx].port == 0) {
           locators[idx].port = ipv6_local_address().get_port_number();
         }


### PR DESCRIPTION
Problem
-------

In reflective mode, the RTPS UDP transport attempts to ignore nacks
that are pipelined due to latency.  This is done by sampling the
heartbeat count to determine a minimum for the count member of an
acknack.  In the current code, this limit was updated every time a new
enough acknack was received.

In this scheme, there is the opportunity to send a heartbeat
immediately after an acknack is received but before the nack
response.  This means the acknack that reflects this heartbeat would
be processed.  Most likely, it would be a duplicate of the acknack
that caused the nack response.

Solution
--------

Adjust the limit in the nack response.  This will cause the writer to
ignore acknacks until the reader has had an opportunity to receive any
requested data.