### PR TITLE
Latency is not reported in ConnectionRecord

### DIFF
--- a/dds/DCPS/RTPS/ICE/Ice.cpp
+++ b/dds/DCPS/RTPS/ICE/Ice.cpp
@@ -129,6 +129,8 @@ ServerReflexiveStateMachine::send(const ACE_INET_Addr& address,
                                   size_t indication_count_limit,
                                   const DCPS::GuidPrefix_t& guid_prefix)
 {
+  timestamp_ = DCPS::MonotonicTimePoint::now();
+
   if (stun_server_address_ == ACE_INET_Addr() &&
       address == ACE_INET_Addr()) {
     // Do nothing.
@@ -153,6 +155,8 @@ ServerReflexiveStateMachine::send(const ACE_INET_Addr& address,
 ServerReflexiveStateMachine::StateChange
 ServerReflexiveStateMachine::receive(const STUN::Message& message)
 {
+  latency_ = DCPS::MonotonicTimePoint::now() - timestamp_;
+
   switch (message.class_) {
   case STUN::SUCCESS_RESPONSE:
     return success_response(message);

--- a/dds/DCPS/RTPS/ICE/Ice.h
+++ b/dds/DCPS/RTPS/ICE/Ice.h
@@ -261,6 +261,16 @@ public:
     return message.transaction_id == message_.transaction_id;
   }
 
+  DCPS::TimeDuration latency() const
+  {
+    return latency_;
+  }
+
+  bool connected() const
+  {
+    return server_reflexive_address_ != ACE_INET_Addr();
+  }
+
 private:
   StateChange start(const ACE_INET_Addr& address, size_t indication_count_limit, const DCPS::GuidPrefix_t& guid_prefix);
   StateChange stop();
@@ -274,6 +284,8 @@ private:
   ACE_INET_Addr stun_server_address_;
   ACE_INET_Addr server_reflexive_address_;
   size_t send_count_;
+  DCPS::MonotonicTimePoint timestamp_;
+  DCPS::TimeDuration latency_;
  };
 
 } // namespace ICE

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4236,12 +4236,18 @@ void Spdp::SpdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::St
 
   switch (sc) {
   case ICE::ServerReflexiveStateMachine::SRSM_None:
+    if (relay_srsm_.connected()) {
+      connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
+      connection_record.latency = relay_srsm_.latency().to_dds_duration();
+      outer->sedp_->job_queue()->enqueue(DCPS::make_rch<DCPS::WriteConnectionRecords>(outer->bit_subscriber(), true, connection_record));
+    }
     break;
   case ICE::ServerReflexiveStateMachine::SRSM_Set:
   case ICE::ServerReflexiveStateMachine::SRSM_Change:
     // Lengthen to normal period.
     relay_stun_task_falloff_.set(ICE::Configuration::instance()->server_reflexive_address_period());
     connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
+    connection_record.latency = relay_srsm_.latency().to_dds_duration();
     outer->sedp_->job_queue()->enqueue(DCPS::make_rch<DCPS::WriteConnectionRecords>(outer->bit_subscriber(), true, connection_record));
     break;
   case ICE::ServerReflexiveStateMachine::SRSM_Unset:

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -956,12 +956,18 @@ RtpsUdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::StateChang
 
   switch (sc) {
   case ICE::ServerReflexiveStateMachine::SRSM_None:
+    if (relay_srsm_.connected()) {
+      connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
+      connection_record.latency = relay_srsm_.latency().to_dds_duration();
+      deferred_connection_records_.push_back(std::make_pair(true, connection_record));
+    }
     break;
   case ICE::ServerReflexiveStateMachine::SRSM_Set:
   case ICE::ServerReflexiveStateMachine::SRSM_Change:
     // Lengthen to normal period.
     relay_stun_task_falloff_.set(ICE::Configuration::instance()->server_reflexive_address_period());
     connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
+    connection_record.latency = relay_srsm_.latency().to_dds_duration();
     deferred_connection_records_.push_back(std::make_pair(true, connection_record));
     break;
   case ICE::ServerReflexiveStateMachine::SRSM_Unset:

--- a/dds/OpenddsDcpsExt.idl
+++ b/dds/OpenddsDcpsExt.idl
@@ -64,6 +64,7 @@ module OpenDDS
       BUILT_IN_TOPIC_KEY DDS::OctetArray16 guid;
       BUILT_IN_TOPIC_KEY string address;
       BUILT_IN_TOPIC_KEY string protocol;
+      DDS::Duration_t latency;
     };
 
     // OpenDDS extension built-in topic for thread


### PR DESCRIPTION
Problem
-------

Measuring the latency of a connection can provide valuable information
for debugging and tuning.

Solution
--------

Measure the latency and report it via ConnectionRecord.