### PR TITLE
Updates for Heartbeat Count Mapping

### DIFF
--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -523,6 +523,7 @@ module OpenDDS {
     const octet FLAG_D = 4; // Data: sample Data present
     const octet FLAG_L = 4; // Heartbeat: Liveliness
     const octet FLAG_K_IN_FRAG = 4;  // DataFrag: Key present
+    const octet OPENDDS_FLAG_R = 8; // Heartbeat: Reflective - Send-Side Internal Use Only - For Remapping Counts
     const octet FLAG_K_IN_DATA = 8;  // Data: Key present
     const octet FLAG_N_IN_FRAG = 8;  // DataFrag:  indicates that the SerializedPayload has non-standard encoding
     const octet FLAG_N_IN_DATA = 16; // Data: indicates that the SerializedPayload has non-standard encoding

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -701,7 +701,9 @@ private:
   typedef OPENDDS_SET(CORBA::Long) CountSet;
   typedef OPENDDS_MAP_CMP(EntityId_t, CountSet, EntityId_tKeyLessThan) IdCountSet;
   struct CountMapPair {
+    CountMapPair() : assigned_(false), undirected_(false) {}
     bool assigned_;
+    bool undirected_;
     CORBA::Long new_;
   };
   typedef OPENDDS_MAP(CORBA::Long, CountMapPair) CountMap;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -573,6 +573,7 @@ private:
     void gather_heartbeats_i(MetaSubmessageVec& meta_submessages);
     void gather_heartbeats(const RepoIdSet& additional_guids,
                            MetaSubmessageVec& meta_submessages);
+    void update_required_acknack_count(const RepoId& id, CORBA::ULong previous, CORBA::ULong current);
 
     RcHandle<SingleSendBuffer> get_send_buff() { return send_buff_; }
   };
@@ -730,6 +731,7 @@ private:
     CountKeeper& counts);
 
   void queue_submessages(MetaSubmessageVec& meta_submessages, double scale = 1.0);
+  void update_required_acknack_count(const RepoId& local_id, const RepoId& remote_id, CORBA::ULong previous, CORBA::ULong current);
   void bundle_and_send_submessages(MetaSubmessageVecVecVec& meta_submessages);
 
   typedef OPENDDS_MAP(ACE_thread_t, MetaSubmessageVecVec) ThreadSendQueueMap;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -701,15 +701,16 @@ private:
   typedef OPENDDS_SET(CORBA::Long) CountSet;
   typedef OPENDDS_MAP_CMP(EntityId_t, CountSet, EntityId_tKeyLessThan) IdCountSet;
   struct CountMapPair {
-    CountMapPair() : assigned_(false), undirected_(false) {}
-    bool assigned_;
+    CountMapPair() : undirected_(false), is_new_assigned_(false) {}
     bool undirected_;
+    bool is_new_assigned_;
     CORBA::Long new_;
   };
   typedef OPENDDS_MAP(CORBA::Long, CountMapPair) CountMap;
   struct CountMapping {
     CountMap map_;
-    CountMap::iterator next_unassigned_;
+    CountMap::iterator next_directed_unassigned_;
+    CountMap::iterator next_undirected_unassigned_;
   };
   typedef OPENDDS_MAP_CMP(EntityId_t, CountMapping, EntityId_tKeyLessThan) IdCountMapping;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -700,10 +700,19 @@ private:
   typedef OPENDDS_VECTOR(MetaSubmessageIterVec) MetaSubmessageIterVecVec;
   typedef OPENDDS_SET(CORBA::Long) CountSet;
   typedef OPENDDS_MAP_CMP(EntityId_t, CountSet, EntityId_tKeyLessThan) IdCountSet;
-  typedef OPENDDS_MAP(size_t, IdCountSet) HeartbeatCounts;
+  struct CountMapPair {
+    bool assigned_;
+    CORBA::Long new_;
+  };
+  typedef OPENDDS_MAP(CORBA::Long, CountMapPair) CountMap;
+  struct CountMapping {
+    CountMap map_;
+    CountMap::iterator next_unassigned_;
+  };
+  typedef OPENDDS_MAP_CMP(EntityId_t, CountMapping, EntityId_tKeyLessThan) IdCountMapping;
 
   struct CountKeeper {
-    HeartbeatCounts heartbeat_counts_;
+    IdCountMapping heartbeat_counts_;
     IdCountSet nackfrag_counts_;
   };
 
@@ -714,8 +723,8 @@ private:
     AddrDestMetaSubmessageMap& adr_map,
     MetaSubmessageIterVecVec& meta_submessage_bundles,
     OPENDDS_VECTOR(AddressCacheEntryProxy)& meta_submessage_bundle_addrs,
-                               OPENDDS_VECTOR(size_t)& meta_submessage_bundle_sizes,
-                               CountKeeper& counts);
+    OPENDDS_VECTOR(size_t)& meta_submessage_bundle_sizes,
+    CountKeeper& counts);
 
   void queue_submessages(MetaSubmessageVec& meta_submessages, double scale = 1.0);
   void bundle_and_send_submessages(MetaSubmessageVecVecVec& meta_submessages);


### PR DESCRIPTION
Problem: Heartbeat count remapping currently reorders within a given RTPS message, but not across all messages sent in a given transaction. This can lead to dropped heartbeats when "earlier" message counts then block later messages.

Solution: There is no guarantee of message delivery order, but in general we should assume earlier messages will be delivered first. This means reordering counts across messages is required to prevent "blocking" of later submessages. But we also need to make sure that the count order within a given message doesn't cause blocking, which is especially relevant when a message contains both undirected and directed heartbeats from the same writer. We can accomplish this by developing a translation between existing heartbeat count values, placing low count values in earlier messages, but also assigning undirected heartbeats the lowest values since they will always appear before directed heartbeats within any single message.