### PR TITLE
RTPS transport sends too many heartbeats

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4228,6 +4228,7 @@ void Spdp::SpdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::St
   DCPS::ConnectionRecord connection_record;
   std::memset(connection_record.guid, 0, sizeof(connection_record.guid));
   connection_record.protocol = DCPS::RTPS_RELAY_STUN_PROTOCOL;
+  connection_record.latency = DCPS::TimeDuration::zero_value.to_dds_duration();
 
   DCPS::ConnectionRecordDataReaderImpl* dr = outer->connection_record_bit();
   if (!dr) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -953,6 +953,7 @@ RtpsUdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::StateChang
   DCPS::ConnectionRecord connection_record;
   std::memset(connection_record.guid, 0, sizeof(connection_record.guid));
   connection_record.protocol = RTPS_RELAY_STUN_PROTOCOL;
+  connection_record.latency = TimeDuration::zero_value.to_dds_duration();
 
   switch (sc) {
   case ICE::ServerReflexiveStateMachine::SRSM_None:


### PR DESCRIPTION
Problem
-------

Logs in high latency scenarios with responsive mode and heartbeat
reflection show a number of acks being dropped due to heartbeat
reflection.  Theses nacks are only generated when a heartbeat is
received.

Solution
--------

* Send a heartbeat when adding a reader or on end historic
  samples (not both).
* Always send a preassociation acknack when adding a writer.
* Don't send a heartbeat in process_acknack.  The nack response is
  sufficient.
* Don't remove a reader that expects data if fragments have been
  requested.
* Clean up acknowledged fragments.
* Send a heartbeat when data is requested.