### PR TITLE
ConnectionRecord writes when no change

### DIFF
--- a/dds/DCPS/RTPS/ICE/Ice.cpp
+++ b/dds/DCPS/RTPS/ICE/Ice.cpp
@@ -156,6 +156,7 @@ ServerReflexiveStateMachine::StateChange
 ServerReflexiveStateMachine::receive(const STUN::Message& message)
 {
   latency_ = DCPS::MonotonicTimePoint::now() - timestamp_;
+  latency_available_ = true;
 
   switch (message.class_) {
   case STUN::SUCCESS_RESPONSE:

--- a/dds/DCPS/RTPS/ICE/Ice.h
+++ b/dds/DCPS/RTPS/ICE/Ice.h
@@ -239,6 +239,7 @@ public:
   ServerReflexiveStateMachine()
     : message_class_(STUN::REQUEST)
     , send_count_(0)
+    , latency_available_(false)
   {}
 
   // Return Unset if transitioning from a determined SRA to an undetermined SRA.
@@ -266,6 +267,16 @@ public:
     return latency_;
   }
 
+  bool latency_available() const
+  {
+    return latency_available_;
+  }
+
+  void latency_available(bool flag)
+  {
+    latency_available_ = flag;
+  }
+
   bool connected() const
   {
     return server_reflexive_address_ != ACE_INET_Addr();
@@ -286,6 +297,7 @@ private:
   size_t send_count_;
   DCPS::MonotonicTimePoint timestamp_;
   DCPS::TimeDuration latency_;
+  bool latency_available_;
  };
 
 } // namespace ICE

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4237,9 +4237,10 @@ void Spdp::SpdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::St
 
   switch (sc) {
   case ICE::ServerReflexiveStateMachine::SRSM_None:
-    if (relay_srsm_.connected()) {
+    if (relay_srsm_.latency_available()) {
       connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
       connection_record.latency = relay_srsm_.latency().to_dds_duration();
+      relay_srsm_.latency_available(false);
       outer->sedp_->job_queue()->enqueue(DCPS::make_rch<DCPS::WriteConnectionRecords>(outer->bit_subscriber(), true, connection_record));
     }
     break;
@@ -4249,6 +4250,7 @@ void Spdp::SpdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::St
     relay_stun_task_falloff_.set(ICE::Configuration::instance()->server_reflexive_address_period());
     connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
     connection_record.latency = relay_srsm_.latency().to_dds_duration();
+    relay_srsm_.latency_available(false);
     outer->sedp_->job_queue()->enqueue(DCPS::make_rch<DCPS::WriteConnectionRecords>(outer->bit_subscriber(), true, connection_record));
     break;
   case ICE::ServerReflexiveStateMachine::SRSM_Unset:

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -957,9 +957,10 @@ RtpsUdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::StateChang
 
   switch (sc) {
   case ICE::ServerReflexiveStateMachine::SRSM_None:
-    if (relay_srsm_.connected()) {
+    if (relay_srsm_.latency_available()) {
       connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
       connection_record.latency = relay_srsm_.latency().to_dds_duration();
+      relay_srsm_.latency_available(false);
       deferred_connection_records_.push_back(std::make_pair(true, connection_record));
     }
     break;
@@ -969,6 +970,7 @@ RtpsUdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::StateChang
     relay_stun_task_falloff_.set(ICE::Configuration::instance()->server_reflexive_address_period());
     connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
     connection_record.latency = relay_srsm_.latency().to_dds_duration();
+    relay_srsm_.latency_available(false);
     deferred_connection_records_.push_back(std::make_pair(true, connection_record));
     break;
   case ICE::ServerReflexiveStateMachine::SRSM_Unset:


### PR DESCRIPTION
Problem
-------

The ConnectionRecords for tracking the RtpsRelay write when there is
no change.  This was added to track changes in latency.

Solution
--------

Track when a new latency measurement is available.