### PR TITLE
StaticDiscovery test uses publication handles

### DIFF
--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -112,7 +112,7 @@ DataReaderListenerImpl::on_subscription_matched(
 {
   OPENDDS_ASSERT(status.current_count >= 0);
   if (status.current_count > total_writers_) {
-    ACE_ERROR((LM_ERROR, "(%P|%t) DataReaderListenerImpl::on_subscription_matched: more writers than expected\n"))
+    ACE_ERROR((LM_ERROR, "(%P|%t) DataReaderListenerImpl::on_subscription_matched: more writers than expected\n"));
   }
   OPENDDS_ASSERT(previous_count_ + status.current_count_change == status.current_count);
   previous_count_ = status.current_count;

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -9,6 +9,9 @@
 #include "DataReaderListenerImpl.h"
 #include "TestMsgTypeSupportC.h"
 #include "TestMsgTypeSupportImpl.h"
+#include "dds/DCPS/DomainParticipantImpl.h"
+#include "dds/DCPS/DataReaderImpl.h"
+#include "dds/DCPS/GuidConverter.h"
 #if !defined (DDS_HAS_MINIMUM_BIT)
 #include "dds/DdsDcpsCoreTypeSupportC.h"
 #endif // !defined (DDS_HAS_MINIMUM_BIT)
@@ -72,9 +75,12 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
   while (error == DDS::RETCODE_OK) {
     if (info.valid_data) {
-      SampleSetMap::iterator it = ph_received_samples_.find(info.publication_handle);
-      if (it == ph_received_samples_.end()) {
-        it = ph_received_samples_.insert(SampleSetMap::value_type(info.publication_handle, std::set<int>())).first;
+      DDS::Subscriber_var subscriber = reader->get_subscriber();
+      DDS::DomainParticipant_var participant = subscriber->get_participant();
+      const OpenDDS::DCPS::GUID_t writer_guid = dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant.in())->get_repoid(info.publication_handle);
+      SampleSetMap::iterator it = guid_received_samples_.find(writer_guid);
+      if (it == guid_received_samples_.end()) {
+        it = guid_received_samples_.insert(SampleSetMap::value_type(writer_guid, std::set<int>())).first;
         if (expect_all_samples_) {
           it->second.insert(0);
         }
@@ -87,11 +93,10 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
         OPENDDS_ASSERT(message.value == expected);
       }
       it->second.insert(message.value);
-      if (static_cast<int>(writers_.size()) == total_writers_) {
-        ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from known writer %C)\n", id_.data(), received_samples_, message.value, writers_[message.src].data()));
-      } else {
-        ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from (ambiguous (PH = %d)) writer #%d)\n", id_.data(), received_samples_, message.value, info.publication_handle, message.src));
-      }
+
+      const OpenDDS::DCPS::GUID_t reader_guid = dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader)->get_repo_id();
+
+      ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from writer %C)\n", OpenDDS::DCPS::LogGuid(reader_guid).c_str(), received_samples_, message.value, OpenDDS::DCPS::LogGuid(writer_guid).c_str()));
       if (++received_samples_ == expected_samples_) {
         done_callback_(builtin_read_error_);
       }
@@ -106,7 +111,9 @@ DataReaderListenerImpl::on_subscription_matched(
   const DDS::SubscriptionMatchedStatus& status)
 {
   OPENDDS_ASSERT(status.current_count >= 0);
-  OPENDDS_ASSERT(status.current_count <= total_writers_);
+  if (status.current_count > total_writers_) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) DataReaderListenerImpl::on_subscription_matched: more writers than expected\n"))
+  }
   OPENDDS_ASSERT(previous_count_ + status.current_count_change == status.current_count);
   previous_count_ = status.current_count;
 #ifndef DDS_HAS_MINIMUM_BIT

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -11,6 +11,7 @@
 #include <dds/DdsDcpsSubscriptionC.h>
 #include <dds/DCPS/LocalObject.h>
 #include <dds/DCPS/Definitions.h>
+#include <dds/DCPS/GuidUtils.h>
 
 #include <string>
 #include <vector>
@@ -22,11 +23,10 @@ typedef void (*callback_t)(bool);
 class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
 public:
-  DataReaderListenerImpl(const std::string& id, bool reliable, bool expect_all_samples, const std::vector<std::string>& writers, const int total_writers, const int expected_samples, callback_t done_callback, DDS::Subscriber_ptr subscriber, bool check_bits)
+  DataReaderListenerImpl(const std::string& id, bool reliable, bool expect_all_samples, const int total_writers, const int expected_samples, callback_t done_callback, DDS::Subscriber_ptr subscriber, bool check_bits)
     : id_(id)
     , reliable_(reliable)
     , expect_all_samples_(expect_all_samples)
-    , writers_(writers)
     , total_writers_(total_writers)
     , expected_samples_(expected_samples)
     , previous_count_(0)
@@ -85,14 +85,13 @@ private:
   std::string id_;
   bool reliable_;
   bool expect_all_samples_;
-  const std::vector<std::string>& writers_;
   const int total_writers_;
   const int expected_samples_;
   int previous_count_;
   int received_samples_;
   typedef std::set<int> SampleSet;
-  typedef std::map<int, SampleSet> SampleSetMap;
-  SampleSetMap ph_received_samples_;
+  typedef std::map<OpenDDS::DCPS::GUID_t, SampleSet, OpenDDS::DCPS::GUID_tKeyLessThan> SampleSetMap;
+  SampleSetMap guid_received_samples_;
   callback_t done_callback_;
   bool builtin_read_error_;
 #ifndef DDS_HAS_MINIMUM_BIT

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -139,7 +139,6 @@ public:
 
     // Write samples
     TestMsg message;
-    message.src = thread_id;
     message.value = 1;
     for (int i = 0; i < MSGS_PER_WRITER; ++i) {
       DDS::ReturnCode_t error = message_writer->write(message, DDS::HANDLE_NIL);
@@ -312,7 +311,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
          pos != limit;
          ++pos) {
       pos->resize(6);
-      DDS::DataReaderListener_var listener(new DataReaderListenerImpl(*pos, reliable, true, writers, total_writers, n_msgs, reader_done_callback, subscriber.in(), check_bits));
+      DDS::DataReaderListener_var listener(new DataReaderListenerImpl(*pos, reliable, true, total_writers, n_msgs, reader_done_callback, subscriber.in(), check_bits));
 
 #ifndef DDS_HAS_MINIMUM_BIT
       DataReaderListenerImpl* listener_servant =

--- a/tests/DCPS/StaticDiscovery/TestMsg.idl
+++ b/tests/DCPS/StaticDiscovery/TestMsg.idl
@@ -2,6 +2,5 @@
 #pragma DCPS_DATA_TYPE "TestMsg"
 
 struct TestMsg {
-  short src;
   short value;
 };


### PR DESCRIPTION
Problem
-------

The StaticDiscovery test uses publication handles to track writers.
Publication handles can get reused which confuses the tracking.

Solution
--------

Track by GUID.