### PR TITLE
Update Stress Test Timings

### DIFF
--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -32,7 +32,7 @@ struct TestObj : public RcObject
     ACE_DEBUG((LM_DEBUG, "TestObj::execute() called at %T\n"));
     ++total_count;
     if (do_schedule_.value()) {
-      sporadic_->schedule(TimeDuration::from_msec(100));
+      sporadic_->schedule(TimeDuration::from_msec(100)); // 0.1 seconds from now
     }
   }
 
@@ -51,6 +51,9 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   ReactorTask reactor_task(false);
   reactor_task.open_reactor_task(0, &tsm);
 
+  // Note: This test is modeled directly on the MultiTask stress test, which has a "fallback" timer
+  // Since SporadicTask doesn't have this, we expect the number of total executions to be different
+
   RcHandle<TestObj> obj = make_rch<TestObj>(time_source, reactor_task.interceptor());
   obj->sporadic_->schedule(TimeDuration::from_msec(2000));
   ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
@@ -63,18 +66,17 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   size_t schedule_calls = 0;
   while (MonotonicTimePoint::now() < deadline) {
     ++schedule_calls;
-    obj->sporadic_->schedule(TimeDuration::from_msec(100));
-    ACE_OS::sleep(ACE_Time_Value(0, 1000));
+    obj->sporadic_->schedule(TimeDuration::from_msec(100)); // 0.1 seconds from now
+    ACE_OS::sleep(ACE_Time_Value(0, 1000)); // sleep for 0.001 seconds
   }
   obj->set_do_schedule(false);
+  ACE_OS::sleep(ACE_Time_Value(0, 110000)); // sleep for 0.11 seconds to catch final "fast" executions
   ACE_DEBUG((LM_DEBUG, "schedule_calls = %d\n", schedule_calls));
   ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
-  TEST_CHECK(total_count >= 19);
-  TEST_CHECK(total_count <= 21);
-  const unsigned int prev_total_count = total_count.value();
-  ACE_OS::sleep(5);
+  TEST_CHECK(total_count == 21); // 1 from the slow period, 20 from the fast period (2.0 / 0.1)
+  ACE_OS::sleep(2);
   ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
-  TEST_CHECK(total_count == prev_total_count + 1);
+  TEST_CHECK(total_count == 21); // No lingering enables / executions mean total count should be unchanged
   obj->sporadic_->cancel();
 
   reactor_task.stop();


### PR DESCRIPTION
Problem: The MultiTask and SporadicTask stress tests were relying on precise system timing to capture and test execution state between "fast" timer executions (seemingly by accident). As a result, the test would occasionally fail when system timing didn't exactly match expectations.

Solution: Attempt to move 2nd-to-last test captures after the "fast" sections and adjust expected total counts accordingly.