### PR TITLE
Consistency In Use Of Virtual Inheritance

### DIFF
--- a/dds/DCPS/Comparator_T.h
+++ b/dds/DCPS/Comparator_T.h
@@ -25,7 +25,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class ComparatorBase : public RcObject {
+class ComparatorBase : public virtual RcObject {
 public:
   typedef RcHandle<ComparatorBase> Ptr;
 

--- a/dds/DCPS/DataDurabilityCache.cpp
+++ b/dds/DCPS/DataDurabilityCache.cpp
@@ -60,7 +60,7 @@ void cleanup_directory(const OPENDDS_VECTOR(OPENDDS_STRING) & path,
  * @brief Event handler that is called when @c service_cleanup_delay
  *        period expires.
  */
-class Cleanup_Handler : public OpenDDS::DCPS::RcEventHandler {
+class Cleanup_Handler : public virtual OpenDDS::DCPS::RcEventHandler {
 public:
 
   typedef

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -178,7 +178,7 @@ private:
   };
 };
 
-class MessageHolder : public RcObject {
+class MessageHolder : public virtual RcObject {
 public:
   virtual const void* get() const = 0;
 };

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -57,7 +57,7 @@ namespace OpenDDS {
     typedef OPENDDS_MAP(DDS::InstanceHandle_t, typename InstanceMap::iterator) ReverseInstanceMap;
 
     class SharedInstanceMap
-      : public RcObject
+      : public virtual RcObject
       , public InstanceMap
     {
     };

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -733,7 +733,7 @@ private:
 typedef RcHandle<DataWriterImpl> DataWriterImpl_rch;
 
 
-class LivenessTimer : public RcEventHandler
+class LivenessTimer : public virtual RcEventHandler
 {
 public:
   LivenessTimer(DataWriterImpl& writer)

--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -53,7 +53,7 @@ class DataReaderImpl;
  * InfoRepo-based discovery and RTPS Discovery.
  *
  */
-class OpenDDS_Dcps_Export Discovery : public RcObject {
+class OpenDDS_Dcps_Export Discovery : public virtual RcObject {
 public:
   /// Key type for storing discovery objects.
   /// Probably should just be Discovery::Key

--- a/dds/DCPS/DomainParticipantImpl.h
+++ b/dds/DCPS/DomainParticipantImpl.h
@@ -563,7 +563,7 @@ private:
   /// Protect the replayers collection.
   ACE_Recursive_Thread_Mutex replayers_protector_;
 
-  class LivelinessTimer : public RcObject {
+  class LivelinessTimer : public virtual RcObject {
   public:
     LivelinessTimer(DomainParticipantImpl& impl, DDS::LivelinessQosPolicyKind kind);
     virtual ~LivelinessTimer();

--- a/dds/DCPS/FileSystemStorage.h
+++ b/dds/DCPS/FileSystemStorage.h
@@ -95,7 +95,7 @@ using OpenDDS::DCPS::RcHandle;
 
 class File;
 
-class OpenDDS_Dcps_Export Directory : public RcObject {
+class OpenDDS_Dcps_Export Directory : public virtual RcObject {
 public:
   typedef RcHandle<Directory> Ptr;
 
@@ -216,7 +216,7 @@ private:
   // phys. prefix (before '.') -> next available counter #
 };
 
-class OpenDDS_Dcps_Export File : public RcObject {
+class OpenDDS_Dcps_Export File : public virtual RcObject {
 public:
   typedef RcHandle<File> Ptr;
 

--- a/dds/DCPS/FilterEvaluator.h
+++ b/dds/DCPS/FilterEvaluator.h
@@ -85,7 +85,7 @@ struct OpenDDS_Dcps_Export Value {
   bool conversion_preferred_;
 };
 
-class OpenDDS_Dcps_Export FilterEvaluator : public RcObject {
+class OpenDDS_Dcps_Export FilterEvaluator : public virtual RcObject {
 public:
 
   struct AstNodeWrapper;

--- a/dds/DCPS/InternalDataReader.h
+++ b/dds/DCPS/InternalDataReader.h
@@ -25,7 +25,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class InternalEntity : public RcObject {};
+class InternalEntity : public virtual RcObject {};
 typedef WeakRcHandle<InternalEntity> InternalEntity_wrch;
 
 enum InternalSampleInfoKind {

--- a/dds/DCPS/InternalTopic.h
+++ b/dds/DCPS/InternalTopic.h
@@ -25,7 +25,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 template <typename T>
-class InternalTopic : public RcObject {
+class InternalTopic : public virtual RcObject {
 public:
   typedef RcHandle<InternalDataWriter<T> > InternalDataWriter_rch;
   typedef WeakRcHandle<InternalDataWriter<T> > InternalDataWriter_wrch;

--- a/dds/DCPS/LocalObject.h
+++ b/dds/DCPS/LocalObject.h
@@ -39,7 +39,7 @@ public:
 /// OpenDDS::DCPS::LocalObject resolves ambiguously-inherited members like
 /// _narrow and _ptr_type.  It is used from client code like so:
 /// class MyReaderListener
-///   : public OpenDDS::DCPS::LocalObject<OpenDDS::DCPS::DataReaderListener> {...};
+///   : public virtual OpenDDS::DCPS::LocalObject<OpenDDS::DCPS::DataReaderListener> {...};
 template <class Stub>
 class LocalObject
   : public virtual Stub

--- a/dds/DCPS/MultiTask.h
+++ b/dds/DCPS/MultiTask.h
@@ -18,7 +18,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class MultiTask : public RcEventHandler {
+class MultiTask : public virtual RcEventHandler {
 public:
   explicit MultiTask(RcHandle<ReactorInterceptor> interceptor, const TimeDuration& delay)
     : interceptor_(interceptor)

--- a/dds/DCPS/PeriodicTask.h
+++ b/dds/DCPS/PeriodicTask.h
@@ -16,7 +16,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class PeriodicTask : public RcEventHandler {
+class PeriodicTask : public virtual RcEventHandler {
 public:
   explicit PeriodicTask(RcHandle<ReactorInterceptor> interceptor)
     : user_enabled_(false)

--- a/dds/DCPS/PublicationInstance.h
+++ b/dds/DCPS/PublicationInstance.h
@@ -37,7 +37,7 @@ typedef ACE_UINT16 CoherencyGroup;
   *        from typed datawriter. The data will be duplicated for the register,
   *        unregister and dispose control message.
   */
-struct OpenDDS_Dcps_Export PublicationInstance : public RcObject {
+struct OpenDDS_Dcps_Export PublicationInstance : public virtual RcObject {
 
   PublicationInstance(Message_Block_Ptr registered_sample)
     : sequence_(),

--- a/dds/DCPS/RTPS/ICE/AgentImpl.cpp
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.cpp
@@ -87,8 +87,8 @@ int AgentImpl::handle_timeout(const ACE_Time_Value& a_now, const void* /*act*/)
 }
 
 AgentImpl::AgentImpl()
-  : ReactorInterceptor(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner())
-  , DCPS::InternalDataReaderListener<DCPS::NetworkInterfaceAddress>(TheServiceParticipant->job_queue())
+  : DCPS::InternalDataReaderListener<DCPS::NetworkInterfaceAddress>(TheServiceParticipant->job_queue())
+  , ReactorInterceptor(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner())
   , unfreeze_(false)
   , reader_(DCPS::make_rch<DCPS::InternalDataReader<DCPS::NetworkInterfaceAddress> >(true, DCPS::rchandle_from(this)))
   , reader_added_(false)

--- a/dds/DCPS/RTPS/ICE/AgentImpl.h
+++ b/dds/DCPS/RTPS/ICE/AgentImpl.h
@@ -35,9 +35,9 @@ typedef std::vector<FoundationType> FoundationList;
 
 class AgentImpl
   : public virtual Agent
-  , public virtual DCPS::ReactorInterceptor
   , public virtual DCPS::ShutdownListener
   , public virtual DCPS::InternalDataReaderListener<DCPS::NetworkInterfaceAddress>
+  , public DCPS::ReactorInterceptor
 {
 public:
   AgentImpl();

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -367,7 +367,7 @@ struct DiscoveredParticipant {
 #endif
 };
 
-class Sedp : public DCPS::RcEventHandler {
+class Sedp : public virtual DCPS::RcEventHandler {
 private:
   struct DiscoveredSubscription : PoolAllocationBase {
     DiscoveredSubscription()

--- a/dds/DCPS/RcEventHandler.h
+++ b/dds/DCPS/RcEventHandler.h
@@ -20,14 +20,13 @@ namespace DCPS {
 /// Templated Reference counted handle to a pointer.
 /// A non-DDS specific helper class.
 class RcEventHandler
-  : public ACE_Event_Handler
+  : public virtual ACE_Event_Handler
   , public virtual RcObject {
 public:
 
   RcEventHandler()
   {
     this->reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
-
   }
 
   ACE_Event_Handler::Reference_Count add_reference()

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -25,11 +25,11 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class OpenDDS_Dcps_Export ReactorInterceptor : public RcEventHandler {
+class OpenDDS_Dcps_Export ReactorInterceptor : public virtual RcEventHandler {
 public:
 
   class OpenDDS_Dcps_Export Command
-  : public RcObject {
+  : public virtual RcObject {
   public:
     Command();
     virtual ~Command() { }

--- a/dds/DCPS/Recorder.h
+++ b/dds/DCPS/Recorder.h
@@ -32,7 +32,7 @@ class Recorder;
  *
  * This class is for handling callbacks from the Recorder object.
  */
-class OpenDDS_Dcps_Export RecorderListener : public RcObject {
+class OpenDDS_Dcps_Export RecorderListener : public virtual RcObject {
 
 public:
   virtual ~RecorderListener();

--- a/dds/DCPS/Replayer.h
+++ b/dds/DCPS/Replayer.h
@@ -31,7 +31,7 @@ class Replayer;
  *
  * This class is for handling callbacks from the Replayer object.
  */
-class OpenDDS_Dcps_Export ReplayerListener : public RcObject {
+class OpenDDS_Dcps_Export ReplayerListener : public virtual RcObject {
 public:
   ~ReplayerListener();
   /**

--- a/dds/DCPS/RequestedDeadlineWatchdog.cpp
+++ b/dds/DCPS/RequestedDeadlineWatchdog.cpp
@@ -16,12 +16,15 @@
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
-OpenDDS::DCPS::RequestedDeadlineWatchdog::RequestedDeadlineWatchdog(
-  lock_type & lock,
+namespace OpenDDS {
+namespace DCPS {
+
+RequestedDeadlineWatchdog::RequestedDeadlineWatchdog(
+  lock_type& lock,
   DDS::DeadlineQosPolicy qos,
-  OpenDDS::DCPS::DataReaderImpl & reader_impl,
-  DDS::RequestedDeadlineMissedStatus & status,
-  CORBA::Long & last_total_count)
+  DataReaderImpl& reader_impl,
+  DDS::RequestedDeadlineMissedStatus& status,
+  CORBA::Long& last_total_count)
   : Watchdog(TimeDuration(qos.period))
   , status_lock_(lock)
   , reverse_status_lock_(status_lock_)
@@ -31,13 +34,13 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::RequestedDeadlineWatchdog(
 {
 }
 
-OpenDDS::DCPS::RequestedDeadlineWatchdog::~RequestedDeadlineWatchdog()
+RequestedDeadlineWatchdog::~RequestedDeadlineWatchdog()
 {
 }
 
 void
-OpenDDS::DCPS::RequestedDeadlineWatchdog::schedule_timer(
-  OpenDDS::DCPS::SubscriptionInstance_rch instance)
+RequestedDeadlineWatchdog::schedule_timer(
+  SubscriptionInstance_rch instance)
 {
   if (instance->deadline_timer_id_ == -1) {
     intptr_t handle = instance->instance_handle_;
@@ -53,8 +56,8 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::schedule_timer(
 }
 
 void
-OpenDDS::DCPS::RequestedDeadlineWatchdog::cancel_timer(
-  OpenDDS::DCPS::SubscriptionInstance_rch instance)
+RequestedDeadlineWatchdog::cancel_timer(
+  SubscriptionInstance_rch instance)
 {
   if (instance->deadline_timer_id_ != -1) {
     Watchdog::cancel_timer(instance->deadline_timer_id_);
@@ -66,7 +69,7 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::cancel_timer(
 }
 
 int
-OpenDDS::DCPS::RequestedDeadlineWatchdog::handle_timeout(const ACE_Time_Value&, const void* act)
+RequestedDeadlineWatchdog::handle_timeout(const ACE_Time_Value&, const void* act)
 {
   ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
 
@@ -84,7 +87,7 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::handle_timeout(const ACE_Time_Value&, 
 }
 
 void
-OpenDDS::DCPS::RequestedDeadlineWatchdog::execute(SubscriptionInstance_rch instance, bool timer_called)
+RequestedDeadlineWatchdog::execute(SubscriptionInstance_rch instance, bool timer_called)
 {
   if (instance->deadline_timer_id_ != -1) {
     bool missed = false;
@@ -162,11 +165,14 @@ OpenDDS::DCPS::RequestedDeadlineWatchdog::execute(SubscriptionInstance_rch insta
 }
 
 void
-OpenDDS::DCPS::RequestedDeadlineWatchdog::reschedule_deadline()
+RequestedDeadlineWatchdog::reschedule_deadline()
 {
   DataReaderImpl_rch reader = this->reader_impl_.lock();
   if (reader)
     reader->reschedule_deadline();
 }
+
+} // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/RequestedDeadlineWatchdog.h
+++ b/dds/DCPS/RequestedDeadlineWatchdog.h
@@ -36,7 +36,7 @@ class DataReaderImpl;
  * @c on_requested_deadline_missed() listener callback when the
  * configured finite deadline period expires.
  */
-class RequestedDeadlineWatchdog : public virtual OpenDDS::DCPS::Watchdog {
+class RequestedDeadlineWatchdog : public virtual Watchdog {
 public:
 
   typedef ACE_Recursive_Thread_Mutex  lock_type;

--- a/dds/DCPS/RequestedDeadlineWatchdog.h
+++ b/dds/DCPS/RequestedDeadlineWatchdog.h
@@ -36,18 +36,18 @@ class DataReaderImpl;
  * @c on_requested_deadline_missed() listener callback when the
  * configured finite deadline period expires.
  */
-class RequestedDeadlineWatchdog : public Watchdog {
+class RequestedDeadlineWatchdog : public virtual OpenDDS::DCPS::Watchdog {
 public:
 
   typedef ACE_Recursive_Thread_Mutex  lock_type;
   typedef ACE_Reverse_Lock<lock_type> reverse_lock_type;
 
   RequestedDeadlineWatchdog(
-    lock_type & lock,
+    lock_type& lock,
     DDS::DeadlineQosPolicy qos,
     DataReaderImpl& reader_impl,
-    DDS::RequestedDeadlineMissedStatus & status,
-    CORBA::Long & last_total_count);
+    DDS::RequestedDeadlineMissedStatus& status,
+    CORBA::Long& last_total_count);
 
   virtual ~RequestedDeadlineWatchdog();
 
@@ -73,7 +73,7 @@ public:
 private:
 
   /// Lock for synchronization of @c status_ member.
-  lock_type & status_lock_;
+  lock_type& status_lock_;
   /// Reverse lock used for releasing the @c status_lock_ listener upcall.
   reverse_lock_type reverse_status_lock_;
 
@@ -86,7 +86,7 @@ private:
   DDS::RequestedDeadlineMissedStatus& status_;
 
   /// Last total_count when status was last checked.
-  CORBA::Long & last_total_count_;
+  CORBA::Long& last_total_count_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/SporadicTask.h
+++ b/dds/DCPS/SporadicTask.h
@@ -18,7 +18,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class SporadicTask : public RcEventHandler {
+class SporadicTask : public virtual RcEventHandler {
 public:
   SporadicTask(const TimeSource& time_source,
                RcHandle<ReactorInterceptor> interceptor)

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -128,7 +128,7 @@ public:
 
 class StaticParticipant;
 class StaticEndpointManager
-  : public RcEventHandler
+  : public virtual RcEventHandler
   , public DiscoveryListener
 {
 protected:
@@ -521,7 +521,7 @@ private:
   OrigSeqNumberMap orig_seq_numbers_;
 };
 
-class StaticParticipant : public RcObject {
+class StaticParticipant : public virtual RcObject {
 public:
   StaticParticipant(RepoId& guid,
                     const DDS::DomainParticipantQos& qos,

--- a/dds/DCPS/SubscriptionInstance.h
+++ b/dds/DCPS/SubscriptionInstance.h
@@ -33,7 +33,7 @@ class DataReaderImpl;
   * @brief Struct that has information about an instance and the instance
   *        sample list.
   */
-class OpenDDS_Dcps_Export SubscriptionInstance : public RcObject {
+class OpenDDS_Dcps_Export SubscriptionInstance : public virtual RcObject {
 public:
   SubscriptionInstance(DataReaderImpl* reader,
                        const DDS::DataReaderQos& qos,

--- a/dds/DCPS/WaitSet.h
+++ b/dds/DCPS/WaitSet.h
@@ -50,7 +50,7 @@ typedef WaitSet* WaitSet_ptr;
 typedef TAO_Objref_Var_T<WaitSet> WaitSet_var;
 
 class OpenDDS_Dcps_Export WaitSet
-  : public OpenDDS::DCPS::LocalObject<WaitSetInterf> {
+  : public virtual OpenDDS::DCPS::LocalObject<WaitSetInterf> {
 public:
   typedef WaitSet_ptr _ptr_type;
   typedef WaitSet_var _var_type;

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -119,7 +119,7 @@ typedef OPENDDS_MAP(DDS::InstanceHandle_t, PublicationInstance_rch)
  *           we do not deadlock; and, 2) we incur the cost of
  *           obtaining the lock only once.
  */
-class OpenDDS_Dcps_Export WriteDataContainer : public RcObject {
+class OpenDDS_Dcps_Export WriteDataContainer : public virtual RcObject {
 public:
 
   friend class DataWriterImpl;

--- a/dds/DCPS/WriterInfo.h
+++ b/dds/DCPS/WriterInfo.h
@@ -81,7 +81,7 @@ enum Coherent_State {
 #endif
 
 /// Keeps track of a DataWriter's liveliness for a DataReader.
-class OpenDDS_Dcps_Export WriterInfo : public RcObject {
+class OpenDDS_Dcps_Export WriterInfo : public virtual RcObject {
   friend class WriteInfoListner;
 
 public:

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -270,7 +270,7 @@ public:
     bool reactor_is_shut_down() const;
   };
 
-  class ImmediateStart : public ReactorInterceptor::Command {
+  class ImmediateStart : public virtual ReactorInterceptor::Command {
   public:
     ImmediateStart(RcHandle<DataLink> link, WeakRcHandle<TransportClient> client, const RepoId& remote) : link_(link), client_(client), remote_(remote) {}
     void execute();

--- a/dds/DCPS/transport/framework/DataLinkSet.h
+++ b/dds/DCPS/transport/framework/DataLinkSet.h
@@ -27,7 +27,7 @@ class DataSampleElement;
 class DataLinkSet;
 typedef RcHandle<DataLinkSet> DataLinkSet_rch;
 
-class OpenDDS_Dcps_Export DataLinkSet : public RcObject {
+class OpenDDS_Dcps_Export DataLinkSet : public virtual RcObject {
 public:
 
   DataLinkSet();

--- a/dds/DCPS/transport/framework/ReceiveListenerSet.h
+++ b/dds/DCPS/transport/framework/ReceiveListenerSet.h
@@ -25,7 +25,7 @@ class ReceivedDataSample;
 typedef WeakRcHandle<TransportReceiveListener> TransportReceiveListener_wrch;
 
 class OpenDDS_Dcps_Export ReceiveListenerSet :
-      public RcObject {
+      public virtual RcObject {
 public:
 
   enum ConstrainReceiveSet {

--- a/dds/DCPS/transport/framework/ScheduleOutputHandler.h
+++ b/dds/DCPS/transport/framework/ScheduleOutputHandler.h
@@ -29,7 +29,7 @@ class TransportSendStrategy;
  * is queueing data, then the reactor is enabled to process on output
  * events.  Otherwise the output processing callbacks are cancelled.
  */
-class ScheduleOutputHandler : public ACE_Event_Handler, public PoolAllocationBase {
+class ScheduleOutputHandler : public virtual ACE_Event_Handler, public PoolAllocationBase {
   public:
     /// Construct with the reactor and strategy.
     ScheduleOutputHandler( TransportSendStrategy* strategy,

--- a/dds/DCPS/transport/framework/ThreadSynchStrategy.h
+++ b/dds/DCPS/transport/framework/ThreadSynchStrategy.h
@@ -22,7 +22,7 @@ class ThreadSynchResource;
 
 //MJM: Some class documentation here would be extremely helpful.
 class OpenDDS_Dcps_Export ThreadSynchStrategy
-  : public RcObject
+  : public virtual RcObject
 {
 public:
 

--- a/dds/DCPS/transport/framework/ThreadSynchWorker.h
+++ b/dds/DCPS/transport/framework/ThreadSynchWorker.h
@@ -20,7 +20,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 class OpenDDS_Dcps_Export ThreadSynchWorker
-  : public RcObject {
+  : public virtual RcObject {
 public:
 
   virtual ~ThreadSynchWorker();

--- a/dds/DCPS/transport/framework/TransportConfig.h
+++ b/dds/DCPS/transport/framework/TransportConfig.h
@@ -25,7 +25,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-class OpenDDS_Dcps_Export TransportConfig : public RcObject {
+class OpenDDS_Dcps_Export TransportConfig : public virtual RcObject {
 public:
 
   static const unsigned long DEFAULT_PASSIVE_CONNECT_DURATION = 60000;

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -59,7 +59,7 @@ typedef WeakRcHandle<TransportClient> TransportClient_wrch;
 *     but has a references via smart pointer then the reference should be freed;
 *     if this object has ownership of task objects then the tasks should be closed.
 */
-class OpenDDS_Dcps_Export TransportImpl : public RcObject {
+class OpenDDS_Dcps_Export TransportImpl : public virtual RcObject {
 public:
 
   virtual ~TransportImpl();

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -58,7 +58,7 @@ namespace DCPS {
  * The TransportInst object is supplied to the
  * TransportImpl::configure() method.
  */
-class OpenDDS_Dcps_Export TransportInst : public RcObject {
+class OpenDDS_Dcps_Export TransportInst : public virtual RcObject {
 public:
 
   const OPENDDS_STRING& name() const { return name_; }

--- a/dds/DCPS/transport/framework/TransportReassembly.h
+++ b/dds/DCPS/transport/framework/TransportReassembly.h
@@ -60,7 +60,7 @@ struct FragKey {
   OPENDDS_OOAT_CUSTOM_HASH(FragKey, OpenDDS_Dcps_Export, FragKeyHash);
 #endif
 
-class OpenDDS_Dcps_Export TransportReassembly : public RcObject {
+class OpenDDS_Dcps_Export TransportReassembly : public virtual RcObject {
 public:
   explicit TransportReassembly(const TimeDuration& timeout = TimeDuration(300));
 

--- a/dds/DCPS/transport/framework/TransportSendBuffer.h
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.h
@@ -70,7 +70,7 @@ private:
 /// domain of SequenceNumbers -- for a given SingleSendBuffer object, the
 /// sequence numbers passed to insert() must be generated from the same place.
 class OpenDDS_Dcps_Export SingleSendBuffer
-  : public TransportSendBuffer, public RcObject {
+  : public TransportSendBuffer, public virtual RcObject {
 public:
 
   static const size_t UNLIMITED;

--- a/dds/DCPS/transport/framework/TransportType.h
+++ b/dds/DCPS/transport/framework/TransportType.h
@@ -34,7 +34,7 @@ typedef RcHandle<TransportInst> TransportInst_rch;
  * to provide the new concrete transport object.
  *
  */
-class OpenDDS_Dcps_Export TransportType : public RcObject {
+class OpenDDS_Dcps_Export TransportType : public virtual RcObject {
 public:
 
   virtual const char* name() = 0;

--- a/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastReceiveStrategy.h
@@ -22,7 +22,7 @@ class MulticastDataLink;
 
 class OpenDDS_Multicast_Export MulticastReceiveStrategy
   : public TransportReceiveStrategy<>,
-    public RcEventHandler
+    public virtual RcEventHandler
 {
 public:
   explicit MulticastReceiveStrategy(MulticastDataLink* link);

--- a/dds/DCPS/transport/multicast/MulticastSession.h
+++ b/dds/DCPS/transport/multicast/MulticastSession.h
@@ -32,7 +32,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 class OpenDDS_Multicast_Export MulticastSession
-  : public RcObject {
+  : public virtual RcObject {
 public:
   virtual ~MulticastSession();
 

--- a/dds/DCPS/transport/multicast/MulticastSessionFactory.h
+++ b/dds/DCPS/transport/multicast/MulticastSessionFactory.h
@@ -32,7 +32,7 @@ class MulticastSession;
 typedef RcHandle<MulticastSession> MulticastSession_rch;
 
 class OpenDDS_Multicast_Export MulticastSessionFactory
-  : public RcObject {
+  : public virtual RcObject {
 public:
   virtual ~MulticastSessionFactory();
 

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -27,7 +27,7 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public RcObject {
+struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
   BundlingCacheKey(const GUID_t& dst_guid, const GUID_t& src_guid, RcHandle<ConstSharedRepoIdSet> addr_guids)
     : RcObject()
     , src_guid_(src_guid)

--- a/dds/DCPS/transport/rtps_udp/ConstSharedRepoIdSet.h
+++ b/dds/DCPS/transport/rtps_udp/ConstSharedRepoIdSet.h
@@ -16,7 +16,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-struct ConstSharedRepoIdSet : public RcObject {
+struct ConstSharedRepoIdSet : public virtual RcObject {
   ConstSharedRepoIdSet()
     : guids_()
 #if defined ACE_HAS_CPP11

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -26,7 +26,7 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public RcObject {
+struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public virtual RcObject {
   LocatorCacheKey(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
     : remote_(remote)
     , local_(local)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -334,7 +334,7 @@ private:
   typedef OPENDDS_MAP(FragmentNumberValue, RTPS::FragmentNumberSet) RequestedFragMap;
   typedef OPENDDS_MAP(SequenceNumber, RequestedFragMap) RequestedFragSeqMap;
 
-  struct ReaderInfo : public RcObject {
+  struct ReaderInfo : public virtual RcObject {
     const RepoId id_;
     const MonotonicTime_t participant_discovered_at_;
     CORBA::Long acknack_recvd_count_, nackfrag_recvd_count_;
@@ -415,7 +415,7 @@ private:
     }
   };
 
-  class RtpsWriter : public RcObject {
+  class RtpsWriter : public virtual RcObject {
   private:
     ReaderInfoMap remote_readers_;
     RcHandle<ConstSharedRepoIdSet> remote_reader_guids_;
@@ -606,7 +606,7 @@ private:
 #endif
   typedef OPENDDS_SET(WriterInfo_rch) WriterInfoSet;
 
-  class RtpsReader : public RcObject {
+  class RtpsReader : public virtual RcObject {
   public:
     RtpsReader(RcHandle<RtpsUdpDataLink> link, const RepoId& id)
       : link_(link)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -39,7 +39,7 @@ class ReceivedDataSample;
 
 class OpenDDS_Rtps_Udp_Export RtpsUdpReceiveStrategy
   : public TransportReceiveStrategy<RtpsTransportHeader, RtpsSampleHeader>,
-    public RcEventHandler
+    public virtual RcEventHandler
 {
 public:
   explicit RtpsUdpReceiveStrategy(RtpsUdpDataLink* link, const GuidPrefix_t& local_prefix);

--- a/dds/DCPS/transport/tcp/TcpConnection.h
+++ b/dds/DCPS/transport/tcp/TcpConnection.h
@@ -35,7 +35,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 class TcpConnection
-  : public RcObject
+  : public virtual RcObject
   , public ACE_Svc_Handler<ACE_SOCK_STREAM, ACE_NULL_SYNCH> {
 public:
 

--- a/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
+++ b/dds/DCPS/transport/tcp/TcpReceiveStrategy.h
@@ -23,7 +23,7 @@ class TcpConnection;
 
 class TcpReceiveStrategy
   : public TransportReceiveStrategy<>,
-    public RcEventHandler
+    public virtual RcEventHandler
 {
 public:
 

--- a/dds/DCPS/transport/udp/UdpReceiveStrategy.h
+++ b/dds/DCPS/transport/udp/UdpReceiveStrategy.h
@@ -24,7 +24,7 @@ class UdpDataLink;
 
 class OpenDDS_Udp_Export UdpReceiveStrategy
   : public TransportReceiveStrategy<>,
-    public RcEventHandler
+    public virtual RcEventHandler
 {
 public:
   explicit UdpReceiveStrategy(UdpDataLink* link);

--- a/dds/FACE/FaceTSS.h
+++ b/dds/FACE/FaceTSS.h
@@ -273,7 +273,7 @@ void send_message(FACE::CONNECTION_ID_TYPE connection_id,
 }
 
 template <typename Msg>
-class Listener : public DCPS::LocalObject<DDS::DataReaderListener> {
+class Listener : public virtual DCPS::LocalObject<DDS::DataReaderListener> {
 public:
   typedef void (*Callback)(FACE::TRANSACTION_ID_TYPE, Msg&,
                            FACE::MESSAGE_TYPE_GUID,

--- a/dds/InfoRepo/DCPSInfoRepoServ.h
+++ b/dds/InfoRepo/DCPSInfoRepoServ.h
@@ -23,7 +23,7 @@
 #include "ace/Condition_Thread_Mutex.h"
 
 class OpenDDS_DCPSInfoRepoServ_Export InfoRepo
-  : public ShutdownInterface, public ACE_Event_Handler {
+  : public ShutdownInterface, public virtual ACE_Event_Handler {
 public:
   struct InitError {
     InitError(const char* msg)

--- a/dds/InfoRepo/DCPSInfo_i.h
+++ b/dds/InfoRepo/DCPSInfo_i.h
@@ -52,7 +52,7 @@ class ShutdownInterface;
  */
 class  OpenDDS_InfoRepoLib_Export TAO_DDS_DCPSInfo_i
   : public virtual POA_OpenDDS::DCPS::DCPSInfo,
-    public ACE_Event_Handler {
+    public virtual ACE_Event_Handler {
 public:
   TAO_DDS_DCPSInfo_i(
     CORBA::ORB_ptr orb,

--- a/dds/InfoRepo/InfoRepoMulticastResponder.h
+++ b/dds/InfoRepo/InfoRepoMulticastResponder.h
@@ -39,7 +39,7 @@ namespace Federator {
  * registered with a reactor and should be initialized with the
  * ior of the  service to be multicasted.
  */
-class OpenDDS_Federator_Export InfoRepoMulticastResponder : public ACE_Event_Handler {
+class OpenDDS_Federator_Export InfoRepoMulticastResponder : public virtual ACE_Event_Handler {
 public:
   InfoRepoMulticastResponder();
 

--- a/performance-tests/bench/node_controller/main.cpp
+++ b/performance-tests/bench/node_controller/main.cpp
@@ -242,7 +242,7 @@ private:
 using SpawnedProcessPtr = std::shared_ptr<SpawnedProcess>;
 using ProcessStatsCollectorPtr = std::shared_ptr<ProcessStatsCollector>;
 
-class SpawnedProcessManager : public ACE_Event_Handler {
+class SpawnedProcessManager : public virtual ACE_Event_Handler {
 public:
 
   explicit SpawnedProcessManager(const std::string& node_name, const NodeId& node_id, ProcessManagerPtr process_manager)

--- a/tests/stress-tests/dds/DCPS/MultiTask.cpp
+++ b/tests/stress-tests/dds/DCPS/MultiTask.cpp
@@ -17,7 +17,7 @@ using namespace OpenDDS::DCPS;
 
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> total_count = 0;
 
-struct TestObj : public RcObject
+struct TestObj : public virtual RcObject
 {
   typedef PmfMultiTask<TestObj> Multi;
 

--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -17,7 +17,7 @@ using namespace OpenDDS::DCPS;
 
 ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> total_count = 0;
 
-struct TestObj : public RcObject
+struct TestObj : public virtual RcObject
 {
   typedef PmfSporadicTask<TestObj> Sporadic;
 

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -11,7 +11,7 @@
 
 using namespace OpenDDS::DCPS;
 
-struct TestKey : public RcObject {
+struct TestKey : public virtual RcObject {
   TestKey(const RepoId& from, const RepoId& to) : from_(from), to_(to) {}
   TestKey(const TestKey& val) : RcObject(), from_(val.from_), to_(val.to_) {}
   bool operator<(const TestKey& rhs) const {

--- a/tests/unit-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/unit-tests/dds/DCPS/SporadicTask.cpp
@@ -48,7 +48,7 @@ namespace {
     MOCK_METHOD1(execute, void(const MonotonicTimePoint&));
   };
 
-  class MyTestClass : public RcObject {
+  class MyTestClass : public virtual RcObject {
   public:
     MyTestClass(const TimeSource& time_source,
                 RcHandle<ReactorInterceptor> interceptor)


### PR DESCRIPTION
Problem: There are occasional TSAN warnings reported surrounding races between destructors and virtual function calls, as well as double destruction. While these might signal an issue with RcObject or RcHandle, it's also possible they are related to inconsistent use of virtual inheritance surrounding reference counted objects. There are, for example, several places where we do not use virtual inheritance for ACE_Event_Handler, RcObject, RcEventHandler, etc.

Solution: Be more consistent in use of virtual inheritance for these classes.

Note: Originally, this PR encompassed ReactorInterceptor as well, but the use of a protected constructor made consistent use of virtual inheritance difficult. Specifically, under virtual inheritance, grand-child classes (such as RequestedDeadlineWatchdog (via Watchdog)), indirectly complain about not having access to ReactorInterceptor's protected constructor (complaining instead about a lack of a default constructor, which is intentional). Consequently, use of ReactorInterceptor was made consistently non-virtual.