### PR TITLE
Update logic for choosing address and hostname in NetworkResource

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9398,133 +9398,133 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-#  cmake_w22_x86_i0_sec:
-#
-#    runs-on: windows-2022
-#
-#    needs: build_w22_x86_i0_sec
-#
-#    steps:
-#    - name: install openssl & xerces-c
-#      uses: lukka/run-vcpkg@v7
-#      with:
-#        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
-#        vcpkgArguments: --recurse openssl xerces-c
-#        vcpkgTriplet: x86-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v3
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: ACE_TAO_w22_x86_i0_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ACE_TAO_w22_x86_i0.tar.xz
-#        rm -f ACE_TAO_w22_x86_i0.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: build_w22_x86_i0_sec_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ build_w22_x86_i0_sec.tar.xz
-#        rm -f build_w22_x86_i0_sec.tar.xz
-#    - name: move OpenDDS to C drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS /c/
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.9.0
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: Build CMake Tests
-#      shell: cmd
-#      run: |
-#        cd /d C:\OpenDDS
-#        call setenv.cmd
-#        mkdir tests\cmake\build
-#        cd tests\cmake\build
-#        cmake -A Win32 ..
-#        cmake --build .
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd /d C:\OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd /c/OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="C:/OpenDDS"/>
-#        <variable name="root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_cmake_version"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="msvc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS --no-dcps --cmake"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#    - name: run OpenDDS CMake tests
-#      shell: cmd
-#      run: |
-#        cd /d C:\OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "C:\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: C:\OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        /c/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "/c/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-#        cat "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  cmake_w22_x86_i0_sec:
+
+    runs-on: windows-2022
+
+    needs: build_w22_x86_i0_sec
+
+    steps:
+    - name: install openssl & xerces-c
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
+        vcpkgArguments: --recurse openssl xerces-c
+        vcpkgTriplet: x86-windows
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_w22_x86_i0_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_w22_x86_i0.tar.xz
+        rm -f ACE_TAO_w22_x86_i0.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_w22_x86_i0_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w22_x86_i0_sec.tar.xz
+        rm -f build_w22_x86_i0_sec.tar.xz
+    - name: move OpenDDS to C drive
+      shell: bash
+      run: |
+        mv OpenDDS /c/
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.9.0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: Build CMake Tests
+      shell: cmd
+      run: |
+        cd /d C:\OpenDDS
+        call setenv.cmd
+        mkdir tests\cmake\build
+        cd tests\cmake\build
+        cmake -A Win32 ..
+        cmake --build .
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd /d C:\OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd /c/OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="C:/OpenDDS"/>
+        <variable name="root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS --no-dcps --cmake"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+    - name: run OpenDDS CMake tests
+      shell: cmd
+      run: |
+        cd /d C:\OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "C:\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: C:\OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        /c/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "/c/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
 #  test_w22_x86_i0_sec:
 #

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9631,7 +9631,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config DCPS_MIN"/>
+        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config XERCES3 -Config OPENDDS_SECURITY --security --cmake"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9631,7 +9631,7 @@ jobs:
         <command name="check_compiler" options="msvc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config XERCES3 -Config OPENDDS_SECURITY --security --cmake"/>
+        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config DCPS_MIN"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9526,134 +9526,134 @@ jobs:
         cat "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-#  test_w22_x86_i0_sec:
-#
-#    runs-on: windows-2022
-#
-#    needs: build_w22_x86_i0_sec
-#
-#    steps:
-#    - name: install openssl & xerces-c
-#      uses: lukka/run-vcpkg@v7
-#      with:
-#        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
-#        vcpkgArguments: --recurse openssl xerces-c
-#        vcpkgTriplet: x86-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v3
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: ACE_TAO_w22_x86_i0_artifact
-#        path: ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd ACE_TAO
-#        tar xvfJ ACE_TAO_w22_x86_i0.tar.xz
-#        rm -f ACE_TAO_w22_x86_i0.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: build_w22_x86_i0_sec_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ build_w22_x86_i0_sec.tar.xz
-#        rm -f build_w22_x86_i0_sec.tar.xz
-#    - name: move OpenDDS to C drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS /c/
-#    - name: setup gtest
-#      shell: cmd
-#      run: |
-#        cd /d C:\OpenDDS\tests\googletest
-#        git submodule init
-#        git submodule update
-#        mkdir build
-#        cd build
-#        mkdir install
-#        cmake -DCMAKE_INSTALL_PREFIX=./install -A Win32 ..
-#        cmake --build . --target install
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd /d C:\OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd /c/OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="C:/OpenDDS"/>
-#        <variable name="root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_cmake_version"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="msvc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config DCPS_MIN"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd /d C:\OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "C:\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: C:\OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        /c/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "/c/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-#        cat "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  test_w22_x86_i0_sec:
+
+    runs-on: windows-2022
+
+    needs: build_w22_x86_i0_sec
+
+    steps:
+    - name: install openssl & xerces-c
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
+        vcpkgArguments: --recurse openssl xerces-c
+        vcpkgTriplet: x86-windows
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_w22_x86_i0_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_w22_x86_i0.tar.xz
+        rm -f ACE_TAO_w22_x86_i0.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_w22_x86_i0_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w22_x86_i0_sec.tar.xz
+        rm -f build_w22_x86_i0_sec.tar.xz
+    - name: move OpenDDS to C drive
+      shell: bash
+      run: |
+        mv OpenDDS /c/
+    - name: setup gtest
+      shell: cmd
+      run: |
+        cd /d C:\OpenDDS\tests\googletest
+        git submodule init
+        git submodule update
+        mkdir build
+        cd build
+        mkdir install
+        cmake -DCMAKE_INSTALL_PREFIX=./install -A Win32 ..
+        cmake --build . --target install
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd /d C:\OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd /c/OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="C:/OpenDDS"/>
+        <variable name="root" value="C:/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config DCPS_MIN"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+    - name: run OpenDDS tests
+      shell: cmd
+      run: |
+        cd /d C:\OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "C:\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: C:\OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        /c/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "/c/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "/c/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   build_w22_x86_i0_j_FM-1f:
 
@@ -9746,126 +9746,126 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-#  cmake_w22_x86_i0_j_FM-1f:
-#
-#    runs-on: windows-2022
-#
-#    needs: build_w22_x86_i0_j_FM-1f
-#
-#    steps:
-#    - name: install openssl & xerces-c
-#      uses: lukka/run-vcpkg@v7
-#      with:
-#        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
-#        vcpkgArguments: --recurse openssl xerces-c
-#        vcpkgTriplet: x86-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v3
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: ACE_TAO_w22_x86_i0_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ ACE_TAO_w22_x86_i0.tar.xz
-#        rm -f ACE_TAO_w22_x86_i0.tar.xz
-#    - name: Move ACE and MPC to C Drive
-#      shell: bash
-#      run: |
-#        mv OpenDDS/ACE_TAO /c/
-#        mv MPC /c/
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: build_w22_x86_i0_j_FM-1f_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ build_w22_x86_i0_j_FM-1f.tar.xz
-#        rm -f build_w22_x86_i0_j_FM-1f.tar.xz
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1.9.0
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-#        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_cmake_version"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="msvc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake -Config OPENDDS_TESTING_FEATURES"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  cmake_w22_x86_i0_j_FM-1f:
+
+    runs-on: windows-2022
+
+    needs: build_w22_x86_i0_j_FM-1f
+
+    steps:
+    - name: install openssl & xerces-c
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
+        vcpkgArguments: --recurse openssl xerces-c
+        vcpkgTriplet: x86-windows
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_w22_x86_i0_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_w22_x86_i0.tar.xz
+        rm -f ACE_TAO_w22_x86_i0.tar.xz
+    - name: Move ACE and MPC to C Drive
+      shell: bash
+      run: |
+        mv OpenDDS/ACE_TAO /c/
+        mv MPC /c/
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_w22_x86_i0_j_FM-1f_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w22_x86_i0_j_FM-1f.tar.xz
+        rm -f build_w22_x86_i0_j_FM-1f.tar.xz
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1.9.0
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake -Config OPENDDS_TESTING_FEATURES"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   ACE_TAO_w22_p1:
 
@@ -10034,275 +10034,275 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-#  cmake_w22_p1:
-#
-#    runs-on: windows-2022
-#
-#    needs: build_w22_p1
-#
-#    steps:
-#    - name: install openssl & xerces-c
-#      uses: lukka/run-vcpkg@v7
-#      with:
-#        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
-#        vcpkgArguments: --recurse openssl xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v3
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: ACE_TAO_w22_p1_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ ACE_TAO_w22_p1.tar.xz
-#        rm -f ACE_TAO_w22_p1.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: build_w22_p1_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ build_w22_p1.tar.xz
-#        rm -f build_w22_p1.tar.xz
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: Build CMake Tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        mkdir tests\cmake\build
-#        cd tests\cmake\build
-#        cmake ..
-#        cmake --build .
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-#        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_cmake_version"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="msvc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS CMake tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+  cmake_w22_p1:
 
-#  messenger_w22_p1:
-#
-#    runs-on: windows-2022
-#
-#    needs: build_w22_p1
-#
-#    steps:
-#    - name: install openssl & xerces-c
-#      uses: lukka/run-vcpkg@v7
-#      with:
-#        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
-#        vcpkgArguments: --recurse openssl xerces-c
-#        vcpkgTriplet: x64-windows
-#    - name: checkout MPC
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/MPC
-#        path: MPC
-#    - name: checkout autobuild
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/autobuild
-#        path: autobuild
-#    - name: checkout OpenDDS
-#      uses: actions/checkout@v3
-#      with:
-#        path: OpenDDS
-#        submodules: true
-#    - name: checkout ACE_TAO
-#      uses: actions/checkout@v3
-#      with:
-#        repository: DOCGroup/ACE_TAO
-#        ref: ace6tao2
-#        path: OpenDDS/ACE_TAO
-#    - name: download ACE_TAO artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: ACE_TAO_w22_p1_artifact
-#        path: OpenDDS/ACE_TAO
-#    - name: extract ACE_TAO artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS/ACE_TAO
-#        tar xvfJ ACE_TAO_w22_p1.tar.xz
-#        rm -f ACE_TAO_w22_p1.tar.xz
-#    - name: download OpenDDS artifact
-#      uses: actions/download-artifact@v3
-#      with:
-#        name: build_w22_p1_artifact
-#        path: OpenDDS
-#    - name: extract OpenDDS artifact
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        tar xvfJ build_w22_p1.tar.xz
-#        rm -f build_w22_p1.tar.xz
-#    - name: set up msvc env
-#      uses: ilammy/msvc-dev-cmd@v1
-#    - name: check build configuration
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        perl tools\scripts\show_build_config.pl
-#    - name: configure messenger tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd tests\DCPS\Messenger
-#        perl %ACE_ROOT%\bin\mwc.pl -type vs2022 -features no_rapidjson=0 -features ipv6=1 -features ssl=1 -features no_cxx11=0
-#    - uses: ammaraskar/msvc-problem-matcher@0.1
-#    - name: make messenger tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd tests\DCPS\Messenger
-#        msbuild -p:Configuration=Debug,Platform=x64 -m Messenger.sln
-#    - name: configure C++11 messenger test
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd tests\DCPS\C++11
-#        perl %ACE_ROOT%\bin\mwc.pl -type vs2022 -features no_rapidjson=0 -features ipv6=1 -features ssl=1 -features no_cxx11=0
-#    - name: make C++11 messenger test
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd tests\DCPS\C++11
-#        msbuild -p:Configuration=Debug,Platform=x64 -m C++11.sln
-#    - name: create autobuild config
-#      shell: bash
-#      run: |
-#        cd OpenDDS
-#        mkdir ${{ github.job }}_autobuild_workspace
-#        cd ${{ github.job }}_autobuild_workspace
-#        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
-#        echo using commit $TRIGGERING_COMMIT for SHA
-#        echo $TRIGGERING_COMMIT >> ./SHA
-#        cat > config.xml <<EOF
-#        <autobuild>
-#        <configuration>
-#        <variable name="log_file" value="output.log"/>
-#        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
-#        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
-#        <variable name="junit_xml_output" value="Tests"/>
-#        </configuration>
-#        <command name="log" options="on"/>
-#        <command name="print_os_version"/>
-#        <command name="print_env_vars"/>
-#        <command name="print_ace_config"/>
-#        <command name="print_make_version"/>
-#        <command name="check_compiler" options="msvc"/>
-#        <command name="print_perl_version"/>
-#        <command name="print_autobuild_config"/>
-#        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Debug -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS -Config RAPIDJSON"/>
-#        <command name="log" options="off"/>
-#        <command name="process_logs" options="prettify"/>
-#        </autobuild>
-#        EOF
-#        cat config.xml
-#    - name: run OpenDDS Messenger tests
-#      shell: cmd
-#      run: |
-#        cd OpenDDS
-#        call setenv.cmd
-#        cd ${{ github.job }}_autobuild_workspace
-#        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
-#    - name: upload autobuild output
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: ${{ github.job }}_autobuild_output
-#        path: OpenDDS\${{ github.job }}_autobuild_workspace
-#    - name: check results
-#      shell: bash
-#      run: |
-#        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-#        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-#        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    runs-on: windows-2022
+
+    needs: build_w22_p1
+
+    steps:
+    - name: install openssl & xerces-c
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
+        vcpkgArguments: --recurse openssl xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_w22_p1_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_w22_p1.tar.xz
+        rm -f ACE_TAO_w22_p1.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_w22_p1_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w22_p1.tar.xz
+        rm -f build_w22_p1.tar.xz
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: Build CMake Tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        mkdir tests\cmake\build
+        cd tests\cmake\build
+        cmake ..
+        cmake --build .
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS CMake tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  messenger_w22_p1:
+
+    runs-on: windows-2022
+
+    needs: build_w22_p1
+
+    steps:
+    - name: install openssl & xerces-c
+      uses: lukka/run-vcpkg@v7
+      with:
+        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
+        vcpkgArguments: --recurse openssl xerces-c
+        vcpkgTriplet: x64-windows
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_w22_p1_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_w22_p1.tar.xz
+        rm -f ACE_TAO_w22_p1.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_w22_p1_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_w22_p1.tar.xz
+        rm -f build_w22_p1.tar.xz
+    - name: set up msvc env
+      uses: ilammy/msvc-dev-cmd@v1
+    - name: check build configuration
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        perl tools\scripts\show_build_config.pl
+    - name: configure messenger tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\Messenger
+        perl %ACE_ROOT%\bin\mwc.pl -type vs2022 -features no_rapidjson=0 -features ipv6=1 -features ssl=1 -features no_cxx11=0
+    - uses: ammaraskar/msvc-problem-matcher@0.1
+    - name: make messenger tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\Messenger
+        msbuild -p:Configuration=Debug,Platform=x64 -m Messenger.sln
+    - name: configure C++11 messenger test
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\C++11
+        perl %ACE_ROOT%\bin\mwc.pl -type vs2022 -features no_rapidjson=0 -features ipv6=1 -features ssl=1 -features no_cxx11=0
+    - name: make C++11 messenger test
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd tests\DCPS\C++11
+        msbuild -p:Configuration=Debug,Platform=x64 -m C++11.sln
+    - name: create autobuild config
+      shell: bash
+      run: |
+        cd OpenDDS
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        export FS_GHW=$(echo $GITHUB_WORKSPACE | sed 's/\\/\//g')
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$FS_GHW/OpenDDS"/>
+        <variable name="root" value="$FS_GHW/OpenDDS/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="msvc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Debug -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS -Config RAPIDJSON"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        cat config.xml
+    - name: run OpenDDS Messenger tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        cd ${{ github.job }}_autobuild_workspace
+        perl "%GITHUB_WORKSPACE%\autobuild\autobuild.pl" "%GITHUB_WORKSPACE%\OpenDDS\${{ github.job }}_autobuild_workspace\config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS\${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   compiler_w22_p1:
 

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -605,11 +605,9 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_topic_i(
     TopicImpl* the_topic_servant = dynamic_cast<TopicImpl*>(a_topic);
 
     if (!the_topic_servant) {
-      if (DCPS_debug_level > 0) {
-        ACE_ERROR((LM_ERROR,
-                   ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::delete_topic_i, ")
-                   ACE_TEXT("%p\n"),
-                   ACE_TEXT("failed to obtain TopicImpl.")));
+      if (log_level >= LogLevel::Notice) {
+        ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DomainParticipantImpl::delete_topic_i: %p\n"
+                   "failed to obtain TopicImpl."));
       }
       return DDS::RETCODE_ERROR;
     }
@@ -620,22 +618,20 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_topic_i(
       dynamic_cast<DomainParticipantImpl*>(dp.in());
 
     if (the_dp_servant != this) {
-      if (DCPS_debug_level >= 1) {
-        ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("(%P|%t) DomainParticipantImpl::delete_topic_i: ")
-                   ACE_TEXT("will return PRECONDITION_NOT_MET because this is not the ")
-                   ACE_TEXT("participant that owns this topic\n")));
+      if (log_level >= LogLevel::Notice) {
+        ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DomainParticipantImpl::delete_topic_i: "
+                   "will return PRECONDITION_NOT_MET because this is not the "
+                   "participant that owns this topic\n"));
       }
       return DDS::RETCODE_PRECONDITION_NOT_MET;
     }
     if (!remove_objref && the_topic_servant->has_entity_refs()) {
       // If entity_refs is true (nonzero), then some reader or writer is using
       // this topic and the spec requires delete_topic() to fail with the error:
-      if (DCPS_debug_level >= 1) {
-        ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("(%P|%t) DomainParticipantImpl::delete_topic_i: ")
-                   ACE_TEXT("will return PRECONDITION_NOT_MET because there are still ")
-                   ACE_TEXT("outstanding references to this topic\n")));
+      if (log_level >= LogLevel::Notice) {
+        ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DomainParticipantImpl::delete_topic_i: "
+                   "will return PRECONDITION_NOT_MET because there are still "
+                   "outstanding references to this topic\n"));
       }
       return DDS::RETCODE_PRECONDITION_NOT_MET;
     }
@@ -658,9 +654,8 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_topic_i(
         }
       }
       if (entry == 0) {
-        if (DCPS_debug_level > 0) {
-          ACE_ERROR((LM_ERROR,
-                     ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::delete_topic_i, not found\n")));
+        if (log_level >= LogLevel::Notice) {
+          ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DomainParticipantImpl::delete_topic_i: not found\n"));
         }
         return DDS::RETCODE_ERROR;
       }
@@ -676,11 +671,9 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_topic_i(
           the_dp_servant->get_domain_id(), the_dp_servant->get_id(), topicId);
 
         if (status != REMOVED) {
-          if (DCPS_debug_level > 0) {
-            ACE_ERROR((LM_ERROR,
-                       ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::delete_topic_i, ")
-                       ACE_TEXT("remove_topic failed with return value <%C>\n"),
-                       topicstatus_to_string(status)));
+          if (log_level >= LogLevel::Notice) {
+            ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DomainParticipantImpl::delete_topic_i, "
+                       "remove_topic failed with return value <%C>\n", topicstatus_to_string(status)));
            }
           return DDS::RETCODE_ERROR;
         }
@@ -689,19 +682,17 @@ DDS::ReturnCode_t DomainParticipantImpl::delete_topic_i(
 
       } else {
         if (DCPS_debug_level > 4) {
-          ACE_DEBUG((LM_DEBUG,
-            ACE_TEXT("(%P|%t) DomainParticipantImpl::delete_topic_i: ")
-            ACE_TEXT("Didn't remove topic from the map, remove_objref %d client_refs %d\n"),
-            remove_objref, client_refs));
+          ACE_DEBUG((LM_DEBUG, "(%P|%t) DomainParticipantImpl::delete_topic_i: "
+                     "Didn't remove topic from the map, remove_objref %d client_refs %d\n",
+                     remove_objref, client_refs));
         }
       }
     }
 
   } catch (...) {
-    if (DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: DomainParticipantImpl::delete_topic_i, ")
-                 ACE_TEXT(" Caught Unknown Exception\n")));
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DomainParticipantImpl::delete_topic_i, "
+                 " Caught Unknown Exception\n"));
     }
     ret = DDS::RETCODE_ERROR;
   }

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -69,7 +69,7 @@ namespace DCPS {
 bool verify_hostname(String hostname, ACE_INET_Addr* addr_array, size_t addr_count,
                      bool prefer_loopback, bool allow_ipv4_fallback)
 {
-  const ACE_INET_Addr addr = choose_single_coherent_address(hostname, prefer_feedback, allow_ipv4_fallback);
+  const ACE_INET_Addr addr = choose_single_coherent_address(hostname, prefer_loopback, allow_ipv4_fallback);
   for (size_t i = 0; i < addr_count; ++i) {
     if (addr == addr_array[i]) {
       return true;

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -66,7 +66,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-bool verify_hostname(String hostname, ACE_INET_Addr* addr_array, size_t addr_count,
+bool verify_hostname(const String& hostname, ACE_INET_Addr* addr_array, size_t addr_count,
                      bool prefer_loopback, bool allow_ipv4_fallback)
 {
   const ACE_INET_Addr addr = choose_single_coherent_address(hostname, prefer_loopback, allow_ipv4_fallback);

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -901,6 +901,7 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
   // "some_domain.com:1234". We would expect to have address 10.1.0.71:1234 returned. However,
   // address 10.1.0.71:0 can be returned if it is still in the cache when the second call is made.
 
+
   // Maybe a better way to maintain the address cache is to have it only store IP addresses and
   // leave out the port number (by setting it to 0). This is because the choose_single_coherent_address
   // vector version only cares about IP part. That way we can reduce the number of entries in the cache

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -870,7 +870,7 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
 
     ACE_INET_Addr temp;
     temp.set_addr(&addr, sizeof addr);
-    temp.set_port_number(port_number, 1 /*encode*/);
+    //temp.set_port_number(port_number, 1 /*encode*/);
     addresses.push_back(temp);
 #ifdef ACE_WIN32
     ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Adding address %C to cache\n",

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -823,7 +823,7 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
   }
   AddrCacheMap::iterator it = addr_cache_map_.find(host_name);
   if (it != addr_cache_map_.end()) {
-    for (OPENDDS_SET::iterator i = it->second.second.begin(); i != it->second.second.end(); ++i) {
+    for (OPENDDS_SET(ACE_INET_Addr)::iterator i = it->second.second.begin(); i != it->second.second.end(); ++i) {
       ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): From cache, adding %C\n",
                  LogAddr::ip(*i).c_str()));
     }

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -119,7 +119,7 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
         if (ACE::get_fqdn(addr_array[i], hostname, MAXHOSTNAMELEN+1) == 0) {
           VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Considering fqdn %C\n", hostname), 4);
           // Find the first FQDN that resolves to a valid IP interface address.
-          // If there is no such FQDN, consider the list of non-FQDN.
+          // If there is no such FQDN, consider the list of non-FQDNs.
           if (ACE_OS::strchr(hostname, '.') != 0) {
             if (!addr_array[i].is_loopback() &&
                 choose_single_coherent_address(hostname, false, false) != ACE_INET_Addr()) {
@@ -139,7 +139,6 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
               addr_array[i].get_host_addr(hostname, MAXHOSTNAMELEN);
             }
 
-            // Verify that this non-FQDN resolves to a valid IP.
             if (choose_single_coherent_address(hostname, false) != ACE_INET_Addr()) {
               OpenDDS::DCPS::HostnameInfo info;
               info.index_ = i;
@@ -186,6 +185,7 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
       }
     }
 
+    // As a last resort, return the first loopback address from the non-FQDNs list if not empty.
     if (itBegin != itEnd) {
       ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: get_fully_qualified_hostname: Could not find FQDN. Using "
                  "\"%C\" as fully qualified hostname, please "

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -656,17 +656,19 @@ ACE_INET_Addr choose_single_coherent_address(const OPENDDS_VECTOR(ACE_INET_Addr)
 ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_loopback, bool allow_ipv4_fallback)
 {
   ACE_INET_Addr result;
+
   struct LogGuard {
-    LogGuard()
+    LogGuard(ACE_INET_Addr* addr) : addr_(addr)
     {
       ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Starting...\n"));
     }
     ~LogGuard()
     {
       ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Returning address %C\n",
-                 LogAddr::ip(result).c_str()));
+                 LogAddr::ip(*addr_).c_str()));
     }
-  } log_guard;
+    ACE_INET_Addr* const addr_;
+  } log_guard(&result);
 
   if (address.empty()) {
     return ACE_INET_Addr();
@@ -868,7 +870,8 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
   g.release();
 #endif /* ACE_WIN32 */
 
-  return choose_single_coherent_address(addresses, prefer_loopback, host_name);
+  result = choose_single_coherent_address(addresses, prefer_loopback, host_name);
+  return result;
 }
 
 int locator_to_address(ACE_INET_Addr& dest,

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -170,8 +170,8 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
     // If no non-loopback IP is found from the list of non-FQDNs, return a non-loopback IP
     // address from the IP interfaces list.
     for (size_t i = 0; i < addr_count; ++i) {
-      if (!addr_array[i].is_loop_back()) {
-        char addr_str[MAXHOSTNAMLEN+1] = "";
+      if (!addr_array[i].is_loopback()) {
+        char addr_str[MAXHOSTNAMELEN+1] = "";
         addr_array[i].get_host_addr(addr_str, MAXHOSTNAMELEN);
         ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: get_fully_qualified_hostname: Could not find FQDN. Using "
                    "\"%C\" as fully qualified hostname, please "
@@ -799,8 +799,7 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
 
   size_t addr_count;
   ACE_INET_Addr* addr_array = 0;
-  const int result = ACE::get_ip_interfaces(addr_count, addr_array);
-  if (result != 0 || addr_count < 1) {
+  if (ACE::get_ip_interfaces(addr_count, addr_array) != 0 || addr_count < 1) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: choose_single_coherent_address: Unable to get IP interfaces. %p\n",
                "ACE::get_ip_interfaces"));
     ACE_OS::freeaddrinfo(res);
@@ -833,6 +832,10 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
 #ifdef ACE_WIN32
         if (it != addr_cache_map_.end()) {
           it->second.second.insert(temp);
+        } else {
+          OPENDDS_SET(ACE_INET_Addr) my_set;
+          my_set.insert(temp);
+          addr_cache_map_[host_name] = make_pair(now, my_set);
         }
 #endif /* ACE_WIN32 */
       }

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -72,13 +72,9 @@ bool verify_hostname(String hostname, ACE_INET_Addr* addr_array, size_t addr_cou
   const ACE_INET_Addr addr = choose_single_coherent_address(hostname, prefer_loopback, allow_ipv4_fallback);
   for (size_t i = 0; i < addr_count; ++i) {
     if (addr == addr_array[i]) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: verify_hostname: IP interface %C is chosen from hostname %C\n",
-                 LogAddr(addr).c_str(), hostname.c_str()));
       return true;
     }
   }
-  ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: verify_hostname: Bogus IP %C is chosen. Ignoring hostname %C\n",
-             LogAddr(addr).c_str(), hostname.c_str()));
   return false;
 }
 
@@ -88,18 +84,6 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
   // address to be used on subsequent calls
   static String fullname;
   static ACE_INET_Addr selected_address;
-
-  struct LogGuard {
-    LogGuard(const String& name, const ACE_INET_Addr& addr) : name_(name), addr_(addr) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) XXXXXX DEBUG: get_fully_qualified_hostname: Beginning...\n"));
-    }
-    ~LogGuard() {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) XXXXXX DEBUG: get_fully_qualified_hostname: Returning hostname %C, address %C\n",
-                 name_.c_str(), LogAddr(addr_).c_str()));
-    }
-    const String& name_;
-    const ACE_INET_Addr& addr_;
-  } log_guard(fullname, selected_address);
 
   if (fullname.length() == 0) {
     size_t addr_count;
@@ -123,8 +107,7 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
 
     } else {
       for (size_t i = 0; i < addr_count; i++) {
-        //VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Found IP interface %C\n", LogAddr::ip(addr_array[i]).c_str()), 4);
-        ACE_DEBUG((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Found IP interface %C\n", LogAddr(addr_array[i]).c_str()));
+        VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Found IP interface %C\n", LogAddr::ip(addr_array[i]).c_str()), 4);
       }
 
 #ifdef ACE_HAS_IPV6
@@ -146,8 +129,7 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
 
         // Discover the fully qualified hostname
         if (ACE::get_fqdn(addr_array[i], hostname, MAXHOSTNAMELEN+1) == 0) {
-          //VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Considering fqdn %C\n", hostname), 4);
-          ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: get_fully_qualified_hostname: Considering fqdn %C (from address %C)\n", hostname, LogAddr(addr_array[i]).c_str()));
+          VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Considering fqdn %C\n", hostname), 4);
           // Find the first FQDN that resolves to an IP interface address.
           if (!addr_array[i].is_loopback() && ACE_OS::strchr(hostname, '.') != 0 &&
               verify_hostname(hostname, addr_array, addr_count, false, false)) {
@@ -674,21 +656,6 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
 {
   ACE_INET_Addr result;
 
-  struct LogGuard {
-    LogGuard(const String& hostname, const ACE_INET_Addr& addr) : hostname_(hostname), addr_(addr)
-    {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Starting( %C )...\n",
-                 hostname_.c_str()));
-    }
-    ~LogGuard()
-    {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Returning address %C\n\n",
-                 LogAddr(addr_).c_str()));
-    }
-    const String& hostname_;
-    const ACE_INET_Addr& addr_;
-  } log_guard(address, result);
-
   if (address.empty()) {
     return ACE_INET_Addr();
   }
@@ -842,10 +809,6 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
   }
   AddrCacheMap::iterator it = addr_cache_map_.find(host_name);
   if (it != addr_cache_map_.end()) {
-    for (OPENDDS_SET(ACE_INET_Addr)::iterator i = it->second.second.begin(); i != it->second.second.end(); ++i) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): From cache, adding %C\n",
-                 LogAddr(*i).c_str()));
-    }
     addresses.insert(addresses.end(), it->second.second.begin(), it->second.second.end());
     it->second.first = now;
   }
@@ -870,11 +833,8 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
 
     ACE_INET_Addr temp;
     temp.set_addr(&addr, sizeof addr);
-    //temp.set_port_number(port_number, 1 /*encode*/);
     addresses.push_back(temp);
 #ifdef ACE_WIN32
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Adding address %C to cache\n",
-               LogAddr(temp).c_str()));
     if (it != addr_cache_map_.end()) {
       it->second.second.insert(temp);
     } else {
@@ -890,23 +850,7 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
 #endif /* ACE_WIN32 */
 
   result = choose_single_coherent_address(addresses, prefer_loopback, host_name);
-  // NOTE(sonndinh):
-  // Make sure to set the port number since the returned address can have a different port number
-  // than the desired one. This can happen if that address is a residue from a previous call to
-  // this function and the cache hasn't been cleanup since then.
-  // Example: Suppose a first call to this function with hostname "some_domain.com" returns
-  // 10.1.0.71:0. The port is 0 because there is no port number in the hostname argument, and
-  // the addresses returned from the getaddrinfo with that hostname typically have 0 as port number.
-  // Next, this function is called with the same hostname but now with a port number
-  // "some_domain.com:1234". We would expect to have address 10.1.0.71:1234 returned. However,
-  // address 10.1.0.71:0 can be returned if it is still in the cache when the second call is made.
-
-
-  // Maybe a better way to maintain the address cache is to have it only store IP addresses and
-  // leave out the port number (by setting it to 0). This is because the choose_single_coherent_address
-  // vector version only cares about IP part. That way we can reduce the number of entries in the cache
-  // and simplify the logic which would help reduce future bugs.
-  result.set_port_number(port_number, 1);
+  result.set_port_number(port_number, 1 /*encode*/);
   return result;
 }
 

--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -72,9 +72,13 @@ bool verify_hostname(String hostname, ACE_INET_Addr* addr_array, size_t addr_cou
   const ACE_INET_Addr addr = choose_single_coherent_address(hostname, prefer_loopback, allow_ipv4_fallback);
   for (size_t i = 0; i < addr_count; ++i) {
     if (addr == addr_array[i]) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: verify_hostname: IP interface %C is chosen from hostname %C",
+                 LogAddr::ip(addr).c_str(), hostname.c_str()));
       return true;
     }
   }
+  ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: verify_hostname: Bogus IP %C is chosen. Ignoring hostname %C\n",
+             LogAddr::ip(addr).c_str(), hostname.c_str()));
   return false;
 }
 
@@ -130,7 +134,8 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
 
         // Discover the fully qualified hostname
         if (ACE::get_fqdn(addr_array[i], hostname, MAXHOSTNAMELEN+1) == 0) {
-          VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Considering fqdn %C\n", hostname), 4);
+          //VDBG_LVL((LM_DEBUG, "(%P|%t) get_fully_qualified_hostname: Considering fqdn %C\n", hostname), 4);
+          ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: get_fully_qualified_hostname: Considering fqdn %C (from address %C)\n", hostname, LogAddr::ip(addr_array[i]).c_str()));
           // Find the first FQDN that resolves to an IP interface address.
           if (!addr_array[i].is_loopback() && ACE_OS::strchr(hostname, '.') != 0 &&
               verify_hostname(hostname, addr_array, addr_count, false, false)) {
@@ -664,7 +669,7 @@ ACE_INET_Addr choose_single_coherent_address(const String& address, bool prefer_
     }
     ~LogGuard()
     {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Returning address %C\n",
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) DEBUG: choose_single_coherent_address(string): Returning address %C\n\n",
                  LogAddr::ip(*addr_).c_str()));
     }
     ACE_INET_Addr* const addr_;

--- a/dds/DCPS/NetworkResource.h
+++ b/dds/DCPS/NetworkResource.h
@@ -63,6 +63,10 @@ struct OpenDDS_Dcps_Export NetworkResource {
   String addr_;
 };
 
+// Make sure that choose_single_coherent_address picks one of the IP interface addresses.
+bool verify_hostname(String hostname, ACE_INET_Addr* addrs, size_t addr_count,
+                     bool prefer_loopback, bool allow_ipv4_fallback);
+
 /// Helper function to get the fully qualified hostname.
 /// It attempts to discover the FQDN by the network interface addresses, however
 /// the result is impacted by the network configuration, so it returns name in the

--- a/dds/DCPS/NetworkResource.h
+++ b/dds/DCPS/NetworkResource.h
@@ -64,7 +64,7 @@ struct OpenDDS_Dcps_Export NetworkResource {
 };
 
 // Make sure that choose_single_coherent_address picks one of the IP interface addresses.
-bool verify_hostname(String hostname, ACE_INET_Addr* addrs, size_t addr_count,
+bool verify_hostname(const String& hostname, ACE_INET_Addr* addrs, size_t addr_count,
                      bool prefer_loopback, bool allow_ipv4_fallback);
 
 /// Helper function to get the fully qualified hostname.

--- a/docs/internal/dev_guidelines.rst
+++ b/docs/internal/dev_guidelines.rst
@@ -494,7 +494,7 @@ Message Content
   We shouldn't go out of our way to replace it in existing logging points, but it should be avoided it in new ones.
 
   - ``ACE_TEXT``'s purpose is to wrap strings and characters in ``L`` on builds where ``uses_wchar=1``, so they become the wide versions.
-  - While not doing it might result in a performance hit for character encoding conversion at runtime, the builds where this happens are rare, so the it's outweighed by the added visual noise to the code and the possibility of bugs introduced by improper use of ``ACE_TEXT``.
+  - While not doing it might result in a performance hit for character encoding conversion at runtime, the builds where this happens are rare, so it's outweighed by the added visual noise to the code and the possibility of bugs introduced by improper use of ``ACE_TEXT``.
 
 - Avoid new usage of ``ACE_ERROR_RETURN`` in order to not hide the return statement within a macro.
 
@@ -504,7 +504,7 @@ Examples
 .. code-block:: C++
 
   if (log_level >= LogLevel::Error) {
-    ACE_ERROR((LM_DEBUG, "(%P|%t) ERROR: example_function: Hello, World!\n"));
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: example_function: Hello, World!\n"));
   }
 
   if (log_level >= LogLevel::Warning) {


### PR DESCRIPTION
A couple of functions in `NetworkResource` are updated to check for hostnames that resolve to bogus IP addresses.
- `get_fully_qualified_hostname`: ignore hostnames that resolve to an IP address that is not found from the list of IP interface addresses.
- `choose_single_coherent_address` (string version): cache addresses returned from `getaddrinfo` for Windows. Ignore the port numbers of the cached addresses. The port numbers are set accordingly before returning a chosen address to the caller.

In addition, it enables Windows 2022 GitHub Actions test jobs as the above changes should fix the IP choosing issue on Windows 2022.