### PR TITLE
Required acknack flag not reset

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2705,19 +2705,17 @@ RtpsUdpDataLink::queue_submessages(MetaSubmessageVec& in, double scale)
 }
 
 void
-RtpsUdpDataLink::RtpsWriter::update_required_acknack_count(const RepoId& id, CORBA::Long previous, CORBA::Long current)
+RtpsUdpDataLink::RtpsWriter::update_required_acknack_count(const RepoId& id, CORBA::Long current)
 {
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   ReaderInfoMap::iterator ri = remote_readers_.find(id);
   if (ri != remote_readers_.end()) {
-    if (ri->second->required_acknack_count_ == previous) {
-      ri->second->required_acknack_count_ = current;
-    }
+    ri->second->required_acknack_count_ = current;
   }
 }
 
 void
-RtpsUdpDataLink::update_required_acknack_count(const RepoId& local_id, const RepoId& remote_id, CORBA::Long previous, CORBA::Long current)
+RtpsUdpDataLink::update_required_acknack_count(const RepoId& local_id, const RepoId& remote_id, CORBA::Long current)
 {
   RtpsWriter_rch writer;
   {
@@ -2728,7 +2726,7 @@ RtpsUdpDataLink::update_required_acknack_count(const RepoId& local_id, const Rep
     }
   }
   if (writer) {
-    writer->update_required_acknack_count(remote_id, previous, current);
+    writer->update_required_acknack_count(remote_id, current);
   }
 }
 
@@ -2805,7 +2803,7 @@ RtpsUdpDataLink::bundle_and_send_submessages(MetaSubmessageVec& meta_submessages
               ++mapping.next_directed_unassigned_;
               if (res.sm_.heartbeat_sm().smHeader.flags & RTPS::OPENDDS_FLAG_R) {
                 if (res.sm_.heartbeat_sm().count.value != map_pair.new_) {
-                  update_required_acknack_count(res.src_guid_, res.dst_guid_, res.sm_.heartbeat_sm().count.value, map_pair.new_);
+                  update_required_acknack_count(res.src_guid_, res.dst_guid_, map_pair.new_);
                 }
                 res.sm_.heartbeat_sm().smHeader.flags &= ~RTPS::OPENDDS_FLAG_R;
               }
@@ -3712,6 +3710,7 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
       meta_submessage.sm_.heartbeat_sm().smHeader.flags |= RTPS::OPENDDS_FLAG_R;
       gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
       reader->required_acknack_count_ = heartbeat_count_;
+      meta_submessage.sm_.heartbeat_sm().smHeader.flags &= ~RTPS::OPENDDS_FLAG_R;
     } else {
       gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
     }
@@ -3724,13 +3723,7 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
   for (ReaderInfoSet::const_iterator pos = readers_expecting_heartbeat_.begin(), limit = readers_expecting_heartbeat_.end();
        pos != limit; ++pos) {
     const ReaderInfo_rch& reader = *pos;
-    if (reader->reflects_heartbeat_count()) {
-      meta_submessage.sm_.heartbeat_sm().smHeader.flags |= RTPS::OPENDDS_FLAG_R;
-      gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
-      reader->required_acknack_count_ = heartbeat_count_;
-    } else {
-      gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
-    }
+    gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, reader);
   }
   readers_expecting_heartbeat_.clear();
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -557,7 +557,7 @@ private:
     void gather_heartbeats_i(MetaSubmessageVec& meta_submessages);
     void gather_heartbeats(RcHandle<ConstSharedRepoIdSet> additional_guids,
                            MetaSubmessageVec& meta_submessages);
-    void update_required_acknack_count(const RepoId& id, CORBA::Long previous, CORBA::Long current);
+    void update_required_acknack_count(const RepoId& id, CORBA::Long current);
 
     RcHandle<SingleSendBuffer> get_send_buff() { return send_buff_; }
   };
@@ -714,7 +714,7 @@ private:
     CountKeeper& counts);
 
   void queue_submessages(MetaSubmessageVec& meta_submessages, double scale = 1.0);
-  void update_required_acknack_count(const RepoId& local_id, const RepoId& remote_id, CORBA::Long previous, CORBA::Long current);
+  void update_required_acknack_count(const RepoId& local_id, const RepoId& remote_id, CORBA::Long current);
   void bundle_and_send_submessages(MetaSubmessageVec& meta_submessages);
 
   ThreadedRtpsSendQueue sq_;


### PR DESCRIPTION
Problem
-------

The required acknack count flag is not reset.  The logic for updating
the required acknack count can be simplified.

Solution
--------

* Reset the flag when adding the submessage.
* Any submessage with the flag should update the count.