### PR TITLE
Substituted GuidConverter with calls to LogGuid as per issue #3036

### DIFF
--- a/dds/DCPS/BitPubListenerImpl.cpp
+++ b/dds/DCPS/BitPubListenerImpl.cpp
@@ -58,11 +58,10 @@ void BitPubListenerImpl::on_data_available(DDS::DataReader_ptr reader)
           CORBA::Long const ownership_strength = data.ownership_strength.value;
           this->partipant_->update_ownership_strength(pub_id, ownership_strength);
           if (DCPS_debug_level > 4) {
-            GuidConverter writer_converter(pub_id);
             ACE_DEBUG((LM_DEBUG,
               ACE_TEXT("(%P|%t) BitPubListenerImpl::on_data_available: %X ")
               ACE_TEXT("reset ownership strength %d for writer %C.\n"),
-              this, ownership_strength, OPENDDS_STRING(writer_converter).c_str()));
+              this, ownership_strength, LogGuid(pub_id).c_str()));
           }
 #endif
         }

--- a/dds/DCPS/CoherentChangeControl.cpp
+++ b/dds/DCPS/CoherentChangeControl.cpp
@@ -109,16 +109,14 @@ std::ostream& operator<<(std::ostream& str, const CoherentChangeControl& value)
       << ", last_sample: " << value.coherent_samples_.last_sample_.getValue()
       << ", ";
   if (value.group_coherent_) {
-    GuidConverter converter(value.publisher_id_);
-    str << "publisher: " << std::dec << OPENDDS_STRING(converter).c_str() << ", ";
+    str << "publisher: " << std::dec << LogGuid(value.publisher_id_).c_str() << ", ";
     str << "group size: " << std::dec << value.group_coherent_samples_.size()
         << ", ";
     GroupCoherentSamples::const_iterator itEnd =
       value.group_coherent_samples_.end();
     for (GroupCoherentSamples::const_iterator it =
            value.group_coherent_samples_.begin(); it != itEnd; ++it) {
-      GuidConverter converter(it->first);
-      str << "writer: " << OPENDDS_STRING(converter).c_str() << ", "
+      str << "writer: " << LogGuid(it->first).c_str() << ", "
           << "num_samples: " << it->second.num_samples_ << ", "
           << "last_sample: " << it->second.last_sample_.getValue()  << std::endl;
     }

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -225,12 +225,10 @@ DataReaderImpl::add_association(const RepoId& yourId,
     bool active)
 {
   if (DCPS_debug_level) {
-    GuidConverter reader_converter(yourId);
-    GuidConverter writer_converter(writer.writerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl::add_association - ")
         ACE_TEXT("bit %d local %C remote %C\n"), is_bit_,
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str()));
+        LogGuid(yourId).c_str(),
+        LogGuid(writer.writerId).c_str()));
   }
 
   if (get_deleted()) {
@@ -293,24 +291,21 @@ DataReaderImpl::add_association(const RepoId& yourId,
     }
 
     if (DCPS_debug_level > 4) {
-      GuidConverter converter(writer_id);
       ACE_DEBUG((LM_DEBUG,
           "(%P|%t) DataReaderImpl::add_association: "
           "inserted writer %C.return %d\n",
-          OPENDDS_STRING(converter).c_str(), bpair.second));
+          LogGuid(writer_id).c_str(), bpair.second));
 
       WriterMapType::iterator iter = writers_.find(writer_id);
       if (iter != writers_.end()) {
         // This may not be an error since it could happen that the sample
         // is delivered to the datareader after the write is dis-associated
         // with this datareader.
-        GuidConverter reader_converter(get_repo_id());
-        GuidConverter writer_converter(writer_id);
         ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) DataReaderImpl::add_association: ")
             ACE_TEXT("reader %C is associated with writer %C.\n"),
-            OPENDDS_STRING(reader_converter).c_str(),
-            OPENDDS_STRING(writer_converter).c_str()));
+            LogGuid(get_repo_id()).c_str(),
+            LogGuid(writer_id).c_str()));
       }
     }
   }
@@ -357,11 +352,10 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
 {
   if (!(flags & ASSOC_OK)) {
     if (DCPS_debug_level) {
-      const GuidConverter conv(remote_id);
       ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
           ACE_TEXT("ERROR: transport layer failed to associate %C\n"),
-          OPENDDS_STRING(conv).c_str()));
+          LogGuid(remote_id).c_str()));
     }
     return;
   }
@@ -373,11 +367,10 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
     // LIVELINESS policy timers are managed here.
     if (!liveliness_lease_duration_.is_zero()) {
       if (DCPS_debug_level >= 5) {
-        GuidConverter converter(get_repo_id());
         ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
             ACE_TEXT("starting/resetting liveliness timer for reader %C\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(get_repo_id()).c_str()));
       }
       // this call will start the timer if it is not already set
       liveliness_timer_->check_liveliness();
@@ -404,11 +397,10 @@ DataReaderImpl::transport_assoc_done(int flags, const RepoId& remote_id)
           RepoIdToHandleMap::value_type(remote_id, handle));
 
       if (DCPS_debug_level > 4) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_DEBUG,
             ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
             ACE_TEXT("id_to_handle_map_[ %C] = 0x%x.\n"),
-            OPENDDS_STRING(converter).c_str(),
+            LogGuid(remote_id).c_str(),
             handle));
       }
 
@@ -478,14 +470,12 @@ DataReaderImpl::remove_associations(const WriterIdSeq& writers,
   }
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::remove_associations: ")
         ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
         is_bit_,
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str(),
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writers[0]).c_str(),
         writers.length()));
   }
   if (!get_deleted()) {
@@ -520,14 +510,12 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
   }
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::remove_associations_i: ")
         ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
         is_bit_,
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str(),
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writers[0]).c_str(),
         writers.length()));
   }
   DDS::InstanceHandleSeq handles;
@@ -566,11 +554,10 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
 
       if (this->writers_.erase(writer_id) == 0) {
         if (DCPS_debug_level >= 1) {
-          GuidConverter converter(writer_id);
           ACE_DEBUG((LM_DEBUG,
               ACE_TEXT("(%P|%t) DataReaderImpl::remove_associations_i: ")
               ACE_TEXT("the writer local %C was already removed.\n"),
-              OPENDDS_STRING(converter).c_str()));
+              LogGuid(writer_id).c_str()));
         }
 
       } else {
@@ -1372,13 +1359,11 @@ DataReaderImpl::writer_activity(const DataSampleHeader& header)
       // This may not be an error since it could happen that the sample
       // is delivered to the datareader after the write is dis-associated
       // with this datareader.
-      GuidConverter reader_converter(get_repo_id());
-      GuidConverter writer_converter(header.publication_id_);
       ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) DataReaderImpl::writer_activity: ")
           ACE_TEXT("reader %C is not associated with writer %C.\n"),
-          OPENDDS_STRING(reader_converter).c_str(),
-          OPENDDS_STRING(writer_converter).c_str()));
+          LogGuid(get_repo_id()).c_str(),
+          LogGuid(header.publication_id_).c_str()));
     }
   }
 
@@ -1412,11 +1397,10 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
   if (get_deleted()) return;
 
   if (DCPS_debug_level > 9) {
-    GuidConverter converter(get_repo_id());
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::data_received: ")
         ACE_TEXT("%C received sample: %C.\n"),
-        OPENDDS_STRING(converter).c_str(),
+        LogGuid(get_repo_id()).c_str(),
         to_string(sample.header_).c_str()));
   }
 
@@ -1459,14 +1443,11 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
 
     // Per sample logging
     if (DCPS_debug_level >= 8) {
-      GuidConverter reader_converter(get_repo_id());
-      GuidConverter writer_converter(header.publication_id_);
-
       ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) DataReaderImpl::data_received: reader %C writer %C ")
           ACE_TEXT("instance %d is_new_instance %d filtered %d\n"),
-          OPENDDS_STRING(reader_converter).c_str(),
-          OPENDDS_STRING(writer_converter).c_str(),
+          LogGuid(get_repo_id()).c_str(),
+          LogGuid(header.publication_id_).c_str(),
           instance ? instance->instance_handle_ : 0,
           is_new_instance, filtered));
     }
@@ -1510,14 +1491,12 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
           this->writers_.find(sample.header_.publication_id_);
 
       if (it == this->writers_.end()) {
-        GuidConverter sub_id(get_repo_id());
-        GuidConverter pub_id(sample.header_.publication_id_);
         ACE_DEBUG((LM_WARNING,
             ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::data_received() - ")
             ACE_TEXT(" subscription %C failed to find ")
             ACE_TEXT(" publication data for %C!\n"),
-            OPENDDS_STRING(sub_id).c_str(),
-            OPENDDS_STRING(pub_id).c_str()));
+            LogGuid(get_repo_id()).c_str(),
+            LogGuid(sample.header_.publication_id_).c_str()));
         return;
       }
       else {
@@ -1535,13 +1514,11 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
 
   case DATAWRITER_LIVELINESS: {
     if (DCPS_debug_level >= 4) {
-      GuidConverter reader_converter(get_repo_id());
-      GuidConverter writer_converter(sample.header_.publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataReaderImpl::data_received: ")
                  ACE_TEXT("reader %C got datawriter liveliness from writer %C\n"),
-                 OPENDDS_STRING(reader_converter).c_str(),
-                 OPENDDS_STRING(writer_converter).c_str()));
+                 LogGuid(get_repo_id()).c_str(),
+                 LogGuid(sample.header_.publication_id_).c_str()));
     }
     this->writer_activity(sample.header_);
 
@@ -1676,11 +1653,10 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     guard.release();
     resume_sample_processing(sample.header_.publication_id_);
     if (DCPS_debug_level > 4) {
-      GuidConverter pub_id(sample.header_.publication_id_);
       ACE_DEBUG((
           LM_INFO,
           "(%P|%t) Resumed sample processing for durable writer %C\n",
-          OPENDDS_STRING(pub_id).c_str()));
+          LogGuid(sample.header_.publication_id_).c_str()));
     }
     break;
   }
@@ -1877,11 +1853,10 @@ DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
 
   if (local_timer_id != -1 && cancel) {
     if (DCPS_debug_level >= 5) {
-      GuidConverter converter(data_reader->get_repo_id());
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
                  ACE_TEXT(" canceling timer for reader %C.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(data_reader->get_repo_id()).c_str()));
     }
 
     // called from add_associations and there is already a timer
@@ -1943,11 +1918,10 @@ DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
   }
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter converter(data_reader->get_repo_id());
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
         ACE_TEXT("reader %C has %d live writers; from_reactor=%d\n"),
-        OPENDDS_STRING(converter).c_str(),
+        LogGuid(data_reader->get_repo_id()).c_str(),
         alive_writers,
         !cancel));
   }
@@ -2056,13 +2030,11 @@ DataReaderImpl::writer_removed(WriterInfo& info)
   const PublicationId info_writer_id = info.writer_id();
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(info_writer_id);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::writer_removed: ")
         ACE_TEXT("reader %C from writer %C.\n"),
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(info_writer_id).c_str()));
   }
 
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
@@ -2108,12 +2080,10 @@ DataReaderImpl::writer_became_alive(WriterInfo& info, const MonotonicTimePoint& 
   const PublicationId info_writer_id = info.writer_id();
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(info_writer_id);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl::writer_became_alive: ")
                ACE_TEXT("reader %C from writer %C previous state %C.\n"),
-               OPENDDS_STRING(reader_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str(),
+               LogGuid(get_repo_id()).c_str(),
+               LogGuid(info_writer_id).c_str(),
                info.get_state_str()));
   }
 
@@ -2180,12 +2150,10 @@ DataReaderImpl::writer_became_dead(WriterInfo& info)
   const PublicationId info_writer_id = info.writer_id();
 
   if (DCPS_debug_level >= 5) {
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(info_writer_id);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl::writer_became_dead: ")
                ACE_TEXT("reader %C from writer %C previous state %C.\n"),
-               OPENDDS_STRING(reader_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str(),
+               LogGuid(get_repo_id()).c_str(),
+               LogGuid(info_writer_id).c_str(),
                info.get_state_str()));
   }
 
@@ -2342,13 +2310,11 @@ void DataReaderImpl::process_latency(const ReceivedDataSample& sample)
     ///     association has been torn down).  We may want to promote this
     ///     to a warning if other conditions causing this symptom are
     ///     discovered.
-    GuidConverter reader_converter(get_repo_id());
-    GuidConverter writer_converter(sample.header_.publication_id_);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::process_latency() - ")
         ACE_TEXT("reader %C is not associated with writer %C (late sample?).\n"),
-        OPENDDS_STRING(reader_converter).c_str(),
-        OPENDDS_STRING(writer_converter).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(sample.header_.publication_id_).c_str()));
   }
 }
 
@@ -2577,7 +2543,7 @@ DataReaderImpl::lookup_instance_handles(const WriterIdSeq& ids,
 
     for (CORBA::ULong i = 0; i < num_wrts; ++i) {
       guids += separator;
-      guids += OPENDDS_STRING(GuidConverter(ids[i]));
+      guids += LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 
@@ -2659,13 +2625,11 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
         // This may not be an error since it could happen that the sample
         // is delivered to the datareader after the write is dis-associated
         // with this datareader.
-        GuidConverter reader_converter(get_repo_id());
-        GuidConverter writer_converter(pubid);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
                    ACE_TEXT("reader %C is not associated with writer %C.\n"),
-                   OPENDDS_STRING(reader_converter).c_str(),
-                   OPENDDS_STRING(writer_converter).c_str()));
+                   LogGuid(get_repo_id()).c_str(),
+                   LogGuid(pubid).c_str()));
       }
       return true;
     }
@@ -2686,30 +2650,24 @@ DataReaderImpl::ownership_filter_instance(const SubscriptionInstance_rch& instan
 
       if (! is_owner) {
         if (DCPS_debug_level >= 1) {
-          GuidConverter reader_converter(get_repo_id());
-          GuidConverter writer_converter(pubid);
-          GuidConverter owner_converter(instance->instance_state_->get_owner());
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
                      ACE_TEXT("reader %C writer %C is not elected as owner %C\n"),
-                     OPENDDS_STRING(reader_converter).c_str(),
-                     OPENDDS_STRING(writer_converter).c_str(),
-                     OPENDDS_STRING(owner_converter).c_str()));
+                     LogGuid(get_repo_id()).c_str(),
+                     LogGuid(pubid).c_str(),
+                     LogGuid(instance->instance_state_->get_owner()).c_str()));
         }
         return true;
       }
     }
     else if (! (instance->instance_state_->get_owner() == pubid)) {
       if (DCPS_debug_level >= 1) {
-        GuidConverter reader_converter(get_repo_id());
-        GuidConverter writer_converter(pubid);
-        GuidConverter owner_converter(instance->instance_state_->get_owner());
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataReaderImpl::ownership_filter_instance: ")
                    ACE_TEXT("reader %C writer %C is not owner %C\n"),
-                   OPENDDS_STRING(reader_converter).c_str(),
-                   OPENDDS_STRING(writer_converter).c_str(),
-                   OPENDDS_STRING(owner_converter).c_str()));
+                   LogGuid(get_repo_id()).c_str(),
+                   LogGuid(pubid).c_str(),
+                   LogGuid(instance->instance_state_->get_owner()).c_str()));
       }
       return true;
     }
@@ -2792,7 +2750,7 @@ void DataReaderImpl::notify_liveliness_change()
     ACE_Guard<ACE_Thread_Mutex> g(listener_mutex_);
     OPENDDS_STRING output_str;
     output_str += "subscription ";
-    output_str += OPENDDS_STRING(GuidConverter(get_repo_id()));
+    output_str += LogGuid(get_repo_id()).conv_;
     output_str += ", listener at: 0x";
     output_str += to_dds_string(this->listener_.in());
 
@@ -2801,7 +2759,7 @@ void DataReaderImpl::notify_liveliness_change()
          ++current) {
       const RepoId id = current->first;
       output_str += "\n\tNOTIFY: writer[ ";
-      output_str += OPENDDS_STRING(GuidConverter(id));
+      output_str += LogGuid(id).conv_;
       output_str += "] == ";
       output_str += current->second->get_state_str();
     }
@@ -2900,13 +2858,11 @@ DataReaderImpl::update_ownership_strength(const PublicationId& pub_id,
     if (iter->second->writer_id() == pub_id) {
       if (ownership_strength != iter->second->writer_qos_ownership_strength()) {
         if (DCPS_debug_level >= 1) {
-          GuidConverter reader_converter(get_repo_id());
-          GuidConverter writer_converter(pub_id);
           ACE_DEBUG((LM_DEBUG,
               ACE_TEXT("(%P|%t) DataReaderImpl::update_ownership_strength - ")
               ACE_TEXT("local %C update remote %C strength from %d to %d\n"),
-              OPENDDS_STRING(reader_converter).c_str(),
-              OPENDDS_STRING(writer_converter).c_str(),
+              LogGuid(get_repo_id()).c_str(),
+              LogGuid(pub_id).c_str(),
               iter->second->writer_qos_ownership_strength(), ownership_strength));
         }
         iter->second->writer_qos_ownership_strength(ownership_strength);
@@ -2959,15 +2915,12 @@ void DataReaderImpl::accept_coherent(const PublicationId& writer_id,
     const RepoId& publisher_id)
 {
   if (::OpenDDS::DCPS::DCPS_debug_level > 0) {
-    GuidConverter reader (get_repo_id());
-    GuidConverter writer (writer_id);
-    GuidConverter publisher (publisher_id);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::accept_coherent()")
         ACE_TEXT(" reader %C writer %C publisher %C\n"),
-        OPENDDS_STRING(reader).c_str(),
-        OPENDDS_STRING(writer).c_str(),
-        OPENDDS_STRING(publisher).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writer_id).c_str(),
+        LogGuid(publisher_id).c_str()));
   }
   SubscriptionInstanceSet localsubs;
   {
@@ -2989,15 +2942,12 @@ void DataReaderImpl::reject_coherent(const PublicationId& writer_id,
     const RepoId& publisher_id)
 {
   if (::OpenDDS::DCPS::DCPS_debug_level > 0) {
-    GuidConverter reader (get_repo_id());
-    GuidConverter writer (writer_id);
-    GuidConverter publisher (publisher_id);
     ACE_DEBUG((LM_DEBUG,
         ACE_TEXT("(%P|%t) DataReaderImpl::reject_coherent()")
         ACE_TEXT(" reader %C writer %C publisher %C\n"),
-        OPENDDS_STRING(reader).c_str(),
-        OPENDDS_STRING(writer).c_str(),
-        OPENDDS_STRING(publisher).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(writer_id).c_str(),
+        LogGuid(publisher_id).c_str()));
   }
 
   SubscriptionInstanceSet localsubs;
@@ -3414,14 +3364,12 @@ void DataReaderImpl::accept_sample_processing(const SubscriptionInstance_rch& in
       }
     }
     else {
-      GuidConverter subscriptionBuffer(get_repo_id());
-      GuidConverter publicationBuffer(header.publication_id_);
       ACE_DEBUG((LM_WARNING,
         ACE_TEXT("(%P|%t) WARNING: DataReaderImpl::accept_sample_processing - ")
         ACE_TEXT("subscription %C failed to find ")
         ACE_TEXT("publication data for %C.\n"),
-        OPENDDS_STRING(subscriptionBuffer).c_str(),
-        OPENDDS_STRING(publicationBuffer).c_str()));
+        LogGuid(get_repo_id()).c_str(),
+        LogGuid(header.publication_id_).c_str()));
     }
   }
 
@@ -3499,11 +3447,9 @@ int EndHistoricSamplesMissedSweeper::handle_timeout(
     return 0;
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter sub_repo(reader->get_repo_id());
-    GuidConverter pub_repo(pub_id);
     ACE_DEBUG((LM_INFO, "(%P|%t) EndHistoricSamplesMissedSweeper::handle_timeout reader: %C waiting on writer: %C\n",
-               OPENDDS_STRING(sub_repo).c_str(),
-               OPENDDS_STRING(pub_repo).c_str()));
+               LogGuid(reader->get_repo_id()).c_str(),
+               LogGuid(pub_id).c_str()));
   }
 
   reader->resume_sample_processing(pub_id);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1433,10 +1433,9 @@ DDS::ReturnCode_t read_instance_i(MessageSequenceType& received_data,
       msg += state_obj->instance_state_string();
       msg += " while the validity mask is " + InstanceState::instance_state_mask_string(instance_states);
     }
-    const GuidConverter conv(get_repo_id());
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl_T::read_instance_i: ")
                ACE_TEXT("will return no data reading sub %C because:\n  %C\n"),
-               OPENDDS_STRING(conv).c_str(), msg.c_str()));
+               LogGuid(get_repo_id()).c_str(), msg.c_str()));
   }
 
   results.copy_to_user();

--- a/dds/DCPS/DataSampleHeader.cpp
+++ b/dds/DCPS/DataSampleHeader.cpp
@@ -583,10 +583,10 @@ OPENDDS_STRING to_string(const DataSampleHeader& value)
       ret += ", ";
     }
 
-    ret += "Publication: " + OPENDDS_STRING(GuidConverter(value.publication_id_));
+    ret += "Publication: " + LogGuid(value.publication_id_).conv_;
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
     if (value.group_coherent_) {
-      ret += ", Publisher: " + OPENDDS_STRING(GuidConverter(value.publisher_id_));
+      ret += ", Publisher: " + LogGuid(value.publisher_id_).conv_;
     }
 #endif
 
@@ -596,7 +596,7 @@ OPENDDS_STRING to_string(const DataSampleHeader& value)
       ret += to_dds_string(len);
       ret += "): [";
       for (CORBA::ULong i(0); i < len; ++i) {
-        ret += OPENDDS_STRING(GuidConverter(value.content_filter_entries_[i])) + ' ';
+        ret += LogGuid(value.content_filter_entries_[i]).conv_ + ' ';
       }
       ret += ']';
     }

--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -205,12 +205,10 @@ DataWriterImpl::add_association(const RepoId& yourId,
   DBG_ENTRY_LVL("DataWriterImpl", "add_association", 6);
 
   if (DCPS_debug_level) {
-    GuidConverter writer_converter(yourId);
-    GuidConverter reader_converter(reader.readerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataWriterImpl::add_association - ")
                ACE_TEXT("bit %d local %C remote %C\n"), is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str()));
+               LogGuid(yourId).c_str(),
+               LogGuid(reader.readerId).c_str()));
   }
 
   if (get_deleted()) {
@@ -235,11 +233,10 @@ DataWriterImpl::add_association(const RepoId& yourId,
   }
 
   if (DCPS_debug_level > 4) {
-    GuidConverter converter(get_repo_id());
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::add_association(): ")
                ACE_TEXT("adding subscription to publication %C with priority %d.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(get_repo_id()).c_str(),
                qos_.transport_priority.value));
   }
 
@@ -276,11 +273,10 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
 
   if (!(flags & ASSOC_OK)) {
     if (DCPS_debug_level) {
-      const GuidConverter conv(remote_id);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                  ACE_TEXT("ERROR: transport layer failed to associate %C\n"),
-                 OPENDDS_STRING(conv).c_str()));
+                 LogGuid(remote_id).c_str()));
     }
 
     return;
@@ -289,26 +285,22 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
 
   if (DCPS_debug_level) {
-    const GuidConverter writer_conv(publication_id_);
-    const GuidConverter conv(remote_id);
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                ACE_TEXT("writer %C succeeded in associating with reader %C\n"),
-               OPENDDS_STRING(writer_conv).c_str(),
-               OPENDDS_STRING(conv).c_str()));
+               LogGuid(publication_id_).c_str(),
+               LogGuid(remote_id).c_str()));
   }
 
   if (flags & ASSOC_ACTIVE) {
 
     // Have we already received an association_complete() callback?
     if (DCPS_debug_level) {
-      const GuidConverter writer_conv(publication_id_);
-      const GuidConverter converter(remote_id);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                  ACE_TEXT("writer %C reader %C calling association_complete_i\n"),
-                 OPENDDS_STRING(writer_conv).c_str(),
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str(),
+                 LogGuid(remote_id).c_str()));
     }
     association_complete_i(remote_id);
 
@@ -316,11 +308,10 @@ DataWriterImpl::transport_assoc_done(int flags, const RepoId& remote_id)
     // In the current implementation, DataWriter is always active, so this
     // code will not be applicable.
     if (DCPS_debug_level) {
-      const GuidConverter conv(publication_id_);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) DataWriterImpl::transport_assoc_done: ")
                  ACE_TEXT("ERROR: DataWriter (%C) should always be active in current implementation\n"),
-                 OPENDDS_STRING(conv).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
   }
 }
@@ -430,20 +421,18 @@ DataWriterImpl::association_complete_i(const RepoId& remote_id)
       ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
 
       if (OpenDDS::DCPS::bind(id_to_handle_map_, remote_id, handle) != 0) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x failed.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
         return;
 
       } else if (DCPS_debug_level > 4) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataWriterImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
       }
 
@@ -567,14 +556,12 @@ DataWriterImpl::remove_associations(const ReaderIdSeq & readers,
   }
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter writer_converter(publication_id_);
-    GuidConverter reader_converter(readers[0]);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::remove_associations: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
                is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str(),
+               LogGuid(publication_id_).c_str(),
+               LogGuid(readers[0]).c_str(),
                readers.length()));
   }
 
@@ -908,11 +895,10 @@ DataWriterImpl::update_subscription_params(const RepoId& readerId,
 
   } else if (DCPS_debug_level > 4 &&
              TheServiceParticipant->publisher_content_filter()) {
-    GuidConverter pubConv(this->publication_id_), subConv(readerId);
     ACE_DEBUG((LM_WARNING,
                ACE_TEXT("(%P|%t) WARNING: DataWriterImpl::update_subscription_params()")
                ACE_TEXT(" - writer: %C has no info about reader: %C\n"),
-               OPENDDS_STRING(pubConv).c_str(), OPENDDS_STRING(subConv).c_str()));
+               LogGuid(this->publication_id_).c_str(), LogGuid(readerId).c_str()));
   }
 
 #endif
@@ -2155,11 +2141,10 @@ DataWriterImpl::create_control_message(MessageId message_id,
     }
   }
   if (DCPS_debug_level >= 4) {
-    const GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::create_control_message: ")
                ACE_TEXT("from publication %C sending control sample: %C .\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(publication_id_).c_str(),
                to_string(header_data).c_str()));
   }
   return message;
@@ -2240,11 +2225,10 @@ DataWriterImpl::create_sample_data_message(Message_Block_Ptr data,
   message.reset(tmp_message);
   *message << header_data;
   if (DCPS_debug_level >= 4) {
-    const GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DataWriterImpl::create_sample_data_message: ")
                ACE_TEXT("from publication %C sending data sample: %C .\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(publication_id_).c_str(),
                to_string(header_data).c_str()));
   }
   return DDS::RETCODE_OK;
@@ -2256,14 +2240,12 @@ DataWriterImpl::data_delivered(const DataSampleElement* sample)
   DBG_ENTRY_LVL("DataWriterImpl","data_delivered",6);
 
   if (!(sample->get_pub_id() == this->publication_id_)) {
-    GuidConverter sample_converter(sample->get_pub_id());
-    GuidConverter writer_converter(publication_id_);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::data_delivered: ")
                ACE_TEXT("The publication id %C from delivered element ")
                ACE_TEXT("does not match the datawriter's id %C\n"),
-               OPENDDS_STRING(sample_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str()));
+               LogGuid(sample->get_pub_id()).c_str(),
+               LogGuid(publication_id_).c_str()));
     return;
   }
   //provided for statistics tracking in tests
@@ -2702,7 +2684,7 @@ DataWriterImpl::lookup_instance_handles(const ReaderIdSeq& ids,
     OPENDDS_STRING buffer;
 
     for (CORBA::ULong i = 0; i < num_rds; ++i) {
-      buffer += separator + OPENDDS_STRING(GuidConverter(ids[i]));
+      buffer += separator + LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -179,14 +179,13 @@ DomainParticipantFactoryImpl::delete_participant(
     DPMap::iterator pos = participants_.find(domain_id);
     if (pos == participants_.end()) {
       if (DCPS_debug_level > 0) {
-        GuidConverter converter(dp_id);
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: ")
                    ACE_TEXT("DomainParticipantFactoryImpl::delete_participant: ")
                    ACE_TEXT("%p domain_id=%d dp_id=%C.\n"),
                    ACE_TEXT("find"),
                    domain_id,
-                   OPENDDS_STRING(converter).c_str()));
+                   LogGuid(dp_id).c_str()));
       }
       return DDS::RETCODE_ERROR;
     }

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -1251,11 +1251,10 @@ DomainParticipantImpl::ignore_participant(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_participant: ")
                ACE_TEXT("%C ignoring handle %x.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1273,11 +1272,10 @@ DomainParticipantImpl::ignore_participant(
 
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_participant: ")
                ACE_TEXT("%C repo call returned.\n"),
-               OPENDDS_STRING(converter).c_str()));
+               LogGuid(dp_id_).c_str()));
   }
 
   return DDS::RETCODE_OK;
@@ -1313,11 +1311,10 @@ DomainParticipantImpl::ignore_topic(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_topic: ")
                ACE_TEXT("%C ignoring handle %x.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1355,11 +1352,10 @@ DomainParticipantImpl::ignore_publication(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_publication: ")
                ACE_TEXT("%C ignoring handle %x.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1399,11 +1395,10 @@ DomainParticipantImpl::ignore_subscription(
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter converter(dp_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) DomainParticipantImpl::ignore_subscription: ")
                ACE_TEXT("%C ignoring handle %d.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(dp_id_).c_str(),
                handle));
   }
 
@@ -1865,7 +1860,7 @@ DomainParticipantImpl::enable()
   if (DCPS_debug_level > 1) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DomainParticipantImpl::enable: ")
                ACE_TEXT("enabled participant %C in domain %d\n"),
-               OPENDDS_STRING(GuidConverter(dp_id_)).c_str(), domain_id_));
+               LogGuid(dp_id_).c_str(), domain_id_));
   }
 
   if (ret == DDS::RETCODE_OK && !TheTransientKludge->is_enabled()) {

--- a/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.cpp
@@ -38,12 +38,12 @@ DataReaderRemoteImpl::add_association(const RepoId& yourId,
                                       bool active)
 {
   if (DCPS_debug_level) {
-    GuidConverter writer_converter(yourId);
-    GuidConverter reader_converter(writer.writerId);
+    LogGuid writer_log(yourId);
+    LogGuid reader_log(writer.writerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderRemoteImpl::add_association - ")
                ACE_TEXT("local %C remote %C\n"),
-               std::string(writer_converter).c_str(),
-               std::string(reader_converter).c_str()));
+               writer_log.c_str(),
+               reader_log.c_str()));
   }
 
   // the local copy of parent_ is necessary to prevent race condition

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
@@ -38,12 +38,12 @@ DataWriterRemoteImpl::add_association(const RepoId& yourId,
                                       bool active)
 {
   if (DCPS_debug_level) {
-    GuidConverter writer_converter(yourId);
-    GuidConverter reader_converter(reader.readerId);
+    LogGuid writer_log(yourId);
+    LogGuid reader_log(reader.readerId);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataWriterRemoteImpl::add_association - ")
                ACE_TEXT("local %C remote %C\n"),
-               std::string(writer_converter).c_str(),
-               std::string(reader_converter).c_str()));
+               writer_log.c_str(),
+               reader_log.c_str()));
   }
 
   // the local copy of parent_ is necessary to prevent race condition

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -150,9 +150,8 @@ bool InstanceState::dispose_was_received(const PublicationId& writer_id)
 bool InstanceState::unregister_was_received(const PublicationId& writer_id)
 {
   if (DCPS_debug_level > 1) {
-    GuidConverter conv(writer_id);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) InstanceState::unregister_was_received on %C\n"),
-      OPENDDS_STRING(conv).c_str()
+      LogGuid(writer_id).c_str()
     ));
   }
 

--- a/dds/DCPS/OwnershipManager.cpp
+++ b/dds/DCPS/OwnershipManager.cpp
@@ -390,12 +390,11 @@ OwnershipManager::broadcast_new_owner(const DDS::InstanceHandle_t& instance_hand
     // This may not be an error since it could happen that the sample
     // is delivered to the datareader after the write is dis-associated
     // with this datareader.
-    GuidConverter writer_converter(owner);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) OwnershipManager::broadcast_new_owner: ")
                ACE_TEXT("owner writer %C, instance handle %d strength %d num ")
                ACE_TEXT("of candidates %d\n"),
-               OPENDDS_STRING(writer_converter).c_str(), instance_handle,
+               LogGuid(owner).c_str(), instance_handle,
                infos.owner_.ownership_strength_,
                (int)infos.candidates_.size()));
   }

--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -194,13 +194,11 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
 
     if (dw_publisher.in() != this) {
       if (DCPS_debug_level > 0) {
-        RepoId id = dw_servant->get_repo_id();
-        GuidConverter converter(id);
         ACE_ERROR((LM_ERROR,
             ACE_TEXT("(%P|%t) PublisherImpl::delete_datawriter: ")
             ACE_TEXT("the data writer %C doesn't ")
             ACE_TEXT("belong to this subscriber\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(dw_servant->get_repo_id()).c_str()));
       }
       return DDS::RETCODE_PRECONDITION_NOT_MET;
     }
@@ -228,12 +226,11 @@ PublisherImpl::delete_datawriter(DDS::DataWriter_ptr a_datawriter)
 
     if (it == publication_map_.end()) {
       if (DCPS_debug_level > 0) {
-        GuidConverter converter(publication_id);
         ACE_ERROR((LM_ERROR,
             ACE_TEXT("(%P|%t) ERROR: ")
             ACE_TEXT("PublisherImpl::delete_datawriter, ")
             ACE_TEXT("datawriter %C not found.\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(publication_id).c_str()));
       }
       return DDS::RETCODE_ERROR;
     }
@@ -407,14 +404,13 @@ DDS::ReturnCode_t PublisherImpl::delete_contained_entities()
 
     if (ret != DDS::RETCODE_OK) {
       if (DCPS_debug_level > 0) {
-        GuidConverter converter(pub_id);
         ACE_ERROR((LM_ERROR,
             ACE_TEXT("(%P|%t) ERROR: ")
             ACE_TEXT("PublisherImpl::")
             ACE_TEXT("delete_contained_entities: ")
             ACE_TEXT("failed to delete ")
             ACE_TEXT("datawriter %C.\n"),
-            OPENDDS_STRING(converter).c_str()));
+            LogGuid(pub_id).c_str()));
       }
       return ret;
     }
@@ -460,13 +456,12 @@ PublisherImpl::set_qos(const DDS::PublisherQos & qos)
 
           if (!pair.second) {
             if (DCPS_debug_level > 0) {
-              GuidConverter converter(id);
               ACE_ERROR((LM_ERROR,
                   ACE_TEXT("(%P|%t) ")
                   ACE_TEXT("PublisherImpl::set_qos: ")
                   ACE_TEXT("insert id %C to DwIdToQosMap ")
                   ACE_TEXT("failed.\n"),
-                  OPENDDS_STRING(converter).c_str()));
+                  LogGuid(id).c_str()));
             }
             return DDS::RETCODE_ERROR;
           }
@@ -923,12 +918,11 @@ PublisherImpl::writer_enabled(const char*     topic_name,
 
   if (!pair.second) {
     if (DCPS_debug_level > 0) {
-      GuidConverter converter(publication_id);
       ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: ")
           ACE_TEXT("PublisherImpl::writer_enabled: ")
           ACE_TEXT("insert publication %C failed.\n"),
-          OPENDDS_STRING(converter).c_str()));
+          LogGuid(publication_id).c_str()));
     }
     return DDS::RETCODE_ERROR;
   }

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4677,7 +4677,7 @@ Sedp::populate_discovered_reader_msg(
   drd.readerProxy.allLocators = sub.trans_info_;
 
   drd.contentFilterProperty.contentFilteredTopicName =
-    OPENDDS_STRING(DCPS::GuidConverter(subscription_id)).c_str();
+    DCPS::LogGuid(subscription_id).c_str();
   drd.contentFilterProperty.relatedTopicName = topic_name.c_str();
   drd.contentFilterProperty.filterClassName = ""; // PLConverter adds default
   drd.contentFilterProperty.filterExpression = sub.filterProperties.filterExpression;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -843,7 +843,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
           if (DCPS::security_debug.auth_debug) {
             ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::handle_participant_data - ")
               ACE_TEXT("Incompatible security attributes in discovered participant: %C\n"),
-              OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+              DCPS::LogGuid(guid).c_str()));
           }
           // FUTURE: This is probably not a good idea since it will just get rediscovered.
           erase_participant(iter);
@@ -868,7 +868,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
             if (DCPS::security_debug.auth_debug) {
               ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::handle_participant_data - ")
                 ACE_TEXT("Incompatible security attributes in discovered participant: %C\n"),
-                OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+                DCPS::LogGuid(guid).c_str()));
             }
             erase_participant(iter);
           } else { // allow_unauthenticated_participants == true
@@ -1306,7 +1306,7 @@ Spdp::send_handshake_request(const DCPS::RepoId& guid, DiscoveredParticipant& dp
   } else if (DCPS::security_debug.auth_debug) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::send_handshake_request() - ")
                ACE_TEXT("Sent handshake request message for participant: %C\n"),
-               OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+               DCPS::LogGuid(guid).c_str()));
   }
 }
 
@@ -1319,7 +1319,7 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
   if (DCPS::security_debug.auth_debug) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication "
       "for %C from_discovery=%d have_remote_token=%d auth_state=%d handshake_state=%d\n",
-      OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str(),
+      DCPS::LogGuid(guid).c_str(),
       from_discovery, !(dp.remote_auth_request_token_ == DDS::Security::Token()),
       dp.auth_state_, dp.handshake_state_));
   }
@@ -1368,7 +1368,7 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
       if (DCPS::security_debug.auth_debug) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
                    ACE_TEXT("Sent auth req message for participant: %C\n"),
-                   OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+                   DCPS::LogGuid(guid).c_str()));
       }
     }
     schedule_handshake_resend(dp.handshake_resend_falloff_.get(), guid);
@@ -1385,7 +1385,7 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
     if (DCPS::security_debug.auth_debug) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
                  ACE_TEXT("Attempting authentication (expecting request) for participant: %C\n"),
-                 OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+                 DCPS::LogGuid(guid).c_str()));
     }
     dp.handshake_state_ = HANDSHAKE_STATE_BEGIN_HANDSHAKE_REPLY;
     dp.is_requester_ = true;
@@ -1395,7 +1395,7 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
     if (DCPS::security_debug.auth_debug) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::attempt_authentication() - ")
                  ACE_TEXT("Attempting authentication (sending request/expecting reply) for participant: %C\n"),
-                 OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+                 DCPS::LogGuid(guid).c_str()));
     }
     dp.handshake_state_ = HANDSHAKE_STATE_BEGIN_HANDSHAKE_REQUEST;
     send_handshake_request(guid, dp);
@@ -1472,7 +1472,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
       ACE_DEBUG((LM_WARNING,
         ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_handshake_message() - ")
         ACE_TEXT("received handshake for undiscovered participant %C. Ignoring.\n"),
-                 OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        DCPS::LogGuid(src_participant).c_str()));
     }
     return;
   }
@@ -1482,7 +1482,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
   if (DCPS::security_debug.auth_debug) {
     ACE_DEBUG((LM_DEBUG, "(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - "
       "for %C auth_state=%d handshake_state=%d\n",
-      OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str(),
+      DCPS::LogGuid(src_participant).c_str(),
       dp.auth_state_, dp.handshake_state_));
   }
 
@@ -1605,7 +1605,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
         if (DCPS::security_debug.auth_debug) {
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
                      ACE_TEXT("Sent handshake reply for participant: %C\n"),
-                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+                     DCPS::LogGuid(src_participant).c_str()));
         }
       }
       dp.handshake_state_ = HANDSHAKE_STATE_PROCESS_HANDSHAKE;
@@ -1623,7 +1623,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
         if (DCPS::security_debug.auth_debug) {
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
                      ACE_TEXT("Sent handshake final for participant: %C\n"),
-                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+                     DCPS::LogGuid(src_participant).c_str()));
         }
       }
       set_auth_state(dp, AUTH_STATE_AUTHENTICATED);
@@ -1656,7 +1656,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
                    ACE_TEXT("Failed to process incoming handshake message when ")
                    ACE_TEXT("expecting %C from %C. Security Exception[%d.%d]: %C\n"),
                    dp.is_requester_ ? "final" : "reply",
-                   OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str(),
+                   DCPS::LogGuid(src_participant).c_str(),
                    se.code, se.minor_code, se.message.in()));
       }
       return;
@@ -1687,7 +1687,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
         if (DCPS::security_debug.auth_debug) {
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
                      ACE_TEXT("Sent handshake unknown message for participant: %C\n"),
-                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+                     DCPS::LogGuid(src_participant).c_str()));
         }
       }
       return;
@@ -1710,7 +1710,7 @@ Spdp::handle_handshake_message(const DDS::Security::ParticipantStatelessMessage&
         if (DCPS::security_debug.auth_debug) {
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::handle_handshake_message() - ")
                      ACE_TEXT("Sent handshake final for participant: %C\n"),
-                     OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+                     DCPS::LogGuid(src_participant).c_str()));
         }
       }
 
@@ -1747,7 +1747,7 @@ Spdp::process_handshake_deadlines(const DCPS::MonotonicTimePoint& now)
       if (DCPS::security_debug.auth_debug) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::process_handshake_deadlines() - ")
                    ACE_TEXT("Removing discovered participant due to authentication timeout: %C\n"),
-                   OPENDDS_STRING(DCPS::GuidConverter(pos->second)).c_str()));
+                   DCPS::LogGuid(pos->second).c_str()));
       }
       const DCPS::MonotonicTimePoint ptime = pos->first;
       if (participant_sec_attr_.allow_unauthenticated_participants == false) {
@@ -1816,7 +1816,7 @@ Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
           if (DCPS::security_debug.auth_debug) {
             ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::process_handshake_resends() - ")
                        ACE_TEXT("Sent auth req message for participant: %C\n"),
-                       OPENDDS_STRING(DCPS::GuidConverter(pit->first)).c_str()));
+                       DCPS::LogGuid(pit->first).c_str()));
           }
         }
       }
@@ -1833,7 +1833,7 @@ Spdp::process_handshake_resends(const DCPS::MonotonicTimePoint& now)
           if (DCPS::security_debug.auth_debug) {
             ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} DEBUG: Spdp::process_handshake_resends() - ")
                        ACE_TEXT("Sent handshake message for participant: %C\n"),
-                       OPENDDS_STRING(DCPS::GuidConverter(pit->first)).c_str()));
+                       DCPS::LogGuid(pit->first).c_str()));
           }
         }
       }
@@ -1889,7 +1889,7 @@ Spdp::handle_participant_crypto_tokens(const DDS::Security::ParticipantVolatileM
       ACE_DEBUG((LM_WARNING,
         ACE_TEXT("(%P|%t) {auth_warn} Spdp::handle_participant_crypto_tokens() - ")
         ACE_TEXT("received tokens for undiscovered participant %C. Ignoring.\n"),
-        OPENDDS_STRING(DCPS::GuidConverter(src_participant)).c_str()));
+        DCPS::LogGuid(src_participant).c_str()));
     }
     return false;
   }
@@ -2055,7 +2055,7 @@ Spdp::match_authenticated(const DCPS::RepoId& guid, DiscoveredParticipantIter& i
   if (DCPS::security_debug.auth_debug) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) {auth_debug} Spdp::match_authenticated - ")
                ACE_TEXT("auth and access control complete for peer %C\n"),
-               OPENDDS_STRING(DCPS::GuidConverter(guid)).c_str()));
+               DCPS::LogGuid(guid).c_str()));
   }
 
   if (DCPS::transport_debug.log_progress) {
@@ -3842,9 +3842,10 @@ Spdp::send_participant_crypto_tokens(const DCPS::RepoId& id)
   const DiscoveredParticipantIter iter = participants_.find(peer);
   if (iter == participants_.end()) {
     if (DCPS::DCPS_debug_level > 0) {
-      const DCPS::GuidConverter conv(peer);
+      const DCPS::LogGuid logger(peer);
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::send_participant_crypto_tokens() - ")
-                ACE_TEXT("Discovered participant %C not found.\n"), OPENDDS_STRING(conv).c_str()));
+                ACE_TEXT("Discovered participant %C not found.\n"),
+                logger.c_str()));
     }
     return;
   }
@@ -4784,7 +4785,7 @@ void Spdp::remove_discovered_participant(const DiscoveredParticipantIter& iter)
     if (DCPS_debug_level > 3) {
       ACE_DEBUG((LM_DEBUG, "(%P|%t) LocalParticipant::remove_discovered_participant: "
         "erasing %C (%B)\n",
-        LogGuid(iter->first).c_str(), participants_.size()));
+        DCPS::LogGuid(iter->first).c_str(), participants_.size()));
     }
 
     remove_discovered_participant_i(iter);

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -420,11 +420,10 @@ RecorderImpl::add_association(const RepoId&            yourId,
         RepoIdToHandleMap::value_type(writer.writerId, handle));
 
       if (DCPS_debug_level > 4) {
-        GuidConverter converter(writer.writerId);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) RecorderImpl::add_association: ")
                    ACE_TEXT("id_to_handle_map_[ %C] = 0x%x.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(writer.writerId).c_str(),
                    handle));
       }
 
@@ -509,14 +508,12 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
   }
 
   if (DCPS_debug_level >= 4) {
-    GuidConverter reader_converter(subscription_id_);
-    GuidConverter writer_converter(writers[0]);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) RecorderImpl::remove_associations_i: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
                is_bit_,
-               OPENDDS_STRING(reader_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str(),
+               LogGuid(subscription_id_).c_str(),
+               LogGuid(writers[0]).c_str(),
                writers.length()));
   }
   DDS::InstanceHandleSeq handles;
@@ -556,11 +553,10 @@ RecorderImpl::remove_associations_i(const WriterIdSeq& writers,
 
       if (this->writers_.erase(writer_id) == 0) {
         if (DCPS_debug_level >= 4) {
-          GuidConverter converter(writer_id);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) RecorderImpl::remove_associations_i: ")
                      ACE_TEXT("the writer local %C was already removed.\n"),
-                     OPENDDS_STRING(converter).c_str()));
+                     LogGuid(writer_id).c_str()));
         }
 
       } else {
@@ -843,7 +839,7 @@ RecorderImpl::lookup_instance_handles(const WriterIdSeq&       ids,
     OPENDDS_STRING buffer;
 
     for (CORBA::ULong i = 0; i < num_wrts; ++i) {
-      buffer += separator + OPENDDS_STRING(GuidConverter(ids[i]));
+      buffer += separator + LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -405,14 +405,12 @@ ReplayerImpl::add_association(const RepoId&            yourId,
   DBG_ENTRY_LVL("ReplayerImpl", "add_association", 6);
 
   if (DCPS_debug_level >= 1) {
-    GuidConverter writer_converter(yourId);
-    GuidConverter reader_converter(reader.readerId);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ReplayerImpl::add_association - ")
                ACE_TEXT("bit %d local %C remote %C\n"),
                is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str()));
+               LogGuid(yourId).c_str(),
+               LogGuid(reader.readerId).c_str()));
   }
 
   // if (entity_deleted_ == true) {
@@ -437,11 +435,10 @@ ReplayerImpl::add_association(const RepoId&            yourId,
   }
 
   if (DCPS_debug_level > 4) {
-    GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ReplayerImpl::add_association(): ")
                ACE_TEXT("adding subscription to publication %C with priority %d.\n"),
-               OPENDDS_STRING(converter).c_str(),
+               LogGuid(publication_id_).c_str(),
                qos_.transport_priority.value));
   }
 
@@ -498,11 +495,10 @@ ReplayerImpl::association_complete_i(const RepoId& remote_id)
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
     if (OpenDDS::DCPS::insert(readers_, remote_id) == -1) {
-      GuidConverter converter(remote_id);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::association_complete_i: ")
                  ACE_TEXT("insert %C from pending failed.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(remote_id).c_str()));
     }
     // RepoIdToReaderInfoMap::const_iterator it = reader_info_.find(remote_id);
     // if (it != reader_info_.end()) {
@@ -525,20 +521,18 @@ ReplayerImpl::association_complete_i(const RepoId& remote_id)
       ++publication_match_status_.current_count_change;
 
       if (OpenDDS::DCPS::bind(id_to_handle_map_, remote_id, handle) != 0) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x failed.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
         return;
 
       } else if (DCPS_debug_level > 4) {
-        GuidConverter converter(remote_id);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) ReplayerImpl::association_complete_i: ")
                    ACE_TEXT("id_to_handle_map_%C = 0x%x.\n"),
-                   OPENDDS_STRING(converter).c_str(),
+                   LogGuid(remote_id).c_str(),
                    handle));
       }
 
@@ -566,14 +560,12 @@ ReplayerImpl::remove_associations(const ReaderIdSeq & readers,
                                   CORBA::Boolean      notify_lost)
 {
   if (DCPS_debug_level >= 1) {
-    GuidConverter writer_converter(publication_id_);
-    GuidConverter reader_converter(readers[0]);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) ReplayerImpl::remove_associations: ")
                ACE_TEXT("bit %d local %C remote %C num remotes %d\n"),
                is_bit_,
-               OPENDDS_STRING(writer_converter).c_str(),
-               OPENDDS_STRING(reader_converter).c_str(),
+               LogGuid(publication_id_).c_str(),
+               LogGuid(readers[0]).c_str(),
                readers.length()));
   }
 
@@ -791,14 +783,12 @@ ReplayerImpl::data_delivered(const DataSampleElement* sample)
 {
   DBG_ENTRY_LVL("ReplayerImpl","data_delivered",6);
   if (!(sample->get_pub_id() == this->publication_id_)) {
-    GuidConverter sample_converter(sample->get_pub_id());
-    GuidConverter writer_converter(publication_id_);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::data_delivered: ")
                ACE_TEXT(" The publication id %C from delivered element ")
                ACE_TEXT("does not match the datawriter's id %C\n"),
-               OPENDDS_STRING(sample_converter).c_str(),
-               OPENDDS_STRING(writer_converter).c_str()));
+               LogGuid(sample->get_pub_id()).c_str(),
+               LogGuid(publication_id_).c_str()));
     return;
   }
   DataSampleElement* elem = const_cast<DataSampleElement*>(sample);
@@ -1022,7 +1012,7 @@ ReplayerImpl::lookup_instance_handles(const ReaderIdSeq&       ids,
     OPENDDS_STRING buffer;
 
     for (CORBA::ULong i = 0; i < num_rds; ++i) {
-      buffer += separator + OPENDDS_STRING(GuidConverter(ids[i]));
+      buffer += separator + LogGuid(ids[i]).conv_;
       separator = ", ";
     }
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1205,11 +1205,10 @@ Service_Participant::set_repo_domain(const DDS::DomainId_t domain,
               repoList.push_back(std::make_pair(disc_iter->second, id));
 
               if (DCPS_debug_level > 0) {
-                GuidConverter converter(id);
                 ACE_DEBUG((LM_DEBUG,
                            ACE_TEXT("(%P|%t) Service_Participant::set_repo_domain: ")
                            ACE_TEXT("participant %C attached to Repo[ %C].\n"),
-                           OPENDDS_STRING(converter).c_str(),
+                           LogGuid(id).c_str(),
                            key.c_str()));
               }
 
@@ -1227,12 +1226,11 @@ Service_Participant::set_repo_domain(const DDS::DomainId_t domain,
   // Make all of the remote calls after releasing the lock.
   for (unsigned int index = 0; index < repoList.size(); ++index) {
     if (DCPS_debug_level > 0) {
-      GuidConverter converter(repoList[ index].second);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Service_Participant::set_repo_domain: ")
                  ACE_TEXT("(%d of %d) attaching domain %d participant %C to Repo[ %C].\n"),
                  (1+index), repoList.size(), domain,
-                 OPENDDS_STRING(converter).c_str(),
+                 LogGuid(repoList[ index].second).c_str(),
                  key.c_str()));
     }
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -838,10 +838,9 @@ void StaticEndpointManager::update_publication_locators(
   LocalPublicationIter iter = local_publications_.find(publicationId);
   if (iter != local_publications_.end()) {
     if (DCPS_debug_level > 3) {
-      const GuidConverter conv(publicationId);
       ACE_DEBUG((LM_INFO,
         ACE_TEXT("(%P|%t) StaticEndpointManager::update_publication_locators - updating locators for %C\n"),
-        OPENDDS_STRING(conv).c_str()));
+        LogGuid(publicationId).c_str()));
     }
     iter->second.trans_info_ = transInfo;
     write_publication_data(publicationId, iter->second);
@@ -925,10 +924,9 @@ void StaticEndpointManager::update_subscription_locators(
   LocalSubscriptionIter iter = local_subscriptions_.find(subscriptionId);
   if (iter != local_subscriptions_.end()) {
     if (DCPS_debug_level > 3) {
-      const GuidConverter conv(subscriptionId);
       ACE_DEBUG((LM_INFO,
         ACE_TEXT("(%P|%t) StaticEndpointManager::update_subscription_locators updating locators for %C\n"),
-        OPENDDS_STRING(conv).c_str()));
+        LogGuid(subscriptionId).c_str()));
     }
     iter->second.trans_info_ = transInfo;
     write_subscription_data(subscriptionId, iter->second);
@@ -1400,8 +1398,8 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
     if (call_writer) {
       if (DCPS_debug_level > 3) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) StaticEndpointManager::match_continue - ")
-          ACE_TEXT("adding writer %C association for reader %C\n"), OPENDDS_STRING(GuidConverter(writer)).c_str(),
-          OPENDDS_STRING(GuidConverter(reader)).c_str()));
+          ACE_TEXT("adding writer %C association for reader %C\n"), LogGuid(writer).c_str(),
+          LogGuid(reader).c_str()));
       }
       DataWriterCallbacks_rch dwr_lock = dwr.lock();
       if (dwr_lock) {
@@ -1421,7 +1419,7 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
       if (DCPS_debug_level > 3) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) StaticEndpointManager::match_continue - ")
           ACE_TEXT("adding reader %C association for writer %C\n"),
-          OPENDDS_STRING(GuidConverter(reader)).c_str(), OPENDDS_STRING(GuidConverter(writer)).c_str()));
+          LogGuid(reader).c_str(), LogGuid(writer).c_str()));
       }
       DataReaderCallbacks_rch drr_lock = drr.lock();
       if (drr_lock) {
@@ -3189,9 +3187,8 @@ void StaticParticipant::remove_discovered_participant(DiscoveredParticipantIter&
     }
 #endif /* DDS_HAS_MINIMUM_BIT */
     if (DCPS_debug_level > 3) {
-      GuidConverter conv(iter->first);
       ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) LocalParticipant::remove_discovered_participant")
-                 ACE_TEXT(" - erasing %C (%B)\n"), OPENDDS_STRING(conv).c_str(), participants_.size()));
+                 ACE_TEXT(" - erasing %C (%B)\n"), LogGuid(iter->first).c_str(), participants_.size()));
     }
 
     remove_discovered_participant_i(iter);

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -350,13 +350,12 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
       }
       if (DCPS_debug_level > 0) {
         RepoId id = dr_servant->get_repo_id();
-        GuidConverter converter(id);
         ACE_ERROR((LM_ERROR,
                   ACE_TEXT("(%P|%t) ERROR: ")
                   ACE_TEXT("SubscriberImpl::delete_datareader: ")
                   ACE_TEXT("datareader(topic_name=%C) %C not found.\n"),
                   topic_name.in(),
-                  OPENDDS_STRING(converter).c_str()));
+                  LogGuid(id).c_str()));
       }
       return ::DDS::RETCODE_ERROR;
     }
@@ -663,11 +662,10 @@ SubscriberImpl::set_qos(
 
           if (!pair.second) {
             if (DCPS_debug_level > 0) {
-              GuidConverter converter(id);
               ACE_ERROR((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: SubscriberImpl::set_qos: ")
                         ACE_TEXT("insert %C to DrIdToQosMap failed.\n"),
-                        OPENDDS_STRING(converter).c_str()));
+                        LogGuid(id).c_str()));
             }
             return ::DDS::RETCODE_ERROR;
           }

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -380,16 +380,14 @@ WriteDataContainer::reenqueue_all(const RepoId& reader_id,
   }
 
   if (DCPS_debug_level > 9 && resend_data_.size()) {
-    GuidConverter converter(publication_id_);
-    GuidConverter reader(reader_id);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) WriteDataContainer::reenqueue_all: ")
                ACE_TEXT("domain %d topic %C publication %C copying ")
                ACE_TEXT("sending/sent to resend to %C.\n"),
                domain_id_,
                topic_name_,
-               OPENDDS_STRING(converter).c_str(),
-               OPENDDS_STRING(reader).c_str()));
+               LogGuid(publication_id_).c_str(),
+               LogGuid(reader_id).c_str()));
   }
 
   return DDS::RETCODE_OK;
@@ -707,13 +705,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
       if (stale->get_header().message_id_ != SAMPLE_DATA) {
         //this message was a control message so release it
         if (DCPS_debug_level > 9) {
-          GuidConverter converter(publication_id_);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
                      ACE_TEXT("domain %d topic %C publication %C control message delivered.\n"),
                      domain_id_,
                      topic_name_,
-                     OPENDDS_STRING(converter).c_str()));
+                     LogGuid(publication_id_).c_str()));
         }
         writer_->controlTracker.message_delivered();
       }
@@ -748,13 +745,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
   if (stale->get_header().message_id_ != SAMPLE_DATA) {
     //this message was a control message so release it
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
                  ACE_TEXT("domain %d topic %C publication %C control message delivered.\n"),
                  domain_id_,
                  topic_name_,
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
     release_buffer(stale);
     stale = 0;
@@ -776,13 +772,12 @@ WriteDataContainer::data_delivered(const DataSampleElement* sample)
     }
 
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::data_delivered: ")
                  ACE_TEXT("domain %d topic %C publication %C seq# %q %s.\n"),
                  domain_id_,
                  topic_name_,
-                 OPENDDS_STRING(converter).c_str(),
+                 LogGuid(publication_id_).c_str(),
                  acked_seq.getValue(),
                  max_durable_per_instance_
                  ? ACE_TEXT("stored for durability")
@@ -905,13 +900,12 @@ WriteDataContainer::data_dropped(const DataSampleElement* sample,
       if (stale->get_header().message_id_ != SAMPLE_DATA) {
         //this message was a control message so release it
         if (DCPS_debug_level > 9) {
-          GuidConverter converter(publication_id_);
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) WriteDataContainer::data_dropped: ")
                      ACE_TEXT("domain %d topic %C publication %C control message dropped.\n"),
                      domain_id_,
                      topic_name_,
-                     OPENDDS_STRING(converter).c_str()));
+                     LogGuid(publication_id_).c_str()));
         }
         writer_->controlTracker.message_dropped();
       }
@@ -975,12 +969,11 @@ WriteDataContainer::remove_excess_durable()
   }
 
   if (n_released && DCPS_debug_level > 9) {
-    const GuidConverter converter(publication_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) WriteDataContainer::remove_excess_durable: ")
                ACE_TEXT("domain %d topic %C publication %C %B samples removed ")
                ACE_TEXT("from durable data.\n"), domain_id_, topic_name_,
-               OPENDDS_STRING(converter).c_str(), n_released));
+               LogGuid(publication_id_).c_str(), n_released));
   }
 }
 
@@ -1073,13 +1066,12 @@ WriteDataContainer::remove_oldest_sample(
     released = true;
 
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::remove_oldest_sample: ")
                  ACE_TEXT("domain %d topic %C publication %C sample removed from HISTORY.\n"),
                  this->domain_id_,
                  this->topic_name_,
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
 
   } else if (containing_list == &this->unsent_data_) {
@@ -1092,13 +1084,12 @@ WriteDataContainer::remove_oldest_sample(
     released = true;
 
     if (DCPS_debug_level > 9) {
-      GuidConverter converter(publication_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) WriteDataContainer::remove_oldest_sample: ")
                  ACE_TEXT("domain %d topic %C publication %C sample removed from unsent.\n"),
                  this->domain_id_,
                  this->topic_name_,
-                 OPENDDS_STRING(converter).c_str()));
+                 LogGuid(publication_id_).c_str()));
     }
   } else {
     ACE_ERROR_RETURN((LM_ERROR,

--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -381,13 +381,13 @@ DataLink::make_reservation(const RepoId& remote_subscription_id,
   DBG_ENTRY_LVL("DataLink", "make_reservation", 6);
 
   if (DCPS_debug_level > 9) {
-    GuidConverter local(local_publication_id), remote(remote_subscription_id);
+    LogGuid local_log(local_publication_id), remote_log(remote_subscription_id);
     ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) DataLink::make_reservation() - ")
-               ACE_TEXT("creating association local publication  %C ")
-               ACE_TEXT("<--> with remote subscription %C.\n"),
-               OPENDDS_STRING(local).c_str(),
-               OPENDDS_STRING(remote).c_str()));
+        ACE_TEXT("(%P|%t) DataLink::make_reservation() - ")
+        ACE_TEXT("creating association local publication  %C ")
+        ACE_TEXT("<--> with remote subscription %C.\n"),
+        local_log .c_str(),
+        remote_log.c_str()));
   }
 
   TransportSendStrategy_rch strategy = get_send_strategy();

--- a/dds/DCPS/transport/framework/DataLink.inl
+++ b/dds/DCPS/transport/framework/DataLink.inl
@@ -294,11 +294,11 @@ DataLink::remove_listener(const RepoId& local_id)
     if (pos != send_listeners_.end()) {
       send_listeners_.erase(pos);
       if (Transport_debug_level > 5) {
-        GuidConverter converter(local_id);
+        LogGuid logger(local_id);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataLink::remove_listener: ")
                    ACE_TEXT("removed %C from send_listeners\n"),
-                   OPENDDS_STRING(converter).c_str()));
+                   logger.c_str()));
       }
       return;
     }
@@ -308,11 +308,11 @@ DataLink::remove_listener(const RepoId& local_id)
     if (pos != recv_listeners_.end()) {
       recv_listeners_.erase(pos);
       if (Transport_debug_level > 5) {
-        GuidConverter converter(local_id);
+        LogGuid logger(local_id);
         ACE_DEBUG((LM_DEBUG,
                    ACE_TEXT("(%P|%t) DataLink::remove_listener: ")
                    ACE_TEXT("removed %C from recv_listeners\n"),
-                   OPENDDS_STRING(converter).c_str()));
+                   logger.c_str()));
       }
       return;
     }

--- a/dds/DCPS/transport/framework/DataLinkSet.inl
+++ b/dds/DCPS/transport/framework/DataLinkSet.inl
@@ -113,12 +113,12 @@ OpenDDS::DCPS::DataLinkSet::send_control(RepoId                           pub_id
   if (dup_map.empty()) {
     // similar to the "no links" case in TransportClient::send()
     if (DCPS_debug_level > 4) {
-      const GuidConverter converter(pub_id);
+      const LogGuid logger(pub_id);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) DataLinkSet::send_control: ")
                  ACE_TEXT("no links for publication %C, ")
                  ACE_TEXT("not sending control message.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 logger.c_str()));
     }
     listener->control_delivered(msg);
     return SEND_CONTROL_OK;

--- a/dds/DCPS/transport/framework/ReceiveListenerSet.cpp
+++ b/dds/DCPS/transport/framework/ReceiveListenerSet.cpp
@@ -35,21 +35,21 @@ ReceiveListenerSet::exist(const RepoId& local_id, bool& last)
   TransportReceiveListener_wrch listener;
 
   if (find(map_, local_id, listener) == -1) {
-    GuidConverter converter(local_id);
+    LogGuid logger(local_id);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ReceiveListenerSet::exist: ")
                ACE_TEXT("could not find local %C.\n"),
-               OPENDDS_STRING(converter).c_str()));
+               logger.c_str()));
 
     return false;
   }
 
   if (!listener) {
-    GuidConverter converter(local_id);
+    LogGuid logger(local_id);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ReceiveListenerSet::exist: ")
                ACE_TEXT("listener for local %C is nil.\n"),
-               OPENDDS_STRING(converter).c_str()));
+               logger.c_str()));
 
     return false;
   }

--- a/dds/DCPS/transport/framework/ReceiveListenerSetMap.cpp
+++ b/dds/DCPS/transport/framework/ReceiveListenerSetMap.cpp
@@ -30,12 +30,12 @@ OpenDDS::DCPS::ReceiveListenerSetMap::insert
 
   if (listener_set.is_nil()) {
     // find_or_create failure
-    GuidConverter converter(publisher_id);
+    LogGuid pub_log(publisher_id);
     ACE_ERROR_RETURN((LM_ERROR,
                       ACE_TEXT("(%P|%t) ERROR: ReceiveListenerSetMap::insert: ")
                       ACE_TEXT("failed to find_or_create entry for ")
                       ACE_TEXT("publisher %C.\n"),
-                      OPENDDS_STRING(converter).c_str()), -1);
+                      pub_log.c_str()), -1);
   }
 
   int result = listener_set->insert(subscriber_id, receive_listener);
@@ -44,14 +44,14 @@ OpenDDS::DCPS::ReceiveListenerSetMap::insert
     return 0;
   }
 
-  GuidConverter sub_converter(subscriber_id);
-  GuidConverter pub_converter(publisher_id);
+  LogGuid sub_log(subscriber_id);
+  LogGuid pub_log(publisher_id);
   ACE_ERROR((LM_ERROR,
              ACE_TEXT("(%P|%t) ERROR: ReceiveListenerSetMap::insert: ")
              ACE_TEXT("failed to insert subscriber %C for ")
              ACE_TEXT("publisher %C.\n"),
-             OPENDDS_STRING(sub_converter).c_str(),
-             OPENDDS_STRING(pub_converter).c_str()));
+             sub_log.c_str(),
+             pub_log.c_str()));
 
   // Deal with possibility that the listener_set just got
   // created - and just for us.  This is to make sure we don't leave any
@@ -64,7 +64,7 @@ OpenDDS::DCPS::ReceiveListenerSetMap::insert
                  ACE_TEXT("(%P|%t) ERROR: ReceiveListenerSetMap::insert: ")
                  ACE_TEXT("failed to remove (undo create) ReceiveListenerSet ")
                  ACE_TEXT("for publisher %C.\n"),
-                 OPENDDS_STRING(pub_converter).c_str()));
+                 pub_log.c_str()));
     }
   }
 
@@ -89,12 +89,12 @@ OpenDDS::DCPS::ReceiveListenerSetMap::remove(RepoId publisher_id,
 
   if (listener_set->size() == 0) {
     if (unbind(map_, publisher_id) != 0) {
-      GuidConverter converter(publisher_id);
+      LogGuid pub_log(publisher_id);
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: ReceiveListenerSetMap::remove: ")
                         ACE_TEXT("failed to remove empty ReceiveListenerSet for ")
                         ACE_TEXT("publisher %C.\n"),
-                        OPENDDS_STRING(converter).c_str()), -1);
+                        pub_log.c_str()), -1);
     }
   }
 
@@ -123,11 +123,11 @@ OpenDDS::DCPS::ReceiveListenerSetMap::release_subscriber(RepoId publisher_id,
   ReceiveListenerSet_rch listener_set;
 
   if (OpenDDS::DCPS::find(map_, publisher_id, listener_set) != 0) {
-    GuidConverter converter(publisher_id);
+    LogGuid pub_log(publisher_id);
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: ReciveListenerSetMap::release_subscriber: ")
                ACE_TEXT("publisher %C not found in map_.\n"),
-               OPENDDS_STRING(converter).c_str()));
+               pub_log.c_str()));
     // Return 1 to indicate that the publisher_id is no longer associated
     // with any subscribers at all.
     return 1;
@@ -140,12 +140,12 @@ OpenDDS::DCPS::ReceiveListenerSetMap::release_subscriber(RepoId publisher_id,
 
   if (listener_set->size() == 0) {
     if (unbind(map_, publisher_id) != 0) {
-      GuidConverter converter(publisher_id);
+      LogGuid pub_log(publisher_id);
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: ReceiveListenerSetMap::release_subscriber: ")
                  ACE_TEXT("failed to remove empty ReceiveListenerSet for ")
                  ACE_TEXT("publisher %C.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 pub_log.c_str()));
     }
 
     // We always return 1 if we know the publisher_id is no longer

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -48,10 +48,10 @@ TransportClient::TransportClient()
 TransportClient::~TransportClient()
 {
   if (Transport_debug_level > 5) {
-    GuidConverter converter(repo_id_);
+    LogGuid logger(repo_id_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) TransportClient::~TransportClient: %C\n"),
-               OPENDDS_STRING(converter).c_str()));
+               logger.c_str()));
   }
 
   stop_associating();
@@ -206,12 +206,12 @@ TransportClient::associate(const AssociationData& data, bool active)
 
   if (impls_.empty()) {
     if (DCPS_debug_level) {
-      GuidConverter writer_converter(repo_id_);
-      GuidConverter reader_converter(data.remote_id_);
+      LogGuid writer_log(repo_id_);
+      LogGuid reader_log(data.remote_id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TransportClient::associate - ")
                  ACE_TEXT("local %C remote %C no available impls\n"),
-                 OPENDDS_STRING(writer_converter).c_str(),
-                 OPENDDS_STRING(reader_converter).c_str()));
+                 writer_log.c_str(),
+                 reader_log.c_str()));
     }
     return false;
   }
@@ -227,12 +227,12 @@ TransportClient::associate(const AssociationData& data, bool active)
 
   if (all_impls_shut_down) {
     if (DCPS_debug_level) {
-      GuidConverter writer_converter(repo_id_);
-      GuidConverter reader_converter(data.remote_id_);
+      LogGuid writer_log(repo_id_);
+      LogGuid reader_log(data.remote_id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TransportClient::associate - ")
                  ACE_TEXT("local %C remote %C all available impls previously shutdown\n"),
-                 OPENDDS_STRING(writer_converter).c_str(),
-                 OPENDDS_STRING(reader_converter).c_str()));
+                 writer_log.c_str(),
+                 reader_log.c_str()));
     }
     return false;
   }
@@ -245,12 +245,12 @@ TransportClient::associate(const AssociationData& data, bool active)
     RepoId remote_copy(data.remote_id_);
     iter = pending_.insert(std::make_pair(remote_copy, make_rch<PendingAssoc>(this))).first;
 
-    GuidConverter tc_assoc(repo_id_);
-    GuidConverter remote_new(data.remote_id_);
+    LogGuid tc_assoc_log(repo_id_);
+    LogGuid remote_log(data.remote_id_);
     VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::associate added PendingAssoc "
               "between %C and remote %C\n",
-              OPENDDS_STRING(tc_assoc).c_str(),
-              OPENDDS_STRING(remote_new).c_str()), 0);
+              tc_assoc_log.c_str(),
+              remote_log.c_str()), 0);
   } else {
 
     ACE_ERROR((LM_ERROR,
@@ -376,24 +376,24 @@ TransportClient::initiate_connect_i(TransportImpl::AcceptConnectResult& result,
 {
   if (!guard.locked()) {
     //don't own the lock_ so can't release it...shouldn't happen
-    GuidConverter local(repo_id_);
-    GuidConverter remote_conv(remote.repo_id_);
+    LogGuid local_log(repo_id_);
+    LogGuid remote_log(remote.repo_id_);
     VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) TransportClient::initiate_connect_i ")
                         ACE_TEXT("between local %C and remote %C unsuccessful because ")
                         ACE_TEXT("guard was not locked\n"),
-                        OPENDDS_STRING(local).c_str(),
-                        OPENDDS_STRING(remote_conv).c_str()), 0);
+                        local_log.c_str(),
+                        remote_log.c_str()), 0);
     return false;
   }
 
   {
     //can't call connect while holding lock due to possible reactor deadlock
-    GuidConverter local(repo_id_);
-    GuidConverter remote_conv(remote.repo_id_);
+    LogGuid local_log(repo_id_);
+    LogGuid remote_log(remote.repo_id_);
     VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::initiate_connect_i - "
                         "attempt to connect_datalink between local %C and remote %C\n",
-                        OPENDDS_STRING(local).c_str(),
-                        OPENDDS_STRING(remote_conv).c_str()), 0);
+                        local_log.c_str(),
+                        remote_log.c_str()), 0);
     {
       TransportImpl::ConnectionAttribs attribs = attribs_;
       RcHandle<TransportClient> client = rchandle_from(this);
@@ -402,23 +402,23 @@ TransportClient::initiate_connect_i(TransportImpl::AcceptConnectResult& result,
     }
     if (!result.success_) {
       if (DCPS_debug_level) {
-        GuidConverter writer_converter(repo_id_);
-        GuidConverter reader_converter(remote.repo_id_);
+        LogGuid writer_log(repo_id_);
+        LogGuid reader_log(remote.repo_id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TransportClient::associate - ")
                    ACE_TEXT("connect_datalink between local %C remote %C not successful\n"),
-                   OPENDDS_STRING(writer_converter).c_str(),
-                   OPENDDS_STRING(reader_converter).c_str()));
+                   writer_log.c_str(),
+                   reader_log.c_str()));
       }
       return false;
     }
   }
 
-  GuidConverter local(repo_id_);
-  GuidConverter remote_conv(remote.repo_id_);
+  LogGuid local_log(repo_id_);
+  LogGuid remote_log(remote.repo_id_);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::initiate_connect_i - "
                       "connection between local %C and remote %C initiation successful\n",
-                      OPENDDS_STRING(local).c_str(),
-                      OPENDDS_STRING(remote_conv).c_str()), 0);
+                      local_log.c_str(),
+                      remote_log.c_str()), 0);
   return true;
 }
 
@@ -426,12 +426,12 @@ bool
 TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
                                                 Guard& guard)
 {
-  GuidConverter local(tc->repo_id_);
-  GuidConverter remote(data_.remote_id_);
+  LogGuid local_log(tc->repo_id_);
+  LogGuid remote_log(data_.remote_id_);
   VDBG_LVL((LM_DEBUG, "(%P|%t) PendingAssoc::initiate_connect - "
                       "between %C and remote %C\n",
-                      OPENDDS_STRING(local).c_str(),
-                      OPENDDS_STRING(remote).c_str()), 0);
+                      local_log.c_str(),
+                      remote_log.c_str()), 0);
   // find the next impl / blob entry that have matching types
   while (!impls_.empty()) {
     RcHandle<TransportImpl> impl = impls_.back().lock();
@@ -454,15 +454,15 @@ TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
           if (res.success_ ) {
             VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) PendingAssoc::initiate_connect - ")
                                 ACE_TEXT("between %C and remote %C success\n"),
-                                OPENDDS_STRING(local).c_str(),
-                                OPENDDS_STRING(remote).c_str()), 0);
+                                local_log.c_str(),
+                                remote_log.c_str()), 0);
             return true;
           }
 
           VDBG_LVL((LM_DEBUG, "(%P|%t) PendingAssoc::initiate_connect - "
                               "between %C and remote %C unsuccessful\n",
-                              OPENDDS_STRING(local).c_str(),
-                              OPENDDS_STRING(remote).c_str()), 0);
+                              local_log.c_str(),
+                              remote_log.c_str()), 0);
         }
 
         if (res.success_) {
@@ -475,16 +475,16 @@ TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
           } else {
             VDBG_LVL((LM_DEBUG, "(%P|%t) PendingAssoc::intiate_connect - "
                                 "resulting link from initiate_connect_i (local: %C to remote: %C) was nil\n",
-                                OPENDDS_STRING(local).c_str(),
-                                OPENDDS_STRING(remote).c_str()), 0);
+                                local_log.c_str(),
+                                remote_log.c_str()), 0);
           }
 
           return true;
         } else {
           VDBG_LVL((LM_DEBUG, "(%P|%t) PendingAssoc::intiate_connect - "
                               "result of initiate_connect_i (local: %C to remote: %C) was not success\n",
-                              OPENDDS_STRING(local).c_str(),
-                              OPENDDS_STRING(remote).c_str()), 0);
+                              local_log.c_str(),
+                              remote_log.c_str()), 0);
         }
       }
     }
@@ -517,12 +517,12 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
   // Does changing this from a reference to a local affect anything going forward?
   RepoId remote_id(remote_id_ref);
 
-  GuidConverter peerId_conv(remote_id);
+  LogGuid peerId_log(remote_id);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::use_datalink_i "
             "TransportClient(%@) using datalink[%@] from %C\n",
             this,
             link.in(),
-            OPENDDS_STRING(peerId_conv).c_str()), 0);
+            peerId_log.c_str()), 0);
 
   PendingMap::iterator iter = pending_.find(remote_id);
 
@@ -531,7 +531,7 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
                         "TransportClient(%@) using datalink[%@] did not find Pending Association to remote %C\n",
                         this,
                         link.in(),
-                        OPENDDS_STRING(peerId_conv).c_str()), 0);
+                        peerId_log.c_str()), 0);
     return;
   }
 
@@ -546,7 +546,7 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
                           "TransportClient(%@) using datalink[%@] link is nil, since this is active side, initiate_connect to remote %C\n",
                           this,
                           link.in(),
-                          OPENDDS_STRING(peerId_conv).c_str()), 0);
+                          peerId_log.c_str()), 0);
       return;
     }
 
@@ -554,13 +554,13 @@ TransportClient::use_datalink_i(const RepoId& remote_id_ref,
               "TransportClient(%@) using datalink[%@] link is nil, since this is passive side, connection to remote %C timed out\n",
               this,
               link.in(),
-              OPENDDS_STRING(peerId_conv).c_str()), 0);
+              peerId_log.c_str()), 0);
   } else { // link is ready to use
     VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::use_datalink_i "
               "TransportClient(%@) about to add_link[%@] to remote: %C\n",
               this,
               link.in(),
-              OPENDDS_STRING(peerId_conv).c_str()), 0);
+              peerId_log.c_str()), 0);
 
     add_link(link, remote_id);
     ok = true;
@@ -641,11 +641,11 @@ TransportClient::send_final_acks()
 void
 TransportClient::disassociate(const RepoId& peerId)
 {
-  GuidConverter peerId_conv(peerId);
+  LogGuid peerId_log(peerId);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TransportClient::disassociate "
             "TransportClient(%@) disassociating from %C\n",
             this,
-            OPENDDS_STRING(peerId_conv).c_str()), 5);
+            peerId_log.c_str()), 5);
 
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
 
@@ -669,11 +669,11 @@ TransportClient::disassociate(const RepoId& peerId)
 
   if (found == data_link_index_.end()) {
     if (DCPS_debug_level > 4) {
-      const GuidConverter converter(peerId);
+      const LogGuid log(peerId);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) TransportClient::disassociate: ")
                  ACE_TEXT("no link for remote peer %C\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 log.c_str()));
     }
 
     return;
@@ -706,10 +706,10 @@ TransportClient::disassociate(const RepoId& peerId)
     links_.remove_link(link);
 
     if (DCPS_debug_level > 4) {
-      GuidConverter converter(repo_id_);
+      LogGuid logger(repo_id_);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) TransportClient::disassociate: calling remove_listener %C on link[%@]\n"),
-                 OPENDDS_STRING(converter).c_str(),
+                 logger.c_str(),
                  link.in()));
     }
     // Datalink is no longer used for any remote peer by this TransportClient
@@ -846,12 +846,12 @@ TransportClient::send_response(const RepoId& peer,
 
   if (found == data_link_index_.end()) {
     if (DCPS_debug_level > 4) {
-      GuidConverter converter(peer);
+      LogGuid logger(peer);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) TransportClient::send_response: ")
                  ACE_TEXT("no link for publication %C, ")
                  ACE_TEXT("not sending response.\n"),
-                 OPENDDS_STRING(converter).c_str()));
+                 logger.c_str()));
     }
 
     return false;
@@ -934,12 +934,12 @@ TransportClient::send_i(SendStateDataSampleList send_list, ACE_UINT64 transactio
         //       associated with any remote subscriber ids" case.
 
         if (DCPS_debug_level > 4) {
-          GuidConverter converter(cur->get_pub_id());
+          LogGuid logger(cur->get_pub_id());
           ACE_DEBUG((LM_DEBUG,
                      ACE_TEXT("(%P|%t) TransportClient::send_i: ")
                      ACE_TEXT("no links for publication %C, ")
                      ACE_TEXT("not sending element %@ for transaction: %d.\n"),
-                     OPENDDS_STRING(converter).c_str(),
+                     logger.c_str(),
                      cur,
                      cur->transaction_id()));
         }

--- a/dds/DCPS/transport/framework/TransportReassembly.cpp
+++ b/dds/DCPS/transport/framework/TransportReassembly.cpp
@@ -303,11 +303,11 @@ TransportReassembly::reassemble_i(const SequenceRange& seqRange,
                                   ACE_UINT32 total_frags)
 {
   if (Transport_debug_level > 5) {
-    GuidConverter conv(data.header_.publication_id_);
+    LogGuid logger(data.header_.publication_id_);
     ACE_DEBUG((LM_DEBUG, "(%P|%t) DBG:   TransportReassembly::reassemble_i "
       "tseq %q-%q first %d dseq %q pub %C\n", seqRange.first.getValue(),
       seqRange.second.getValue(), firstFrag ? 1 : 0,
-      data.header_.sequence_.getValue(), OPENDDS_STRING(conv).c_str()));
+      data.header_.sequence_.getValue(), logger.c_str()));
   }
 
   const MonotonicTimePoint now = MonotonicTimePoint::now();

--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -173,11 +173,11 @@ void
 SingleSendBuffer::retain_all(const RepoId& pub_id)
 {
   if (Transport_debug_level > 5) {
-    GuidConverter converter(pub_id);
+    LogGuid logger(pub_id);
     ACE_DEBUG((LM_DEBUG,
       ACE_TEXT("(%P|%t) SingleSendBuffer::retain_all() - ")
       ACE_TEXT("copying out blocks for publication: %C\n"),
-      OPENDDS_STRING(converter).c_str()
+      logger.c_str()
     ));
   }
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
@@ -185,12 +185,12 @@ SingleSendBuffer::retain_all(const RepoId& pub_id)
        it != buffers_.end();) {
     if (it->second.first && it->second.second) {
       if (retain_buffer(pub_id, it->second) == REMOVE_ERROR) {
-        GuidConverter converter(pub_id);
+        LogGuid logger(pub_id);
         ACE_ERROR((LM_WARNING,
                    ACE_TEXT("(%P|%t) WARNING: ")
                    ACE_TEXT("SingleSendBuffer::retain_all: ")
                    ACE_TEXT("failed to retain data from publication: %C!\n"),
-                   OPENDDS_STRING(converter).c_str()));
+                   logger.c_str()));
         release_i(it++);
       } else {
         ++it;
@@ -202,12 +202,12 @@ SingleSendBuffer::retain_all(const RepoId& pub_id)
         for (BufferMap::iterator bm_it = fm_it->second.begin();
              bm_it != fm_it->second.end();) {
           if (retain_buffer(pub_id, bm_it->second) == REMOVE_ERROR) {
-            GuidConverter converter(pub_id);
+            LogGuid logger(pub_id);
             ACE_ERROR((LM_WARNING,
                        ACE_TEXT("(%P|%t) WARNING: ")
                        ACE_TEXT("SingleSendBuffer::retain_all: failed to ")
                        ACE_TEXT("retain fragment data from publication: %C!\n"),
-                       OPENDDS_STRING(converter).c_str()));
+                       logger.c_str()));
             release_i(bm_it++);
           } else {
             ++bm_it;

--- a/dds/DCPS/transport/multicast/ReliableSession.cpp
+++ b/dds/DCPS/transport/multicast/ReliableSession.cpp
@@ -88,12 +88,12 @@ ReliableSession::ready_to_deliver(const TransportHeader& header,
       || (nak_sequence_.empty() && header.sequence_ > 1)) {
 
     if (Transport_debug_level > 5) {
-      GuidConverter writer(data.header_.publication_id_);
+      LogGuid writer(data.header_.publication_id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ReliableSession::ready_to_deliver -")
                            ACE_TEXT(" tseq: %q data seq: %q from %C being WITHHELD because can't receive yet\n"),
                            header.sequence_.getValue(),
                            data.header_.sequence_.getValue(),
-                           OPENDDS_STRING(writer).c_str()));
+                           writer.c_str()));
     }
     {
       ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, held_lock_, false);
@@ -106,12 +106,12 @@ ReliableSession::ready_to_deliver(const TransportHeader& header,
                              ACE_TEXT(" held_ data currently contains: %d samples\n"),
                              held_.size()));
         while (it != held_.end()) {
-          GuidConverter writer(it->second.header_.publication_id_);
+          LogGuid writer(it->second.header_.publication_id_);
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ReliableSession::ready_to_deliver -")
                                ACE_TEXT(" held_ data currently contains: tseq: %q dseq: %q from %C HELD\n"),
                                it->first.getValue(),
                                it->second.header_.sequence_.getValue(),
-                               OPENDDS_STRING(writer).c_str()));
+                               writer.c_str()));
           ++it;
         }
       }
@@ -120,12 +120,12 @@ ReliableSession::ready_to_deliver(const TransportHeader& header,
     return false;
   } else {
     if (Transport_debug_level > 5) {
-      GuidConverter writer(data.header_.publication_id_);
+      LogGuid writer(data.header_.publication_id_);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) ReliableSession::ready_to_deliver -")
                            ACE_TEXT(" tseq: %q data seq: %q from %C OK to deliver\n"),
                            header.sequence_.getValue(),
                            data.header_.sequence_.getValue(),
-                           OPENDDS_STRING(writer).c_str()));
+                           writer.c_str()));
     }
     return true;
   }
@@ -146,12 +146,12 @@ ReliableSession::deliver_held_data()
     const iter end = this->held_.upper_bound(ca);
     for (iter it = this->held_.begin(); it != end; /*increment in loop body*/) {
       if (Transport_debug_level > 5) {
-        GuidConverter writer(it->second.header_.publication_id_);
+        LogGuid writer(it->second.header_.publication_id_);
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) MulticastDataLink::deliver_held_data -")
                              ACE_TEXT(" deliver tseq: %q dseq: %q from %C\n"),
                              it->first.getValue(),
                              it->second.header_.sequence_.getValue(),
-                             OPENDDS_STRING(writer).c_str()));
+                             writer.c_str()));
       }
       to_deliver.push_back(it->second);
       this->held_.erase(it++);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1195,11 +1195,11 @@ RtpsUdpDataLink::RtpsWriter::customize_queue_element_helper(
         ri->second->durable_data_[rtps->sequence()] = rtps;
         ri->second->durable_timestamp_.set_to_now();
         if (Transport_debug_level > 3) {
-          const GuidConverter conv(pub_id), sub_conv(sub);
+          const LogGuid conv(pub_id), sub_conv(sub);
           ACE_DEBUG((LM_DEBUG,
             "(%P|%t) RtpsUdpDataLink::customize_queue_element() - "
             "storing durable data for local %C remote %C seq %q\n",
-            OPENDDS_STRING(conv).c_str(), OPENDDS_STRING(sub_conv).c_str(),
+            conv.c_str(), sub_conv.c_str(),
             rtps->sequence().getValue()));
         }
         return 0;
@@ -1403,9 +1403,9 @@ RtpsUdpDataLink::RtpsWriter::request_ack_i(const DataSampleHeader& header,
       initialize_heartbeat(proxy, meta_submessage);
       gather_directed_heartbeat_i(proxy, meta_submessages, meta_submessage, iter->second);
       if (Transport_debug_level > 3) {
-        const GuidConverter conv(id_), sub_conv(sub);
+        const LogGuid conv(id_), sub_conv(sub);
         ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::request_ack"
-                   " local %C remote %C\n", LogGuid(id_).c_str(), LogGuid(sub).c_str()));
+                   " local %C remote %C\n", conv.c_str(), sub_conv.c_str()));
       }
     }
   }
@@ -3129,7 +3129,7 @@ RtpsUdpDataLink::RtpsWriter::gather_gaps_i(const ReaderInfo_rch& reader,
   meta_submessage.sm_.gap_sm(gap);
 
   if (Transport_debug_level > 5) {
-    const GuidConverter conv(id_);
+    const LogGuid conv(id_);
     SequenceRange sr;
     sr.first = to_opendds_seqnum(gap.gapStart);
     const SequenceNumber srbase = to_opendds_seqnum(gap.gapList.bitmapBase);
@@ -3137,7 +3137,7 @@ RtpsUdpDataLink::RtpsWriter::gather_gaps_i(const ReaderInfo_rch& reader,
     ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::RtpsWriter::gather_gaps_i "
               "GAP with range [%q, %q] from %C\n",
               sr.first.getValue(), sr.second.getValue(),
-              OPENDDS_STRING(conv).c_str()));
+              conv.c_str()));
   }
 
   meta_submessages.push_back(meta_submessage);
@@ -3272,11 +3272,11 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
 
     if (!reader->durable_data_.empty()) {
       if (Transport_debug_level > 5) {
-        const GuidConverter local_conv(id_), remote_conv(src);
+        const LogGuid local_conv(id_), remote_conv(src);
         ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::RtpsWriter::process_acknack: "
                    "local %C has durable for remote %C\n",
-                   OPENDDS_STRING(local_conv).c_str(),
-                   OPENDDS_STRING(remote_conv).c_str()));
+                   local_conv.c_str(),
+                   remote_conv.c_str()));
       }
       const SequenceNumber& dd_last = reader->durable_data_.rbegin()->first;
       if (Transport_debug_level > 5) {
@@ -4015,10 +4015,10 @@ void RtpsUdpDataLink::durability_resend(TransportQueueElement* element,
   }
   const AddrSet addrs = get_addresses(element->publication_id(), element->subscription_id());
   if (addrs.empty()) {
-    const GuidConverter conv(element->subscription_id());
+    const LogGuid conv(element->subscription_id());
     ACE_ERROR((LM_ERROR,
                "(%P|%t) ERROR: RtpsUdpDataLink::durability_resend() - "
-               "no locator for remote %C\n", OPENDDS_STRING(conv).c_str()));
+               "no locator for remote %C\n", conv.c_str()));
     return;
   }
 
@@ -4525,11 +4525,11 @@ RtpsUdpDataLink::RtpsReader::deliver_held_data(const RepoId& src)
 
   for (OPENDDS_VECTOR(ReceivedDataSample)::iterator it = to_deliver.begin(); it != to_deliver.end(); ++it) {
     if (Transport_debug_level > 5) {
-      GuidConverter reader(dst);
+      LogGuid reader(dst);
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpDataLink::DeliverHeldData::~DeliverHeldData -")
                  ACE_TEXT(" deliver sequence: %q to %C\n"),
                  it->header_.sequence_.getValue(),
-                 OPENDDS_STRING(reader).c_str()));
+                 reader.c_str()));
     }
     link->data_received(*it, dst);
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -158,10 +158,10 @@ namespace {
   ssize_t recv_err(const char* msg, const ACE_INET_Addr& remote, const DCPS::RepoId& peer, bool& stop)
   {
     if (security_debug.encdec_warn) {
-      GuidConverter gc(peer);
+      LogGuid gc(peer);
       ACE_ERROR((LM_WARNING, "(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy::receive_bytes - "
                  "from %C %C secure RTPS processing failed: %C\n",
-                 DCPS::LogAddr(remote).c_str(), OPENDDS_STRING(gc).c_str(), msg));
+                 DCPS::LogAddr(remote).c_str(), gc.c_str(), msg));
     }
     stop = true;
     return 0;
@@ -268,7 +268,7 @@ RtpsUdpReceiveStrategy::receive_bytes(iovec iov[],
       if (security_debug.encdec_warn) {
         ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy::receive_bytes: ")
                    ACE_TEXT("decode_rtps_message no remote participant crypto handle for %C, dropping\n"),
-                   OPENDDS_STRING(GuidConverter(peer)).c_str()));
+                   LogGuid(peer).c_str()));
       }
       stop = true;
       return ret;
@@ -322,14 +322,14 @@ bool RtpsUdpReceiveStrategy::check_encoded(const EntityId_t& sender)
 #ifdef OPENDDS_SECURITY
   using namespace DDS::Security;
   const GUID_t sendGuid = make_id(receiver_.source_guid_prefix_, sender);
-  const GuidConverter conv(sendGuid);
+  const LogGuid conv(sendGuid);
 
   if (link_->local_crypto_handle() != DDS::HANDLE_NIL
       && !encoded_rtps_ && !RtpsUdpDataLink::separate_message(sender)) {
     if (security_debug.encdec_warn) {
       ACE_DEBUG((LM_WARNING, "(%P|%t) RtpsUdpReceiveStrategy::check_encoded "
                  "Full message from %C requires protection, dropping\n",
-                 OPENDDS_STRING(conv).c_str()));
+                 conv.c_str()));
     }
     return false;
   }
@@ -460,10 +460,10 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
       if (!readers_withheld_.count(reader) &&
           (directedWriteReaders.empty() || directedWriteReaders.find(reader) != directedWriteReaders.end())) {
         if (Transport_debug_level > 5) {
-          GuidConverter reader_conv(reader);
+          LogGuid reader_conv(reader);
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpReceiveStrategy[%@]::deliver_sample_i - ")
             ACE_TEXT("calling DataLink::data_received for seq: %q to reader %C\n"),
-            this, sample.header_.sequence_.getValue(), OPENDDS_STRING(reader_conv).c_str()));
+            this, sample.header_.sequence_.getValue(), reader_conv.c_str()));
         }
         link_->data_received(sample, reader);
       }
@@ -473,7 +473,7 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
         bool first = true;
         RepoIdSet::iterator iter = readers_selected_.begin();
         while (iter != readers_selected_.end()) {
-          included_ids += (first ? "" : "\n") + OPENDDS_STRING(GuidConverter(*iter));
+          included_ids += (first ? "" : "\n") + LogGuid(*iter).conv_;
           first = false;
           ++iter;
         }
@@ -481,7 +481,7 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
         first = true;
         RepoIdSet::iterator iter2 = this->readers_withheld_.begin();
         while (iter2 != readers_withheld_.end()) {
-          excluded_ids += (first ? "" : "\n") + OPENDDS_STRING(GuidConverter(*iter2));
+          excluded_ids += (first ? "" : "\n") + LogGuid(*iter2).conv_;
           first = false;
           ++iter2;
         }
@@ -654,7 +654,7 @@ RtpsUdpReceiveStrategy::deliver_from_secure(const RTPS::Submessage& submessage,
     if (security_debug.encdec_warn) {
       ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy: ")
                  ACE_TEXT("preprocess_secure_submsg failed remote %C RPCH %d, [%d.%d]: %C\n"),
-                 OPENDDS_STRING(GuidConverter(peer)).c_str(), peer_pch, ex.code, ex.minor_code, ex.message.in()));
+                 LogGuid(peer).c_str(), peer_pch, ex.code, ex.minor_code, ex.message.in()));
     }
     return;
   }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -158,10 +158,9 @@ namespace {
   ssize_t recv_err(const char* msg, const ACE_INET_Addr& remote, const DCPS::RepoId& peer, bool& stop)
   {
     if (security_debug.encdec_warn) {
-      LogGuid gc(peer);
       ACE_ERROR((LM_WARNING, "(%P|%t) {encdec_warn} RtpsUdpReceiveStrategy::receive_bytes - "
                  "from %C %C secure RTPS processing failed: %C\n",
-                 DCPS::LogAddr(remote).c_str(), gc.c_str(), msg));
+                 DCPS::LogAddr(remote).c_str(), LogGuid(peer).c_str(), msg));
     }
     stop = true;
     return 0;
@@ -322,14 +321,14 @@ bool RtpsUdpReceiveStrategy::check_encoded(const EntityId_t& sender)
 #ifdef OPENDDS_SECURITY
   using namespace DDS::Security;
   const GUID_t sendGuid = make_id(receiver_.source_guid_prefix_, sender);
-  const LogGuid conv(sendGuid);
+  const GuidConverter conv(sendGuid);
 
   if (link_->local_crypto_handle() != DDS::HANDLE_NIL
       && !encoded_rtps_ && !RtpsUdpDataLink::separate_message(sender)) {
     if (security_debug.encdec_warn) {
       ACE_DEBUG((LM_WARNING, "(%P|%t) RtpsUdpReceiveStrategy::check_encoded "
                  "Full message from %C requires protection, dropping\n",
-                 conv.c_str()));
+                 OPENDDS_STRING(conv).c_str()));
     }
     return false;
   }
@@ -460,10 +459,9 @@ RtpsUdpReceiveStrategy::deliver_sample_i(ReceivedDataSample& sample,
       if (!readers_withheld_.count(reader) &&
           (directedWriteReaders.empty() || directedWriteReaders.find(reader) != directedWriteReaders.end())) {
         if (Transport_debug_level > 5) {
-          LogGuid reader_conv(reader);
           ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) RtpsUdpReceiveStrategy[%@]::deliver_sample_i - ")
             ACE_TEXT("calling DataLink::data_received for seq: %q to reader %C\n"),
-            this, sample.header_.sequence_.getValue(), reader_conv.c_str()));
+            this, sample.header_.sequence_.getValue(), LogGuid(reader).c_str()));
         }
         link_->data_received(sample, reader);
       }

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -392,9 +392,8 @@ bool
 OpenDDS::DCPS::TcpDataLink::handle_send_request_ack(TransportQueueElement* element)
 {
   if (Transport_debug_level >= 1) {
-    const GuidConverter converter(element->publication_id());
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::handle_send_request_ack(%@) sequence number %q, publication_id=%C\n"),
-      element, element->sequence().getValue(), OPENDDS_STRING(converter).c_str()));
+      element, element->sequence().getValue(), LogGuid(element->publication_id()).c_str()));
   }
   bool result = false;
   TcpConnection_rch connection(connection_.lock());
@@ -418,9 +417,8 @@ OpenDDS::DCPS::TcpDataLink::ack_received(const ReceivedDataSample& sample)
   }
 
   if (Transport_debug_level >= 1) {
-    const GuidConverter converter(sample.header_.publication_id_);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) TcpDataLink::ack_received() received sequence number %q, publiction_id=%C\n"),
-      sequence.getValue(), OPENDDS_STRING(converter).c_str()));
+      sequence.getValue(), LogGuid(sample.header_.publication_id_).c_str()));
   }
 
   TransportQueueElement* elem=0;
@@ -515,8 +513,7 @@ OpenDDS::DCPS::TcpDataLink::do_association_actions()
 
     for (OnStartCallbackMap::const_iterator it = on_start_callbacks_.begin(); it != on_start_callbacks_.end(); ++it) {
       for (RepoToClientMap::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
-        GuidConverter conv(it2->first);
-        if (conv.isReader()) {
+        if (GuidConverter(it2->first).isReader()) {
           to_call_and_send.push_back(std::make_pair(it2->first, it->first));
         }
       }

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -221,13 +221,11 @@ TcpTransport::accept_datalink(const RemoteTransport& remote,
     return AcceptConnectResult();
   }
 
-  GuidConverter remote_conv(remote.repo_id_);
-  GuidConverter local_conv(attribs.local_id_);
 
   VDBG_LVL((LM_DEBUG, "(%P|%t) TcpTransport::accept_datalink local %C "
             "accepting connection from remote %C\n",
-            std::string(local_conv).c_str(),
-            std::string(remote_conv).c_str()), 5);
+            LogGuid(attribs.local_id_).c_str(),
+            LogGuid(remote.repo_id_).c_str()), 5);
 
   const PriorityKey key =
     blob_to_key(remote.blob_, attribs.priority_, false /* !active */);
@@ -296,10 +294,9 @@ TcpTransport::stop_accepting_or_connecting(const TransportClient_wrch& client,
                                            bool /*disassociate*/,
                                            bool /*association_failed*/)
 {
-  GuidConverter remote_converted(remote_id);
   VDBG_LVL((LM_DEBUG, "(%P|%t) TcpTransport::stop_accepting_or_connecting "
             "stop connecting to remote: %C\n",
-            std::string(remote_converted).c_str()), 5);
+            LogGuid(remote_id).c_str()), 5);
 
   GuardType guard(pending_connections_lock_);
   typedef PendConnMap::iterator iter_t;

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -1032,7 +1032,7 @@ void DCPS_IR_Domain::publish_participant_bit(DCPS_IR_Participant* participant)
       if (OpenDDS::DCPS::DCPS_debug_level > 0) {
         ACE_DEBUG((LM_DEBUG,
                    "(%P|%t) DCPS_IR_Domain::publish_participant_bit: %C, handle %d.\n",
-                   OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
+                   OpenDDS::DCPS::LogGuid(OpenDDS::DCPS::bit_key_to_repo_id(data.key)).c_str(), handle));
       }
 
       bitParticipantDataWriter_->write(data, handle);
@@ -1088,7 +1088,7 @@ void DCPS_IR_Domain::publish_topic_bit(DCPS_IR_Topic* topic)
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) DCPS_IR_Domain::publish_topic_bit: %C, handle %d.\n",
-                     OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
+                     OpenDDS::DCPS::LogGuid(OpenDDS::DCPS::bit_key_to_repo_id(data.key)).c_str(), handle));
         }
 
         bitTopicDataWriter_->write(data, handle);
@@ -1154,7 +1154,7 @@ void DCPS_IR_Domain::publish_subscription_bit(DCPS_IR_Subscription* subscription
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) DCPS_IR_Domain::publish_subscription_bit: %C, handle %d.\n",
-                     OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
+                     OpenDDS::DCPS::LogGuid(OpenDDS::DCPS::bit_key_to_repo_id(data.key)).c_str(), handle));
         }
 
         bitSubscriptionDataWriter_->write(data,
@@ -1230,7 +1230,7 @@ void DCPS_IR_Domain::publish_publication_bit(DCPS_IR_Publication* publication)
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) DCPS_IR_Domain::publish_publication_bit: %C, handle %d.\n",
-                     OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(OpenDDS::DCPS::bit_key_to_repo_id(data.key))).c_str(), handle));
+                     OpenDDS::DCPS::LogGuid(OpenDDS::DCPS::bit_key_to_repo_id(data.key)).c_str(), handle));
         }
 
         DDS::ReturnCode_t status = bitPublicationDataWriter_->write(data, handle);

--- a/performance-tests/DCPS/Priority/Subscriber.cpp
+++ b/performance-tests/DCPS/Priority/Subscriber.cpp
@@ -353,8 +353,7 @@ operator<<( std::ostream& str, const Test::Subscriber& value)
   value.reader_->get_latency_stats( statistics);
   str << " --- statistical summary ---" << std::endl;
   for( unsigned long index = 0; index < statistics.length(); ++index) {
-    OpenDDS::DCPS::GuidConverter converter(statistics[ index].publication);
-    str << "  Writer[ " << OPENDDS_STRING(converter) << "]" << std::endl;
+    str << "  Writer[ " << OpenDDS::DCPS::LogGuid(statistics[ index].publication).conv_ << "]" << std::endl;
     str << "     samples: " << statistics[ index].n << std::endl;
     str << "        mean: " << statistics[ index].mean << std::endl;
     str << "     minimum: " << statistics[ index].minimum << std::endl;
@@ -388,8 +387,7 @@ Subscriber::rawData( std::ostream& str) const
          = readerImpl->raw_latency_statistics().begin();
        current != readerImpl->raw_latency_statistics().end();
        ++current, ++index) {
-    OpenDDS::DCPS::GuidConverter converter(current->first);
-    str << std::endl << "  Writer[ " << OPENDDS_STRING(converter) << "]" << std::endl;
+    str << std::endl << "  Writer[ " << OpenDDS::DCPS::LogGuid(current->first).conv_ << "]" << std::endl;
 #ifndef OPENDDS_SAFETY_PROFILE
     current->second.raw_data( str);
 #endif //OPENDDS_SAFETY_PROFILE

--- a/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
+++ b/tests/DCPS/RtpsDiscovery/RtpsDiscoveryTest.cpp
@@ -167,11 +167,10 @@ bool read_participant_bit(const Subscriber_var& bit_sub,
       ++num_valid;
       OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].key);
 
-      OpenDDS::DCPS::GuidConverter converter(repo_id);
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("%P ")
                  ACE_TEXT("Read Participant BIT GUID=%C handle=%d\n"),
-                 OPENDDS_STRING(converter).c_str(), infos[i].instance_handle));
+                 OpenDDS::DCPS::LogGuid(repo_id).c_str(), infos[i].instance_handle));
 
       if (repo_id == other_dp_repo_id) {
         if (data[i].user_data.value.length() != 1) {
@@ -412,14 +411,12 @@ bool read_publication_bit(const Subscriber_var& bit_sub,
       OpenDDS::DCPS::RepoId publication_repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].key);
       OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].participant_key);
 
-      OpenDDS::DCPS::GuidConverter converter(repo_id);
-
       ACE_DEBUG((LM_DEBUG,
                  "%P Read Publication BIT with key: %C and handle %d\n"
                  "\tParticipant's GUID=%C\n\tTopic: %C\tType: %C\n",
-                 OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(publication_repo_id)).c_str(),
+                 OpenDDS::DCPS::LogGuid(publication_repo_id).c_str(),
                  infos[i].instance_handle,
-                 OPENDDS_STRING(converter).c_str (), data[i].topic_name.in(),
+                 OpenDDS::DCPS::LogGuid(repo_id).c_str(), data[i].topic_name.in(),
                  data[i].type_name.in()));
 
       if (repo_id == publisher_repo_id) {
@@ -540,14 +537,12 @@ bool read_subscription_bit(const Subscriber_var& bit_sub,
       OpenDDS::DCPS::RepoId subscription_repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].key);
       OpenDDS::DCPS::RepoId repo_id = OpenDDS::DCPS::bit_key_to_repo_id(data[i].participant_key);
 
-      OpenDDS::DCPS::GuidConverter converter(repo_id);
-
       ACE_DEBUG((LM_DEBUG,
                  "%P Read Subscription BIT with key: %C and handle %d\n"
                  "\tParticipant's GUID=%C\n\tTopic: %C\tType: %C\n",
-                 OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(subscription_repo_id)).c_str(),
+                 OpenDDS::DCPS::LogGuid(subscription_repo_id).c_str(),
                  infos[i].instance_handle,
-                 OPENDDS_STRING(converter).c_str (), data[i].topic_name.in(),
+                 OpenDDS::DCPS::LogGuid(repo_id).c_str(), data[i].topic_name.in(),
                  data[i].type_name.in()));
       if (repo_id == subscriber_repo_id) {
         found_subscriber = true;
@@ -654,13 +649,11 @@ bool check_discovered_participants(DomainParticipant_var& dp,
       }
       handle = part_handles[0];
       {
-        OpenDDS::DCPS::GuidConverter converter1(dp_impl->get_id ());
-        OpenDDS::DCPS::GuidConverter converter2(repo_id);
         ACE_DEBUG ((LM_DEBUG,
                     ACE_TEXT("%P ")
                     ACE_TEXT("%C discovered %C\n"),
-                    OPENDDS_STRING(converter1).c_str(),
-                    OPENDDS_STRING(converter2).c_str()));
+                    OpenDDS::DCPS::LogGuid(dp_impl->get_id()).c_str(),
+                    OpenDDS::DCPS::LogGuid(repo_id).c_str()));
       }
     }
   }
@@ -683,11 +676,10 @@ bool run_test(DomainParticipant_var& dp_sub,
     }
 
     sub_repo_id = dp_impl->get_id ();
-    OpenDDS::DCPS::GuidConverter converter(sub_repo_id);
     ACE_DEBUG ((LM_DEBUG,
                 ACE_TEXT("%P ")
                 ACE_TEXT("Sub Domain Participant GUID=%C\n"),
-                OPENDDS_STRING(converter).c_str()));
+                OpenDDS::DCPS::LogGuid(sub_repo_id).c_str()));
   }
 
   {
@@ -701,11 +693,10 @@ bool run_test(DomainParticipant_var& dp_sub,
     }
 
     pub_repo_id = dp_impl->get_id ();
-    OpenDDS::DCPS::GuidConverter converter(pub_repo_id);
     ACE_DEBUG ((LM_DEBUG,
                 ACE_TEXT("%P ")
                 ACE_TEXT("Pub Domain Participant GUID=%C\n"),
-                OPENDDS_STRING(converter).c_str()));
+                OpenDDS::DCPS::LogGuid(pub_repo_id).c_str()));
   }
 
   // If we are running with an rtps_udp transport, it can't be shared between

--- a/tests/transport/best_effort_reader/AppConfig.cpp
+++ b/tests/transport/best_effort_reader/AppConfig.cpp
@@ -99,8 +99,8 @@ OpenDDS::DCPS::RepoId AppConfig::createID(long participantId, long key, CORBA::O
 }
 
 void AppConfig::to_cerr(const OpenDDS::DCPS::RepoId& remote, const OpenDDS::DCPS::RepoId& local, const std::string& txt) const {
-  std::cerr << OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(remote)) << " <- "
-            << OPENDDS_STRING(OpenDDS::DCPS::GuidConverter(local)) << " " << txt << std::endl;
+  std::cerr << OpenDDS::DCPS::LogGuid(remote).conv_ << " <- "
+            << OpenDDS::DCPS::LogGuid(local).conv_ << " " << txt << std::endl;
 }
 
 void AppConfig::cleanup() {

--- a/tests/transport/best_effort_reader/SimpleDataReader.cpp
+++ b/tests/transport/best_effort_reader/SimpleDataReader.cpp
@@ -59,7 +59,7 @@ void SimpleDataReader::data_received(const ReceivedDataSample& sample)
 
   if (data.key == 99) {
     ACE_DEBUG((LM_INFO, ACE_TEXT("%C received terminating sample\n"),
-      OPENDDS_STRING(GuidConverter(get_repo_id())).c_str()));
+      LogGuid(get_repo_id()).c_str()));
     done_ = true;
     return;
   }
@@ -67,13 +67,11 @@ void SimpleDataReader::data_received(const ReceivedDataSample& sample)
   DDS::Time_t ts = {sample.header_.source_timestamp_sec_, sample.header_.source_timestamp_nanosec_};
   ACE_Time_Value atv = time_to_time_value(ts);
 
-  GuidConverter pub(sample.header_.publication_id_);
-  GuidConverter id(get_repo_id());
   ACE_INT64 seqN = sample.header_.sequence_.getValue();
 
   std::ostringstream oss;
-  oss << '(' << atv.usec() << " usec) data_received by " << OPENDDS_STRING(id)
-    << "\n    Writer " << OPENDDS_STRING(pub) << " seq#" << seqN
+  oss << '(' << atv.usec() << " usec) data_received by " << LogGuid(get_repo_id()).conv_
+    << "\n    Writer " << LogGuid(sample.header_.publication_id_).conv_ << " seq#" << seqN
     << " key:" << data.key << " value:"  << data.value << "\n\n";
 
   ACE_DEBUG((LM_INFO, ACE_TEXT("%C"), oss.str().c_str()));

--- a/tests/transport/best_effort_reader/SocketWriter.cpp
+++ b/tests/transport/best_effort_reader/SocketWriter.cpp
@@ -158,7 +158,7 @@ bool SocketWriter::send(const ACE_Message_Block& mb) const
     ssize_t res = socket_.send(mb.rd_ptr(), mb.length(), dest);
     if (res >= 0) {
       ACE_DEBUG((LM_INFO, "SocketWriter %C sent %C (%d bytes)\n",
-                 OPENDDS_STRING(GuidConverter(id_)).c_str(), LogAddr::ip(*i).c_str(), res));
+                 LogGuid(id_).c_str(), LogAddr::ip(*i).c_str(), res));
     } else {
       ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: in socket_.send()%m\n")), false);
     }

--- a/tests/transport/rtps_directed_write/subscriber.cpp
+++ b/tests/transport/rtps_directed_write/subscriber.cpp
@@ -47,7 +47,7 @@ public:
     if (!associate(publication, false)) {
       throw std::string("subscriber TransportClient::associate() failed");
     }
-    std::cerr << "Reader " << OPENDDS_STRING(GuidConverter(get_repo_id())) << " called associate()\n";
+    std::cerr << "Reader " << LogGuid(get_repo_id()).conv_ << " called associate()\n";
   }
 
   virtual ~SimpleDataReader() { disassociate(config.getPubWtrId()); }

--- a/tests/transport/rtps_directed_write/subscriber.cpp
+++ b/tests/transport/rtps_directed_write/subscriber.cpp
@@ -116,7 +116,7 @@ void SimpleDataReader::data_received(const ReceivedDataSample& sample)
 
   if (data.key == 99) {
     ACE_DEBUG((LM_INFO, ACE_TEXT("%C received terminating sample\n"),
-      OPENDDS_STRING(GuidConverter(get_repo_id())).c_str()));
+      LogGuid(get_repo_id()).c_str()));
     done_ = true;
     return;
   }
@@ -129,7 +129,7 @@ void SimpleDataReader::data_received(const ReceivedDataSample& sample)
   ACE_TCHAR buffer[32];
   std::string timestr(ACE_TEXT_ALWAYS_CHAR(ACE_OS::ctime_r(&seconds, buffer, 32)));
   std::ostringstream oss;
-  oss << "data_received() by " << OPENDDS_STRING(GuidConverter(get_repo_id())).c_str() << "\n\t"
+  oss << "data_received() by " << LogGuid(get_repo_id()).c_str() << "\n\t"
     "id = "          << int(sample.header_.message_id_) << "\n\t"
     "timestamp = "   << atv.usec() << " usec " << timestr << "\t"
     "seq# = "        << sample.header_.sequence_.getValue() << "\n\t"

--- a/tools/dissector/giop_base.cpp
+++ b/tools/dissector/giop_base.cpp
@@ -158,11 +158,10 @@ namespace OpenDDS
       guint len = 16; // size of RepoId
       const RepoId *rid =
         reinterpret_cast<const RepoId *>(tvb_get_ptr(tvb_, *offset_, len));
-      GuidConverter converter (*rid);
       proto_tree_add_bytes_format_value
         ( tree, fieldId, tvb_, *offset_, len,
           reinterpret_cast<const guint8*>(rid),
-          "%s", std::string(converter).c_str() );
+          "%s", LogGuid(*rid).c_str() );
       *offset_ += len;
       return rid;
     }

--- a/tools/dissector/packet-opendds.cpp
+++ b/tools/dissector/packet-opendds.cpp
@@ -398,10 +398,9 @@ namespace OpenDDS
         reinterpret_cast<const guint8*>(&sample.publication_id_);
       if (sample.message_id_ != TRANSPORT_CONTROL)
         {
-          GuidConverter converter (sample.publication_id_);
           proto_tree_add_bytes_format_value (ltree, hf_sample_publication,
                                              tvb_, offset, len, data_ptr, "%s",
-                                             std::string(converter).c_str());
+                                             LogGuid(sample.publication_id_).c_str());
         }
       offset += len;
 
@@ -413,11 +412,10 @@ namespace OpenDDS
           data_ptr = reinterpret_cast<const guint8*>(&sample.publisher_id_);
           if (sample.message_id_ != DCPS::TRANSPORT_CONTROL)
             {
-              DCPS::GuidConverter converter(sample.publisher_id_);
               proto_tree_add_bytes_format_value (ltree, hf_sample_publisher,
                                                  tvb_, offset, len,
                                                  data_ptr, "%s",
-                                                 std::string(converter).c_str()
+                                                 LogGuid(sample.publisher_id_).c_str()
                                                  );
             }
           offset += len;
@@ -444,9 +442,8 @@ namespace OpenDDS
                 {
                   // Get Entry Value
                   const GUID_t &filter = sample.content_filter_entries_[i];
-                  DCPS::GuidConverter converter(filter);
                   std::stringstream strm;
-                  strm << converter;
+                  strm << LogGuid(filter).c_str();
                   std::string guid = strm.str();
 
                   // Get Entry Size
@@ -504,8 +501,6 @@ namespace OpenDDS
           return;
         }
 
-      GuidConverter converter(header.publication_id_);
-
       if (header.cdr_encapsulation_) {
         ACE_DEBUG ((LM_DEBUG,
                     "DDS_Dissector::dissect_sample_payload: "
@@ -532,11 +527,12 @@ namespace OpenDDS
       const char * data_name =
         InfoRepo_Dissector::instance().topic_for_pub(&header.publication_id_);
 
+      LogGuid publication_log(header.publication_id_);
       if (data_name == 0) {
         ACE_DEBUG ((LM_DEBUG,
                     "DDS_Dissector::dissect_sample_payload: "
                     "couldn't dissect payload: no topic for %C\n",
-                    std::string(converter).c_str()));
+                    publication_log.c_str()));
 
         // Mark Packet
 #ifndef NO_EXPERT
@@ -548,7 +544,7 @@ namespace OpenDDS
           offset,
           (gint) header.message_length_,
           "Couldn't Dissect Payload: No Topic Found for %s\n",
-          std::string(converter).c_str()
+          publication_log.c_str()
         );
 #endif
 

--- a/tools/monitor/MonitorDataStorage.cpp
+++ b/tools/monitor/MonitorDataStorage.cpp
@@ -250,10 +250,9 @@ Monitor::MonitorDataStorage::createParticipantNode(
   TreeNode* parent = this->getProcessNode( pid, create);
 
   // DomainParticipant data.
-  OpenDDS::DCPS::GuidConverter converter( id);
   QList<QVariant> list;
   list << QString("DomainParticipant")
-       << QString( QObject::tr( std::string( converter).c_str()));
+       << QString( QObject::tr( LogGuid(id).c_str()));
   TreeNode* node = new TreeNode( list, parent);
   if( parent) {
     parent->append( node);
@@ -389,10 +388,9 @@ Monitor::MonitorDataStorage::getEndpointNode(
     }
 
     // Node data.
-    OpenDDS::DCPS::GuidConverter converter( id);
     QList<QVariant> list;
     list << QString( QObject::tr( label.c_str()))
-         << QString( QObject::tr( std::string( converter).c_str()));
+         << QString( QObject::tr( LogGuid( id).c_str()));
     node = new TreeNode( list, parent);
     if( parent) {
       parent->append( node);
@@ -453,10 +451,9 @@ Monitor::MonitorDataStorage::getNode(
     }
 
     // Node data.
-    OpenDDS::DCPS::GuidConverter converter( id);
     QList<QVariant> list;
     list << QString( QObject::tr( label.c_str()))
-         << QString( QObject::tr( std::string( converter).c_str()));
+         << QString( QObject::tr( LogGuid( id).c_str()));
     node = new TreeNode( list, parent);
     if( parent) {
       parent->append( node);

--- a/tools/monitor/MonitorDataStorage.cpp
+++ b/tools/monitor/MonitorDataStorage.cpp
@@ -252,7 +252,7 @@ Monitor::MonitorDataStorage::createParticipantNode(
   // DomainParticipant data.
   QList<QVariant> list;
   list << QString("DomainParticipant")
-       << QString( QObject::tr( LogGuid(id).c_str()));
+       << QString( QObject::tr( OpenDDS::DCPS::LogGuid(id).c_str()));
   TreeNode* node = new TreeNode( list, parent);
   if( parent) {
     parent->append( node);
@@ -390,7 +390,7 @@ Monitor::MonitorDataStorage::getEndpointNode(
     // Node data.
     QList<QVariant> list;
     list << QString( QObject::tr( label.c_str()))
-         << QString( QObject::tr( LogGuid( id).c_str()));
+         << QString( QObject::tr( OpenDDS::DCPS::LogGuid( id).c_str()));
     node = new TreeNode( list, parent);
     if( parent) {
       parent->append( node);
@@ -453,7 +453,7 @@ Monitor::MonitorDataStorage::getNode(
     // Node data.
     QList<QVariant> list;
     list << QString( QObject::tr( label.c_str()))
-         << QString( QObject::tr( LogGuid( id).c_str()));
+         << QString( QObject::tr( OpenDDS::DCPS::LogGuid( id).c_str()));
     node = new TreeNode( list, parent);
     if( parent) {
       parent->append( node);

--- a/tools/monitor/MonitorDataStorage.inl
+++ b/tools/monitor/MonitorDataStorage.inl
@@ -160,13 +160,12 @@ MonitorDataStorage::update<OpenDDS::DCPS::DomainParticipantReport>(
   //    NVPSeq           values;
   //  };
 
-  OpenDDS::DCPS::GuidConverter converter( data.dp_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s DomainParticipantReport, id: %C, domain: %d.\n"),
     remove? "removing": "processing",
     (data.dp_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(data.dp_id).c_str(),
     data.domain_id
   ));
 
@@ -241,13 +240,12 @@ MonitorDataStorage::update<OpenDDS::DCPS::TopicReport>(
   //    NVPSeq  values;
   //  };
 
-  OpenDDS::DCPS::GuidConverter converter( data.topic_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s TopicReport, id: %C, name: %C, type: %C.\n"),
     remove? "removing": "processing",
     (data.topic_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(data.topic_id).c_str(),
     (const char*)data.topic_name,
     (const char*)data.type_name
   ));
@@ -328,13 +326,12 @@ MonitorDataStorage::update<OpenDDS::DCPS::PublisherReport>(
   //   NVPSeq        values;
   // };
 
-  OpenDDS::DCPS::GuidConverter converter( data.dp_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s PublisherReport, id: %C, handle: %d, transport: 0x%x.\n"),
     remove? "removing": "processing",
     (data.dp_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(data.dp_id).c_str(),
     data.handle,
     data.transport_id
   ));
@@ -405,13 +402,12 @@ MonitorDataStorage::update<OpenDDS::DCPS::SubscriberReport>(
   //   NVPSeq        values;
   // };
 
-  OpenDDS::DCPS::GuidConverter converter( data.dp_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s SubscriberReport, id: %C, handle: %d, transport: 0x%x.\n"),
     remove? "removing": "processing",
     (data.dp_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(data.dp_id).c_str(),
     data.handle,
     data.transport_id
   ));
@@ -488,16 +484,14 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataWriterReport>(
   //    NVPSeq                 values;
   //  };
 
-  OpenDDS::DCPS::GuidConverter idconverter( data.dw_id);
-  OpenDDS::DCPS::GuidConverter topicconverter( data.topic_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s DataWriterReport, id: %C, topic: %C.\n"),
     remove? "removing": "processing",
     (data.dw_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(idconverter).c_str(),
+    OpenDDS::DCPS::LogGuid(data.dw_id).c_str(),
     (data.topic_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(topicconverter).c_str()
+    OpenDDS::DCPS::LogGuid(data.topic_id).c_str()
   ));
 
   // Retain knowledge of node insertions, updates, and deletions.
@@ -538,8 +532,7 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataWriterReport>(
   for( int index = 0; index < size; ++index) {
     // Create a child node to hold the association if its not already in
     // the tree.
-    OpenDDS::DCPS::GuidConverter converter( data.associations[ index].dr_id);
-    QString reader( std::string(converter).c_str());
+    QString reader(OpenDDS::DCPS::LogGuid(data.associations[index].dr_id).c_str());
     int row = node->indexOf( 1, reader);
     if( row == -1) {
       // New data, insert.
@@ -579,13 +572,12 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataWriterPeriodicReport>(
   //   NVPSeq        values;
   // };
 
-  OpenDDS::DCPS::GuidConverter converter( data.dw_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s DataWriterPeriodicReport, id: %C.\n"),
     remove? "removing": "processing",
     (data.dw_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str()
+    OpenDDS::DCPS::LogGuid(data.dw_id).c_str()
   ));
 
   // Ignore remove flag for these samples - the static reports control
@@ -671,8 +663,7 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataWriterPeriodicReport>(
     // Create a child node to hold the association if its not already in
     // the tree.
     TreeNode* readerNode = 0;
-    OpenDDS::DCPS::GuidConverter converter( data.associations[ index].dr_id);
-    QString reader( std::string(converter).c_str());
+    QString reader( OpenDDS::DCPS::LogGuid(data.associations[index].dr_id).c_str());
     int row = node->indexOf( 1, reader);
     if( row == -1) {
       // New data, insert.
@@ -730,16 +721,14 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataReaderReport>(
   //    NVPSeq                 values;
   //  };
 
-  OpenDDS::DCPS::GuidConverter idconverter( data.dr_id);
-  OpenDDS::DCPS::GuidConverter topicconverter( data.topic_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s DataReaderReport, id: %C, topic: %C.\n"),
     remove? "removing": "processing",
     (data.dr_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(idconverter).c_str(),
+    OpenDDS::DCPS::LogGuid(data.dr_id).c_str(),
     (data.topic_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(topicconverter).c_str()
+    OpenDDS::DCPS::LogGuid(data.topic_id).c_str()
   ));
 
   // Retain knowledge of node insertions, updates, and deletions.
@@ -780,8 +769,7 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataReaderReport>(
   for( int index = 0; index < size; ++index) {
     // Create a child node to hold the association if its not already in
     // the tree.
-    OpenDDS::DCPS::GuidConverter converter( data.associations[ index].dw_id);
-    QString writer( std::string(converter).c_str());
+    QString writer( OpenDDS::DCPS::LogGuid(data.associations[index].dw_id).c_str());
     int row = node->indexOf( 1, writer);
     if( row == -1) {
       // New data, insert.
@@ -818,13 +806,12 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataReaderPeriodicReport>(
   //   NVPSeq        values;
   // };
 
-  OpenDDS::DCPS::GuidConverter converter( data.dr_id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s DataReaderPeriodicReport, id: %C.\n"),
     remove? "removing": "processing",
     (data.dr_id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str()
+    OpenDDS::DCPS::LogGuid(data.dr_id).c_str()
   ));
 
   // Ignore remove flag for these samples - the static reports control
@@ -854,8 +841,7 @@ MonitorDataStorage::update<OpenDDS::DCPS::DataReaderPeriodicReport>(
     // Create a child node to hold the association if its not already in
     // the tree.
     TreeNode* writerNode = 0;
-    OpenDDS::DCPS::GuidConverter converter( data.associations[ index].dw_id);
-    QString writer( std::string(converter).c_str());
+    QString writer( OpenDDS::DCPS::LogGuid(data.associations[index].dw_id).c_str());
     int row = node->indexOf( 1, writer);
     if( row == -1) {
       // New data, insert.
@@ -969,14 +955,13 @@ MonitorDataStorage::update<DDS::ParticipantBuiltinTopicData>(
   // Extract a GUID from the key.
   const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
-  OpenDDS::DCPS::GuidConverter converter(id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s Participant Builtin Topic %C, key: ")
     ACE_TEXT("[0x%x, 0x%x, 0x%x].\n"),
     remove? "removing": "processing",
     (id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(id).c_str(),
     data.key.value[0], data.key.value[1], data.key.value[2]
   ));
 
@@ -1045,14 +1030,13 @@ MonitorDataStorage::update<DDS::TopicBuiltinTopicData>(
   // Extract a GUID from the key.
   const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
-  OpenDDS::DCPS::GuidConverter converter( id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s Topic Builtin Topic %C, key: ")
     ACE_TEXT("[0x%x, 0x%x, 0x%x].\n"),
     remove? "removing": "processing",
     (id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(id).c_str(),
     data.key.value[0], data.key.value[1], data.key.value[2]
   ));
 
@@ -1130,14 +1114,13 @@ MonitorDataStorage::update<DDS::PublicationBuiltinTopicData>(
   // Extract a GUID from the key.
   const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
-  OpenDDS::DCPS::GuidConverter converter( id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s Publication Builtin Topic %C, key: ")
     ACE_TEXT("[0x%x, 0x%x, 0x%x].\n"),
     remove? "removing": "processing",
     (id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(id).c_str(),
     data.key.value[0], data.key.value[1], data.key.value[2]
   ));
 
@@ -1213,14 +1196,13 @@ MonitorDataStorage::update<DDS::SubscriptionBuiltinTopicData>(
   // Extract a GUID from the key.
   const OpenDDS::DCPS::RepoId id = OpenDDS::DCPS::bit_key_to_repo_id(data.key);
 
-  OpenDDS::DCPS::GuidConverter converter( id);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("(%P|%t) MonitorDataStorage::update() - ")
     ACE_TEXT("%s Subscription Builtin Topic %C, key: ")
     ACE_TEXT("[0x%x, 0x%x, 0x%x].\n"),
     remove? "removing": "processing",
     (id == OpenDDS::DCPS::GUID_UNKNOWN)? "GUID_UNKNOWN":
-    std::string(converter).c_str(),
+    OpenDDS::DCPS::LogGuid(id).c_str(),
     data.key.value[0], data.key.value[1], data.key.value[2]
   ));
 

--- a/tools/monitor/MonitorTask.cpp
+++ b/tools/monitor/MonitorTask.cpp
@@ -871,25 +871,23 @@ Monitor::MonitorTask::readBuiltinTopicData(
   const DDS::InstanceHandle_t instance = dpi->lookup_handle(id);
 
   if (this->options_.verbose()) {
-    OpenDDS::DCPS::GuidConverter converter(id);
     ACE_DEBUG((LM_DEBUG,
       ACE_TEXT("(%P|%t) MonitorTask::readBuiltinTopicData<%s>() - ")
       ACE_TEXT("id: %C ==> BuiltinTopic key: ")
       ACE_TEXT("[0x%x, 0x%x, 0x%x], handle %d.\n"),
       topicName,
-      std::string(converter).c_str(),
+      LogGuid(id).c_str(),
       data.key.value[0], data.key.value[1], data.key.value[2],
       instance
     ));
   }
 
   if (instance == DDS::HANDLE_NIL) {
-    OpenDDS::DCPS::GuidConverter converter(id);
     ACE_DEBUG((LM_DEBUG,
       ACE_TEXT("(%P|%t) MonitorTask::readBuiltinTopicData<%s>() - ")
       ACE_TEXT("no data for id %C at this time.\n"),
       topicName,
-      std::string(converter).c_str()
+      LogGuid(id).c_str()
     ));
     return false;
   }

--- a/tools/monitor/MonitorTask.cpp
+++ b/tools/monitor/MonitorTask.cpp
@@ -876,7 +876,7 @@ Monitor::MonitorTask::readBuiltinTopicData(
       ACE_TEXT("id: %C ==> BuiltinTopic key: ")
       ACE_TEXT("[0x%x, 0x%x, 0x%x], handle %d.\n"),
       topicName,
-      LogGuid(id).c_str(),
+      OpenDDS::DCPS::LogGuid(id).c_str(),
       data.key.value[0], data.key.value[1], data.key.value[2],
       instance
     ));
@@ -887,7 +887,7 @@ Monitor::MonitorTask::readBuiltinTopicData(
       ACE_TEXT("(%P|%t) MonitorTask::readBuiltinTopicData<%s>() - ")
       ACE_TEXT("no data for id %C at this time.\n"),
       topicName,
-      LogGuid(id).c_str()
+      OpenDDS::DCPS::LogGuid(id).c_str()
     ));
     return false;
   }


### PR DESCRIPTION
Closes issue #3036

@Pyrotacticz, @teechoi, and I replaced GuidConverter with, mostly, inline calls to LogGuid as per issue #3036.

This also served as an exercise for one of our CS classes at UW. In the process, we learned about the architecture of OpenDDS, the intricacies of working with git, and the process of contributing to an open-source project with a large codebase.