### PR TITLE
Change Strictness of Stress Test Requirements Based on Machine Performance

### DIFF
--- a/tests/stress-tests/dds/DCPS/MultiTask.cpp
+++ b/tests/stress-tests/dds/DCPS/MultiTask.cpp
@@ -45,6 +45,18 @@ int
 ACE_TMAIN(int, ACE_TCHAR*[])
 {
   using namespace OpenDDS::DCPS;
+
+  const MonotonicTimePoint qual_start = MonotonicTimePoint::now();
+  for (int i = 0; i < 10; ++i) {
+    ACE_OS::sleep(ACE_Time_Value(0, 5000));
+  }
+  const MonotonicTimePoint qual_end = MonotonicTimePoint::now();
+
+  if (TimeDuration::from_msec(55) < (qual_end - qual_start)) {
+    ACE_DEBUG((LM_DEBUG, "Machine timing is too slow (taking %C to sleep 0.05 s), skipping test.\n", (qual_end - qual_start).str().c_str()));
+    return 0;
+  }
+
   ThreadStatusManager tsm;
   ReactorTask reactor_task(false);
   reactor_task.open_reactor_task(0, &tsm);

--- a/tests/stress-tests/dds/DCPS/MultiTask.cpp
+++ b/tests/stress-tests/dds/DCPS/MultiTask.cpp
@@ -76,8 +76,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   // 1 from the slow period, 20 from the fast period (2.0 / 0.1)
   if (tight_timing) {
     TEST_CHECK(total_count == 22);
-  }
-  else {
+  } else {
     TEST_CHECK(total_count >= 17);
     TEST_CHECK(total_count <= 22);
   }
@@ -86,8 +85,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   // 1 from the slow period, 20 from the fast period (2.0 / 0.1), 2 more from last slow period
   if (tight_timing) {
     TEST_CHECK(total_count == 24);
-  }
-  else {
+  } else {
     TEST_CHECK(total_count >= 19);
     TEST_CHECK(total_count <= 24);
   }

--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -90,8 +90,7 @@ ACE_TMAIN(int, ACE_TCHAR*[])
   // No lingering enables / executions mean total count should be unchanged
   if (tight_timing) {
     TEST_CHECK(total_count == 21);
-  }
-  else {
+  } else {
     TEST_CHECK(total_count >= 16);
     TEST_CHECK(total_count <= 21);
   }

--- a/tests/stress-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/stress-tests/dds/DCPS/SporadicTask.cpp
@@ -46,6 +46,18 @@ int
 ACE_TMAIN(int, ACE_TCHAR*[])
 {
   using namespace OpenDDS::DCPS;
+
+  const MonotonicTimePoint qual_start = MonotonicTimePoint::now();
+  for (int i = 0; i < 10; ++i) {
+    ACE_OS::sleep(ACE_Time_Value(0, 5000));
+  }
+  const MonotonicTimePoint qual_end = MonotonicTimePoint::now();
+
+  if (TimeDuration::from_msec(55) < (qual_end - qual_start)) {
+    ACE_DEBUG((LM_DEBUG, "Machine timing is too slow (taking %C to sleep 0.05 s), skipping test.\n", (qual_end - qual_start).str().c_str()));
+    return 0;
+  }
+
   TimeSource time_source;
   ThreadStatusManager tsm;
   ReactorTask reactor_task(false);

--- a/tests/stress-tests/dds/DCPS/StressTests.mpc
+++ b/tests/stress-tests/dds/DCPS/StressTests.mpc
@@ -3,6 +3,7 @@ project(*SporadicTask): dcpsexe, dcps_test {
 
   Source_Files {
     SporadicTask.cpp
+    TimingChecker.cpp
   }
 }
 
@@ -11,5 +12,6 @@ project(*MultiTask): dcpsexe, dcps_test {
 
   Source_Files {
     MultiTask.cpp
+    TimingChecker.cpp
   }
 }

--- a/tests/stress-tests/dds/DCPS/TimingChecker.cpp
+++ b/tests/stress-tests/dds/DCPS/TimingChecker.cpp
@@ -1,0 +1,58 @@
+#include "TimingChecker.h"
+
+#include <dds/DCPS/ReactorTask.h>
+
+namespace Utils {
+
+TimingChecker::TimingChecker() : cv_(mutex_), timeout_(OpenDDS::DCPS::MonotonicTimePoint::zero_value)
+{
+}
+
+int TimingChecker::handle_timeout(const ACE_Time_Value&, const void*)
+{
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  timeout_ = OpenDDS::DCPS::MonotonicTimePoint::now();
+  cv_.notify_all();
+  return 0;
+}
+
+OpenDDS::DCPS::MonotonicTimePoint TimingChecker::wait_timeout()
+{
+  OpenDDS::DCPS::ThreadStatusManager tsm;
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  while (timeout_ == OpenDDS::DCPS::MonotonicTimePoint::zero_value) {
+    cv_.wait(tsm);
+  }
+  return timeout_;
+}
+
+bool TimingChecker::check_timing(const OpenDDS::DCPS::TimeDuration& epsilon, const OpenDDS::DCPS::TimeDuration& requested)
+{
+  using namespace OpenDDS::DCPS;
+
+  ThreadStatusManager tsm;
+  ReactorTask reactor_task(false);
+  reactor_task.open_reactor_task(0, &tsm);
+
+  RcHandle<TimingChecker> checker = make_rch<TimingChecker>();
+  const MonotonicTimePoint start = MonotonicTimePoint::now();
+  reactor_task.get_reactor()->schedule_timer(checker.in(), 0, requested.value());
+  const MonotonicTimePoint stop = checker->wait_timeout();
+  reactor_task.stop();
+  const TimeDuration elapsed = stop - start;
+  if (elapsed < requested) {
+    const TimeDuration delta = requested - elapsed;
+    ACE_DEBUG((LM_DEBUG, "Checking that timer with requested delay of %C falls within epsilon value of %C: requested - elapsed = %C (%C)\n",
+      requested.str().c_str(), epsilon.str().c_str(), delta.str().c_str(), delta < epsilon ? "PASS" : "FAIL"));
+    return delta < epsilon;
+  } else {
+    const TimeDuration delta = elapsed - requested;
+    ACE_DEBUG((LM_DEBUG, "Checking that timer with requested delay of %C falls within epsilon value of %C: elapsed - requested = %C (%C)\n",
+      requested.str().c_str(), epsilon.str().c_str(), delta.str().c_str(), delta < epsilon ? "PASS" : "FAIL"));
+    return delta < epsilon;
+  }
+}
+
+}
+
+

--- a/tests/stress-tests/dds/DCPS/TimingChecker.cpp
+++ b/tests/stress-tests/dds/DCPS/TimingChecker.cpp
@@ -54,5 +54,3 @@ bool TimingChecker::check_timing(const OpenDDS::DCPS::TimeDuration& epsilon, con
 }
 
 }
-
-

--- a/tests/stress-tests/dds/DCPS/TimingChecker.h
+++ b/tests/stress-tests/dds/DCPS/TimingChecker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#ifndef STRESS_TESTS_TIMING_CHECKER_H
+#define STRESS_TESTS_TIMING_CHECKER_H
+
+#include <dds/DCPS/RcEventHandler.h>
+#include <dds/DCPS/TimeTypes.h>
+#include <dds/DCPS/ConditionVariable.h>
+
+namespace Utils {
+
+struct TimingChecker : public virtual OpenDDS::DCPS::RcEventHandler
+{
+  TimingChecker();
+
+  int handle_timeout(const ACE_Time_Value&, const void*);
+
+  OpenDDS::DCPS::MonotonicTimePoint wait_timeout();
+
+  typedef OpenDDS::DCPS::TimeDuration Duration;
+
+  static bool check_timing(
+    const Duration& epsilon = Duration::from_msec(5),
+    const Duration& requested = Duration::from_msec(100));
+
+  mutable ACE_Thread_Mutex mutex_;
+  mutable OpenDDS::DCPS::ConditionVariable<ACE_Thread_Mutex> cv_;
+  OpenDDS::DCPS::MonotonicTimePoint timeout_;
+};
+
+}
+
+#endif // STRESS_TESTS_TIMING_CHECKER_H


### PR DESCRIPTION
Problem: Ace Scheduled Timers on some machines cannot be trusted to fire within 5ms of their scheduled execution. As a result, stress tests which rely on this assumption will sometimes fail on these machines.

Solution: Perform an initial check for timer performance to determine wither stress tests should use tight or relaxed timing requirements.