### PR TITLE
Associations not removed when participant expires

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -7638,7 +7638,7 @@ void Sedp::WriterRemoveAssociations::execute()
     if (DCPS_debug_level > 3) {
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Sedp::WriterRemoveAssociations::execute - ")
-                 ACE_TEXT("removing writer %C association for writer %C\n"), LogGuid(record_->writer_id()).c_str(),
+                 ACE_TEXT("removing writer %C association for reader %C\n"), LogGuid(record_->writer_id()).c_str(),
                  LogGuid(record_->reader_id()).c_str()));
     }
     DCPS::ReaderIdSeq reader_seq(1);

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -605,6 +605,13 @@ TransportClient::stop_associating()
 {
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
   for (PendingMap::iterator it = pending_.begin(); it != pending_.end(); ++it) {
+    // The transport impl may have resource for a pending connection.
+    for (size_t i = 0; i < it->second->impls_.size(); ++i) {
+      RcHandle<TransportImpl> impl = it->second->impls_[i].lock();
+      if (impl) {
+        impl->stop_accepting_or_connecting(*this, it->second->data_.remote_id_, true, true);
+      }
+    }
     it->second->reset_client();
     pending_assoc_timer_->cancel_timer(it->second);
     prev_pending_.insert(std::make_pair(it->first, it->second));
@@ -623,6 +630,13 @@ TransportClient::stop_associating(const GUID_t* repos, CORBA::ULong length)
     for (CORBA::ULong i = 0; i < length; ++i) {
       PendingMap::iterator iter = pending_.find(repos[i]);
       if (iter != pending_.end()) {
+        // The transport impl may have resource for a pending connection.
+        for (size_t i = 0; i < iter->second->impls_.size(); ++i) {
+          RcHandle<TransportImpl> impl = iter->second->impls_[i].lock();
+          if (impl) {
+            impl->stop_accepting_or_connecting(*this, iter->second->data_.remote_id_, true, true);
+          }
+        }
         iter->second->reset_client();
         pending_assoc_timer_->cancel_timer(iter->second);
         prev_pending_.insert(std::make_pair(iter->first, iter->second));


### PR DESCRIPTION
Problem
-------

Suppose that a local participant is using the RTPS transport and that
a remote participant's lease duration is less than the passive connect
duration.  Suppose that discovery proceeds to the point where a reader
on the local is sending preassociation acknacks to a remote writer
when the writer terminates.

The local reader will continue to send preassociation acknacks because
the call to remove the remote writer never comes.

Solution
--------

Add a call to `stop_accepting_or_connecting` when a pending
association is removed.