### PR TITLE
Remove addr_guids from BundlingCacheKey for Performance

### DIFF
--- a/dds/DCPS/NetworkAddress.h
+++ b/dds/DCPS/NetworkAddress.h
@@ -16,6 +16,7 @@
 
 #include "Definitions.h"
 #include "PoolAllocator.h"
+#include "Hash.h"
 
 #include "ace/INET_Addr.h"
 
@@ -95,5 +96,9 @@ bool is_more_local(const NetworkAddress& current, const NetworkAddress& incoming
 } // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#if defined ACE_HAS_CPP11
+OPENDDS_OOAT_STD_HASH(OpenDDS::DCPS::NetworkAddress, OpenDDS_Dcps_Export);
+#endif
 
 #endif /*OPENDDS_DCPS_NETWORK_ADDRESS_H*/

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -50,17 +50,6 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
     return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (BundlingCacheKey)) == 0;
   }
 
-  /*
-  BundlingCacheKey& operator=(const BundlingCacheKey& rhs)
-  {
-    if (this != &rhs) {
-      const_cast<GUID_t&>(src_guid_) = rhs.src_guid_;
-      const_cast<GUID_t&>(dst_guid_) = rhs.dst_guid_;
-    }
-    return *this;
-  }
-  */
-
   void get_contained_guids(GuidSet& set) const
   {
     set.clear();

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -42,12 +42,12 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
 
   bool operator<(const BundlingCacheKey& rhs) const
   {
-    return std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t)) < 0;
+    return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (BundlingCacheKey)) < 0;
   }
 
   bool operator==(const BundlingCacheKey& rhs) const
   {
-    return std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t)) == 0;
+    return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (BundlingCacheKey)) == 0;
   }
 
   BundlingCacheKey& operator=(const BundlingCacheKey& rhs)

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -50,6 +50,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
     return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (BundlingCacheKey)) == 0;
   }
 
+  /*
   BundlingCacheKey& operator=(const BundlingCacheKey& rhs)
   {
     if (this != &rhs) {
@@ -58,6 +59,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
     }
     return *this;
   }
+  */
 
   void get_contained_guids(GuidSet& set) const
   {

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -57,15 +57,8 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
     set.insert(dst_guid_);
   }
 
-  const GUID_t src_guid_;
-  const GUID_t dst_guid_;
-
-#if defined ACE_HAS_CPP11
-  inline size_t calculate_hash() const
-  {
-    return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&src_guid_), 2 * sizeof (OpenDDS::DCPS::GUID_t)));
-  }
-#endif
+  GUID_t src_guid_;
+  GUID_t dst_guid_;
 };
 
 #pragma pack(pop)
@@ -76,18 +69,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #if defined ACE_HAS_CPP11
-namespace std
-{
-
-template<> struct OpenDDS_Rtps_Udp_Export hash<OpenDDS::DCPS::BundlingCacheKey>
-{
-  std::size_t operator()(const OpenDDS::DCPS::BundlingCacheKey& val) const noexcept
-  {
-    return val.calculate_hash();
-  }
-};
-
-} // namespace std
+OPENDDS_OOAT_STD_HASH(OpenDDS::DCPS::BundlingCacheKey, OpenDDS_Rtps_Udp_Export);
 #endif
 
 #endif /* OPENDDS_DCPS_TRANSPORT_RTPS_UDP_BUNDLINGCACHEKEY_H */

--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -27,120 +27,57 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export BundlingCacheKeyCore {
-  BundlingCacheKeyCore(const GUID_t& dst_guid, const GUID_t& src_guid, RcHandle<ConstSharedRepoIdSet> addr_guids)
+struct OpenDDS_Rtps_Udp_Export BundlingCacheKey {
+  BundlingCacheKey(const GUID_t& dst_guid, const GUID_t& src_guid)
     : src_guid_(src_guid)
     , dst_guid_(dst_guid)
-    , addr_guids_(addr_guids)
-#if defined ACE_HAS_CPP11
-    , hash_(calculate_hash())
-#endif
-  {
-  }
-
-  BundlingCacheKeyCore(const BundlingCacheKeyCore& val)
-    : src_guid_(val.src_guid_)
-    , dst_guid_(val.dst_guid_)
-    , addr_guids_(val.addr_guids_)
-#if defined ACE_HAS_CPP11
-    , hash_(val.hash_)
-#endif
-  {
-  }
-
-  bool operator<(const BundlingCacheKeyCore& rhs) const
-  {
-    int r = std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t));
-    if (r < 0) {
-      return true;
-    } else if (r == 0) {
-      return addr_guids_->guids_ < rhs.addr_guids_->guids_;
-    }
-    return false;
-  }
-
-  bool operator==(const BundlingCacheKeyCore& rhs) const
-  {
-    return std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t)) == 0 &&
-#if defined ACE_HAS_CPP11
-      addr_guids_->hash() == rhs.addr_guids_->hash() &&
-#endif
-      addr_guids_->guids_ == rhs.addr_guids_->guids_;
-  }
-
-  BundlingCacheKeyCore& operator=(const BundlingCacheKeyCore& rhs)
-  {
-    if (this != &rhs) {
-      const_cast<GUID_t&>(src_guid_) = rhs.src_guid_;
-      const_cast<GUID_t&>(dst_guid_) = rhs.dst_guid_;
-      addr_guids_ = rhs.addr_guids_;
-    }
-    return *this;
-  }
-
-  const GUID_t src_guid_;
-  const GUID_t dst_guid_;
-  RcHandle<ConstSharedRepoIdSet> addr_guids_;
-#if defined ACE_HAS_CPP11
-  const size_t hash_;
-
-  size_t calculate_hash()
-  {
-    uint32_t hash = addr_guids_->hash();
-    hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&src_guid_), 2 * sizeof (OpenDDS::DCPS::GUID_t), hash);
-    return static_cast<size_t>(hash);
-  }
-#endif
-};
-
-#pragma pack(pop)
-
-struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject, public BundlingCacheKeyCore {
-  BundlingCacheKey(const GUID_t& dst_guid, const GUID_t& src_guid, RcHandle<ConstSharedRepoIdSet> addr_guids)
-    : RcObject()
-    , BundlingCacheKeyCore(dst_guid, src_guid, addr_guids)
   {
   }
 
   BundlingCacheKey(const BundlingCacheKey& val)
-    : RcObject()
-    , BundlingCacheKeyCore(val)
+    : src_guid_(val.src_guid_)
+    , dst_guid_(val.dst_guid_)
   {
   }
 
-  inline bool operator<(const BundlingCacheKey& rhs) const
+  bool operator<(const BundlingCacheKey& rhs) const
   {
-    return BundlingCacheKeyCore::operator<(rhs);
+    return std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t)) < 0;
   }
 
   bool operator==(const BundlingCacheKey& rhs) const
   {
-    return BundlingCacheKeyCore::operator==(rhs);
+    return std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t)) == 0;
   }
 
   BundlingCacheKey& operator=(const BundlingCacheKey& rhs)
   {
     if (this != &rhs) {
-      BundlingCacheKeyCore::operator=(rhs);
+      const_cast<GUID_t&>(src_guid_) = rhs.src_guid_;
+      const_cast<GUID_t&>(dst_guid_) = rhs.dst_guid_;
     }
     return *this;
   }
 
   void get_contained_guids(GuidSet& set) const
   {
-    set = addr_guids_->guids_;
+    set.clear();
     set.insert(src_guid_);
     set.insert(dst_guid_);
   }
 
+  const GUID_t src_guid_;
+  const GUID_t dst_guid_;
+
 #if defined ACE_HAS_CPP11
-  inline size_t calculate_hash()
+  inline size_t calculate_hash() const
   {
-    return BundlingCacheKeyCore::calculate_hash();
+    return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&src_guid_), 2 * sizeof (OpenDDS::DCPS::GUID_t)));
   }
 #endif
 };
 
+#pragma pack(pop)
 
 } // namespace DCPS
 } // namespace OpenDDS
@@ -155,7 +92,7 @@ template<> struct OpenDDS_Rtps_Udp_Export hash<OpenDDS::DCPS::BundlingCacheKey>
 {
   std::size_t operator()(const OpenDDS::DCPS::BundlingCacheKey& val) const noexcept
   {
-    return val.hash_;
+    return val.calculate_hash();
   }
 };
 

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -26,75 +26,37 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export LocatorCacheKeyCore {
-  LocatorCacheKeyCore(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
+struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
+  LocatorCacheKey(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
     : remote_(remote)
     , local_(local)
     , prefer_unicast_(prefer_unicast)
   {
   }
 
-  LocatorCacheKeyCore(const LocatorCacheKeyCore& val)
+  LocatorCacheKey(const LocatorCacheKey& val)
     : remote_(val.remote_)
     , local_(val.local_)
     , prefer_unicast_(val.prefer_unicast_)
   {
   }
 
-  bool operator<(const LocatorCacheKeyCore& rhs) const
+  bool operator<(const LocatorCacheKey& rhs) const
   {
     return std::memcmp(static_cast<const void*>(&remote_), static_cast<const void*>(&rhs.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) < 0;
   }
 
-  bool operator==(const LocatorCacheKeyCore& rhs) const
+  bool operator==(const LocatorCacheKey& rhs) const
   {
     return std::memcmp(static_cast<const void*>(&remote_), static_cast<const void*>(&rhs.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) == 0;
-  }
-
-  LocatorCacheKeyCore& operator=(const LocatorCacheKeyCore& rhs)
-  {
-    if (this != &rhs) {
-      const_cast<GUID_t&>(remote_) = rhs.remote_;
-      const_cast<GUID_t&>(local_) = rhs.local_;
-      const_cast<bool&>(prefer_unicast_) = rhs.prefer_unicast_;
-    }
-    return *this;
-  }
-
-  const GUID_t remote_;
-  const GUID_t local_;
-  const bool prefer_unicast_;
-};
-
-#pragma pack(pop)
-
-struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public virtual RcObject, public LocatorCacheKeyCore {
-  LocatorCacheKey(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
-    : RcObject()
-    , LocatorCacheKeyCore(remote, local, prefer_unicast)
-  {
-  }
-
-  LocatorCacheKey(const LocatorCacheKey& val)
-    : RcObject()
-    , LocatorCacheKeyCore(val)
-  {
-  }
-
-  inline bool operator<(const LocatorCacheKey& rhs) const
-  {
-    return LocatorCacheKeyCore::operator<(rhs);
-  }
-
-  inline bool operator==(const LocatorCacheKey& rhs) const
-  {
-    return LocatorCacheKeyCore::operator==(rhs);
   }
 
   LocatorCacheKey& operator=(const LocatorCacheKey& rhs)
   {
     if (this != &rhs) {
-      LocatorCacheKeyCore::operator=(rhs);
+      const_cast<GUID_t&>(remote_) = rhs.remote_;
+      const_cast<GUID_t&>(local_) = rhs.local_;
+      const_cast<bool&>(prefer_unicast_) = rhs.prefer_unicast_;
     }
     return *this;
   }
@@ -105,7 +67,20 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public virtual RcObject, public
     set.insert(remote_);
     set.insert(local_);
   }
+
+#if defined ACE_HAS_CPP11
+  inline size_t calculate_hash() const
+  {
+    return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)));
+  }
+#endif
+
+  const GUID_t remote_;
+  const GUID_t local_;
+  const bool prefer_unicast_;
 };
+
+#pragma pack(pop)
 
 }
 }
@@ -120,8 +95,7 @@ template<> struct OpenDDS_Rtps_Udp_Export hash<OpenDDS::DCPS::LocatorCacheKey>
 {
   std::size_t operator()(const OpenDDS::DCPS::LocatorCacheKey& val) const noexcept
   {
-    uint32_t hash = OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&val.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool));
-    return static_cast<size_t>(hash);
+    return val.calculate_hash();
   }
 };
 

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -51,16 +51,6 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
     return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (LocatorCacheKey)) == 0;
   }
 
-  LocatorCacheKey& operator=(const LocatorCacheKey& rhs)
-  {
-    if (this != &rhs) {
-      const_cast<GUID_t&>(remote_) = rhs.remote_;
-      const_cast<GUID_t&>(local_) = rhs.local_;
-      const_cast<bool&>(prefer_unicast_) = rhs.prefer_unicast_;
-    }
-    return *this;
-  }
-
   void get_contained_guids(GuidSet& set) const
   {
     set.clear();
@@ -68,16 +58,9 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
     set.insert(local_);
   }
 
-#if defined ACE_HAS_CPP11
-  inline size_t calculate_hash() const
-  {
-    return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(this), sizeof (LocatorCacheKey)));
-  }
-#endif
-
-  const GUID_t remote_;
-  const GUID_t local_;
-  const bool prefer_unicast_;
+  GUID_t remote_;
+  GUID_t local_;
+  bool prefer_unicast_;
 };
 
 #pragma pack(pop)
@@ -88,18 +71,7 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 #if defined ACE_HAS_CPP11
-namespace std
-{
-
-template<> struct OpenDDS_Rtps_Udp_Export hash<OpenDDS::DCPS::LocatorCacheKey>
-{
-  std::size_t operator()(const OpenDDS::DCPS::LocatorCacheKey& val) const noexcept
-  {
-    return val.calculate_hash();
-  }
-};
-
-}
+OPENDDS_OOAT_STD_HASH(OpenDDS::DCPS::LocatorCacheKey, OpenDDS_Rtps_Udp_Export);
 #endif
 
 #endif /* OPENDDS_DCPS_TRANSPORT_RTPS_UDP_LOCATORCACHEKEY_H */

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -43,12 +43,12 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
 
   bool operator<(const LocatorCacheKey& rhs) const
   {
-    return std::memcmp(static_cast<const void*>(&remote_), static_cast<const void*>(&rhs.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) < 0;
+    return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (LocatorCacheKey)) < 0;
   }
 
   bool operator==(const LocatorCacheKey& rhs) const
   {
-    return std::memcmp(static_cast<const void*>(&remote_), static_cast<const void*>(&rhs.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) == 0;
+    return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (LocatorCacheKey)) == 0;
   }
 
   LocatorCacheKey& operator=(const LocatorCacheKey& rhs)
@@ -71,7 +71,7 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey {
 #if defined ACE_HAS_CPP11
   inline size_t calculate_hash() const
   {
-    return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(&remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)));
+    return static_cast<size_t>(OpenDDS::DCPS::one_at_a_time_hash(reinterpret_cast<const uint8_t*>(this), sizeof (LocatorCacheKey)));
   }
 #endif
 

--- a/dds/DCPS/transport/rtps_udp/MetaSubmessage.h
+++ b/dds/DCPS/transport/rtps_udp/MetaSubmessage.h
@@ -19,21 +19,19 @@ namespace DCPS {
 
 struct OpenDDS_Rtps_Udp_Export MetaSubmessage {
   MetaSubmessage()
-    : src_guid_(GUID_UNKNOWN), dst_guid_(GUID_UNKNOWN), addr_guids_(make_rch<ConstSharedRepoIdSet>()), redundant_(false) {}
+    : src_guid_(GUID_UNKNOWN), dst_guid_(GUID_UNKNOWN), redundant_(false) {}
   MetaSubmessage(const RepoId& src, const RepoId& dst)
-    : src_guid_(src), dst_guid_(dst), addr_guids_(make_rch<ConstSharedRepoIdSet>()), redundant_(false) {}
+    : src_guid_(src), dst_guid_(dst), redundant_(false) {}
   MetaSubmessage(const RepoId& src, const RepoId& dst, RcHandle<ConstSharedRepoIdSet> addr_guids)
-    : src_guid_(src), dst_guid_(dst), addr_guids_(addr_guids), redundant_(false) {}
+    : src_guid_(src), dst_guid_(dst), redundant_(false) {}
 
   void reset_destination()
   {
     dst_guid_ = GUID_UNKNOWN;
-    addr_guids_ = make_rch<ConstSharedRepoIdSet>();
   }
 
   RepoId src_guid_;
   RepoId dst_guid_;
-  RcHandle<ConstSharedRepoIdSet> addr_guids_;
   RTPS::Submessage sm_;
   bool redundant_;
 };

--- a/dds/DCPS/transport/rtps_udp/RoutedGuidPair.h
+++ b/dds/DCPS/transport/rtps_udp/RoutedGuidPair.h
@@ -19,10 +19,11 @@ struct OpenDDS_Rtps_Udp_Export RoutedGuidPair {
   RoutedGuidPair(const GUID_t& src, const GUID_t dst) : src_(src), dst_(dst) {}
 
   bool operator<(const RoutedGuidPair& rhs) const {
-    return std::memcmp(static_cast<const void*>(&src_), static_cast<const void*>(&rhs.src_), 2 * sizeof(GUID_t)) < 0;
+    return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (RoutedGuidPair)) < 0;
   }
+
   bool operator==(const RoutedGuidPair& rhs) const {
-    return std::memcmp(static_cast<const void*>(&src_), static_cast<const void*>(&rhs.src_), 2 * sizeof(GUID_t)) == 0;
+    return std::memcmp(static_cast<const void*>(this), static_cast<const void*>(&rhs), sizeof (RoutedGuidPair)) == 0;
   }
 
   // Note: The comparison operators for RoutedGuidPair assume a tightly packed pair of GUIDs

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4564,14 +4564,16 @@ RtpsUdpDataLink::get_addresses_i(const RepoId& local) const
       writer = pos->second;
     }
     guard.release();
-    RcHandle<ConstSharedRepoIdSet> addr_guids = writer->get_remote_reader_guids();
-    if (addr_guids) {
-      for (RepoIdSet::const_iterator it = addr_guids->guids_.begin(),
-        limit = addr_guids->guids_.end(); it != limit; ++it) {
-        accumulate_addresses(local, *it, retval);
+    if (writer) {
+      RcHandle<ConstSharedRepoIdSet> addr_guids = writer->get_remote_reader_guids();
+      if (addr_guids) {
+        for (RepoIdSet::const_iterator it = addr_guids->guids_.begin(),
+          limit = addr_guids->guids_.end(); it != limit; ++it) {
+          accumulate_addresses(local, *it, retval);
 
+        }
+        use_peers = false;
       }
-      use_peers = false;
     }
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2547,7 +2547,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
   for (AddrDestMetaSubmessageMap::iterator addr_it = addr_map.begin(), limit = addr_map.end(); addr_it != limit; ++addr_it) {
 
     // A new address set always starts a new bundle
-    bundles.push_back(BundleStruct(addr_it->first));
+    bundles.push_back(Bundle(addr_it->first));
 
     prev_dst = GUID_UNKNOWN;
 
@@ -2560,7 +2560,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
       // Check to see if we're sending separate messages per destination guid
       if (new_bundle_per_dest_guid && bundles.back().submessages_.size()) {
         helper.end_bundle();
-        bundles.push_back(BundleStruct(addr_it->first));
+        bundles.push_back(Bundle(addr_it->first));
         prev_dst = GUID_UNKNOWN;
       }
 
@@ -2571,7 +2571,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
           // If adding an INFO_DST prefix bumped us over the limit, push the
           // size difference into the next bundle, reset prev_dst, and keep going
           if (!helper.add_to_bundle(idst)) {
-            bundles.push_back(BundleStruct(addr_it->first));
+            bundles.push_back(Bundle(addr_it->first));
           }
         }
 
@@ -2613,7 +2613,7 @@ RtpsUdpDataLink::bundle_mapped_meta_submessages(const Encoding& encoding,
         // If adding the submessage bumped us over the limit, push the size
         // difference into the next bundle, reset prev_dst, and keep going
         if (!result) {
-          bundles.push_back(BundleStruct(addr_it->first));
+          bundles.push_back(Bundle(addr_it->first));
           prev_dst = GUID_UNKNOWN;
         }
         bundles.back().submessages_.push_back(*resp_it);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -2404,9 +2404,6 @@ RtpsUdpDataLink::build_meta_submessage_map(MetaSubmessageVec& meta_submessages, 
       } else {
         addrs = get_addresses_i(it->src_guid_);
       }
-      for (RepoIdSet::const_iterator it2 = it->addr_guids_->guids_.begin(), limit2 = it->addr_guids_->guids_.end(); it2 != limit2; ++it2) {
-        accumulate_addresses(it->src_guid_, *it2, addrs, directed);
-      }
 #ifdef OPENDDS_SECURITY
       if (local_crypto_handle() != DDS::HANDLE_NIL && separate_message(it->src_guid_.entityId)) {
         addrs.insert(BUNDLING_PLACEHOLDER); // removed in bundle_mapped_meta_submessages
@@ -4200,7 +4197,6 @@ RtpsUdpDataLink::RtpsWriter::gather_heartbeats_i(MetaSubmessageVec& meta_submess
       meta_submessage.sm_.heartbeat_sm().readerId = ENTITYID_UNKNOWN;
       meta_submessage.sm_.heartbeat_sm().firstSN = to_rtps_seqnum(firstSN);
       meta_submessage.sm_.heartbeat_sm().lastSN = to_rtps_seqnum(lastSN);
-      //meta_submessage.addr_guids_ = remote_reader_guids_;
 
       meta_submessages.push_back(meta_submessage);
       meta_submessage.reset_destination();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -560,7 +560,7 @@ private:
     void update_required_acknack_count(const RepoId& id, CORBA::Long current);
 
     RcHandle<SingleSendBuffer> get_send_buff() { return send_buff_; }
-    RcHandle<ConstSharedRepoIdSet> get_remote_reader_guids() { ACE_Guard<ACE_Thread_Mutex> guard(mutex_); return remote_reader_guids_; }
+    RcHandle<ConstSharedRepoIdSet> get_remote_reader_guids() { return remote_reader_guids_; }
   };
   typedef RcHandle<RtpsWriter> RtpsWriter_rch;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -87,6 +87,8 @@ typedef AddressCache<BundlingCacheKey> BundlingCache;
 
 typedef OPENDDS_MAP_CMP(RepoId, SeqReaders, GUID_tKeyLessThan) WriterToSeqReadersMap;
 
+const size_t initial_bundle_size = 32;
+
 class OpenDDS_Rtps_Udp_Export RtpsUdpDataLink
   : public virtual DataLink
   , public virtual InternalDataReaderListener<NetworkInterfaceAddress>
@@ -706,14 +708,14 @@ private:
   };
 
 public:
-  struct BundleStruct {
-    BundleStruct(const AddressCacheEntryProxy& proxy) : proxy_(proxy), size_(0) { submessages_.reserve(32); }
+  struct Bundle {
+    explicit Bundle(const AddressCacheEntryProxy& proxy) : proxy_(proxy), size_(0) { submessages_.reserve(initial_bundle_size); }
     MetaSubmessageIterVec submessages_; // a vectors of iterators pointing to meta_submessages
     AddressCacheEntryProxy proxy_; // a bundle's destination address
     size_t size_; // bundle message size
   };
 
-  typedef OPENDDS_VECTOR(BundleStruct) BundleVec;
+  typedef OPENDDS_VECTOR(Bundle) BundleVec;
 
 private:
   void build_meta_submessage_map(MetaSubmessageVec& meta_submessages, AddrDestMetaSubmessageMap& addr_map);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -679,9 +679,9 @@ private:
   typedef OPENDDS_VECTOR(MetaSubmessageVec::iterator) MetaSubmessageIterVec;
   typedef OPENDDS_MAP_CMP(RepoId, MetaSubmessageIterVec, GUID_tKeyLessThan) DestMetaSubmessageMap;
 #ifdef ACE_HAS_CPP11
-  typedef OPENDDS_UNORDERED_MAP(NetworkAddress, DestMetaSubmessageMap) AddrDestMetaSubmessageMap;
+  typedef OPENDDS_UNORDERED_MAP(AddressCacheEntryProxy, DestMetaSubmessageMap) AddrDestMetaSubmessageMap;
 #else
-  typedef OPENDDS_MAP(NetworkAddress, DestMetaSubmessageMap) AddrDestMetaSubmessageMap;
+  typedef OPENDDS_MAP(AddressCacheEntryProxy, DestMetaSubmessageMap) AddrDestMetaSubmessageMap;
 #endif
   typedef OPENDDS_VECTOR(MetaSubmessageIterVec) MetaSubmessageIterVecVec;
   typedef OPENDDS_SET(CORBA::Long) CountSet;
@@ -707,9 +707,9 @@ private:
 
 public:
   struct BundleStruct {
-    BundleStruct(const NetworkAddress& addr) : addr_(addr), size_(0) { submessages_.reserve(32); }
+    BundleStruct(const AddressCacheEntryProxy& proxy) : proxy_(proxy), size_(0) { submessages_.reserve(32); }
     MetaSubmessageIterVec submessages_; // a vectors of iterators pointing to meta_submessages
-    NetworkAddress addr_; // a bundle's destination address
+    AddressCacheEntryProxy proxy_; // a bundle's destination address
     size_t size_; // bundle message size
   };
 
@@ -730,7 +730,6 @@ private:
   ThreadedRtpsSendQueue sq_;
   ACE_Thread_Mutex fsq_mutex_;
   MetaSubmessageVec fsq_vec_;
-  AddrDestMetaSubmessageMap fsq_addr_map_;
   typedef PmfSporadicTask<RtpsUdpDataLink> Sporadic;
   RcHandle<Sporadic> flush_send_queue_task_;
   void flush_send_queue(const MonotonicTimePoint& now);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -560,6 +560,7 @@ private:
     void update_required_acknack_count(const RepoId& id, CORBA::Long current);
 
     RcHandle<SingleSendBuffer> get_send_buff() { return send_buff_; }
+    RcHandle<ConstSharedRepoIdSet> get_remote_reader_guids() { return remote_reader_guids_; }
   };
   typedef RcHandle<RtpsWriter> RtpsWriter_rch;
 

--- a/tests/unit-tests/dds/DCPS/AddressCache.cpp
+++ b/tests/unit-tests/dds/DCPS/AddressCache.cpp
@@ -11,9 +11,9 @@
 
 using namespace OpenDDS::DCPS;
 
-struct TestKey : public virtual RcObject {
+struct TestKey {
   TestKey(const RepoId& from, const RepoId& to) : from_(from), to_(to) {}
-  TestKey(const TestKey& val) : RcObject(), from_(val.from_), to_(val.to_) {}
+  TestKey(const TestKey& val) : from_(val.from_), to_(val.to_) {}
   bool operator<(const TestKey& rhs) const {
     return std::memcmp(static_cast<const void*>(&from_), static_cast<const void*>(&rhs.from_), 2 * sizeof (RepoId)) < 0;
   }


### PR DESCRIPTION
Remove addr_guids from BundlingCacheKey to improve bundling cache lookup performance and work around for Static Discovery. This allows for AddressCache Key simplification and removes the need for keys to inherit from RcObject. Additionally, this PR combines the three separate bundling vector structures (submessages, sizes, addresses) into a single structure to reduce total number of allocations and improve code clarity.