### PR TITLE
Avoid pragma pack of RcObject

### DIFF
--- a/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/BundlingCacheKey.h
@@ -27,10 +27,9 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
-  BundlingCacheKey(const GUID_t& dst_guid, const GUID_t& src_guid, RcHandle<ConstSharedRepoIdSet> addr_guids)
-    : RcObject()
-    , src_guid_(src_guid)
+struct OpenDDS_Rtps_Udp_Export BundlingCacheKeyCore {
+  BundlingCacheKeyCore(const GUID_t& dst_guid, const GUID_t& src_guid, RcHandle<ConstSharedRepoIdSet> addr_guids)
+    : src_guid_(src_guid)
     , dst_guid_(dst_guid)
     , addr_guids_(addr_guids)
 #if defined ACE_HAS_CPP11
@@ -39,9 +38,8 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
   {
   }
 
-  BundlingCacheKey(const BundlingCacheKey& val)
-    : RcObject()
-    , src_guid_(val.src_guid_)
+  BundlingCacheKeyCore(const BundlingCacheKeyCore& val)
+    : src_guid_(val.src_guid_)
     , dst_guid_(val.dst_guid_)
     , addr_guids_(val.addr_guids_)
 #if defined ACE_HAS_CPP11
@@ -50,7 +48,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
   {
   }
 
-  bool operator<(const BundlingCacheKey& rhs) const
+  bool operator<(const BundlingCacheKeyCore& rhs) const
   {
     int r = std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t));
     if (r < 0) {
@@ -61,7 +59,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
     return false;
   }
 
-  bool operator==(const BundlingCacheKey& rhs) const
+  bool operator==(const BundlingCacheKeyCore& rhs) const
   {
     return std::memcmp(static_cast<const void*>(&src_guid_), static_cast<const void*>(&rhs.src_guid_), 2 * sizeof (GUID_t)) == 0 &&
 #if defined ACE_HAS_CPP11
@@ -70,7 +68,7 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
       addr_guids_->guids_ == rhs.addr_guids_->guids_;
   }
 
-  BundlingCacheKey& operator=(const BundlingCacheKey& rhs)
+  BundlingCacheKeyCore& operator=(const BundlingCacheKeyCore& rhs)
   {
     if (this != &rhs) {
       const_cast<GUID_t&>(src_guid_) = rhs.src_guid_;
@@ -78,13 +76,6 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
       addr_guids_ = rhs.addr_guids_;
     }
     return *this;
-  }
-
-  void get_contained_guids(GuidSet& set) const
-  {
-    set = addr_guids_->guids_;
-    set.insert(src_guid_);
-    set.insert(dst_guid_);
   }
 
   const GUID_t src_guid_;
@@ -103,6 +94,53 @@ struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject {
 };
 
 #pragma pack(pop)
+
+struct OpenDDS_Rtps_Udp_Export BundlingCacheKey : public virtual RcObject, public BundlingCacheKeyCore {
+  BundlingCacheKey(const GUID_t& dst_guid, const GUID_t& src_guid, RcHandle<ConstSharedRepoIdSet> addr_guids)
+    : RcObject()
+    , BundlingCacheKeyCore(dst_guid, src_guid, addr_guids)
+  {
+  }
+
+  BundlingCacheKey(const BundlingCacheKey& val)
+    : RcObject()
+    , BundlingCacheKeyCore(val)
+  {
+  }
+
+  inline bool operator<(const BundlingCacheKey& rhs) const
+  {
+    return BundlingCacheKeyCore::operator<(rhs);
+  }
+
+  bool operator==(const BundlingCacheKey& rhs) const
+  {
+    return BundlingCacheKeyCore::operator==(rhs);
+  }
+
+  BundlingCacheKey& operator=(const BundlingCacheKey& rhs)
+  {
+    if (this != &rhs) {
+      BundlingCacheKeyCore::operator=(rhs);
+    }
+    return *this;
+  }
+
+  void get_contained_guids(GuidSet& set) const
+  {
+    set = addr_guids_->guids_;
+    set.insert(src_guid_);
+    set.insert(dst_guid_);
+  }
+
+#if defined ACE_HAS_CPP11
+  inline size_t calculate_hash()
+  {
+    return BundlingCacheKeyCore::calculate_hash();
+  }
+#endif
+};
+
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
+++ b/dds/DCPS/transport/rtps_udp/LocatorCacheKey.h
@@ -26,38 +26,75 @@ namespace DCPS {
 
 #pragma pack(push, 1)
 
-struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public virtual RcObject {
-  LocatorCacheKey(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
+struct OpenDDS_Rtps_Udp_Export LocatorCacheKeyCore {
+  LocatorCacheKeyCore(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
     : remote_(remote)
     , local_(local)
     , prefer_unicast_(prefer_unicast)
   {
   }
 
-  LocatorCacheKey(const LocatorCacheKey& val)
-    : RcObject()
-    , remote_(val.remote_)
+  LocatorCacheKeyCore(const LocatorCacheKeyCore& val)
+    : remote_(val.remote_)
     , local_(val.local_)
     , prefer_unicast_(val.prefer_unicast_)
   {
   }
 
-  bool operator<(const LocatorCacheKey& rhs) const
+  bool operator<(const LocatorCacheKeyCore& rhs) const
   {
     return std::memcmp(static_cast<const void*>(&remote_), static_cast<const void*>(&rhs.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) < 0;
   }
 
-  bool operator==(const LocatorCacheKey& rhs) const
+  bool operator==(const LocatorCacheKeyCore& rhs) const
   {
     return std::memcmp(static_cast<const void*>(&remote_), static_cast<const void*>(&rhs.remote_), 2 * sizeof (OpenDDS::DCPS::GUID_t) + sizeof (bool)) == 0;
   }
 
-  LocatorCacheKey& operator=(const LocatorCacheKey& rhs)
+  LocatorCacheKeyCore& operator=(const LocatorCacheKeyCore& rhs)
   {
     if (this != &rhs) {
       const_cast<GUID_t&>(remote_) = rhs.remote_;
       const_cast<GUID_t&>(local_) = rhs.local_;
       const_cast<bool&>(prefer_unicast_) = rhs.prefer_unicast_;
+    }
+    return *this;
+  }
+
+  const GUID_t remote_;
+  const GUID_t local_;
+  const bool prefer_unicast_;
+};
+
+#pragma pack(pop)
+
+struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public virtual RcObject, public LocatorCacheKeyCore {
+  LocatorCacheKey(const GUID_t& remote, const GUID_t& local, bool prefer_unicast)
+    : RcObject()
+    , LocatorCacheKeyCore(remote, local, prefer_unicast)
+  {
+  }
+
+  LocatorCacheKey(const LocatorCacheKey& val)
+    : RcObject()
+    , LocatorCacheKeyCore(val)
+  {
+  }
+
+  inline bool operator<(const LocatorCacheKey& rhs) const
+  {
+    return LocatorCacheKeyCore::operator<(rhs);
+  }
+
+  inline bool operator==(const LocatorCacheKey& rhs) const
+  {
+    return LocatorCacheKeyCore::operator==(rhs);
+  }
+
+  LocatorCacheKey& operator=(const LocatorCacheKey& rhs)
+  {
+    if (this != &rhs) {
+      LocatorCacheKeyCore::operator=(rhs);
     }
     return *this;
   }
@@ -68,13 +105,7 @@ struct OpenDDS_Rtps_Udp_Export LocatorCacheKey : public virtual RcObject {
     set.insert(remote_);
     set.insert(local_);
   }
-
-  const GUID_t remote_;
-  const GUID_t local_;
-  const bool prefer_unicast_;
 };
-
-#pragma pack(pop)
 
 }
 }


### PR DESCRIPTION
It seems like older compilers don't like this?