### PR TITLE
StaticDiscovery shutdown looks like startup

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -923,11 +923,6 @@ private:
 
   RcHandle<InternalDataReader<NetworkInterfaceAddress> > network_interface_address_reader_;
   MulticastManager multicast_manager_;
-
-  void send_interesting_ack_nack(const RepoId& writerid,
-                                 const RepoId& readerid,
-                                 CORBA::Long count,
-                                 MetaSubmessageVec& meta_submessages);
 };
 
 } // namespace DCPS

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -92,6 +92,9 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
           it->second.insert(0);
         }
       }
+
+      ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from writer %C)\n", OpenDDS::DCPS::LogGuid(reader_guid_).c_str(), received_samples_, message.value, OpenDDS::DCPS::LogGuid(writer_guid).c_str()));
+
       if (reliable_ && !it->second.empty()) {
         int expected = *(it->second.rbegin()) + 1;
         if (message.value != expected) {
@@ -101,7 +104,6 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
       }
       it->second.insert(message.value);
 
-      ACE_DEBUG((LM_INFO, "(%P|%t) Reader %C got message %d (#%d from writer %C)\n", OpenDDS::DCPS::LogGuid(reader_guid_).c_str(), received_samples_, message.value, OpenDDS::DCPS::LogGuid(writer_guid).c_str()));
       if (++received_samples_ == expected_samples_) {
         done_callback_(builtin_read_error_, reader_guid_);
       }

--- a/tests/DCPS/StaticDiscovery/run_test.pl
+++ b/tests/DCPS/StaticDiscovery/run_test.pl
@@ -149,7 +149,7 @@ sub runTest {
     print "Spawning $alpha_count alphas\n";
 
     for (my $i = 0; $i != $alpha_count; ++$i) {
-        $test->process("alpha$i", 'StaticDiscoveryTest', "-ORBVerboseLogging 1 -DCPSDebugLevel 1 -ORBLogFile alpha_$i.log -DCPSConfigFile config.ini -reliable $reliable $alpha_participant_array[$i] @{$alpha_reader_array[$i]} @{$alpha_writer_array[$i]} -total_readers $readers -total_writers $writers");
+        $test->process("alpha$i", 'StaticDiscoveryTest', "-ORBVerboseLogging 1 -DCPSDebugLevel 1 -DCPSTransportDebugLevel 1 -ORBLogFile alpha_$i.log -DCPSConfigFile config.ini -reliable $reliable $alpha_participant_array[$i] @{$alpha_reader_array[$i]} @{$alpha_writer_array[$i]} -total_readers $readers -total_writers $writers");
         $test->start_process("alpha$i");
     }
 
@@ -158,7 +158,7 @@ sub runTest {
     print "Spawning $beta_count betas\n";
 
     for (my $i = 0; $i != $beta_count; ++$i) {
-        $test->process("beta$i", 'StaticDiscoveryTest', "-ORBVerboseLogging 1 -DCPSDebugLevel 1 -ORBLogFile beta_$i.log -DCPSConfigFile config.ini -reliable $reliable $beta_participant_array[$i] @{$beta_reader_array[$i]} @{$beta_writer_array[$i]} -total_readers $readers -total_writers $writers");
+        $test->process("beta$i", 'StaticDiscoveryTest', "-ORBVerboseLogging 1 -DCPSDebugLevel 1 -DCPSTransportDebugLevel 1 -ORBLogFile beta_$i.log -DCPSConfigFile config.ini -reliable $reliable $beta_participant_array[$i] @{$beta_reader_array[$i]} @{$beta_writer_array[$i]} -total_readers $readers -total_writers $writers");
         $test->start_process("beta$i");
     }
 


### PR DESCRIPTION
Problem
-------

Due to lazy loading in the transport framework, StaticDiscovery
"simulates" heartbeats and acknacks to drive discovery.  That is,
StaticDiscovery declares local writer/remote reader and local
reader/remote writer pairs to the RtpsUdpDataLink.  The datalink sends
heartbeats and acknacks for local writers and readers.  When activity
from the remote is detected (which may be simulated), the association
is added and the local writer/reader is created.

When a writer or reader is deleted, the data link resumes this
behavior, i.e., it sends heartbeats for writers that don't exist and
acknacks for readers that don't exist.  These messages can causes the
association to be added again.  For tests that rely on the
publication/subscription match status, this presents a problem since
they will need to wait an additional cycle (10 times the heartbeat
period) to shutdown.

Solution
--------

Do not send acknacks for readers that don't exist.