### PR TITLE
Fix Issues with DynamicTypes run_test.pl

### DIFF
--- a/tests/DCPS/DynamicTypes/run_test.pl
+++ b/tests/DCPS/DynamicTypes/run_test.pl
@@ -2,48 +2,71 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
      & eval 'exec perl -S $0 $argv:q'
      if 0;
 
+use strict;
+
 use lib "$ENV{ACE_ROOT}/bin";
 use lib "$ENV{DDS_ROOT}/bin";
 use PerlDDS::Run_Test;
-use Getopt::Long;
-use strict;
-
-my $test = new PerlDDS::TestFramework();
-$test->enable_console_logging();
-
-my $status = 0;
 
 sub run_test {
-  my @test_name_params = ("my_struct", "outer_struct", "inner_union", "outer_union");
-  my @test_extensibilities = ("_final", "_appendable", "_mutable");
-  my @xcdr_version_params = ("1", "2");
+  my $type = shift;
+  my $extensibility = shift;
+  my $xcdr = shift;
 
-  foreach my $test_name_param(@test_name_params) {
-    foreach my $test_extensibility(@test_extensibilities) {
-      foreach my $xcdr_version_param(@xcdr_version_params) {
-        if ($xcdr_version_param != "1" || $test_extensibility != "_mutable") {
-          my $reader_name = "reader_$test_name_param" . $test_extensibility . "_XCDR$xcdr_version_param";
-          my $writer_name = "writer_$test_name_param" . $test_extensibility . "_XCDR$xcdr_version_param";
-          my @reader_args = ($test_name_param . "$test_extensibility $xcdr_version_param -DCPSConfigFile rtps_disc.ini -ORBLogFile recorder_$reader_name.log -ORBDebugLevel 10 -DCPSDebugLevel 10");
-          my @writer_args = ($test_name_param . "$test_extensibility $xcdr_version_param -DCPSConfigFile rtps_disc.ini -ORBLogFile publisher_$writer_name.log -ORBDebugLevel 10 -DCPSDebugLevel 10");
-          $test->process($reader_name, './Recorder/xtypes_dynamic_recorder', join(' ', @reader_args));
-          $test->start_process($reader_name);
 
-          $test->process($writer_name, './Pub/xtypes_dynamic_pub', join(' ', @writer_args));
-          $test->start_process($writer_name);
+  my $test_name = "${type}_${extensibility}_XCDR$xcdr";
+  my @common_args = (
+    "${type}_${extensibility}",
+    $xcdr,
+    '-DCPSConfigFile rtps_disc.ini',
+    '-ORBDebugLevel 10 -DCPSDebugLevel 10',
+    '-ORBLogFile',
+  );
+  my $reader_name = "reader_$test_name";
+  my @reader_args = (@common_args, "$reader_name.log");
+  my $writer_name = "writer_$test_name";
+  my @writer_args = (@common_args, "$writer_name.log");
 
-          $status |= $test->wait_kill($reader_name, 15);
-          $status |= $test->wait_kill($writer_name, 15);
-        }
+  my $test = new PerlDDS::TestFramework();
+  $test->enable_console_logging();
+
+  $test->process($reader_name, './Recorder/xtypes_dynamic_recorder', join(' ', @reader_args));
+  $test->start_process($reader_name);
+
+  $test->process($writer_name, './Pub/xtypes_dynamic_pub', join(' ', @writer_args));
+  $test->start_process($writer_name);
+
+  my $failed = 0;
+  $failed |= $test->wait_kill($reader_name, 15);
+  $failed |= $test->wait_kill($writer_name, 15);
+  $failed |= $test->finish(60);
+  if ($failed) {
+    print STDERR "ERROR: $test_name failed\n";
+    return 1;
+  }
+  return 0;
+}
+
+my $total_tests = 0;
+my $failed_tests = 0;
+my @types = ("my_struct", "outer_struct", "inner_union", "outer_union");
+my @extensibilities = ("final", "appendable", "mutable");
+my @xcdrs = ("1", "2");
+
+foreach my $type (@types) {
+  foreach my $extensibility (@extensibilities) {
+    foreach my $xcdr (@xcdrs) {
+      if (!($xcdr eq "1" && $extensibility eq "mutable")) {
+        $total_tests++;
+        $failed_tests++ if (run_test($type, $extensibility, $xcdr));
       }
     }
   }
 }
 
-run_test();
-
-if ($status) {
-  print STDERR "ERROR: test failed\n";
+print "$total_tests tests ran\n";
+if ($failed_tests) {
+  print STDERR "ERROR: $failed_tests test(s) failed\n";
 }
 
-exit $test->finish(60);
+exit($failed_tests ? 1 : 0);


### PR DESCRIPTION
- When one subtest fails, it appears the logs for all the subtests are
  dumped. This is fixed by using a separate TestFramework for each
  subtest.
- Using `!=` to compare string instead of `ne` caused 8 out of the 20
  subtests to be skipped.

These changes also appear to have the side effect of fixing an issue the
test has on the scoreboard, but I'm still investigating that.