### PR TITLE
Fix Jekyll Template Issue from #3551

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _site
 vendor
 .vscode/
 /Gemfile.lock
+/.bundle

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ bundle exec jekyll serve
 
 It will print the URL of the locally hosted site.
 
+## Running `htmlproofer.sh` Locally
+
+[`htmlproofer.sh'](htmlproofer.sh) is a wrapper around
+[the html-proofer Ruby program](https://github.com/gjtorikian/html-proofer).
+
+It is run as part of GitHub Actions workflow on this branch, but can be run
+locally by first building the site:
+
+```
+bundle exec jekyll serve
+```
+
+A `\_site` directory will appear, and then the script can be run on it:
+
+```
+bash htmlproofer.sh
+```
+
 ### GitHub API Limits
 
 Generating the site uses the GitHub API, which [has limits for unauthorized

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ It will print the URL of the locally hosted site.
 
 ## Running `htmlproofer.sh` Locally
 
-[`htmlproofer.sh'](htmlproofer.sh) is a wrapper around
-[the html-proofer Ruby program](https://github.com/gjtorikian/html-proofer).
+[`htmlproofer.sh`](htmlproofer.sh) is a wrapper around
+[html-proofer](https://github.com/gjtorikian/html-proofer).
 
 It is run as part of GitHub Actions workflow on this branch, but can be run
 locally by first building the site:
 
 ```
-bundle exec jekyll serve
+bundle exec jekyll build
 ```
 
 A `\_site` directory will appear, and then the script can be run on it:

--- a/_includes/foundation_minutes_sidebar.html
+++ b/_includes/foundation_minutes_sidebar.html
@@ -4,8 +4,8 @@ reverse %}
   <div class="minutes-sidebar-content">
     <h2>MINUTES ARCHIVE</h2>
     <ul>
-      {% assign groups = sorted_pages | group_by_exp:"item", 'item.date | date:
-      "%Y"' %} {% for group in groups %}
+      {% assign groups = sorted_pages | group_by_exp:"item", 'item.date | date: "%Y"' %}
+      {% for group in groups %}
 
       <h4>{{ group.name }}</h4>
       {% for p in group.items %}
@@ -15,7 +15,7 @@ reverse %}
         </a>
       </li>
       {% endfor %}
+      {% endfor %}
     </ul>
-    {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
Fix Jeykell template that produces a malformed `<ul>` element when there
are minutes entries in the "Minutes Archive" Box for multiple years.

Also added instructions on how to run `htmlproofer.sh` locally because
they were not there before and I had re-figure out how to run it.