### PR TITLE
StaticDiscovery mpmrmw generates too much load

### DIFF
--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.cpp
@@ -84,7 +84,15 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
     if (info.valid_data) {
       DDS::Subscriber_var subscriber = reader->get_subscriber();
       DDS::DomainParticipant_var participant = subscriber->get_participant();
-      const OpenDDS::DCPS::GUID_t writer_guid = dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant.in())->get_repoid(info.publication_handle);
+      OpenDDS::DCPS::DomainParticipantImpl* participant_impl = dynamic_cast<OpenDDS::DCPS::DomainParticipantImpl*>(participant.in());
+      if (!participant_impl) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("ERROR: %N:%l: on_data_available() -")
+                   ACE_TEXT(" could not cast participant!\n")));
+        ACE_OS::exit(-1);
+        return;
+      }
+      const OpenDDS::DCPS::GUID_t writer_guid = participant_impl->get_repoid(info.publication_handle);
       SampleSetMap::iterator it = guid_received_samples_.find(writer_guid);
       if (it == guid_received_samples_.end()) {
         it = guid_received_samples_.insert(SampleSetMap::value_type(writer_guid, std::set<int>())).first;

--- a/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
+++ b/tests/DCPS/StaticDiscovery/DataReaderListenerImpl.h
@@ -24,7 +24,8 @@ class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
 public:
   DataReaderListenerImpl(const std::string& id, bool reliable, bool expect_all_samples, const int total_writers, const int expected_samples, callback_t done_callback, bool check_bits)
-    : id_(id)
+    : reader_guid_(OpenDDS::DCPS::GUID_UNKNOWN)
+    , id_(id)
     , reliable_(reliable)
     , expect_all_samples_(expect_all_samples)
     , total_writers_(total_writers)

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -124,7 +124,14 @@ public:
                        -1);
     }
 
-    const OpenDDS::DCPS::GUID_t writer_guid = dynamic_cast<OpenDDS::DCPS::DataWriterImpl*>(writer.in())->get_repo_id();
+    OpenDDS::DCPS::DataWriterImpl* writer_impl = dynamic_cast<OpenDDS::DCPS::DataWriterImpl*>(writer.in());
+    if (!writer_impl) {
+      ACE_ERROR_RETURN((LM_ERROR,
+                        ACE_TEXT("ERROR: %N:%l: main() -")
+                        ACE_TEXT(" casting datawriter failed!\n")),
+                       -1);
+    }
+    const OpenDDS::DCPS::GUID_t writer_guid = writer_impl->get_repo_id();
 
     ACE_DEBUG((LM_INFO, "(%P|%t) DataWriter %C created\n", OpenDDS::DCPS::LogGuid(writer_guid).c_str()));
 
@@ -368,7 +375,13 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                           ACE_TEXT(" create_datareader failed!\n")), -1);
       }
 
-      drl_impl->set_guid(dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader.in())->get_repo_id());
+      OpenDDS::DCPS::DataReaderImpl* reader_impl = dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader.in());
+      if (!reader_impl) {
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("ERROR: %N:%l: main() -")
+                          ACE_TEXT(" casting datareader failed!\n")), -1);
+      }
+      drl_impl->set_guid(reader_impl->get_repo_id());
 
       datareaders.push_back(reader);
 

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -405,7 +405,7 @@ tests/DCPS/StaticDiscovery/run_test.pl mp: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP
 tests/DCPS/StaticDiscovery/run_test.pl mp delay: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscovery/run_test.pl mr: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscovery/run_test.pl mw: !DCPS_MIN !NO_MCAST !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/StaticDiscovery/run_test.pl mpmrmw: !DCPS_MIN !NO_MCAST !TARGET !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/StaticDiscovery/run_test.pl mini: !DCPS_MIN !NO_MCAST !TARGET !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/StaticDiscoveryReconnect/run_test.pl: !DCPS_MIN !NO_MCAST !GH_ACTIONS_M10
 tests/DCPS/SubscriberCycle/run_test.pl: !DCPS_MIN !DDS_NO_CONTENT_FILTERED_TOPIC !DDS_NO_CONTENT_SUBSCRIPTION !DDS_NO_OWNERSHIP_PROFILE
 


### PR DESCRIPTION
Problem
-------

Tests on Windows buildfarm VMs show that the StaticDiscovery mpmrmw
configuration may be generating too much load.

Solution
--------

Use a smaller configuration.