### PR TITLE
RtpsRelay reports error when participant cannot be found for removal

### DIFF
--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -47,7 +47,7 @@ void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& prox
 
   const auto pos = guids_.find(repoid);
   if (pos == guids_.end()) {
-    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+    ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: "
                "RelayParticipantStatusReporter::remove_participant participant %C not found\n",
                guid_to_string(repoid).c_str()));
     return;


### PR DESCRIPTION
Problem
-------

The RelayParticipantStatusReport issues a warning when removing a
participant.  If the participant has already been removed, then it
probably indicates a bug in discovery and/or the builtin topics.
However, the RtpsRelay will continue to operate correctly.

Solution
--------

Downgrade to a warning.