### PR TITLE
Updated the XTypes test's mpc file

### DIFF
--- a/tests/DCPS/XTypes/XTypes.mpc
+++ b/tests/DCPS/XTypes/XTypes.mpc
@@ -2,6 +2,13 @@ project(*Subscriber): dcps_test, dcps_rtps_udp, msvc_bigobj, dcps_transports_for
 
   exename = subscriber
 
+  IDL_Files {
+    Common.idl
+    Subscriber.idl
+    CommonTypeSupport.idl
+    SubscriberTypeSupport.idl
+  }
+
   TypeSupport_Files {
     Common.idl
     Subscriber.idl
@@ -16,6 +23,13 @@ project(*Publisher): dcps_test, dcps_rtps_udp, msvc_bigobj, dcps_transports_for_
 
   exename = publisher
   after += *Subscriber
+
+  IDL_Files {
+    Common.idl
+    Publisher.idl
+    CommonTypeSupport.idl
+    PublisherTypeSupport.idl
+  }
 
   TypeSupport_Files {
     Common.idl


### PR DESCRIPTION
IDL_Files need to be listed explicitly because two projects share the
directory.  If this is left defaulted, all *.idl files that exist at
the time projects are generated are included.  This leads to different
projects depending on when they are generated - before or after a
build is run.