### PR TITLE
Status flag race leads to missing listener invocation

### DIFF
--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -2009,9 +2009,9 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
         sub->listener_for(DDS::DATA_ON_READERS_STATUS);
     if (!CORBA::is_nil(sub_listener.in()) && !coherent_) {
       if (!is_bit()) {
+        sub->set_status_changed_flag(DDS::DATA_ON_READERS_STATUS, false);
         ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
         sub_listener->on_data_on_readers(sub.in());
-        sub->set_status_changed_flag(DDS::DATA_ON_READERS_STATUS, false);
       } else {
         TheServiceParticipant->job_queue()->enqueue(make_rch<OnDataOnReaders>(sub, sub_listener, rchandle_from(static_cast<DataReaderImpl*>(this)), true, false));
       }
@@ -2023,10 +2023,10 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
 
       if (!CORBA::is_nil(listener.in())) {
         if (!is_bit()) {
-          ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
-          listener->on_data_available(this);
           set_status_changed_flag(DDS::DATA_AVAILABLE_STATUS, false);
           sub->set_status_changed_flag(DDS::DATA_ON_READERS_STATUS, false);
+          ACE_GUARD(typename DataReaderImpl::Reverse_Lock_t, unlock_guard, reverse_sample_lock_);
+          listener->on_data_available(this);
         } else {
           TheServiceParticipant->job_queue()->enqueue(make_rch<OnDataAvailable>(listener, rchandle_from(static_cast<DataReaderImpl*>(this)), true, true, true));
         }

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -577,10 +577,10 @@ SubscriberImpl::notify_datareaders()
     if (it->second->have_sample_states(DDS::NOT_READ_SAMPLE_STATE)) {
       DDS::DataReaderListener_var listener = it->second->get_listener();
       if (!it->second->is_bit()) {
+        it->second->set_status_changed_flag(DDS::DATA_AVAILABLE_STATUS, false);
         if (listener) {
           listener->on_data_available(it->second.in());
         }
-        it->second->set_status_changed_flag(DDS::DATA_AVAILABLE_STATUS, false);
       } else {
         TheServiceParticipant->job_queue()->enqueue(make_rch<DataReaderImpl::OnDataAvailable>(listener, it->second, listener, true, false));
       }
@@ -613,10 +613,10 @@ SubscriberImpl::notify_datareaders()
 
     if (dri->have_sample_states(DDS::NOT_READ_SAMPLE_STATE)) {
       DDS::DataReaderListener_var listener = dri->get_listener();
+      dri->set_status_changed_flag(DDS::DATA_AVAILABLE_STATUS, false);
       if (!CORBA::is_nil(listener)) {
         listener->on_data_available(dri);
       }
-      dri->set_status_changed_flag(DDS::DATA_AVAILABLE_STATUS, false);
     }
   }
 #endif

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -26,6 +26,9 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::NOT_READ_SAMPLE_STATE,
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
+  if (ret == DDS::RETCODE_NO_DATA) {
+    return;
+  }
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ParticipantListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -38,6 +38,9 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::NOT_READ_SAMPLE_STATE,
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
+  if (ret == DDS::RETCODE_NO_DATA) {
+    return;
+  }
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: PublicationListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -38,6 +38,9 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
                                    DDS::NOT_READ_SAMPLE_STATE,
                                    DDS::ANY_VIEW_STATE,
                                    DDS::ANY_INSTANCE_STATE);
+  if (ret == DDS::RETCODE_NO_DATA) {
+    return;
+  }
   if (ret != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: SubscriptionListener::on_data_available failed to take %C\n"), OpenDDS::DCPS::retcode_to_string(ret)));
     return;


### PR DESCRIPTION
Problem
-------

Invocation of listeners for builtin topics is asynchronous.  Before,
invoking the listener, it checks for the DATA_AVAILABLE_STATUS flag
and then resets it after the listener is invoked.  This creates a race
condition where a new sample could be inserted before the listener
completes.  At that point, the status is incorrect and the listener
will not be called.

Solution
--------

Clear the status flag before invoking the listener.