### PR TITLE
Delay SPDP Periodic Tasks Enable To After Init Flag Set

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2185,7 +2185,6 @@ Spdp::init_bit(DCPS::RcHandle<DCPS::BitSubscriber> bit_subscriber)
   // Defer initilization until we have the bit subscriber.
   sedp_->init(guid_, *disco_, domain_, type_lookup_service_);
   tport_->open(sedp_->reactor_task(), sedp_->job_queue());
-  tport_->enable_periodic_tasks();
 
 #ifdef OPENDDS_SECURITY
   DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = sedp_->get_ice_endpoint();
@@ -2196,6 +2195,7 @@ Spdp::init_bit(DCPS::RcHandle<DCPS::BitSubscriber> bit_subscriber)
 #endif
 
   initialized_flag_ = true;
+  tport_->enable_periodic_tasks();
 }
 
 void


### PR DESCRIPTION
Problem: For slower startups (e.g. ASAN) sometimes the SPDP initialization_flag_ is still false when SPDP announcements are received for multiple processes started at the same time (all processes miss initial send, causing a delay until the next SPDP announcement).

Solution: Delay periodic task enables until after local initialization flag has been set, ensuring at least one of the processes will see and fully process and announcement.