### PR TITLE
RtpsUdpSendStrategy sporadically reports failure to encode submessage

### DIFF
--- a/dds/DCPS/security/CryptoBuiltInImpl.cpp
+++ b/dds/DCPS/security/CryptoBuiltInImpl.cpp
@@ -1386,7 +1386,6 @@ bool CryptoBuiltInImpl::encode_submessage(
   NativeCryptoHandle sender_handle,
   SecurityException& ex)
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   const KeyTable_t::const_iterator iter = keys_.find(sender_handle);
   if (iter == keys_.end()) {
     encoded_rtps_submessage = plain_rtps_submessage;
@@ -1524,8 +1523,6 @@ bool CryptoBuiltInImpl::encode_datawriter_submessage(
     }
   }
 
-  guard.release();
-
   const bool ok = encode_submessage(encoded_rtps_submessage,
                                     plain_rtps_submessage, encode_handle, ex);
   if (ok) {
@@ -1552,8 +1549,8 @@ bool CryptoBuiltInImpl::encode_datareader_submessage(
   }
 
   NativeCryptoHandle encode_handle = sending_datareader_crypto;
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
   if (receiving_datawriter_crypto_list.length() == 1) {
-    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     const KeyTable_t::const_iterator iter = keys_.find(encode_handle);
     if (iter != keys_.end()) {
       const KeySeq& dr_keys = iter->second;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpSendStrategy.h
@@ -108,14 +108,16 @@ private:
     DDS::OctetSeq encoded_;
   };
 
-  bool encode_writer_submessage(const RepoId& receiver,
+  bool encode_writer_submessage(const GUID_t& sender,
+                                const GUID_t& receiver,
                                 OPENDDS_VECTOR(Chunk)& replacements,
                                 DDS::Security::CryptoTransform* crypto,
                                 const DDS::OctetSeq& plain,
                                 DDS::Security::DatawriterCryptoHandle sender_dwch,
                                 const char* submessage_start, CORBA::Octet msgId);
 
-  bool encode_reader_submessage(const RepoId& receiver,
+  bool encode_reader_submessage(const GUID_t& sender,
+                                const GUID_t& receiver,
                                 OPENDDS_VECTOR(Chunk)& replacements,
                                 DDS::Security::CryptoTransform* crypto,
                                 const DDS::OctetSeq& plain,


### PR DESCRIPTION
Problem
-------

The RtpsUdpSendStrategy sporadically reports an error when encoding a
submessage.  The submessage kind is a heartbeat so it must be a
writer.  Review of the code shows that it is probably the volatile
writer.

Solution
--------

Improve the logging to confirm it is the volatile writer and narrow
down the root cause.  The two possible causes are:

1. Sending to `GUID_UNKNOWN` which is a bug in the RtpsUdpDataLink.

2. No crypto handle for the remote datareader.  This could be caused
   by a race condition where the heartbeat (presumably caused by
   association) is sent before the handle is in place.

Also, improve the atomicity in the Crypto plugin.