### PR TITLE
Implement More Aggressive ASAN Options

### DIFF
--- a/configure
+++ b/configure
@@ -1014,8 +1014,9 @@ my %all_sanitizers = (
     fsanitize => 'address',
     env => {
       LSAN_OPTIONS => "suppressions=$FindBin::RealBin/etc/asan-suppr.txt",
-      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0',
+      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1',
     },
+    compiler_args => ['-fsanitize-address-use-after-scope'],
   },
   tsan => {
     fsanitize => 'thread',

--- a/configure
+++ b/configure
@@ -1014,7 +1014,7 @@ my %all_sanitizers = (
     fsanitize => 'address',
     env => {
       LSAN_OPTIONS => "suppressions=$FindBin::RealBin/etc/asan-suppr.txt",
-      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1',
+      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1::check_initialization_order=1:strict_init_order=1',
     },
     compiler_args => ['-fsanitize-address-use-after-scope'],
   },

--- a/configure
+++ b/configure
@@ -1014,7 +1014,7 @@ my %all_sanitizers = (
     fsanitize => 'address',
     env => {
       LSAN_OPTIONS => "suppressions=$FindBin::RealBin/etc/asan-suppr.txt",
-      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1::check_initialization_order=1:strict_init_order=1',
+      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1',
     },
     compiler_args => ['-fsanitize-address-use-after-scope'],
   },

--- a/configure
+++ b/configure
@@ -1014,7 +1014,7 @@ my %all_sanitizers = (
     fsanitize => 'address',
     env => {
       LSAN_OPTIONS => "suppressions=$FindBin::RealBin/etc/asan-suppr.txt",
-      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1',
+      ASAN_OPTIONS => 'detect_leaks=1:fast_unwind_on_malloc=0:strict_string_checks=1:detect_stack_use_after_return=1',
     },
     compiler_args => ['-fsanitize-address-use-after-scope'],
   },

--- a/dds/DCPS/TimeDuration.inl
+++ b/dds/DCPS/TimeDuration.inl
@@ -27,7 +27,7 @@ TimeDuration::from_double(double duration)
 
 ACE_INLINE
 TimeDuration::TimeDuration()
-: value_(zero_value.value())
+: value_(ACE_Time_Value())
 {
 }
 

--- a/dds/DCPS/debug.cpp
+++ b/dds/DCPS/debug.cpp
@@ -21,6 +21,11 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+#ifndef OPENDDS_UTIL_BUILD
+OpenDDS_Dcps_Export unsigned int Transport_debug_level = 0;
+OpenDDS_Dcps_Export TransportDebug transport_debug;
+#endif
+
 OpenDDS_Dcps_Export LogLevel log_level(LogLevel::Warning);
 OpenDDS_Dcps_Export unsigned int DCPS_debug_level = 0;
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/debug.h
+++ b/dds/DCPS/debug.h
@@ -78,6 +78,13 @@ extern OpenDDS_Dcps_Export unsigned int DCPS_debug_level;
 /// This function allows for possible side-effects of setting the level.
 extern void OpenDDS_Dcps_Export set_DCPS_debug_level(unsigned int lvl);
 
+#ifndef OPENDDS_UTIL_BUILD
+/// Transport Logging verbosity level.
+// This needs to be initialized somewhere.
+extern OpenDDS_Dcps_Export unsigned int Transport_debug_level;
+extern OpenDDS_Dcps_Export TransportDebug transport_debug;
+#endif
+
 #ifdef OPENDDS_SECURITY
 /**
  * Global Security Debug Settings

--- a/dds/DCPS/transport/framework/TransportDebug.cpp
+++ b/dds/DCPS/transport/framework/TransportDebug.cpp
@@ -14,8 +14,6 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-OpenDDS_Dcps_Export unsigned int Transport_debug_level = 0;
-
 TransportDebug::TransportDebug()
   : log_messages(false)
   , log_progress(false)
@@ -24,8 +22,6 @@ TransportDebug::TransportDebug()
   , log_fragment_storage(false)
   , log_remote_counts(false)
 {}
-
-OpenDDS_Dcps_Export TransportDebug transport_debug;
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/tests/DCPS/BuiltInTopicTest/.gitignore
+++ b/tests/DCPS/BuiltInTopicTest/.gitignore
@@ -4,4 +4,5 @@
 /test_run.data
 /test_run_prst.data
 /monitor1_done
+/monitor2_done
 /info.pr

--- a/tests/DCPS/Ownership/publisher.cpp
+++ b/tests/DCPS/Ownership/publisher.cpp
@@ -29,7 +29,7 @@ DDS::Duration_t deadline = {DDS::DURATION_INFINITE_SEC,
 DDS::Duration_t liveliness = {DDS::DURATION_INFINITE_SEC,
                               DDS::DURATION_INFINITE_NSEC};
 ACE_Time_Value dds_delay(1);
-ACE_Time_Value reset_delay(ACE_Time_Value::zero);
+ACE_Time_Value reset_delay; // default is zero
 int ownership_strength = 0;
 int reset_ownership_strength = -1;
 ACE_CString ownership_dw_id = "OwnershipDataWriter";

--- a/tests/DCPS/XTypes/.gitignore
+++ b/tests/DCPS/XTypes/.gitignore
@@ -42,3 +42,6 @@ SubscriberTypeSupportS.h
 
 publisher
 subscriber
+
+/governance.xml
+/governance.xml.p7s


### PR DESCRIPTION
We're currently not taking advantage of all the checks that AddressSanitizer can make. This PR updates our AddressSanitizer builds to do additional checks including stack use after return and initialization order checking, as well as a few fixes for issues discovered.

One of the issues discovered exists in ACE static member initialization, so this PR will also need [that fix](https://github.com/DOCGroup/ACE_TAO/pull/1879) in order to successfully pass all tests.