### PR TITLE
Fix Edge-Case Build Errors For RapidJson + SafetyProfile

### DIFF
--- a/MPC/config/optional_rtps_relay_lib.mpb
+++ b/MPC/config/optional_rtps_relay_lib.mpb
@@ -1,2 +1,2 @@
-feature(!no_cxx11,no_opendds_safety_profile): rtps_relay_lib {
+feature(!no_cxx11, no_opendds_safety_profile): rtps_relay_lib {
 }

--- a/MPC/config/optional_rtps_relay_lib.mpb
+++ b/MPC/config/optional_rtps_relay_lib.mpb
@@ -1,2 +1,2 @@
-feature(!no_cxx11): rtps_relay_lib {
+feature(!no_cxx11,no_opendds_safety_profile): rtps_relay_lib {
 }

--- a/configure
+++ b/configure
@@ -1366,7 +1366,10 @@ if (exists $opts{'gtest'} || $tests) {
       $gtest_root = File::Spec->catdir($sm_dir, 'build', 'install');
       $build_gtest = ! -d $gtest_root;
       $opts{'gtest'} = $sm_dir;
-      # No need to set env. variable with submodule.
+      # No need to set env. variable with submodule UNLESS we're in safetyprofile
+      if ($opts{'safety-profile'}) {
+        setEnv('GTEST_ROOT', $gtest_root);
+      }
     }
     elsif (-f File::Spec->catfile($sys_dir, $gtest_sanity)) {
       $opts{'gtest'} = $sys_dir;

--- a/configure
+++ b/configure
@@ -1368,6 +1368,7 @@ if (exists $opts{'gtest'} || $tests) {
       $opts{'gtest'} = $sm_dir;
       # No need to set env. variable with submodule UNLESS we're in safetyprofile
       if ($opts{'safety-profile'}) {
+        print "Setting GTEST_ROOT to ${gtest_root} for use in safety-profile.\n" if $opts{'verbose'};
         setEnv('GTEST_ROOT', $gtest_root);
       }
     }

--- a/tests/DCPS/Observer/TestObserver.cpp
+++ b/tests/DCPS/Observer/TestObserver.cpp
@@ -156,6 +156,7 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 void TestObserver::on_sample_sent(DDS::DataWriter_ptr w, const Sample& s)
 {
+  ACE_UNUSED_ARG(s);
   ++sent_;
   std::cout << "on_sample_sent " << sent_ << to_str(w) <<
 #if OPENDDS_HAS_JSON_VALUE_WRITER
@@ -166,6 +167,7 @@ void TestObserver::on_sample_sent(DDS::DataWriter_ptr w, const Sample& s)
 
 void TestObserver::on_sample_received(DDS::DataReader_ptr r, const Sample& s)
 {
+  ACE_UNUSED_ARG(s);
   ++received_;
   std::cout << "on_sample_received " << received_ << to_str(r) <<
 #if OPENDDS_HAS_JSON_VALUE_WRITER
@@ -176,6 +178,7 @@ void TestObserver::on_sample_received(DDS::DataReader_ptr r, const Sample& s)
 
 void TestObserver::on_sample_read(DDS::DataReader_ptr r, const Sample& s)
 {
+  ACE_UNUSED_ARG(s);
   ++read_;
   std::cout << "on_sample_read " << read_ << to_str(r) <<
 #if OPENDDS_HAS_JSON_VALUE_WRITER
@@ -186,6 +189,7 @@ void TestObserver::on_sample_read(DDS::DataReader_ptr r, const Sample& s)
 
 void TestObserver::on_sample_taken(DDS::DataReader_ptr r, const Sample& s)
 {
+  ACE_UNUSED_ARG(s);
   ++taken_;
   std::cout << "on_sample_taken " << taken_ << to_str(r) <<
 #if OPENDDS_HAS_JSON_VALUE_WRITER

--- a/tests/DCPS/Observer/TestObserver.cpp
+++ b/tests/DCPS/Observer/TestObserver.cpp
@@ -157,25 +157,41 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 void TestObserver::on_sample_sent(DDS::DataWriter_ptr w, const Sample& s)
 {
   ++sent_;
-  std::cout << "on_sample_sent " << sent_ << to_str(w) << ' ' << OpenDDS::DCPS::to_json(s) << std::endl;
+  std::cout << "on_sample_sent " << sent_ << to_str(w) <<
+#if OPENDDS_HAS_JSON_VALUE_WRITER
+    ' ' << OpenDDS::DCPS::to_json(s) <<
+#endif
+     std::endl;
 }
 
 void TestObserver::on_sample_received(DDS::DataReader_ptr r, const Sample& s)
 {
   ++received_;
-  std::cout << "on_sample_received " << received_ << to_str(r) << ' ' << OpenDDS::DCPS::to_json(s) << std::endl;
+  std::cout << "on_sample_received " << received_ << to_str(r) <<
+#if OPENDDS_HAS_JSON_VALUE_WRITER
+    ' ' << OpenDDS::DCPS::to_json(s) <<
+#endif
+    std::endl;
 }
 
 void TestObserver::on_sample_read(DDS::DataReader_ptr r, const Sample& s)
 {
   ++read_;
-  std::cout << "on_sample_read " << read_ << to_str(r) << ' ' << OpenDDS::DCPS::to_json(s) << std::endl;
+  std::cout << "on_sample_read " << read_ << to_str(r) <<
+#if OPENDDS_HAS_JSON_VALUE_WRITER
+    ' ' << OpenDDS::DCPS::to_json(s) <<
+#endif
+   std::endl;
 }
 
 void TestObserver::on_sample_taken(DDS::DataReader_ptr r, const Sample& s)
 {
   ++taken_;
-  std::cout << "on_sample_taken " << taken_ << to_str(r) << ' ' << OpenDDS::DCPS::to_json(s) << std::endl;
+  std::cout << "on_sample_taken " << taken_ << to_str(r) <<
+#if OPENDDS_HAS_JSON_VALUE_WRITER
+    ' ' << OpenDDS::DCPS::to_json(s) <<
+#endif
+    std::endl;
 }
 
 // ========== ========== ========== ========== ========== ========== ==========

--- a/tests/DCPS/common/ConnectionRecordLogger.cpp
+++ b/tests/DCPS/common/ConnectionRecordLogger.cpp
@@ -39,7 +39,7 @@ class Listener : public DDS::DataReaderListener {
     OpenDDS::DCPS::ConnectionRecord sample;
     DDS::SampleInfo sample_info;
     while (r->take_next_sample(sample, sample_info) == DDS::RETCODE_OK) {
-#ifdef OPENDDS_RAPIDJSON
+#if OPENDDS_HAS_JSON_VALUE_WRITER
       DDS::TopicDescription_var topic = r->get_topicdescription();
       ACE_DEBUG((LM_INFO,
                  ACE_TEXT("%C\n"),


### PR DESCRIPTION
Building the (admittedly odd) combination of safety profile + RapidJSON yields some compile errors surrounding the availability of `OpenDDS::DCPS::to_json()`. This PR should fix those build errors by checking for both RapidJSON availability as well as the lack of a safety profile build.