### PR TITLE
ThreadPool Updates To Accommodate SafetyProfile

### DIFF
--- a/dds/DCPS/ThreadPool.cpp
+++ b/dds/DCPS/ThreadPool.cpp
@@ -54,7 +54,7 @@ ACE_THR_FUNC_RETURN ThreadPool::run(void* arg)
     ACE_Guard<ACE_Thread_Mutex> guard(pool.mutex_);
     pool.id_set_.insert(ACE_Thread::self());
     ++pool.active_threads_;
-    pool.cv_.broadcast();
+    pool.cv_.notify_all();
     while (pool.active_threads_ != pool.ids_.size()) {
       pool.cv_.wait(tsm_);
     }
@@ -64,7 +64,7 @@ ACE_THR_FUNC_RETURN ThreadPool::run(void* arg)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(pool.mutex_);
     ++pool.exited_threads_;
-    pool.cv_.signal();
+    pool.cv_.notify_one();
   }
 #endif
   return 0;

--- a/dds/DCPS/ThreadPool.cpp
+++ b/dds/DCPS/ThreadPool.cpp
@@ -56,7 +56,7 @@ ACE_THR_FUNC_RETURN ThreadPool::run(void* arg)
     ++pool.active_threads_;
     pool.cv_.notify_all();
     while (pool.active_threads_ != pool.ids_.size()) {
-      pool.cv_.wait(tsm_);
+      pool.cv_.wait(pool.tsm_);
     }
   }
   (*pool.fun_)(pool.arg_);

--- a/dds/DCPS/ThreadPool.h
+++ b/dds/DCPS/ThreadPool.h
@@ -10,9 +10,9 @@
 
 #include "dcps_export.h"
 
+#include "ConditionVariable.h"
 #include "PoolAllocator.h"
 
-#include <ace/Condition_Thread_Mutex.h>
 #include <ace/Thread.h>
 
 #if ! defined ACE_HAS_THREAD || (! defined ACE_HAS_STHREADS && defined ACE_HAS_PTHREADS && defined ACE_LACKS_PTHREAD_JOIN)
@@ -64,7 +64,8 @@ private:
   FunPtr fun_;
   void* arg_;
   mutable ACE_Thread_Mutex mutex_;
-  mutable ACE_Condition<ACE_Thread_Mutex> condition_;
+  mutable ConditionVariable<ACE_Thread_Mutex> cv_;
+  ThreadStatusManager tsm_;
   size_t active_threads_;
   size_t exited_threads_;
   OPENDDS_VECTOR(ACE_hthread_t) ids_;

--- a/dds/DCPS/ThreadPool.h
+++ b/dds/DCPS/ThreadPool.h
@@ -15,7 +15,17 @@
 
 #include <ace/Thread.h>
 
-#if ! defined ACE_HAS_THREAD || (! defined ACE_HAS_STHREADS && defined ACE_HAS_PTHREADS && defined ACE_LACKS_PTHREAD_JOIN)
+#if defined ACE_HAS_THREADS
+# if defined ACE_HAS_STHREADS
+# elif defined ACE_HAS_PTHREADS
+#  if defined ACE_LACKS_PTHREAD_JOIN
+#define OPENDDS_NO_THREAD_JOIN
+#  endif
+# elif defined (ACE_HAS_WTHREADS)
+# else
+#define OPENDDS_NO_THREAD_JOIN
+# endif
+#else
 #define OPENDDS_NO_THREAD_JOIN
 #endif
 

--- a/dds/DCPS/ThreadPool.h
+++ b/dds/DCPS/ThreadPool.h
@@ -77,7 +77,9 @@ private:
   mutable ConditionVariable<ACE_Thread_Mutex> cv_;
   ThreadStatusManager tsm_;
   size_t active_threads_;
-  size_t exited_threads_;
+#if defined OPENDDS_NO_THREAD_JOIN
+  size_t finished_threads_;
+#endif
   OPENDDS_VECTOR(ACE_hthread_t) ids_;
   OPENDDS_SET(ACE_thread_t) id_set_;
 };

--- a/dds/DCPS/ThreadPool.h
+++ b/dds/DCPS/ThreadPool.h
@@ -15,17 +15,7 @@
 
 #include <ace/Thread.h>
 
-#if defined ACE_HAS_THREADS
-# if defined ACE_HAS_STHREADS
-# elif defined ACE_HAS_PTHREADS
-#  if defined ACE_LACKS_PTHREAD_JOIN
-#define OPENDDS_NO_THREAD_JOIN
-#  endif
-# elif defined (ACE_HAS_WTHREADS)
-# else
-#define OPENDDS_NO_THREAD_JOIN
-# endif
-#else
+#if defined ACE_HAS_PTHREADS && defined ACE_LACKS_PTHREAD_JOIN
 #define OPENDDS_NO_THREAD_JOIN
 #endif
 

--- a/dds/DCPS/ThreadPool.h
+++ b/dds/DCPS/ThreadPool.h
@@ -12,8 +12,12 @@
 
 #include "PoolAllocator.h"
 
-#include <ace/Barrier.h>
+#include <ace/Condition_Thread_Mutex.h>
 #include <ace/Thread.h>
+
+#if ! defined ACE_HAS_THREAD || (! defined ACE_HAS_STHREADS && defined ACE_HAS_PTHREADS && defined ACE_LACKS_PTHREAD_JOIN)
+#define OPENDDS_NO_THREAD_JOIN
+#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -57,10 +61,12 @@ private:
 
   void join_all();
 
-  ACE_Barrier barrier_;
   FunPtr fun_;
   void* arg_;
   mutable ACE_Thread_Mutex mutex_;
+  mutable ACE_Condition<ACE_Thread_Mutex> condition_;
+  size_t active_threads_;
+  size_t exited_threads_;
   OPENDDS_VECTOR(ACE_hthread_t) ids_;
   OPENDDS_SET(ACE_thread_t) id_set_;
 };


### PR DESCRIPTION
Problem: Safety Profile Does Not Allow For pthread_join (ACE_OS::thr_join returns -1 (Not Supported)).

Solution: Switch from Barrier to Condition + Count. Add additional counter for exited threads and use condition for both startup and shutdown (when join is not available) of thread pool.