### PR TITLE
Sequences in FACE mapping: support == for any type

### DIFF
--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -72,6 +72,9 @@ module Xyz {
 
   typedef sequence<ArrayOfShorts> ArrayOfShortsSeq;
 
+  typedef sequence<TwoDimArrayOfShorts2> TwoDimArrayOfShorts2Seq;
+  typedef sequence<MultiDimArray> MultiDimArraySeq;
+
   // +12
   typedef sequence<short> ShortSeq;
   @topic

--- a/tests/FACE/Compiler/idl_test1_main/main.cpp
+++ b/tests/FACE/Compiler/idl_test1_main/main.cpp
@@ -29,10 +29,63 @@ namespace {
   }
 }
 
+void test_seq_cmp(bool& failed)
+{
+  Xyz::AStringSeq s1, s2;
+  s1.length(1);
+  s2.length(1);
+  s1[0] = "hi";
+  s2[0] = "hi";
+  if (s1 != s2) {
+    failed = true;
+    ACE_ERROR((LM_ERROR, "test_seq_cmp: AStringSeq inequality failed\n"));
+  }
+  s2[0] = "there";
+  if (s1 == s2) {
+    failed = true;
+    ACE_ERROR((LM_ERROR, "test_seq_cmp: AStringSeq equality failed\n"));
+  }
+
+  Xyz::TwoDimArrayOfShorts2Seq tdas2s1;
+  tdas2s1.length(1);
+  FACE::Short s = 0;
+  for (int j = 0; j < 3; ++j)
+    for (int k = 0; k < 4; ++k)
+      tdas2s1[0][j][k] = ++s;
+  Xyz::TwoDimArrayOfShorts2Seq tdas2s2(tdas2s1);
+  if (tdas2s1 != tdas2s2) {
+    failed = true;
+    ACE_ERROR((LM_ERROR, "test_seq_cmp: TwoDimArrayOfShorts2Seq inequality failed\n"));
+  }
+  tdas2s1[0][0][0] = 99;
+  if (tdas2s1 == tdas2s2) {
+    failed = true;
+    ACE_ERROR((LM_ERROR, "test_seq_cmp: TwoDimArrayOfShorts2Seq equality failed\n"));
+  }
+
+  Xyz::MultiDimArraySeq mdas1;
+  mdas1.length(1);
+  for (int i = 0; i < 2; ++i)
+    for (int j = 0; j < 3; ++j)
+      for (int k = 0; k < 4; ++k)
+        for (int m = 0; m < 5; ++m)
+          mdas1[0][i][j][k][m] = "test";
+  Xyz::MultiDimArraySeq mdas2(mdas1);
+  if (mdas1 != mdas2) {
+    failed = true;
+    ACE_ERROR((LM_ERROR, "test_seq_cmp: MultiDimArraySeq inequality failed\n"));
+  }
+  mdas2[0][0][0][0][0] = "there";
+  if (mdas1 == mdas2) {
+    failed = true;
+    ACE_ERROR((LM_ERROR, "test_seq_cmp: MultiDimArraySeq equality failed\n"));
+  }
+}
+
 // this test tests the opendds_idl generated code for type XyZ::Foo from idl_test1_lib.
 int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
-  int failed = false;
+  bool failed = false;
   bool dump_buffer = false;
 
   const unsigned int vers = convert_version(DDS_MAJOR_VERSION,
@@ -432,10 +485,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     return -1;
   }
 
+  test_seq_cmp(failed);
+
   if (failed)
     ACE_ERROR((LM_ERROR, "%s FAILED!\n", argv[0]));
   else
     ACE_ERROR((LM_ERROR, "%s PASSED\n", argv[0]));
 
-  return failed; // let the test framework know it failed
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS; // let the test framework know it failed
 }


### PR DESCRIPTION
As an extension to the language mapping spec, these sequences have
always attempted to support binary == and != operators.  However, the
implementation wasn't correct for certain types of sequences where
directly comparing elements resulted in unwanted array-to-pointer
decay or comparison of strings by memory address instead of by contents.

This should resolve remaining warnings from GCC 12.