### PR TITLE
MulticastManager warns about unexpected unregister

### DIFF
--- a/dds/DCPS/MulticastManager.cpp
+++ b/dds/DCPS/MulticastManager.cpp
@@ -123,10 +123,6 @@ bool MulticastManager::process(InternalDataReader<NetworkInterfaceAddress>::Samp
     }
       break;
     case ISIK_UNREGISTER:
-      if (log_level >= LogLevel::Notice) {
-        ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: MulticastManager::process: unexpected UNREGISTER\n"));
-      }
-      break;
     case ISIK_DISPOSE: {
       if (joined_interfaces_.count(nia.name) != 0 && !nia.is_ipv4()) {
         if (log_level >= LogLevel::Info) {

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2546,6 +2546,10 @@ void Spdp::SpdpTransport::register_handlers(const DCPS::ReactorTask_rch& reactor
   }
   ACE_GUARD(ACE_Thread_Mutex, g, outer->lock_);
 
+  if (outer->shutdown_flag_ == true) {
+    return;
+  }
+
   ACE_Reactor* const reactor = reactor_task->get_reactor();
   register_unicast_socket(reactor, unicast_socket_, "IPV4");
 #ifdef ACE_HAS_IPV6


### PR DESCRIPTION
Problem
-------

The MulticastManager complains about an unexpected unregister.  These
can occur as part of a legitimate shutdown.

Solution
--------

Handle the unregister.