### PR TITLE
Fix TSAN Race Around DataWriterImpl's publication_id_

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -219,9 +219,7 @@ DataWriterImpl::add_association(const RepoId& yourId,
     return;
   }
 
-  if (GUID_UNKNOWN == publication_id_) {
-    publication_id_ = yourId;
-  }
+  check_and_set_repo_id(yourId);
 
   {
     ACE_GUARD(ACE_Thread_Mutex, reader_info_guard, this->reader_info_lock_);

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -478,6 +478,14 @@ public:
 
 protected:
 
+  void check_and_set_repo_id(const RepoId& id)
+  {
+    ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
+    if (GUID_UNKNOWN == publication_id_) {
+      publication_id_ = id;
+    }
+  }
+
   SequenceNumber get_next_sn()
   {
     ACE_Guard<ACE_Thread_Mutex> guard(sn_lock_);


### PR DESCRIPTION
Problem: TSAN builds intermittently complain about a data race in DataWriterImpl::add_association when checking / assigning publication_id_.

Solution: This check / set should lock the mutex.