### PR TITLE
SEDP ConnectionRecord is broken

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -3171,6 +3171,11 @@ bool Sedp::Endpoint::associated_with_counterpart_if_not_pending(
   return associated_with(counterpart) || !pending_association_with(counterpart);
 }
 
+RcHandle<DCPS::BitSubscriber> Sedp::Endpoint::get_builtin_subscriber_proxy() const
+{
+  return sedp_.spdp_.bit_subscriber_;
+}
+
 //---------------------------------------------------------------
 Sedp::Writer::Writer(const RepoId& pub_id, Sedp& sedp, ACE_INT64 seq_init)
   : Endpoint(pub_id, sedp), seq_(seq_init)

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -855,6 +855,8 @@ private:
     bool pending_association_with_counterpart(const DCPS::GUID_t& remote_part) const;
     bool associated_with_counterpart_if_not_pending(const DCPS::GUID_t& remote_part) const;
 
+    RcHandle<DCPS::BitSubscriber> get_builtin_subscriber_proxy() const;
+
   protected:
     DCPS::RepoId repo_id_;
     Sedp& sedp_;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -985,8 +985,10 @@ RtpsUdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::StateChang
     return;
   }
 
-  job_queue_->enqueue(DCPS::make_rch<WriteConnectionRecords>(bit_sub_, deferred_connection_records_));
-  deferred_connection_records_.clear();
+  if (!deferred_connection_records_.empty()) {
+    job_queue_->enqueue(DCPS::make_rch<WriteConnectionRecords>(bit_sub_, deferred_connection_records_));
+    deferred_connection_records_.clear();
+  }
 
 #else
   ACE_UNUSED_ARG(sc);
@@ -1012,8 +1014,10 @@ RtpsUdpTransport::disable_relay_stun_task()
     return;
   }
 
-  job_queue_->enqueue(DCPS::make_rch<WriteConnectionRecords>(bit_sub_, deferred_connection_records_));
-  deferred_connection_records_.clear();
+  if (!deferred_connection_records_.empty()) {
+    job_queue_->enqueue(DCPS::make_rch<WriteConnectionRecords>(bit_sub_, deferred_connection_records_));
+    deferred_connection_records_.clear();
+  }
 
   relay_srsm_ = ICE::ServerReflexiveStateMachine();
 #endif


### PR DESCRIPTION
Problem
-------

The ConnectionRecord for SEDP never reports because the BIT Subscriber
is always null.

Solution
--------

Override the getter for the BIT Subscriber.