### PR TITLE
Add Initial UndefinedBehaviorSanitizer (UBSAN) Jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3919,6 +3919,7 @@ jobs:
     - name: configure OpenDDS
       run: |
         cd OpenDDS
+        sed -i 's/DevGuideExamples/tests\/unit-tests/' DDS_TAOv2.mwc
         ./configure \
           --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
@@ -3928,7 +3929,6 @@ jobs:
           --features=no_hidden_visibility=1 \
           --macros=SOFLAGS+=-Wl,-h,\$\(SONAME\) \
           --ipv6 \
-          --tests \
           --security \
           --rapidjson
     - name: check build configuration

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3919,7 +3919,7 @@ jobs:
     - name: configure OpenDDS
       run: |
         cd OpenDDS
-        sed -i 's/DevGuideExamples/tests\/unit-tests/' DDS_TAOv2.mwc
+        sed -i 's/DevGuideExamples/tests\/unit-tests/' DDS_no_tests.mwc
         ./configure \
           --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3261,7 +3261,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c03_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install clang-12
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install clang-12
@@ -3282,6 +3282,7 @@ jobs:
           --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
           --compiler=clang++-12 \
+          --std=c++11 \
           --sanitize asan \
           --macros=SOFLAGS+=-Wl,-h,\$\(SONAME\) \
           --ipv6 \
@@ -3547,7 +3548,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c02_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install clang-12
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install clang-12
@@ -3568,6 +3569,7 @@ jobs:
           --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
           --compiler=clang++-12 \
+          --std=c++11 \
           --sanitize tsan \
           --ipv6 \
           --tests \
@@ -3641,6 +3643,7 @@ jobs:
           --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
           --compiler=clang++-12 \
+          --std=c++11 \
           --sanitize tsan \
           --ipv6 \
           --tests \
@@ -3773,6 +3776,296 @@ jobs:
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/tsan_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+
+  ACE_TAO_u20_p1_ubsan:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: get compiler version
+      shell: bash
+      run: |
+        export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)
+        echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+    - name: install clang-12
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install clang-12
+    - name: install xerces
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure \
+          --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE \
+          --mpc=$GITHUB_WORKSPACE/MPC \
+          --compiler=clang++-12 \
+          --std=c++11 \
+          --sanitize ubsan \
+          --features=no_hidden_visibility=1 \
+          --macros=SOFLAGS+=-Wl,-h,\$\(SONAME\) \
+          --ipv6 \
+          --tests \
+          --security
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        export UBSAN_OPTIONS=print_stacktrace=1
+        cd ACE_TAO/ACE
+        make -j2
+        cd ../TAO
+        make -j2
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  build_u20_p1_ubsan_sec:
+
+    runs-on: ubuntu-20.04
+
+    needs: ACE_TAO_u20_p1_ubsan
+
+    steps:
+    - name: install clang-12
+      run: sudo apt-get -y install clang-12
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_u20_p1_ubsan_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_u20_p1_ubsan.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        ./configure \
+          --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
+          --mpc=$GITHUB_WORKSPACE/MPC \
+          --compiler=clang++-12 \
+          --std=c++11 \
+          --sanitize ubsan \
+          --features=no_hidden_visibility=1 \
+          --macros=SOFLAGS+=-Wl,-h,\$\(SONAME\) \
+          --ipv6 \
+          --tests \
+          --security \
+          --rapidjson
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        export UBSAN_OPTIONS=print_stacktrace=1
+        make -j2
+    - name: Build CMake Tests
+      run: |
+        source OpenDDS/setenv.sh
+        cd OpenDDS/tests/cmake
+        cmake -DCMAKE_CXX_COMPILER=clang++-12 -DCMAKE_CXX_STANDARD=11 -S . -B build
+        UBSAN_OPTIONS=print_stacktrace=1 cmake --build build -- -j2
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
+
+  test_u20_p1_ubsan_sec:
+
+    runs-on: ubuntu-20.04
+
+    needs: build_u20_p1_ubsan_sec
+
+    steps:
+    - name: install xerces
+      run: sudo apt-get -y install libxerces-c-dev
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_u20_p1_ubsan_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        tar xvfJ ACE_TAO_u20_p1_ubsan.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_u20_p1_ubsan_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_u20_p1_ubsan_sec.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: install lldb
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install lldb
+        echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+    - name: change core file pattern
+      shell: bash
+      run: |
+        sudo sysctl -w kernel.core_pattern=core.%e.%p
+        echo Core file pattern set to:
+        cat /proc/sys/kernel/core_pattern
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        ulimit -c unlimited
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        echo "export ACE_TEST_DEBUGGER=lldb" >> setenv.sh
+        echo "export UBSAN_OPTIONS=print_stacktrace=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/ubsan_tests.lst"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3920,6 +3920,9 @@ jobs:
       run: |
         cd OpenDDS
         sed -i 's/DevGuideExamples/tests\/unit-tests/' DDS_no_tests.mwc
+        echo "---"
+        cat DDS_no_tests.mwc
+        echo "---"
         ./configure \
           --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
@@ -3931,7 +3934,6 @@ jobs:
           --ipv6 \
           --security \
           --rapidjson
-        ls -la
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3920,14 +3920,12 @@ jobs:
       run: |
         cd OpenDDS
         sed -i 's/DevGuideExamples/tests\/unit-tests/' DDS_no_tests.mwc
-        echo "---"
-        cat DDS_no_tests.mwc
-        echo "---"
         ./configure \
           --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
           --compiler=clang++-12 \
           --std=c++11 \
+          --gtest \
           --sanitize ubsan \
           --features=no_hidden_visibility=1 \
           --macros=SOFLAGS+=-Wl,-h,\$\(SONAME\) \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3931,6 +3931,7 @@ jobs:
           --ipv6 \
           --security \
           --rapidjson
+        ls -la
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3983,7 +3983,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: DOCGroup/autobuild
-        ref: update_prettify_for_ubsan
         path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3985,6 +3985,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: DOCGroup/autobuild
+        ref: update_prettify_for_ubsan
         path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3858,7 +3858,6 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        export UBSAN_OPTIONS=print_stacktrace=1
         cd ACE_TAO/ACE
         make -j2
         cd ../TAO
@@ -3944,14 +3943,13 @@ jobs:
       run: |
         cd OpenDDS
         . setenv.sh
-        export UBSAN_OPTIONS=print_stacktrace=1
         make -j2
     - name: Build CMake Tests
       run: |
         source OpenDDS/setenv.sh
         cd OpenDDS/tests/cmake
         cmake -DCMAKE_CXX_COMPILER=clang++-12 -DCMAKE_CXX_STANDARD=11 -S . -B build
-        UBSAN_OPTIONS=print_stacktrace=1 cmake --build build -- -j2
+        cmake --build build -- -j2
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -4043,7 +4041,6 @@ jobs:
         cd OpenDDS
         echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
         echo "export ACE_TEST_DEBUGGER=lldb" >> setenv.sh
-        echo "export UBSAN_OPTIONS=print_stacktrace=1" >> setenv.sh
         . setenv.sh
         mkdir ${{ github.job }}_autobuild_workspace
         cd ${{ github.job }}_autobuild_workspace

--- a/.github/workflows/build_u14_gcc4.Dockerfile
+++ b/.github/workflows/build_u14_gcc4.Dockerfile
@@ -17,4 +17,4 @@ RUN cd /opt && \
 
 RUN cd /opt/OpenDDS && \
     ./configure --compiler 'g++-4.4' --security --tests --no-rapidjson --cmake=/opt/cmake-3.22.1-linux-x86_64/bin/cmake && \
-    make -j $(nproc)
+    make -j $(($(nproc)+1))

--- a/.github/workflows/build_u14_gcc4.Dockerfile
+++ b/.github/workflows/build_u14_gcc4.Dockerfile
@@ -17,4 +17,4 @@ RUN cd /opt && \
 
 RUN cd /opt/OpenDDS && \
     ./configure --compiler 'g++-4.4' --security --tests --no-rapidjson --cmake=/opt/cmake-3.22.1-linux-x86_64/bin/cmake && \
-    make -j $(($(nproc)+1))
+    make -j $(nproc)

--- a/.github/workflows/build_u14_gcc4.Dockerfile
+++ b/.github/workflows/build_u14_gcc4.Dockerfile
@@ -17,4 +17,7 @@ RUN cd /opt && \
 
 RUN cd /opt/OpenDDS && \
     ./configure --compiler 'g++-4.4' --security --tests --no-rapidjson --cmake=/opt/cmake-3.22.1-linux-x86_64/bin/cmake && \
-    make -j $(($(nproc)+1))
+    echo ln -s $(which g++-4.4) bin/g++ && \
+    ln -s $(which g++-4.4) bin/g++ && \
+    echo make -j $(nproc) && \
+    make -j $(nproc)

--- a/.github/workflows/build_u14_gcc4.Dockerfile
+++ b/.github/workflows/build_u14_gcc4.Dockerfile
@@ -17,7 +17,4 @@ RUN cd /opt && \
 
 RUN cd /opt/OpenDDS && \
     ./configure --compiler 'g++-4.4' --security --tests --no-rapidjson --cmake=/opt/cmake-3.22.1-linux-x86_64/bin/cmake && \
-    echo ln -s $(which g++-4.4) bin/g++ && \
-    ln -s $(which g++-4.4) bin/g++ && \
-    echo make -j $(nproc) && \
-    make -j $(nproc)
+    make -j $(($(nproc)+1))

--- a/configure
+++ b/configure
@@ -954,7 +954,7 @@ sub write_config_h {
   my %buildEnv = %{shift()};
   my $platform = $opts{$buildEnv{'build'}};
   my $pi = $platforminfo{$platform};
-  $opts{'optimize'} = 0 if !exists $opts{'optimize'};
+  $opts{'optimize'} = 0 if (!exists $opts{'optimize'} && !exists $opts{'sanitize'});
 
   my $CFGH = backup_and_open("$buildEnv{'ACE_ROOT'}/ace/config.h");
   if ($buildEnv{'build'} eq 'target') {
@@ -1031,7 +1031,7 @@ my %all_sanitizers = (
       UBSAN_OPTIONS => "suppressions=$FindBin::RealBin/etc/ubsan-suppr.txt:print_stacktrace=1",
     },
     configh => ['#define ACE_INITIALIZE_MEMORY_BEFORE_USE'],
-    compiler_args => ['-fsanitize-coverage=trace-pc-guard'],
+    compiler_args => ['-fno-sanitize=enum'],
   },
 );
 my %enabled_sanitizers = ();

--- a/tests/DCPS/DataRepresentation/run_test.pl
+++ b/tests/DCPS/DataRepresentation/run_test.pl
@@ -9,7 +9,6 @@ use strict;
 
 my $test = new PerlDDS::TestFramework();
 $test->enable_console_logging();
-#$test->setup_discovery();
 $test->process('test', 'DataRepresentation', '-DCPSConfigFile rtps_disc.ini');
 $test->start_process('test');
 exit $test->finish(30);

--- a/tests/DCPS/DataRepresentation/run_test.pl
+++ b/tests/DCPS/DataRepresentation/run_test.pl
@@ -9,7 +9,7 @@ use strict;
 
 my $test = new PerlDDS::TestFramework();
 $test->enable_console_logging();
-$test->setup_discovery();
+#$test->setup_discovery();
 $test->process('test', 'DataRepresentation', '-DCPSConfigFile rtps_disc.ini');
 $test->start_process('test');
 exit $test->finish(30);

--- a/tests/ubsan_tests.lst
+++ b/tests/ubsan_tests.lst
@@ -1,0 +1,14 @@
+
+#
+# This is the list of run_test.pl's that need to be run by
+# auto_run_tests.pl.
+# Each line has its own test, and a test can be followed by a
+# list of configurations required to be enabled (or not
+# enabled if preceded by !). For example,
+#
+# tests/DCPS/SomeText/run_test.pl rtps: !DCPS_MIN RTPS
+
+# means to run if the build is not a minimal test and RTPS is enabled.
+#
+
+tests/unit-tests/run_test.pl: !DCPS_MIN !NO_UNIT_TESTS

--- a/tests/unit-tests/dds/DCPS/MemoryPool.cpp
+++ b/tests/unit-tests/dds/DCPS/MemoryPool.cpp
@@ -1305,12 +1305,15 @@ private:
   // Helpers
   void setup(FreeIndex& index, size_t free_size = 1024) {
     memset(pool_ptr_, 0, sizeof(pool_ptr_));
-    next_alloc_ = pool_ptr_;
+    next_alloc_ = pool_ptr_ + (sizeof(AllocHeader*) - reinterpret_cast<uint64_t>(pool_ptr_) % sizeof(AllocHeader*));
+    EXPECT_EQ(reinterpret_cast<uint64_t>(next_alloc_) % 8, 0u);
     largest_free_ = reinterpret_cast<FreeHeader*>(pool_ptr_);
     if (free_size) {
       largest_free_->init_free_block(static_cast<unsigned int>(free_size + sizeof(AllocHeader)));
       index.init(largest_free_);
+      EXPECT_EQ(free_size % 8, 0u);
       next_alloc_ += free_size + (sizeof(AllocHeader)*2) + 32;
+      EXPECT_EQ(reinterpret_cast<uint64_t>(next_alloc_) % 8, 0u);
     }
   }
 
@@ -1318,7 +1321,8 @@ private:
     FreeHeader* block = reinterpret_cast<FreeHeader*>(next_alloc_);
     block->set_size(size);
     block->set_free();
-    next_alloc_ += size + (sizeof(AllocHeader)*2) + 32;
+    next_alloc_ += size + (sizeof(AllocHeader*) - static_cast<uint64_t>(size) % sizeof(AllocHeader*));
+    EXPECT_EQ(reinterpret_cast<uint64_t>(next_alloc_) % 8, 0u);
     list_add(block);
     return block;
   }


### PR DESCRIPTION
Unit tests only, for now. Will incorporate (prior?) fixes once I see what's actually failing in the unit tests. The only default check from 'undefined' group that has been disabled is the check for invalid enum values, since that will take some thought and design changes for OpenDDS's code generation (and may not be worth the benefits).