### PR TITLE
RelayParticipantStatus reverts to original user data

### DIFF
--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -35,6 +35,8 @@ void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
                    guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
                    proxy.get_session_time(repoid, now).sec_str().c_str()));
       }
+    } else {
+      p.first->second = status;
     }
 
     stats_reporter_.local_participants(guids_.size(), now);


### PR DESCRIPTION
Problem
-------

Changes in the active/alive status of a relay participant always show
the original user data from discovery.  Changes in user data are
written out correctly, but not cached for subsequent writes when the
active/alive status changes.

Solution
--------

Save the user data for subsequent writes.