### PR TITLE
Fix TSAN Issue Surrounding Service_Participant::shut_down_

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -310,7 +310,7 @@ DDS::ReturnCode_t Service_Participant::shutdown()
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Service_Participant::shutdown\n"));
   }
 
-  if (shut_down_) {
+  if (is_shut_down()) {
     return DDS::RETCODE_ALREADY_DELETED;
   }
 
@@ -339,11 +339,12 @@ DDS::ReturnCode_t Service_Participant::shutdown()
   }
 
   DDS::ReturnCode_t rc = DDS::RETCODE_OK;
-  shut_down_ = true;
   try {
     TransportRegistry::instance()->release();
     {
       ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, factory_lock_, DDS::RETCODE_OUT_OF_RESOURCES);
+
+      shut_down_ = true;
 
       dp_factory_servant_.reset();
 

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -565,7 +565,7 @@ private:
 
   /// The lock to serialize DomainParticipantFactory singleton
   /// creation and shutdown.
-  ACE_Thread_Mutex factory_lock_;
+  mutable ACE_Thread_Mutex factory_lock_;
 
   /// The initial values of qos policies.
   DDS::UserDataQosPolicy              initial_UserDataQosPolicy_;

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -14,9 +14,9 @@ ACE_INLINE
 Discovery::RepoKey
 Service_Participant::domain_to_repo(const DDS::DomainId_t domain) const
 {
-  DomainRepoMap::const_iterator where = this->domainRepoMap_.find(domain);
+  DomainRepoMap::const_iterator where = domainRepoMap_.find(domain);
 
-  if (where == this->domainRepoMap_.end()) {
+  if (where == domainRepoMap_.end()) {
     return Discovery::DEFAULT_REPO;
 
   } else {
@@ -254,77 +254,77 @@ ACE_INLINE
 int&
 Service_Participant::federation_recovery_duration()
 {
-  return this->federation_recovery_duration_;
+  return federation_recovery_duration_;
 }
 
 ACE_INLINE
 int
 Service_Participant::federation_recovery_duration() const
 {
-  return this->federation_recovery_duration_;
+  return federation_recovery_duration_;
 }
 
 ACE_INLINE
 int&
 Service_Participant::federation_initial_backoff_seconds()
 {
-  return this->federation_initial_backoff_seconds_;
+  return federation_initial_backoff_seconds_;
 }
 
 ACE_INLINE
 int
 Service_Participant::federation_initial_backoff_seconds() const
 {
-  return this->federation_initial_backoff_seconds_;
+  return federation_initial_backoff_seconds_;
 }
 
 ACE_INLINE
 int&
 Service_Participant::federation_backoff_multiplier()
 {
-  return this->federation_backoff_multiplier_;
+  return federation_backoff_multiplier_;
 }
 
 ACE_INLINE
 int
 Service_Participant::federation_backoff_multiplier() const
 {
-  return this->federation_backoff_multiplier_;
+  return federation_backoff_multiplier_;
 }
 
 ACE_INLINE
 int&
 Service_Participant::federation_liveliness()
 {
-  return this->federation_liveliness_;
+  return federation_liveliness_;
 }
 
 ACE_INLINE
 int
 Service_Participant::federation_liveliness() const
 {
-  return this->federation_liveliness_;
+  return federation_liveliness_;
 }
 
 ACE_INLINE
 long&
 Service_Participant::scheduler()
 {
-  return this->scheduler_;
+  return scheduler_;
 }
 
 ACE_INLINE
 long
 Service_Participant::scheduler() const
 {
-  return this->scheduler_;
+  return scheduler_;
 }
 
 ACE_INLINE
 TimeDuration
 Service_Participant::pending_timeout() const
 {
-  return this->pending_timeout_;
+  return pending_timeout_;
 }
 
 ACE_INLINE
@@ -344,35 +344,36 @@ ACE_INLINE
 int
 Service_Participant::priority_min() const
 {
-  return this->priority_min_;
+  return priority_min_;
 }
 
 ACE_INLINE
 int
 Service_Participant::priority_max() const
 {
-  return this->priority_max_;
+  return priority_max_;
 }
 
 ACE_INLINE
 bool&
 Service_Participant::publisher_content_filter()
 {
-  return this->publisher_content_filter_;
+  return publisher_content_filter_;
 }
 
 ACE_INLINE
 bool
 Service_Participant::publisher_content_filter() const
 {
-  return this->publisher_content_filter_;
+  return publisher_content_filter_;
 }
 
 ACE_INLINE
 bool
 Service_Participant::is_shut_down() const
 {
-  return this->shut_down_;
+  ACE_Guard<ACE_Thread_Mutex> guard(factory_lock_);
+  return shut_down_;
 }
 
 ACE_INLINE


### PR DESCRIPTION
Problem: The TSAN build intermittently complains about unprotected access to Service_Participant::shut_down_.

Solution: Use protected access to it.