### PR TITLE
SPDP refuses to shutdown

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3633,6 +3633,10 @@ void Spdp::SpdpTransport::on_data_available(DCPS::RcHandle<DCPS::InternalDataRea
 
   ACE_GUARD(ACE_Thread_Mutex, g, outer->lock_);
 
+  if (outer->shutdown_flag_ == true) {
+    return;
+  }
+
   DCPS::InternalDataReader<DCPS::NetworkInterfaceAddress>::SampleSequence samples;
   DCPS::InternalSampleInfoSequence infos;
 


### PR DESCRIPTION
Problem
-------

Tests that create and destroy participants very quickly sometimes
block.  The root cause is that the registration of handlers is
asychronous.  The bad sequence is that the unregistration of handlers
happens before the registration.  Registering the handler increases
the reference count of the SpdpTransport which blocks shutdown.

In this case, SPDP is registering the multicast handler.  The bad
sequence is:

1. Create transport.
2. Call shutdown.  Remove handlers complete.
3. `on_data_available` called and multicast handlers registered.

Solution
--------

Do not register the handlers if shutdown has started.

Reference
---------

PR #3608