### PR TITLE
Reduce / Reuse Calls to MonotonicTimePoint::now()

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4440,7 +4440,7 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
     }
     const GUID_t guid = make_part_guid(sample.header_.publication_id_);
     sedp_.spdp_.process_participant_ice(data, pdata, guid);
-    sedp_.spdp_.handle_participant_data(id, pdata, DCPS::SequenceNumber::ZERO(), ACE_INET_Addr(), true);
+    sedp_.spdp_.handle_participant_data(id, pdata, DCPS::MonotonicTimePoint::now(), DCPS::SequenceNumber::ZERO(), ACE_INET_Addr(), true);
 
 #endif
   }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -678,12 +678,11 @@ bool ip_in_AgentInfo(const ACE_INET_Addr& from, const ParameterList& plist)
 void
 Spdp::handle_participant_data(DCPS::MessageId id,
                               const ParticipantData_t& cpdata,
+                              const DCPS::MonotonicTimePoint& now,
                               const DCPS::SequenceNumber& seq,
                               const ACE_INET_Addr& from,
                               bool from_sedp)
 {
-  const MonotonicTimePoint now = MonotonicTimePoint::now();
-
   // Make a (non-const) copy so we can tweak values below
   ParticipantData_t pdata(cpdata);
 
@@ -1016,10 +1015,11 @@ Spdp::data_received(const DataSubmessage& data,
     return;
   }
 
+  const MonotonicTimePoint now = MonotonicTimePoint::now();
   ParticipantData_t pdata = ParticipantData_t();
 
   pdata.participantProxy.domainId = domain_;
-  pdata.discoveredAt = MonotonicTimePoint::now().to_monotonic_time();
+  pdata.discoveredAt = now.to_monotonic_time();
 
 
   if (!ParameterListConverter::from_param_list(plist, pdata)) {
@@ -1078,7 +1078,7 @@ Spdp::data_received(const DataSubmessage& data,
   guard.release();
 #endif
 
-  handle_participant_data(msg_id, pdata, to_opendds_seqnum(data.writerSN), from, false);
+  handle_participant_data(msg_id, pdata, now, to_opendds_seqnum(data.writerSN), from, false);
 }
 
 void

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -154,6 +154,7 @@ public:
 
   void handle_participant_data(DCPS::MessageId id,
                                const ParticipantData_t& pdata,
+                               const DCPS::MonotonicTimePoint& now,
                                const DCPS::SequenceNumber& seq,
                                const ACE_INET_Addr& from,
                                bool from_sedp);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1517,7 +1517,7 @@ RtpsUdpDataLink::RtpsWriter::add_gap_submsg_i(RTPS::SubmessageSeq& msg,
   msg[idx].gap_sm(gap);
 }
 
-void RtpsUdpDataLink::update_last_recv_addr(const RepoId& src, const NetworkAddress& addr)
+void RtpsUdpDataLink::update_last_recv_addr(const RepoId& src, const NetworkAddress& addr, const MonotonicTimePoint& now)
 {
   if (addr == config().rtps_relay_address()) {
     return;
@@ -1528,7 +1528,6 @@ void RtpsUdpDataLink::update_last_recv_addr(const RepoId& src, const NetworkAddr
     ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
     const RemoteInfoMap::iterator pos = locators_.find(src);
     if (pos != locators_.end()) {
-      const MonotonicTimePoint now = MonotonicTimePoint::now();
       const bool expired = config().receive_address_duration_ < (MonotonicTimePoint::now() - pos->second.last_recv_time_);
       const bool allow_update = expired ||
                                 pos->second.last_recv_addr_ == addr ||
@@ -1843,7 +1842,7 @@ RtpsUdpDataLink::received(const RTPS::HeartBeatSubmessage& heartbeat,
   const RepoId src = make_id(src_prefix, heartbeat.writerId);
   const MonotonicTimePoint now = MonotonicTimePoint::now();
 
-  update_last_recv_addr(src, remote_addr);
+  update_last_recv_addr(src, remote_addr, now);
 
   MetaSubmessageVec meta_submessages;
   OPENDDS_VECTOR(InterestingRemote) callbacks;
@@ -2996,12 +2995,11 @@ RtpsUdpDataLink::received(const RTPS::AckNackSubmessage& acknack,
 {
   // local side is DW
   const RepoId local = make_id(local_prefix_, acknack.writerId); // can't be ENTITYID_UNKNOWN
-
   const RepoId remote = make_id(src_prefix, acknack.readerId);
-
-  update_last_recv_addr(remote, remote_addr);
-
   const MonotonicTimePoint now = MonotonicTimePoint::now();
+
+  update_last_recv_addr(remote, remote_addr, now);
+
   OPENDDS_VECTOR(DiscoveryListener*) callbacks;
 
   {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -296,7 +296,7 @@ private:
 #endif
   RemoteInfoMap locators_;
 
-  void update_last_recv_addr(const RepoId& src, const NetworkAddress& addr);
+  void update_last_recv_addr(const RepoId& src, const NetworkAddress& addr, const MonotonicTimePoint& now = MonotonicTimePoint::now());
 
   mutable LocatorCache locator_cache_;
   mutable BundlingCache bundling_cache_;


### PR DESCRIPTION
Problem: MonotonicTimePoint::now() was showing up fairly high in the profiling results for the Thrasher test.

Solution: Several of the places where it was being called can make reuse of the same time value.