### PR TITLE
Split Out Service_Participant Protection Of shut_down_ Flag To Avoid Deadlock

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -310,7 +310,7 @@ DDS::ReturnCode_t Service_Participant::shutdown()
     ACE_DEBUG((LM_DEBUG, "(%P|%t) Service_Participant::shutdown\n"));
   }
 
-  if (is_shut_down()) {
+  if (shut_down_.value()) {
     return DDS::RETCODE_ALREADY_DELETED;
   }
 
@@ -344,7 +344,7 @@ DDS::ReturnCode_t Service_Participant::shutdown()
     {
       ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, factory_lock_, DDS::RETCODE_OUT_OF_RESOURCES);
 
-      set_shut_down(true);
+      shut_down_ = true;
 
       dp_factory_servant_.reset();
 
@@ -405,7 +405,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
   if (!dp_factory_servant_) {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, factory_lock_, 0);
 
-    set_shut_down(false);
+    shut_down_ = false;
 
     if (!dp_factory_servant_) {
       // This used to be a call to ORB_init().  Since the ORB is now managed

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -344,7 +344,7 @@ DDS::ReturnCode_t Service_Participant::shutdown()
     {
       ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, factory_lock_, DDS::RETCODE_OUT_OF_RESOURCES);
 
-      shut_down_ = true;
+      set_shut_down(true);
 
       dp_factory_servant_.reset();
 
@@ -405,7 +405,8 @@ Service_Participant::get_domain_participant_factory(int &argc,
   if (!dp_factory_servant_) {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, factory_lock_, 0);
 
-    shut_down_ = false;
+    set_shut_down(false);
+
     if (!dp_factory_servant_) {
       // This used to be a call to ORB_init().  Since the ORB is now managed
       // by InfoRepoDiscovery, just save the -ORB* args for later use.

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -474,6 +474,9 @@ public:
 
 private:
 
+  /// Track shut down state
+  void set_shut_down(bool shut_down);
+
   /// Initialize default qos.
   void initialize();
 
@@ -760,6 +763,9 @@ private:
 
   /// Used to track state of service participant
   bool shut_down_;
+
+  /// Protects the internal shutdown state tracking
+  mutable ACE_Thread_Mutex shut_down_lock_;
 
   RcHandle<ShutdownListener> shutdown_listener_;
 

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -474,9 +474,6 @@ public:
 
 private:
 
-  /// Track shut down state
-  void set_shut_down(bool shut_down);
-
   /// Initialize default qos.
   void initialize();
 
@@ -762,10 +759,7 @@ private:
   bool monitor_enabled_;
 
   /// Used to track state of service participant
-  bool shut_down_;
-
-  /// Protects the internal shutdown state tracking
-  mutable ACE_Thread_Mutex shut_down_lock_;
+  ACE_Atomic_Op<ACE_Thread_Mutex, bool> shut_down_;
 
   RcHandle<ShutdownListener> shutdown_listener_;
 

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -372,16 +372,7 @@ ACE_INLINE
 bool
 Service_Participant::is_shut_down() const
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(shut_down_lock_);
-  return shut_down_;
-}
-
-ACE_INLINE
-void
-Service_Participant::set_shut_down(bool shut_down)
-{
-  ACE_Guard<ACE_Thread_Mutex> guard(shut_down_lock_);
-  shut_down_ = shut_down;
+  return shut_down_.value();
 }
 
 ACE_INLINE

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -372,8 +372,16 @@ ACE_INLINE
 bool
 Service_Participant::is_shut_down() const
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(factory_lock_);
+  ACE_Guard<ACE_Thread_Mutex> guard(shut_down_lock_);
   return shut_down_;
+}
+
+ACE_INLINE
+void
+Service_Participant::set_shut_down(bool shut_down)
+{
+  ACE_Guard<ACE_Thread_Mutex> guard(shut_down_lock_);
+  shut_down_ = shut_down;
 }
 
 ACE_INLINE


### PR DESCRIPTION
Problem: See https://github.com/objectcomputing/OpenDDS/runs/7439373375?check_suite_focus=true

Solution: Break out protection of shut_down_ flag to allow read access without waiting on factor lock.