### PR TITLE
Extend Thrasher Test Time Limit

### DIFF
--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -125,7 +125,7 @@ int Publisher::publish()
     ACE_DEBUG((LM_INFO, (pfx_ + "<-match found! before write for %C\n").c_str(), OpenDDS::DCPS::LogGuid(p->get_repo_id()).c_str()));
   }
 
-  DDS::Duration_t interval = {300, 0};
+  DDS::Duration_t interval = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
   ACE_DEBUG((LM_INFO, (pfx_ + "  waiting for acks\n").c_str()));
   if (DDS::RETCODE_OK != dw_->wait_for_acknowledgments(interval)) {
     ACE_ERROR((LM_ERROR, (pfx_ + " ERROR: timed out waiting for acks!\n").c_str()));

--- a/tests/DCPS/Thrasher/run_test.pl
+++ b/tests/DCPS/Thrasher/run_test.pl
@@ -64,4 +64,4 @@ $test->enable_console_logging();
 $test->process('Thrasher', 'Thrasher', $opts);
 $test->start_process('Thrasher');
 
-exit $test->finish(600);
+exit $test->finish(900);

--- a/tests/DCPS/Thrasher/thrasher_rtps.ini
+++ b/tests/DCPS/Thrasher/thrasher_rtps.ini
@@ -7,12 +7,12 @@ DiscoveryConfig=uni_rtps
 
 [config/myconfig]
 transports=the_rtps_transport
-passive_connect_duration=600000
+passive_connect_duration=900000
 
 [rtps_discovery/uni_rtps]
 SedpMulticast=0
 ResendPeriod=2
-SedpPassiveConnectDuration=600000
+SedpPassiveConnectDuration=900000
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp


### PR DESCRIPTION
Problem: Certain Windows scoreboard machines need longer "aggressive rtps" and "aggressive rtps durable" tests.

Solution: Increase the timeout.