### PR TITLE
OpenDDS applications hang when dynamic library loading fails

### DIFF
--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -1051,20 +1051,8 @@ InfoRepoDiscovery::OrbRunner::svc()
   return 0;
 }
 
-class InfoRepoType : public TransportType {
-public:
-  const char* name() { return "repository"; }
-
-  TransportInst_rch new_inst(const std::string&)
-  {
-    return TransportInst_rch();
-  }
-};
-
 InfoRepoDiscovery::StaticInitializer::StaticInitializer()
 {
-  TransportRegistry* registry = TheTransportRegistry;
-  registry->register_type(make_rch<InfoRepoType>());
   TheServiceParticipant->register_discovery_type("repository", new Config);
 }
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1087,11 +1087,8 @@ Service_Participant::set_repo_ior(const char* ior,
 
   const OPENDDS_STRING repo_type = ACE_TEXT_ALWAYS_CHAR(REPO_SECTION_NAME);
   if (!discovery_types_.count(repo_type)) {
-    // Re-use a transport registry function to attempt a dynamic load of the
-    // library that implements the 'repo_type' (InfoRepoDiscovery)
-    TheTransportRegistry->load_transport_lib(repo_type);
+    TheTransportRegistry->load_dynamic_libraries();
   }
-
   if (discovery_types_.count(repo_type)) {
     ACE_Configuration_Heap cf;
     cf.open();
@@ -2441,8 +2438,7 @@ Service_Participant::load_discovery_configuration(ACE_Configuration_Heap& cf,
       this->discovery_types_.find(sect_name);
 
     if (iter == this->discovery_types_.end()) {
-      // See if we can dynamically load the required libraries
-      TheTransportRegistry->load_transport_lib(sect_name);
+      TheTransportRegistry->load_dynamic_libraries();
       iter = this->discovery_types_.find(sect_name);
     }
 

--- a/dds/DCPS/transport/framework/TransportRegistry.inl
+++ b/dds/DCPS/transport/framework/TransportRegistry.inl
@@ -69,15 +69,20 @@ ACE_INLINE
 void
 TransportRegistry::remove_inst(const OPENDDS_STRING& inst_name)
 {
-  GuardType guard(this->lock_);
-  InstMap::iterator iter = inst_map_.find(inst_name);
-  if (iter == inst_map_.end()) {
-    return;
+  TransportInst_rch inst;
+  {
+    GuardType guard(this->lock_);
+    InstMap::iterator iter = inst_map_.find(inst_name);
+    if (iter == inst_map_.end()) {
+      return;
+    }
+    inst = iter->second;
+    inst_map_.erase(iter);
   }
-  if (iter->second) {
-    iter->second->shutdown();
+
+  if (inst) {
+    inst->shutdown();
   }
-  inst_map_.erase(iter);
 }
 
 ACE_INLINE

--- a/dds/DCPS/transport/framework/TransportType.h
+++ b/dds/DCPS/transport/framework/TransportType.h
@@ -41,6 +41,8 @@ public:
 
   virtual TransportInst_rch new_inst(const OPENDDS_STRING& name) = 0;
 
+  virtual void first_activity() = 0;
+
 protected:
 
   TransportType();

--- a/dds/DCPS/transport/multicast/MulticastLoader.cpp
+++ b/dds/DCPS/transport/multicast/MulticastLoader.cpp
@@ -28,6 +28,30 @@ public:
   {
     return make_rch<MulticastInst>(name);
   }
+
+  void first_activity()
+  {
+    TransportRegistry* registry = TheTransportRegistry;
+    TransportConfig_rch cfg =
+      registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME);
+
+    TransportInst_rch default_unrel =
+      registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
+                            + std::string("0410_MCAST_UNRELIABLE"),
+                            MULTICAST_NAME);
+    MulticastInst* mi = dynamic_cast<MulticastInst*>(default_unrel.in());
+    if (!mi) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) MulticastLoader::init:")
+                 ACE_TEXT(" failed to obtain MulticastInst.\n")));
+    }
+    mi->reliable_ = false;
+    cfg->sorted_insert(default_unrel);
+
+    TransportInst_rch default_rel =
+      registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
+                            + std::string("0420_MCAST_RELIABLE"), MULTICAST_NAME);
+    cfg->sorted_insert(default_rel);
+  }
 };
 
 int
@@ -37,30 +61,9 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
   if (initialized) return 0;  // already initialized
 
-  TransportRegistry* registry = TheTransportRegistry;
-  if (!registry->register_type(make_rch<MulticastType>())) {
+  if (!TheTransportRegistry->register_type(make_rch<MulticastType>())) {
     return 0;
   }
-
-  TransportConfig_rch cfg =
-    registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME);
-
-  TransportInst_rch default_unrel =
-    registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
-                          + std::string("0410_MCAST_UNRELIABLE"),
-                          MULTICAST_NAME, false);
-  MulticastInst* mi = dynamic_cast<MulticastInst*>(default_unrel.in());
-  if (!mi) {
-    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) MulticastLoader::init:")
-      ACE_TEXT(" failed to obtain MulticastInst.\n")), -1);
-  }
-  mi->reliable_ = false;
-  cfg->sorted_insert(default_unrel);
-
-  TransportInst_rch default_rel =
-    registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
-                          + std::string("0420_MCAST_RELIABLE"), MULTICAST_NAME, false);
-  cfg->sorted_insert(default_rel);
 
   initialized = true;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
@@ -28,6 +28,22 @@ public:
   {
     return make_rch<RtpsUdpInst>(name);
   }
+
+  void first_activity()
+  {
+    // Don't create a default for RTPS.  At least for the initial implementation,
+    // the user needs to explicitly configure it...
+#ifdef OPENDDS_SAFETY_PROFILE
+    TransportRegistry* registry = TheTransportRegistry;
+    // ...except for Safety Profile where RTPS is the only option.
+    TransportInst_rch default_inst =
+      registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
+                            OPENDDS_STRING("0600_RTPS_UDP"),
+                            RTPS_UDP_NAME);
+    registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
+      ->sorted_insert(default_inst);
+#endif
+  }
 };
 
 int
@@ -39,23 +55,8 @@ RtpsUdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
 void RtpsUdpLoader::load()
 {
-  TransportRegistry* registry = TheTransportRegistry;
   TransportType_rch type = make_rch<RtpsUdpType>();
-  if (!registry->register_type(type)) {
-    return;
-  }
-
-  // Don't create a default for RTPS.  At least for the initial implementation,
-  // the user needs to explicitly configure it...
-#ifdef OPENDDS_SAFETY_PROFILE
-  // ...except for Safety Profile where RTPS is the only option.
-  TransportInst_rch default_inst =
-    registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
-                          OPENDDS_STRING("0600_RTPS_UDP"),
-                          RTPS_UDP_NAME, false);
-  registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
-    ->sorted_insert(default_inst);
-#endif
+  TheTransportRegistry->register_type(type);
 }
 
 ACE_FACTORY_DEFINE(OpenDDS_Rtps_Udp, RtpsUdpLoader);

--- a/dds/DCPS/transport/shmem/ShmemLoader.cpp
+++ b/dds/DCPS/transport/shmem/ShmemLoader.cpp
@@ -28,6 +28,18 @@ public:
   {
     return make_rch<ShmemInst>(name);
   }
+
+  void first_activity()
+  {
+    //FUTURE: when we're ready, add a ShmemInst to the default config, like so:
+    /*
+      TransportInst_rch default_inst =
+      registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX + "0200_SHMEM",
+      SHMEM_NAME);
+      registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
+      ->sorted_insert(default_inst);
+    */
+  }
 };
 
 int
@@ -37,19 +49,10 @@ ShmemLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
   if (initialized) return 0;  // already initialized
 
-  TransportRegistry* registry = TheTransportRegistry;
-  if (!registry->register_type(make_rch<ShmemType>())) {
+  if (!TheTransportRegistry->register_type(make_rch<ShmemType>())) {
     return 0;
   }
 
-  //FUTURE: when we're ready, add a ShmemInst to the default config, like so:
-  /*
-  TransportInst_rch default_inst =
-    registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX + "0200_SHMEM",
-                          SHMEM_NAME, false);
-  registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
-    ->sorted_insert(default_inst);
-  */
   initialized = true;
 
   return 0;

--- a/dds/DCPS/transport/tcp/TcpLoader.cpp
+++ b/dds/DCPS/transport/tcp/TcpLoader.cpp
@@ -43,6 +43,16 @@ public:
   {
     return make_rch<TcpInst>(name);
   }
+
+  void first_activity()
+  {
+    TransportRegistry* registry = TheTransportRegistry;
+    TransportInst_rch default_inst =
+      registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
+                            std::string("0500_TCP"), TCP_NAME);
+    registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
+      ->sorted_insert(default_inst);
+  }
 };
 
 int
@@ -56,16 +66,9 @@ TcpLoader::init(int, ACE_TCHAR*[])
   if (initialized)
     return 0;
 
-  TransportRegistry* registry = TheTransportRegistry;
-  if (!registry->register_type(make_rch<TcpType>())) {
+  if (!TheTransportRegistry->register_type(make_rch<TcpType>())) {
     return 0;
   }
-
-  TransportInst_rch default_inst =
-    registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
-                          std::string("0500_TCP"), TCP_NAME, false);
-  registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
-    ->sorted_insert(default_inst);
 
   initialized = true;
   return 0;

--- a/dds/DCPS/transport/udp/UdpLoader.cpp
+++ b/dds/DCPS/transport/udp/UdpLoader.cpp
@@ -28,6 +28,16 @@ public:
   {
     return make_rch<UdpInst>(name);
   }
+
+  void first_activity()
+  {
+    TransportRegistry* registry = TheTransportRegistry;
+    TransportInst_rch default_inst =
+      registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
+                            std::string("0300_UDP"), UDP_NAME);
+    registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
+      ->sorted_insert(default_inst);
+  }
 };
 
 int
@@ -37,16 +47,9 @@ UdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
   if (initialized) return 0;  // already initialized
 
-  TransportRegistry* registry = TheTransportRegistry;
-  if (!registry->register_type(make_rch<UdpType>())) {
+  if (!TheTransportRegistry->register_type(make_rch<UdpType>())) {
     return 0;
   }
-
-  TransportInst_rch default_inst =
-    registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
-                          std::string("0300_UDP"), UDP_NAME, false);
-  registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
-    ->sorted_insert(default_inst);
 
   initialized = true;
 


### PR DESCRIPTION
Problem
-------

A user that fails to set the path to the OpenDDS shared libraries will
experience a deadlock when starting an application.  As part of #3342,
a condition variable was added that allows one thread to wait while
another thread loads the required transport type.  In the case of the
missing path, the wait will wait forever leading to the deadlock.

Solution
--------

* Preemptively load all of the shared libraries known by OpenDDS.
  This is currently done in the initialization of the Service
  Participant.

* Remove the condition variable.

Note
----

For dynamic libraries, it is theoretically okay for a
transport-like-thing, e.g., InfoRepoDiscovery, to depend on another
transport-like-thing, e.g., TCP transport, because the load order of
the libraries can be adjusted to accommodate the dependency.  However,
this may not work for static libraries because the load order is
indeterminate.  Thus, it may be necessary to refactor
InfoRepoDiscovery so its static initializer doesn't depend on TCP
being loaded.