### PR TITLE
TSAN Fix And Remove Suppression For Lock-Order-Invserion Issues In Message_Block_Deleter

### DIFF
--- a/dds/DCPS/Message_Block_Ptr.h
+++ b/dds/DCPS/Message_Block_Ptr.h
@@ -17,6 +17,8 @@ namespace DCPS {
 struct Message_Block_Deleter
 {
   void operator()(ACE_Message_Block* ptr) const {
+    // In order to avoid locking order issues for message blocks with different locking strategies,
+    // it is safer to unlink elements in the chain before releasing them individually
     while (ptr) {
       ACE_Message_Block* cont = ptr->cont();
       ptr->cont(0);

--- a/dds/DCPS/Message_Block_Ptr.h
+++ b/dds/DCPS/Message_Block_Ptr.h
@@ -17,6 +17,11 @@ namespace DCPS {
 struct Message_Block_Deleter
 {
   void operator()(ACE_Message_Block* ptr) const {
+    ACE_Message_Block* cont = ptr->cont();
+    if (cont) {
+      ptr->cont(0);
+      operator()(cont);
+    }
     ACE_Message_Block::release(ptr);
   }
 };

--- a/dds/DCPS/Message_Block_Ptr.h
+++ b/dds/DCPS/Message_Block_Ptr.h
@@ -17,12 +17,12 @@ namespace DCPS {
 struct Message_Block_Deleter
 {
   void operator()(ACE_Message_Block* ptr) const {
-    ACE_Message_Block* cont = ptr->cont();
-    if (cont) {
+    while (ptr) {
+      ACE_Message_Block* cont = ptr->cont();
       ptr->cont(0);
-      operator()(cont);
+      ACE_Message_Block::release(ptr);
+      ptr = cont;
     }
-    ACE_Message_Block::release(ptr);
   }
 };
 

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -132,7 +132,7 @@ TransportSendStrategy::perform_work()
   { // scope for the guard(lock_);
     GuardType guard(lock_);
 
-    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: perform_work mode: %C\n", mode_as_str(mode_)), 5);
+    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: perform_work mode: %C\n", mode_as_str(mode_.value())), 5);
 
     if (mode_ == MODE_TERMINATED) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
@@ -161,7 +161,7 @@ TransportSendStrategy::perform_work()
     if (mode_ != MODE_QUEUE && mode_ != MODE_SUSPEND) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Entered perform_work() and mode_ is %C - just return "
-                "WORK_OUTCOME_NO_MORE_TO_DO.\n", mode_as_str(mode_)), 5);
+                "WORK_OUTCOME_NO_MORE_TO_DO.\n", mode_as_str(mode_.value())), 5);
       return WORK_OUTCOME_NO_MORE_TO_DO;
     }
 
@@ -978,7 +978,7 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
       if (mode_ == MODE_QUEUE || mode_ == MODE_SUSPEND) {
         VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                   "mode_ == %C, so queue elem and leave.\n",
-                  mode_as_str(mode_)), 5);
+                  mode_as_str(mode_.value())), 5);
 
         queue_.put(element);
 
@@ -1259,7 +1259,7 @@ TransportSendStrategy::send_stop(RepoId /*repoId*/)
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "But since we are in %C, we don't have to do "
             "anything more in this important send_stop().\n",
-            mode_as_str(mode_)));
+            mode_as_str(mode_.value())));
       // We don't do anything if we are in MODE_QUEUE.  Just leave.
       return;
     }
@@ -1503,7 +1503,7 @@ TransportSendStrategy::direct_send(bool do_relink)
                 "Now flip to MODE_SUSPEND before we try to reconnect.\n"), 5);
 
       if (mode_ != MODE_SUSPEND) {
-        mode_before_suspend_ = mode_;
+        mode_before_suspend_ = mode_.value();
         mode_ = MODE_SUSPEND;
       }
 
@@ -1917,7 +1917,7 @@ TransportSendStrategy::add_delayed_notification(TransportQueueElement* element)
     }
   }
 
-  delayed_delivered_notification_queue_.push_back(std::make_pair(element, mode_));
+  delayed_delivered_notification_queue_.push_back(std::make_pair(element, mode_.value()));
 }
 
 void TransportSendStrategy::deliver_ack_request(TransportQueueElement* element)

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -381,7 +381,7 @@ private:
   unsigned start_counter_;
 
   /// This mode determines how send() calls will be handled.
-  SendMode mode_;
+  ACE_Atomic_Op<ACE_Thread_Mutex, SendMode> mode_;
 
   /// This mode remembers the mode before send is suspended and is
   /// used after the send is resumed because the connection is

--- a/dds/DCPS/transport/framework/TransportSendStrategy.inl
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.inl
@@ -17,7 +17,7 @@ TransportSendStrategy::SendMode TransportSendStrategy::mode() const
 {
   DBG_ENTRY_LVL("TransportSendStrategy","mode",6);
 
-  return mode_;
+  return mode_.value();
 }
 
 ACE_INLINE
@@ -69,7 +69,7 @@ void TransportSendStrategy::suspend_send()
   GuardType guard(this->lock_);
 
   if (this->mode_ != MODE_TERMINATED && this->mode_ != MODE_SUSPEND) {
-    this->mode_before_suspend_ = this->mode_;
+    this->mode_before_suspend_ = this->mode_.value();
     this->mode_ = MODE_SUSPEND;
   }
 }

--- a/etc/tsan-suppr.txt
+++ b/etc/tsan-suppr.txt
@@ -3,7 +3,6 @@
 #   https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
 deadlock:^CORBA::ORB_init
-deadlock:^ACE_Data_Block::release_no_delete
 
 race_top:^ACE_Data_Block::ACE_Data_Block
 race_top:^ACE_Data_Block::release_i


### PR DESCRIPTION
Problem: Currently we suppress lock-order-inversion errors from ACE_Message_Block::release_no_delete, which seem to be caused by ACE_Message_Block chains with differently ordered locking_strategy_ pointers being called from different threads. In general, this is a problem with the locking strategy design of ACE_Message_Block, since ACE_Message_Block tries to acquire the locks of the chain sequentially as it follows the chain during a release.

Solution: Rather than trying to fundamentally change the design of ACE, which might break other users, we can optimize the behavior of Message_Block_Deleter to address the assumptions of OpenDDS, which is namely that it's acceptable to de-chain and individually release ACE_Message_Blocks, so they can lock and unlock their individual locking_strategy_ without introducing lock ordering issues. The PR also makes TransportSendStrategy's SendMode atomic to address a TSAN complaint that showed up during testing.