### PR TITLE
TransportRegistry::create_inst removed wait param

### DIFF
--- a/dds/DCPS/transport/framework/TransportRegistry.h
+++ b/dds/DCPS/transport/framework/TransportRegistry.h
@@ -58,8 +58,7 @@ public:
   void release();
 
   TransportInst_rch create_inst(const OPENDDS_STRING& name,
-                                const OPENDDS_STRING& transport_type,
-                                bool wait = true);
+                                const OPENDDS_STRING& transport_type);
   TransportInst_rch get_inst(const OPENDDS_STRING& name) const;
 
   /// Removing a TransportInst from the registry shuts down the underlying
@@ -117,8 +116,7 @@ public:
 
   /// For internal use by OpenDDS DCPS layer:
   /// Dynamically load the library for the supplied transport type.
-  void load_transport_lib(const OPENDDS_STRING& transport_type,
-                          bool wait = true);
+  void load_transport_lib(const OPENDDS_STRING& transport_type);
 
   bool released() const;
 
@@ -162,8 +160,6 @@ private:
   bool released_;
 
   mutable LockType lock_;
-  // This condition is signaled when a load is completed.
-  mutable ConditionVariable<LockType> load_complete_;
 
   // transport template support
   static const OPENDDS_STRING CUSTOM_ADD_DOMAIN_TO_IP;
@@ -178,8 +174,7 @@ private:
     ValueMap transport_info;
   };
 
-  TransportType_rch load_transport_lib_i(const OPENDDS_STRING& transport_type,
-                                         bool wait);
+  TransportType_rch load_transport_lib_i(const OPENDDS_STRING& transport_type);
 
   OPENDDS_VECTOR(TransportTemplate) transport_templates_;
 

--- a/dds/DCPS/transport/multicast/MulticastLoader.cpp
+++ b/dds/DCPS/transport/multicast/MulticastLoader.cpp
@@ -48,7 +48,7 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
   TransportInst_rch default_unrel =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
                           + std::string("0410_MCAST_UNRELIABLE"),
-                          MULTICAST_NAME, false);
+                          MULTICAST_NAME);
   MulticastInst* mi = dynamic_cast<MulticastInst*>(default_unrel.in());
   if (!mi) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) MulticastLoader::init:")
@@ -59,7 +59,7 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
   TransportInst_rch default_rel =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX
-                          + std::string("0420_MCAST_RELIABLE"), MULTICAST_NAME, false);
+                          + std::string("0420_MCAST_RELIABLE"), MULTICAST_NAME);
   cfg->sorted_insert(default_rel);
 
   initialized = true;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
@@ -52,7 +52,7 @@ void RtpsUdpLoader::load()
   TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           OPENDDS_STRING("0600_RTPS_UDP"),
-                          RTPS_UDP_NAME, false);
+                          RTPS_UDP_NAME);
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
     ->sorted_insert(default_inst);
 #endif

--- a/dds/DCPS/transport/tcp/TcpLoader.cpp
+++ b/dds/DCPS/transport/tcp/TcpLoader.cpp
@@ -63,7 +63,7 @@ TcpLoader::init(int, ACE_TCHAR*[])
 
   TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
-                          std::string("0500_TCP"), TCP_NAME, false);
+                          std::string("0500_TCP"), TCP_NAME);
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
     ->sorted_insert(default_inst);
 

--- a/dds/DCPS/transport/udp/UdpLoader.cpp
+++ b/dds/DCPS/transport/udp/UdpLoader.cpp
@@ -44,7 +44,7 @@ UdpLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
 
   TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
-                          std::string("0300_UDP"), UDP_NAME, false);
+                          std::string("0300_UDP"), UDP_NAME);
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
     ->sorted_insert(default_inst);
 


### PR DESCRIPTION
Also, return an error if we try to load a library via ACE and it fails.