### PR TITLE
[Bench] Report Worker Failures In Test Total Error Count

### DIFF
--- a/performance-tests/bench/example/config/scenario/ci_disco_relay.json
+++ b/performance-tests/bench/example/config/scenario/ci_disco_relay.json
@@ -14,5 +14,5 @@
       "count": 2
     }
   ],
-  "timeout": 20
+  "timeout": 60
 }

--- a/performance-tests/bench/example/config/scenario/ci_disco_relay_only.json
+++ b/performance-tests/bench/example/config/scenario/ci_disco_relay_only.json
@@ -14,5 +14,5 @@
       "count": 2
     }
   ],
-  "timeout": 20
+  "timeout": 60
 }

--- a/performance-tests/bench/example/config/scenario/ci_disco_repo.json
+++ b/performance-tests/bench/example/config/scenario/ci_disco_repo.json
@@ -11,7 +11,7 @@
     },
     {
       "config": "ci_disco_repo.json",
-      "count": 10
+      "count": 20
     }
   ],
   "timeout": 60

--- a/performance-tests/bench/example/config/worker/ci_disco_relay.json
+++ b/performance-tests/bench/example/config/worker/ci_disco_relay.json
@@ -1,6 +1,7 @@
 {
+  "create_time": { "sec": -3, "nsec": 0 },
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -10, "nsec": 0 },
+  "start_time": { "sec": -30, "nsec": 0 },
   "stop_time": { "sec": -1, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
 

--- a/performance-tests/bench/example/config/worker/ci_disco_relay_only.json
+++ b/performance-tests/bench/example/config/worker/ci_disco_relay_only.json
@@ -1,6 +1,7 @@
 {
+  "create_time": { "sec": -3, "nsec": 0 },
   "enable_time": { "sec": -1, "nsec": 0 },
-  "start_time": { "sec": -10, "nsec": 0 },
+  "start_time": { "sec": -30, "nsec": 0 },
   "stop_time": { "sec": -1, "nsec": 0 },
   "destruction_time": { "sec": -1, "nsec": 0 },
 

--- a/performance-tests/bench/example/config/worker/ci_disco_repo.json
+++ b/performance-tests/bench/example/config/worker/ci_disco_repo.json
@@ -1,5 +1,5 @@
 {
-  "create_time": { "sec": -1, "nsec": 0 },
+  "create_time": { "sec": -3, "nsec": 0 },
   "enable_time": { "sec": -1, "nsec": 0 },
   "start_time": { "sec": -30, "nsec": 0 },
   "stop_time": { "sec": -1, "nsec": 0 },
@@ -75,7 +75,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 10 }
+                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 20 }
                   }
                 ],
 
@@ -88,7 +88,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 10 }
+                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 20 }
                   }
                 ],
 
@@ -107,7 +107,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 10 }
+                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 20 }
                   }
                 ]
               },
@@ -117,7 +117,7 @@
                 "listener_status_mask": 4294967295,
                 "listener_properties": [
                   { "name": "expected_match_count",
-                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 10 }
+                    "value": { "$discriminator": "PVK_ULL", "ull_prop": 20 }
                   }
                 ]
               }

--- a/performance-tests/bench/idl/Bench.idl
+++ b/performance-tests/bench/idl/Bench.idl
@@ -227,6 +227,7 @@ module Bench {
       string scenario_name;
       Builder::TimeStamp time;
       NodeReportSeq node_reports;
+      unsigned long missing_reports;
       Builder::PropertySeq properties;
     };
   };

--- a/performance-tests/bench/report_parser/SummaryJsonDashboardFormatter.cpp
+++ b/performance-tests/bench/report_parser/SummaryJsonDashboardFormatter.cpp
@@ -31,7 +31,7 @@ int SummaryJsonDashboardFormatter::format(const Bench::TestController::Report& r
   document.SetObject();
 
   rapidjson::Value& errors_val = document.AddMember("errors", rapidjson::Value(0).Move(), document.GetAllocator())["errors"].SetObject();
-  errors_val.AddMember("total", rapidjson::Value(untagged_error_counts.total_).Move(), document.GetAllocator());
+  errors_val.AddMember("total", rapidjson::Value(report.missing_reports + untagged_error_counts.total_).Move(), document.GetAllocator());
   errors_val.AddMember("discovery", rapidjson::Value(untagged_error_counts.discovery_).Move(), document.GetAllocator());
 
   rapidjson::Value& untagged_stat_val = document.AddMember("stats", rapidjson::Value(0).Move(), document.GetAllocator())["stats"].SetObject();

--- a/performance-tests/bench/test_controller/ScenarioManager.cpp
+++ b/performance-tests/bench/test_controller/ScenarioManager.cpp
@@ -285,6 +285,7 @@ void ScenarioManager::execute(const Bench::TestController::AllocatedScenario& al
 
   // Timeout Thread
   size_t reports_left = allocated_scenario.expected_process_reports;
+  report.missing_reports = reports_left;
   std::mutex reports_left_mutex;
   std::condition_variable timeout_cv;
   const std::chrono::seconds timeout(allocated_scenario.timeout + SCENARIO_TIMEOUT_GRACE_PERIOD);
@@ -378,7 +379,7 @@ void ScenarioManager::execute(const Bench::TestController::AllocatedScenario& al
           }
           std::stringstream ss;
           ss << "Got " << process_report_count << " out of "
-            << allocated_scenario.expected_process_reports << " expected reports";
+            << allocated_scenario.expected_process_reports << " expected process reports";
           if (worker_failures != 0 || parse_failures != 0) {
             ss << " (with " << worker_failures << " worker failures and "
               << parse_failures << " parse failures)";
@@ -394,6 +395,7 @@ void ScenarioManager::execute(const Bench::TestController::AllocatedScenario& al
     {
       std::lock_guard<std::mutex> guard(reports_left_mutex);
       reports_left = static_cast<size_t>(allocated_scenario.expected_process_reports) - process_report_count;
+      report.missing_reports = reports_left + worker_failures + parse_failures;
       if (reports_left == 0) {
         break;
       }

--- a/performance-tests/bench/test_controller/main.cpp
+++ b/performance-tests/bench/test_controller/main.cpp
@@ -429,7 +429,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
       if (total_worker_reports != allocated_scenario.expected_worker_reports) {
         std::string log_msg = "ERROR: Only received " + std::to_string(total_worker_reports) +
-          " out of " + std::to_string(allocated_scenario.expected_worker_reports) + " valid reports!\n";
+          " out of " + std::to_string(allocated_scenario.expected_worker_reports) + " expected worker reports!\n";
         result_file << log_msg;
         std::cerr << log_msg;
         result = EXIT_FAILURE;

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -483,7 +483,7 @@ performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTP
 performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS_ASAN
-performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 
 tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -477,12 +477,13 @@ tests/DCPS/UnregisterType/run_test.pl: !DCPS_MIN
 performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS_ASAN !Win32
 performance-tests/bench/run_test.pl disco_long show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON GH_ACTIONS_ASAN
 performance-tests/bench/run_test.pl disco_long show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON Win32
+performance-tests/bench/run_test.pl disco_repo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS_ASAN
-performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 
 tests/DCPS/DataRepresentation/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -119,12 +119,15 @@ tests/DCPS/Thrasher/run_test.pl medium rtps durable: !DCPS_MIN RTPS !LYNXOS
 tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
 #tests/DCPS/Thrasher/run_test.pl aggressive rtps durable: !DCPS_MIN RTPS !LYNXOS !OPENDDS_SAFETY_PROFILE !GH_ACTIONS_ASAN
 
-performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+#performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl disco_long show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl disco_repo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+#performance-tests/bench/run_test.pl disco_relay show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
-performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -127,7 +127,7 @@ performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DD
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl fan_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
+performance-tests/bench/run_test.pl fan_frag_ws show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS
 performance-tests/bench/run_test.pl mixed show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 


### PR DESCRIPTION
Problem: Bench worker failures (missing reports / report parse failures) are not being correctly reported in test controller report's total error count.

Solution: Add them. Also updating some scenarios for consistency and enabling a few more more scenarios in CI that seem stable.