### PR TITLE
SEDP deadlocks on shutdown

### DIFF
--- a/dds/DCPS/transport/framework/TransportRegistry.inl
+++ b/dds/DCPS/transport/framework/TransportRegistry.inl
@@ -69,15 +69,20 @@ ACE_INLINE
 void
 TransportRegistry::remove_inst(const OPENDDS_STRING& inst_name)
 {
-  GuardType guard(this->lock_);
-  InstMap::iterator iter = inst_map_.find(inst_name);
-  if (iter == inst_map_.end()) {
-    return;
+  TransportInst_rch inst;
+  {
+    GuardType guard(this->lock_);
+    InstMap::iterator iter = inst_map_.find(inst_name);
+    if (iter == inst_map_.end()) {
+      return;
+    }
+    inst = iter->second;
+    inst_map_.erase(iter);
   }
-  if (iter->second) {
-    iter->second->shutdown();
+
+  if (inst) {
+    inst->shutdown();
   }
-  inst_map_.erase(iter);
 }
 
 ACE_INLINE


### PR DESCRIPTION
Problem
-------

The thread that calls `remove_inst` on the TransportRegistry acquires
the lock and then calls `shutdown` on the instance.  This thread
eventually wants the reactor token to shutdown the reactor.

The reactor thread may be processing an event (has the reactor token)
that causes the clean up of SEDP.  This causes SEDP to call
`remove_config` on the TransportRegistry.  `remove_config` wants the
lock.

Solution
--------

Call `shutdown` on the transport inst without the lock.