### PR TITLE
Use Autobuild to Run valgrind Job Tests For Consistency

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4149,15 +4149,55 @@ jobs:
         cd OpenDDS
         . setenv.sh
         tools/scripts/show_build_config.pl
-    - name: run unit tests with valgrind
+    - name: run OpenDDS tests
       shell: bash
       run: |
+        ulimit -c unlimited
         cd OpenDDS
+        echo "export ACE_RUN_VALGRIND_CMD=\"valgrind --leak-check=yes --show-leak-kinds=definite --errors-for-leak-kinds=definite --num-callers=50 --error-exitcode=86\"" >> setenv.sh
+        echo "export ACE_RUNTEST_DELAY=10" >> setenv.sh
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        echo "export ACE_TEST_DEBUGGER=lldb" >> setenv.sh
         . setenv.sh
-        cd tests/unit-tests
-        export ACE_RUN_VALGRIND_CMD="valgrind --leak-check=yes --show-leak-kinds=definite --errors-for-leak-kinds=definite --num-callers=50 --error-exitcode=86"
-        export ACE_RUNTEST_DELAY=10
-        ./run_test.pl --gtest_filter=*-*RecursiveDispatch*
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/valgrind_tests.lst"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   build_u20_p1_j8_FM-1f:
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4111,6 +4111,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: DOCGroup/autobuild
+        ref: 'handle_valgrind_error_summary'
         path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4111,7 +4111,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: DOCGroup/autobuild
-        ref: 'handle_valgrind_error_summary'
         path: autobuild
     - name: checkout ACE_TAO
       uses: actions/checkout@v3

--- a/tests/valgrind_tests.lst
+++ b/tests/valgrind_tests.lst
@@ -1,0 +1,13 @@
+#
+# This is the list of run_test.pl's that need to be run by
+# auto_run_tests.pl.
+# Each line has its own test, and a test can be followed by a
+# list of configurations required to be enabled (or not
+# enabled if preceded by !). For example,
+#
+# tests/DCPS/SomeText/run_test.pl rtps: !DCPS_MIN RTPS
+
+# means to run if the build is not a minimal test and RTPS is enabled.
+#
+
+tests/unit-tests/run_test.pl --gtest_filter=*-*RecursiveDispatch*: !DCPS_MIN !NO_UNIT_TESTS


### PR DESCRIPTION
This should hopefully allow easier expansion / changes of coverage in the future and give output failures consistent reporting (annotations / autobuild artifacts, etc).