### PR TITLE
RtpsRelay doesn't have embedded webserver for meta discovery

### DIFF
--- a/tests/DCPS/RtpsRelay/Smoke/.gitignore
+++ b/tests/DCPS/RtpsRelay/Smoke/.gitignore
@@ -1,3 +1,4 @@
+/metachecker
 /monitor
 /publisher
 /subscriber

--- a/tests/DCPS/RtpsRelay/Smoke/Smoke.mpc
+++ b/tests/DCPS/RtpsRelay/Smoke/Smoke.mpc
@@ -38,3 +38,11 @@ project(RtpsRelayMonitor): dcps_test, opendds_optional_security, dcps_rtps_udp, 
     monitor.cpp
   }
 }
+
+project(RtpsRelayMetaChecker): dcps_test, opendds_cxx11 {
+  exename   = metachecker
+
+  Source_Files {
+    metachecker.cpp
+  }
+}

--- a/tests/DCPS/RtpsRelay/Smoke/metachecker.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/metachecker.cpp
@@ -7,29 +7,34 @@
 #include <ace/SOCK_Connector.h>
 #include <ace/SOCK_Stream.h>
 
-int ACE_TMAIN(int, ACE_TCHAR*[])
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
+  if (argc < 2) {
+    ACE_ERROR((LM_ERROR, "Usage: metachecker IP:PORT\n"));
+    return EXIT_FAILURE;
+  }
+
   ACE_SOCK_Connector connector;
   ACE_SOCK_Stream stream;
-  ACE_INET_Addr remote("127.0.0.1:8081");
+  ACE_INET_Addr remote(argv[1]);
 
   {
     if (connector.connect(stream, remote) != 0) {
-      ACE_ERROR((LM_ERROR, "Could not connect\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Could not connect\n"));
       return EXIT_FAILURE;
     }
 
-    const char request[] = "GET / HTTP/1.1\r\n\r\n";
+    const char request[] = "GET /config HTTP/1.1\r\n\r\n";
     const ssize_t size = sizeof(request) - 1;
     if (stream.send(request, size) != size) {
-      ACE_ERROR((LM_ERROR, "Could not send request\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Could not send request\n"));
       return EXIT_FAILURE;
     }
 
     char response[64 * 1024];
     ssize_t bytes = stream.recv(response, sizeof(response));
     if (bytes <= 0) {
-      ACE_ERROR((LM_ERROR, "Could not read response\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Could not read response\n"));
       return EXIT_FAILURE;
     }
     response[bytes] = 0;
@@ -46,28 +51,28 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
       "{}";
 
     if (strcmp(response, expected_response) != 0) {
-      ACE_ERROR((LM_ERROR, "Did not get expected response\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Did not get expected response\n"));
       return EXIT_FAILURE;
     }
   }
 
   {
     if (connector.connect(stream, remote) != 0) {
-      ACE_ERROR((LM_ERROR, "Could not connect\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Could not connect\n"));
       return EXIT_FAILURE;
     }
 
     const char request[] = "GET /healthcheck HTTP/1.1\r\n\r\n";
     const ssize_t size = sizeof(request) - 1;
     if (stream.send(request, size) != size) {
-      ACE_ERROR((LM_ERROR, "Could not send request\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Could not send request\n"));
       return EXIT_FAILURE;
     }
 
     char response[64 * 1024];
     ssize_t bytes = stream.recv(response, sizeof(response));
     if (bytes <= 0) {
-      ACE_ERROR((LM_ERROR, "Could not read response\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Could not read response\n"));
       return EXIT_FAILURE;
     }
     response[bytes] = 0;
@@ -76,7 +81,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
 
     stream.close();
 
-    const char expected_response[]=
+    const char expected_response[] =
       "HTTP/1.1 200 OK\r\n"
       "Content-Type: text/plain\r\n"
       "Content-Length: 2\r\n"
@@ -84,7 +89,7 @@ int ACE_TMAIN(int, ACE_TCHAR*[])
       "OK";
 
     if (strcmp(response, expected_response) != 0) {
-      ACE_ERROR((LM_ERROR, "Did not get expected response\n"));
+      ACE_ERROR((LM_ERROR, "ERROR: Did not get expected response\n"));
       return EXIT_FAILURE;
     }
   }

--- a/tests/DCPS/RtpsRelay/Smoke/metachecker.cpp
+++ b/tests/DCPS/RtpsRelay/Smoke/metachecker.cpp
@@ -1,0 +1,93 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <ace/Log_Msg.h>
+#include <ace/SOCK_Connector.h>
+#include <ace/SOCK_Stream.h>
+
+int ACE_TMAIN(int, ACE_TCHAR*[])
+{
+  ACE_SOCK_Connector connector;
+  ACE_SOCK_Stream stream;
+  ACE_INET_Addr remote("127.0.0.1:8081");
+
+  {
+    if (connector.connect(stream, remote) != 0) {
+      ACE_ERROR((LM_ERROR, "Could not connect\n"));
+      return EXIT_FAILURE;
+    }
+
+    const char request[] = "GET / HTTP/1.1\r\n\r\n";
+    const ssize_t size = sizeof(request) - 1;
+    if (stream.send(request, size) != size) {
+      ACE_ERROR((LM_ERROR, "Could not send request\n"));
+      return EXIT_FAILURE;
+    }
+
+    char response[64 * 1024];
+    ssize_t bytes = stream.recv(response, sizeof(response));
+    if (bytes <= 0) {
+      ACE_ERROR((LM_ERROR, "Could not read response\n"));
+      return EXIT_FAILURE;
+    }
+    response[bytes] = 0;
+
+    ACE_DEBUG((LM_DEBUG, "Response: %C\n", response));
+
+    stream.close();
+
+    const char expected_response[]=
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: application/json\r\n"
+      "Content-Length: 2\r\n"
+      "\r\n"
+      "{}";
+
+    if (strcmp(response, expected_response) != 0) {
+      ACE_ERROR((LM_ERROR, "Did not get expected response\n"));
+      return EXIT_FAILURE;
+    }
+  }
+
+  {
+    if (connector.connect(stream, remote) != 0) {
+      ACE_ERROR((LM_ERROR, "Could not connect\n"));
+      return EXIT_FAILURE;
+    }
+
+    const char request[] = "GET /healthcheck HTTP/1.1\r\n\r\n";
+    const ssize_t size = sizeof(request) - 1;
+    if (stream.send(request, size) != size) {
+      ACE_ERROR((LM_ERROR, "Could not send request\n"));
+      return EXIT_FAILURE;
+    }
+
+    char response[64 * 1024];
+    ssize_t bytes = stream.recv(response, sizeof(response));
+    if (bytes <= 0) {
+      ACE_ERROR((LM_ERROR, "Could not read response\n"));
+      return EXIT_FAILURE;
+    }
+    response[bytes] = 0;
+
+    ACE_DEBUG((LM_DEBUG, "Response: %C\n", response));
+
+    stream.close();
+
+    const char expected_response[]=
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Type: text/plain\r\n"
+      "Content-Length: 2\r\n"
+      "\r\n"
+      "OK";
+
+    if (strcmp(response, expected_response) != 0) {
+      ACE_ERROR((LM_ERROR, "Did not get expected response\n"));
+      return EXIT_FAILURE;
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/DCPS/RtpsRelay/Smoke/run_test.pl
+++ b/tests/DCPS/RtpsRelay/Smoke/run_test.pl
@@ -67,7 +67,7 @@ $test->process("relay1", "$ENV{DDS_ROOT}/bin/RtpsRelay", get_relay_args(1) . $re
 $test->process("relay2", "$ENV{DDS_ROOT}/bin/RtpsRelay", get_relay_args(2) . $relay_security_opts);
 $test->process("publisher", "publisher", "-ORBDebugLevel 1 -DCPSConfigFile". $pub_ini . $pub_sub_security_opts);
 $test->process("subscriber", "subscriber", "-ORBDebugLevel 1 -DCPSConfigFile" . $sub_ini . $pub_sub_security_opts);
-$test->process("metachecker", "metachecker");
+$test->process("metachecker", "metachecker", "127.0.0.1:8081");
 
 # start a response monitor checking for
 # > 500 ms of clock drift every second.

--- a/tests/DCPS/RtpsRelay/Smoke/run_test.pl
+++ b/tests/DCPS/RtpsRelay/Smoke/run_test.pl
@@ -57,6 +57,7 @@ sub get_relay_args {
     "-ApplicationDomain 42",
     "-VerticalAddress ${port_digit}444",
     "-HorizontalAddress 127.0.0.1:11${port_digit}44",
+    "-MetaDiscoveryAddress 127.0.0.1:808${n}",
     "-ORBVerboseLogging 1"
   );
 }
@@ -66,6 +67,7 @@ $test->process("relay1", "$ENV{DDS_ROOT}/bin/RtpsRelay", get_relay_args(1) . $re
 $test->process("relay2", "$ENV{DDS_ROOT}/bin/RtpsRelay", get_relay_args(2) . $relay_security_opts);
 $test->process("publisher", "publisher", "-ORBDebugLevel 1 -DCPSConfigFile". $pub_ini . $pub_sub_security_opts);
 $test->process("subscriber", "subscriber", "-ORBDebugLevel 1 -DCPSConfigFile" . $sub_ini . $pub_sub_security_opts);
+$test->process("metachecker", "metachecker");
 
 # start a response monitor checking for
 # > 500 ms of clock drift every second.
@@ -90,7 +92,9 @@ if ($test->flag('join')) {
     sleep 1;
     $test->start_process("subscriber");
 }
+$test->start_process("metachecker");
 
+$test->stop_process(5, "metachecker");
 $test->stop_process(20, "subscriber");
 $test->stop_process(5, "publisher");
 

--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -26,6 +26,7 @@ public:
     , log_entries_(false)
     , log_discovery_(false)
     , log_activity_(false)
+    , log_http_(false)
     , log_thread_status_(false)
     , thread_status_safety_factor_(3)
     , utilization_limit_(.95)
@@ -142,6 +143,16 @@ public:
   bool log_activity() const
   {
     return log_activity_;
+  }
+
+  void log_http(bool flag)
+  {
+    log_http_ = flag;
+  }
+
+  bool log_http() const
+  {
+    return log_http_;
   }
 
   void log_thread_status(bool flag)
@@ -276,6 +287,7 @@ private:
   bool log_entries_;
   bool log_discovery_;
   bool log_activity_;
+  bool log_http_;
   bool log_thread_status_;
   int thread_status_safety_factor_;
   double utilization_limit_;

--- a/tools/rtpsrelay/RelayHttpMetaDiscovery.cpp
+++ b/tools/rtpsrelay/RelayHttpMetaDiscovery.cpp
@@ -23,7 +23,7 @@ int HttpConnection::open(void* x)
 {
   relay_http_meta_discovery_ = static_cast<RelayHttpMetaDiscovery*>(x);
 
-  if (-1 == reactor()->register_handler(this, READ_MASK)) {
+  if (HANDLER_ERROR == reactor()->register_handler(this, READ_MASK)) {
     return HANDLER_ERROR;
   }
   return HANDLER_OK;
@@ -65,7 +65,7 @@ bool RelayHttpMetaDiscovery::processRequest(ACE_SOCK_Stream& peer,
   std::string target;
   if (requestIsComplete(request, target)) {
     std::stringstream response;
-    if (target == "/") {
+    if (target == "/config") {
       respond(response);
     } else if (target == "/healthcheck") {
       respondHealthcheck(response);
@@ -125,12 +125,7 @@ void RelayHttpMetaDiscovery::respond(std::stringstream& response) const
 void RelayHttpMetaDiscovery::respondHealthcheck(std::stringstream& response) const
 {
   GuidAddrSet::Proxy proxy(guid_addr_set_);
-
-  if (proxy.admitting()) {
-    respondStatus(response, HTTP_OK);
-  } else {
-    respondStatus(response, HTTP_SERVICE_UNAVAILABLE);
-  }
+  respondStatus(response, proxy.admitting() ? HTTP_OK : HTTP_SERVICE_UNAVAILABLE);
 }
 
 void RelayHttpMetaDiscovery::respondStatus(std::stringstream& response,

--- a/tools/rtpsrelay/RelayHttpMetaDiscovery.cpp
+++ b/tools/rtpsrelay/RelayHttpMetaDiscovery.cpp
@@ -1,0 +1,146 @@
+#include "RelayHttpMetaDiscovery.h"
+
+#include <dds/DCPS/LogAddr.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/ThreadStatusManager.h>
+
+#include <ace/INET_Addr.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+#include <string>
+
+namespace RtpsRelay {
+
+const HttpStatus HTTP_OK(200, "OK");
+const HttpStatus HTTP_NOT_FOUND(404, "Not Found");
+const HttpStatus HTTP_SERVICE_UNAVAILABLE(503, "Service Unavailable");
+
+const int HANDLER_ERROR = -1, HANDLER_REMOVE = -1, HANDLER_OK = 0;
+
+int HttpConnection::open(void* x)
+{
+  relay_http_meta_discovery_ = static_cast<RelayHttpMetaDiscovery*>(x);
+
+  if (-1 == reactor()->register_handler(this, READ_MASK)) {
+    return HANDLER_ERROR;
+  }
+  return HANDLER_OK;
+}
+
+int HttpConnection::handle_input(ACE_HANDLE)
+{
+  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
+
+  const auto bytes = peer().recv(buffer_.wr_ptr(), buffer_.space(),
+                                 &ACE_Time_Value::zero);
+
+  if (bytes == 0) {
+    peer().close_reader();
+    return HANDLER_REMOVE;
+  }
+
+  if (bytes < 0 && errno == ETIME) {
+    return HANDLER_OK;
+  }
+
+  if (bytes <= 0) {
+    return HANDLER_ERROR;
+  }
+
+  buffer_.wr_ptr(bytes);
+  const std::string request(buffer_.rd_ptr(), buffer_.length());
+  if (relay_http_meta_discovery_->processRequest(peer(), request)) {
+    peer().close_writer();
+    buffer_.reset();
+  }
+
+  return HANDLER_OK;
+}
+
+bool RelayHttpMetaDiscovery::processRequest(ACE_SOCK_Stream& peer,
+                                            const std::string& request) const
+{
+  std::string target;
+  if (requestIsComplete(request, target)) {
+    std::stringstream response;
+    if (target == "/") {
+      respond(response);
+    } else if (target == "/healthcheck") {
+      respondHealthcheck(response);
+    } else {
+      respondStatus(response, HTTP_NOT_FOUND);
+    }
+    const std::string& r = response.str();
+    peer.send(r.data(), r.size());
+    if (config_.log_http()) {
+      ACE_INET_Addr remote;
+      peer.get_remote_addr(remote);
+      ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: Request from %C\n%C\n%C\n"), OpenDDS::DCPS::LogAddr(remote).c_str(), request.c_str(), r.c_str()));
+    }
+    return true;
+  }
+  return false;
+}
+
+bool RelayHttpMetaDiscovery::parseRequestLine(const std::string& requestLine,
+                                              std::string& target) const
+{
+  // Only GET is supported
+  static const char METHOD_GET[] = "GET ";
+  static const size_t GET_LEN = sizeof(METHOD_GET) - 1 /* no nul terminator */;
+  if (requestLine.find(METHOD_GET) != 0) return false;
+
+  const auto targetEnd = requestLine.find(' ', GET_LEN);
+  if (targetEnd == std::string::npos ||
+      requestLine.find("HTTP/1.", targetEnd + 1) != targetEnd + 1) {
+    return false;
+  }
+
+  target = std::string(requestLine, GET_LEN, targetEnd - GET_LEN);
+  return true;
+}
+
+bool RelayHttpMetaDiscovery::requestIsComplete(const std::string& request,
+                                               std::string& target) const
+{
+  const auto reqLineEnd = request.find("\r\n");
+  if (reqLineEnd == std::string::npos ||
+      !parseRequestLine(std::string(request, 0, reqLineEnd), target)) {
+    return false;
+  }
+  return request.find("\r\n\r\n") != std::string::npos;
+}
+
+void RelayHttpMetaDiscovery::respond(std::stringstream& response) const
+{
+  response << "HTTP/1.1 200 OK\r\n"
+           << "Content-Type: " << meta_discovery_content_type_ << "\r\n"
+           << "Content-Length: " << meta_discovery_content_.size() << "\r\n"
+           << "\r\n"
+           << meta_discovery_content_;
+}
+
+void RelayHttpMetaDiscovery::respondHealthcheck(std::stringstream& response) const
+{
+  GuidAddrSet::Proxy proxy(guid_addr_set_);
+
+  if (proxy.admitting()) {
+    respondStatus(response, HTTP_OK);
+  } else {
+    respondStatus(response, HTTP_SERVICE_UNAVAILABLE);
+  }
+}
+
+void RelayHttpMetaDiscovery::respondStatus(std::stringstream& response,
+                                           const HttpStatus& status) const
+{
+  response << "HTTP/1.1 " << status.status() << " " << status.message() << "\r\n"
+           << "Content-Type: text/plain\r\n"
+           << "Content-Length: " << status.message().size() << "\r\n"
+           << "\r\n"
+           << status.message();
+}
+
+}

--- a/tools/rtpsrelay/RelayHttpMetaDiscovery.h
+++ b/tools/rtpsrelay/RelayHttpMetaDiscovery.h
@@ -1,0 +1,82 @@
+#ifndef RTPSRELAY_RELAY_HTTP_META_DISCOVERY_H_
+#define RTPSRELAY_RELAY_HTTP_META_DISCOVERY_H_
+
+#include "GuidAddrSet.h"
+
+#include <ace/Acceptor.h>
+#include <ace/Reactor.h>
+#include <ace/SOCK_Acceptor.h>
+#include <ace/SOCK_Stream.h>
+#include <ace/Svc_Handler.h>
+
+namespace RtpsRelay {
+
+const size_t BUFFER_SIZE = 64*1024;
+
+class HttpStatus {
+public:
+  HttpStatus(int status, const char* message)
+    : status_(status)
+    , message_(message)
+  {}
+
+  int status() const { return status_; }
+  const std::string& message() const { return message_; }
+
+private:
+  int status_;
+  std::string message_;
+};
+
+class RelayHttpMetaDiscovery;
+
+// ACE_NULL_SYNCH is appropriate since the reactor is single threaded.
+class HttpConnection : public ACE_Svc_Handler<ACE_SOCK_Stream, ACE_NULL_SYNCH> {
+public:
+  HttpConnection()
+    : relay_http_meta_discovery_(0)
+    , buffer_(BUFFER_SIZE)
+  {}
+
+  int open(void* acceptor); // called by ACE_Acceptor
+
+private:
+  int handle_input(ACE_HANDLE h);
+
+  const RelayHttpMetaDiscovery* relay_http_meta_discovery_;
+  ACE_Message_Block buffer_;
+};
+
+class RelayHttpMetaDiscovery : public ACE_Acceptor<HttpConnection, ACE_SOCK_Acceptor> {
+public:
+  RelayHttpMetaDiscovery(const Config& config,
+                         const std::string& meta_discovery_content_type,
+                         const std::string& meta_discovery_content,
+                         GuidAddrSet& guid_addr_set)
+    : config_(config)
+    , meta_discovery_content_type_(meta_discovery_content_type)
+    , meta_discovery_content_(meta_discovery_content)
+    , guid_addr_set_(guid_addr_set)
+  {}
+
+  bool processRequest(ACE_SOCK_Stream& peer,
+                      const std::string& request) const;
+  bool requestIsComplete(const std::string& request,
+                         std::string& target) const;
+  bool parseRequestLine(const std::string& requestLine,
+                        std::string& target) const;
+
+  void respond(std::stringstream& response) const;
+  void respondHealthcheck(std::stringstream& response) const;
+  void respondStatus(std::stringstream& response, const HttpStatus& status) const;
+
+private:
+  const Config& config_;
+  const std::string meta_discovery_content_type_;
+  const std::string meta_discovery_content_;
+  GuidAddrSet& guid_addr_set_;
+};
+
+}
+
+#endif // RTPSRELAY_RELAY_HTTP_META_DISCOVERY_H_

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -11,6 +11,7 @@
 #include "PublicationListener.h"
 #include "RelayAddressListener.h"
 #include "RelayHandler.h"
+#include "RelayHttpMetaDiscovery.h"
 #include "RelayPartitionTable.h"
 #include "RelayPartitionsListener.h"
 #include "RelayStatisticsReporter.h"
@@ -74,6 +75,10 @@ namespace {
     }
     return ACE_INET_Addr();
   }
+
+  const unsigned short DEFAULT_HORIZONTAL = 17400;
+  const unsigned short DEFAULT_VERTICAL = 7400;
+  const unsigned short DEFAULT_META = 8080;
 }
 
 int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
@@ -85,7 +90,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   DDS::DomainId_t relay_domain = 0;
-  ACE_INET_Addr nic_horizontal, nic_vertical;
+  ACE_INET_Addr nic_horizontal, nic_vertical, meta_discovery_addr;
+  std::string meta_discovery_content_type = "application/json";
+  std::string meta_discovery_content = "{}";
+  std::string meta_discovery_content_path;
   std::string user_data;
   Config config;
 
@@ -111,6 +119,18 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       args.consume_arg();
     } else if ((arg = args.get_the_parameter("-VerticalAddress"))) {
       nic_vertical = ACE_INET_Addr(arg);
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-MetaDiscoveryAddress"))) {
+      meta_discovery_addr = ACE_INET_Addr(arg);
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-MetaDiscoveryContentType"))) {
+      meta_discovery_content_type = arg;
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-MetaDiscoveryContentPath"))) {
+      meta_discovery_content_path = arg;
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-MetaDiscoveryContent"))) {
+      meta_discovery_content = arg;
       args.consume_arg();
     } else if ((arg = args.get_the_parameter("-RelayDomain"))) {
       relay_domain = ACE_OS::atoi(arg);
@@ -144,6 +164,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       args.consume_arg();
     } else if ((arg = args.get_the_parameter("-LogActivity"))) {
       config.log_activity(ACE_OS::atoi(arg));
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-LogHttp"))) {
+      config.log_http(ACE_OS::atoi(arg));
       args.consume_arg();
     } else if ((arg = args.get_the_parameter("-LogThreadStatus"))) {
       config.log_thread_status(ACE_OS::atoi(arg));
@@ -216,12 +239,27 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     }
   }
 
+  if (!meta_discovery_content_path.empty()) {
+    std::ifstream in(meta_discovery_content_path.c_str());
+    if (!in) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Could not open %C\n", meta_discovery_content_path.c_str()));
+      return EXIT_FAILURE;
+    }
+    std::stringstream x;
+    x << in.rdbuf();
+    meta_discovery_content = x.str();
+  }
+
   if (nic_horizontal == ACE_INET_Addr()) {
-    nic_horizontal = get_bind_addr(17400);
+    nic_horizontal = get_bind_addr(DEFAULT_HORIZONTAL);
   }
 
   if (nic_vertical == ACE_INET_Addr()) {
-    nic_vertical = ACE_INET_Addr(7400);
+    nic_vertical = ACE_INET_Addr(DEFAULT_VERTICAL);
+  }
+
+  if (meta_discovery_addr == ACE_INET_Addr()) {
+    meta_discovery_addr = ACE_INET_Addr(DEFAULT_META);
   }
 
   if (config.relay_id().empty()) {
@@ -879,6 +917,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   RelayStatusReporter relay_status_reporter(config, guid_addr_set, relay_status_writer, reactor);
 
   OpenDDS::DCPS::ThreadStatusManager& thread_status_manager = TheServiceParticipant->get_thread_status_manager();
+
+  RelayHttpMetaDiscovery relay_http_meta_discovery(config, meta_discovery_content_type, meta_discovery_content, guid_addr_set);
+  if (relay_http_meta_discovery.open(meta_discovery_addr, reactor) != 0) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: could not open RelayHttpMetaDiscovery\n")));
+    return EXIT_FAILURE;
+  }
+  ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: Meta Discovery listening on %C\n"), OpenDDS::DCPS::LogAddr(meta_discovery_addr).c_str()));
 
   if (thread_status_manager.update_thread_status()) {
     if (relay_thread_monitor->start() == -1) {


### PR DESCRIPTION
Problem
-------

Clients of an RtpsRelay must be configured with the SPDP, SEDP, and
DATA ports of an RtpsRelay instance.  This can be done statically or
dynamically.  In the dynamic scenario, it is convenient to use
TCP/HTTP load balancing to select an instance.  The instance can
return its ports in response to an HTTP request from the client.  For
load balancing, it is useful to include a health check endpoint that
is tied to the RtpsRelay admission control.

The HTTP server to provide this functionality can be implemented
external to the RtpsRelay.  However, deployments will be simplified by
including an embedded webserver in the RtpsRelay can serve the
configuration and answer the healthcheck.

Solution
--------

Embed a webserver in the RtpsRelay that can respond to configuration
and healthcheck requests.
