### PR TITLE
Fix gcc 4.4 Docker Build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3261,7 +3261,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install clang-12
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install clang-12
@@ -3548,7 +3548,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install clang-12
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install clang-12
@@ -3825,7 +3825,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install clang-12
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install clang-12

--- a/.github/workflows/build_u14_gcc4.Dockerfile
+++ b/.github/workflows/build_u14_gcc4.Dockerfile
@@ -17,4 +17,5 @@ RUN cd /opt && \
 
 RUN cd /opt/OpenDDS && \
     ./configure --compiler 'g++-4.4' --security --tests --no-rapidjson --cmake=/opt/cmake-3.22.1-linux-x86_64/bin/cmake && \
+    ln -s $(which g++-4.4) bin/g++ && \
     make -j $(($(nproc)+1))

--- a/configure
+++ b/configure
@@ -954,7 +954,7 @@ sub write_config_h {
   my %buildEnv = %{shift()};
   my $platform = $opts{$buildEnv{'build'}};
   my $pi = $platforminfo{$platform};
-  $opts{'optimize'} = 0 if (!exists $opts{'optimize'} && !exists $opts{'sanitize'});
+  $opts{'optimize'} = 0 if (!exists $opts{'optimize'} || exists $opts{'sanitize'});
 
   my $CFGH = backup_and_open("$buildEnv{'ACE_ROOT'}/ace/config.h");
   if ($buildEnv{'build'} eq 'target') {

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -703,6 +703,13 @@ public:
   bool write_list_end_parameter_id();
 
   /**
+   * Skip a delimiter used for XCDR2 delimited data.
+   *
+   * Returns true if successful
+   */
+  bool skip_delimiter();
+
+  /**
    * Read a delimiter used for XCDR2 delimited data.
    *
    * Returns true if successful and size will be set to the size of the CDR

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -903,14 +903,12 @@ bool Serializer::read_delimiter(size_t& size)
 {
   if (encoding().xcdr_version() == Encoding::XCDR_VERSION_2) {
     ACE_CDR::ULong dheader;
-    if (!(*this >> dheader)) {
-      return false;
+    if (*this >> dheader) {
+      size = dheader;
+      return true;
     }
-    size = dheader;
-  } else {
-    size = 0;
   }
-  return true;
+  return false;
 }
 
 ACE_INLINE

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -899,6 +899,15 @@ Serializer::align_cont_w()
 }
 
 ACE_INLINE
+bool Serializer::skip_delimiter()
+{
+  if (encoding().xcdr_version() == Encoding::XCDR_VERSION_2) {
+    return skip(uint32_cdr_size);
+  }
+  return true;
+}
+
+ACE_INLINE
 bool Serializer::read_delimiter(size_t& size)
 {
   if (encoding().xcdr_version() == Encoding::XCDR_VERSION_2) {

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -907,6 +907,8 @@ bool Serializer::read_delimiter(size_t& size)
       return false;
     }
     size = dheader;
+  } else {
+    size = 0;
   }
   return true;
 }

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -3305,16 +3305,18 @@ bool print_dynamic_data(DDS::DynamicData_ptr dd, DCPS::String& type_string, DCPS
   const DDS::DynamicType_var type = dd->type();
   const DDS::DynamicType_var base_type = get_base_type(type);
 
+  bool result;
   switch (base_type->get_kind()) {
   case TK_STRUCTURE:
-    return print_struct(dd, type_string, indent);
+    result = print_struct(dd, type_string, indent);
     break;
   case TK_UNION:
-    return print_union(dd, type_string, indent);
+    result = print_union(dd, type_string, indent);
     break;
   default:
-    return false;
+    result = false;
   }
+  return result;
 }
 #endif
 


### PR DESCRIPTION
Problem: The UBSAN build changes caused issues with the gcc 4.4 (non-c++11) build on CI. The configure script has a bug which inadvertently turns on optimization for this build, which appears to repeatedly hit an internal compiler bug in gcc 4.4.

Solution: Fix the configure script to avoid `-O3` flag, add symlink to dockerfile to quiet erroneous "no g++" messages, and fix a few low-hanging compiler warnings.