### PR TITLE
Cleanup DataReaderImpl Use of publication_handle_lock_

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -584,6 +584,8 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
 
   // Mirror the add_associations SUBSCRIPTION_MATCHED_STATUS processing.
   if (!this->is_bit_) {
+    ACE_Guard<ACE_Recursive_Thread_Mutex> justMe(publication_handle_lock_);
+
     // Derive the change in the number of publications writing to this reader.
     int matchedPublications = static_cast<int>(this->publication_id_to_handle_map_.size());
     this->subscription_match_status_.current_count_change

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -882,7 +882,6 @@ private:
 
   //Used to protect access to id_to_handle_map_
   ACE_Recursive_Thread_Mutex   publication_handle_lock_;
-  Reverse_Lock_t reverse_pub_handle_lock_;
 
   typedef OPENDDS_MAP_CMP(RepoId, DDS::InstanceHandle_t, GUID_tKeyLessThan) RepoIdToHandleMap;
   RepoIdToHandleMap            publication_id_to_handle_map_;


### PR DESCRIPTION
Problem: Occasionally shutdown hangs while checking if historic samples have been delivered due to a lock order inversion issue.

Solution: Don't lock publication_handle_lock_ so broadly in high level methods, preferring finer grained protection of handles and status.