### PR TITLE
DataWriter doesn't remove unregistered instances

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -1813,21 +1813,10 @@ DataWriterImpl::dispose_and_unregister(DDS::InstanceHandle_t handle,
 void
 DataWriterImpl::unregister_instances(const DDS::Time_t& source_timestamp)
 {
-  {
-    ACE_GUARD(ACE_Thread_Mutex, guard, sync_unreg_rem_assocs_lock_);
+  ACE_GUARD(ACE_Thread_Mutex, guard, sync_unreg_rem_assocs_lock_);
 
-    PublicationInstanceMapType::iterator it =
-      this->data_container_->instances_.begin();
-
-    while (it != this->data_container_->instances_.end()) {
-      if (!it->second->unregistered_) {
-        const DDS::InstanceHandle_t handle = it->first;
-        ++it; // avoid mangling the iterator
-        this->unregister_instance_i(handle, source_timestamp);
-      } else {
-        ++it;
-      }
-    }
+  while (!this->data_container_->instances_.empty()) {
+    this->unregister_instance_i(this->data_container_->instances_.begin()->first, source_timestamp);
   }
 }
 

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -146,9 +146,8 @@ public:
     DDS::InstanceHandle_t instance_handle,
     const DDS::Time_t& timestamp)
   {
-    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
-
     {
+      ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
       typename InstanceMap::iterator pos = instance_map_.find(instance_data);
       if (pos == instance_map_.end()) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::unregister_instance_w_timestamp: ")
@@ -259,9 +258,8 @@ public:
     }
 #endif
 
-    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
-
     {
+      ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
       typename InstanceMap::iterator pos = instance_map_.find(instance_data);
       if (pos == instance_map_.end()) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::dispose_w_timestamp: ")

--- a/dds/DCPS/DataWriterImpl_T.h
+++ b/dds/DCPS/DataWriterImpl_T.h
@@ -146,21 +146,25 @@ public:
     DDS::InstanceHandle_t instance_handle,
     const DDS::Time_t& timestamp)
   {
-    if (instance_handle == DDS::HANDLE_NIL) {
-      instance_handle = this->lookup_instance(instance_data);
-      if (instance_handle == DDS::HANDLE_NIL) {
-        ACE_ERROR_RETURN((
-            LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::unregister_instance_w_timestamp: ")
-            ACE_TEXT("The instance sample is not registered.\n"),
-            TraitsType::type_name()),
-          DDS::RETCODE_ERROR);
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
+
+    {
+      typename InstanceMap::iterator pos = instance_map_.find(instance_data);
+      if (pos == instance_map_.end()) {
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::unregister_instance_w_timestamp: ")
+                          ACE_TEXT("The instance sample is not registered.\n"),
+                          TraitsType::type_name()),
+                         DDS::RETCODE_ERROR);
       }
+
+      if (instance_handle != DDS::HANDLE_NIL && instance_handle != pos->second) {
+        return DDS::RETCODE_PRECONDITION_NOT_MET;
+      }
+
+      instance_handle = pos->second;
+      instance_map_.erase(pos);
     }
 
-    // DataWriterImpl::unregister_instance_i will call back to inform the
-    // DataWriter.
-    // That the instance handle is removed from there and hence
-    // DataWriter can remove the instance here.
     return OpenDDS::DCPS::DataWriterImpl::unregister_instance_i(instance_handle, timestamp);
   }
 
@@ -255,16 +259,22 @@ public:
     }
 #endif
 
-    if (instance_handle == DDS::HANDLE_NIL) {
-      instance_handle = this->lookup_instance(instance_data);
-      if (instance_handle == DDS::HANDLE_NIL) {
-        ACE_ERROR_RETURN((
-            LM_ERROR,
-            ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::dispose_w_timestamp, ")
-            ACE_TEXT("The instance sample is not registered.\n"),
-            TraitsType::type_name()),
-          DDS::RETCODE_ERROR);
+    ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, get_lock(), DDS::RETCODE_ERROR);
+
+    {
+      typename InstanceMap::iterator pos = instance_map_.find(instance_data);
+      if (pos == instance_map_.end()) {
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: %CDataWriterImpl::dispose_w_timestamp: ")
+                          ACE_TEXT("The instance sample is not registered.\n"),
+                          TraitsType::type_name()),
+                         DDS::RETCODE_ERROR);
       }
+
+      if (instance_handle != DDS::HANDLE_NIL && instance_handle != pos->second) {
+        return DDS::RETCODE_PRECONDITION_NOT_MET;
+      }
+
+      instance_handle = pos->second;
     }
 
     return OpenDDS::DCPS::DataWriterImpl::dispose(instance_handle, source_timestamp);
@@ -602,7 +612,7 @@ private:
       handle = it->second;
       OpenDDS::DCPS::PublicationInstance_rch instance = get_handle_instance(handle);
 
-      if (instance && instance->unregistered_ == false) {
+      if (instance) {
         needs_registration = false;
       }
       // else: The instance is unregistered and now register again.

--- a/dds/DCPS/PublicationInstance.h
+++ b/dds/DCPS/PublicationInstance.h
@@ -43,7 +43,6 @@ struct OpenDDS_Dcps_Export PublicationInstance : public virtual RcObject {
     : sequence_(),
       group_id_(0),
       registered_sample_(registered_sample.release()),
-      unregistered_(false),
       instance_handle_(0),
       durable_samples_remaining_(0),
       deadline_()
@@ -64,9 +63,6 @@ struct OpenDDS_Dcps_Export PublicationInstance : public virtual RcObject {
 
   /// History of the instance samples.
   InstanceDataSampleList samples_;
-
-  /// The flag to indicate whether the instance is unregistered.
-  bool unregistered_;
 
   /// The instance handle for the registered object
   DDS::InstanceHandle_t instance_handle_;

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -347,6 +347,14 @@ public:
 
 private:
 
+  DDS::ReturnCode_t unregister_i(PublicationInstance_rch instance,
+                                 Message_Block_Ptr& registered_sample,
+                                 bool dup_registered_sample);
+
+  DDS::ReturnCode_t dispose_i(PublicationInstance_rch instance,
+                              Message_Block_Ptr& registered_sample,
+                              bool dup_registered_sample);
+
   // A class, normally provided by an unit test, that needs access to
   // private methods/members.
   friend class ::DDS_TEST;

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -347,13 +347,9 @@ public:
 
 private:
 
-  DDS::ReturnCode_t unregister_i(PublicationInstance_rch instance,
-                                 Message_Block_Ptr& registered_sample,
-                                 bool dup_registered_sample);
-
-  DDS::ReturnCode_t dispose_i(PublicationInstance_rch instance,
-                              Message_Block_Ptr& registered_sample,
-                              bool dup_registered_sample);
+  DDS::ReturnCode_t remove_instance(PublicationInstance_rch instance,
+                                    Message_Block_Ptr& registered_sample,
+                                    bool dup_registered_sample);
 
   // A class, normally provided by an unit test, that needs access to
   // private methods/members.

--- a/tests/DCPS/FooTest3_0/PubDriver.cpp
+++ b/tests/DCPS/FooTest3_0/PubDriver.cpp
@@ -580,12 +580,17 @@ PubDriver::unregister_test ()
 
   TEST_CHECK (ret == ::DDS::RETCODE_OK);
 
+  TEST_CHECK(DDS::HANDLE_NIL == foo_datawriter_->lookup_instance(foo1));
+
   foo2.sample_sequence = 2;
 
   ret = foo_datawriter_->write(foo2,
                                ::DDS::HANDLE_NIL);
 
   TEST_CHECK (ret == ::DDS::RETCODE_OK);
+
+  handle = foo_datawriter_->lookup_instance(foo2);
+  TEST_CHECK (handle != ::DDS::HANDLE_NIL);
 
   foo2.sample_sequence = 3;
 

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -540,7 +540,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
-  auto participant_statistics_writer_var = relay_publisher->create_datawriter(participant_statistics_topic, writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  auto participant_statistics_writer_qos = writer_qos;
+  participant_statistics_writer_qos.writer_data_lifecycle.autodispose_unregistered_instances = false;
+  auto participant_statistics_writer_var = relay_publisher->create_datawriter(participant_statistics_topic, participant_statistics_writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   if (!participant_statistics_writer_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Participant Statistics data writer\n")));
     return EXIT_FAILURE;
@@ -657,8 +659,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
+  auto relay_participant_status_writer_qos = writer_qos;
+  relay_participant_status_writer_qos.writer_data_lifecycle.autodispose_unregistered_instances = false;
   DDS::DataWriter_var relay_participant_status_writer_var =
-    relay_publisher->create_datawriter(relay_participant_status_topic, writer_qos, nullptr,
+    relay_publisher->create_datawriter(relay_participant_status_topic, relay_participant_status_writer_qos, nullptr,
                                        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   if (!relay_participant_status_writer_var) {


### PR DESCRIPTION
Problem
-------

Entries in the maps of DataWriterImpl_t and WriteDataContainer
correspond to instances.  Unregistering an instance should remove from
these maps to prevent a memory leak.

Solution
--------

Remove from these maps when instances are unregistered.