### PR TITLE
Enums do not have extensibility set

### DIFF
--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2225,7 +2225,7 @@ DomainParticipantImpl::create_recorder(DDS::Topic_ptr a_topic,
 
   recorder->init(dynamic_cast<TopicDescriptionImpl*>(a_topic),
     dr_qos, a_listener,
-    mask, this, subscriber_qos);
+    mask, this, sub_qos);
 
   if ((enabled_ == true) && (qos_.entity_factory.autoenable_created_entities)) {
     recorder->enable();

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -623,8 +623,8 @@ public:
         return true;
       }
     }
-    if (log_level >= LogLevel::Notice) {
-      ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: RtpsDiscoveryConfig::use_xtypes: "
+    if (log_level >= LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: RtpsDiscoveryConfig::use_xtypes: "
                  "invalid XTypes configuration: %C\n", str));
     }
     return false;

--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -1074,7 +1074,9 @@ bool TypeAssignability::assignable_enum(const MinimalTypeObject& ta,
   const TypeFlag extensibility_mask = IS_FINAL | IS_APPENDABLE | IS_MUTABLE;
   TypeFlag ta_ext = ta.enumerated_type.enum_flags & extensibility_mask;
   TypeFlag tb_ext = tb.enumerated_type.enum_flags & extensibility_mask;
-  if (ta_ext != tb_ext) {
+  if (ta_ext != tb_ext  &&
+      // Backwards compatibility.
+      ta_ext != 0 && tb_ext != 0) {
     return false;
   }
 

--- a/dds/DCPS/XTypes/TypeLookupService.h
+++ b/dds/DCPS/XTypes/TypeLookupService.h
@@ -95,6 +95,9 @@ private:
 
   bool get_minimal_type_identifier(const TypeIdentifier& ct, TypeIdentifier& mt) const;
 
+  // Initialize received TypeObjects to defaults.
+  bool set_type_object_defaults(TypeObject& to);
+
   bool complete_to_minimal_struct(const CompleteStructType& ct, MinimalStructType& mt) const;
   bool complete_to_minimal_union(const CompleteUnionType& ct, MinimalUnionType& mt) const;
   bool complete_to_minimal_annotation(const CompleteAnnotationType& ct, MinimalAnnotationType& mt) const;

--- a/dds/DCPS/XTypes/TypeObject.h
+++ b/dds/DCPS/XTypes/TypeObject.h
@@ -1896,7 +1896,7 @@ namespace XTypes {
 
   // Enumerated type
   struct CompleteEnumeratedType  {
-    EnumTypeFlag enum_flags; // unused
+    EnumTypeFlag enum_flags;
     CompleteEnumeratedHeader header;
     CompleteEnumeratedLiteralSeq literal_seq;
 
@@ -1915,7 +1915,7 @@ namespace XTypes {
 
   // Enumerated type
   struct MinimalEnumeratedType  {
-    EnumTypeFlag enum_flags; // unused
+    EnumTypeFlag enum_flags;
     MinimalEnumeratedHeader header;
     MinimalEnumeratedLiteralSeq literal_seq;
 

--- a/dds/idl/be_global.h
+++ b/dds/idl/be_global.h
@@ -217,6 +217,8 @@ public:
    */
   bool warn_about_dcps_data_type();
 
+  ExtensibilityKind extensibility(AST_Decl* node, ExtensibilityKind default_extensibility, bool& has_annotation) const;
+  ExtensibilityKind extensibility(AST_Decl* node, ExtensibilityKind default_extensibility) const;
   ExtensibilityKind extensibility(AST_Decl* node) const;
   AutoidKind autoid(AST_Decl* node) const;
   bool id(AST_Decl* node, ACE_CDR::ULong& value) const;
@@ -239,6 +241,11 @@ public:
 
   bool is_nested(AST_Decl* node);
 
+  bool default_enum_extensibility_zero() const
+  {
+    return default_enum_extensibility_zero_;
+  }
+
 private:
   /// Name of the IDL file we are processing.
   const char* filename_;
@@ -260,6 +267,7 @@ private:
   bool root_default_nested_;
   bool warn_about_dcps_data_type_;
   ExtensibilityKind default_extensibility_;
+  bool default_enum_extensibility_zero_;
   OpenDDS::DataRepresentation default_data_representation_;
   AutoidKind root_default_autoid_;
   TryConstructFailAction default_try_construct_;

--- a/tests/DCPS/Compiler/XtypesExtensibility/.gitignore
+++ b/tests/DCPS/Compiler/XtypesExtensibility/.gitignore
@@ -12,3 +12,16 @@ ExtensibilityTypeSupportImpl.cpp
 ExtensibilityTypeSupportImpl.h
 ExtensibilityTypeSupportS.cpp
 ExtensibilityTypeSupportS.h
+ZeroEnumC.cpp
+ZeroEnumC.h
+ZeroEnumC.inl
+ZeroEnumS.cpp
+ZeroEnumS.h
+ZeroEnumTypeSupport.idl
+ZeroEnumTypeSupportC.cpp
+ZeroEnumTypeSupportC.h
+ZeroEnumTypeSupportC.inl
+ZeroEnumTypeSupportImpl.cpp
+ZeroEnumTypeSupportImpl.h
+ZeroEnumTypeSupportS.cpp
+ZeroEnumTypeSupportS.h

--- a/tests/DCPS/Compiler/XtypesExtensibility/Compiler.mpc
+++ b/tests/DCPS/Compiler/XtypesExtensibility/Compiler.mpc
@@ -3,7 +3,13 @@ project(*XtypesExtensibility): dcps_test, googletest, msvc_bigobj{
   Source_Files {
     XtypesExtensibility.cpp
   }
+
   TypeSupport_Files {
     Extensibility.idl
+  }
+
+  TypeSupport_Files {
+    idlflags += --default-enum-extensibility-zero
+    ZeroEnum.idl
   }
 }

--- a/tests/DCPS/Compiler/XtypesExtensibility/Extensibility.idl
+++ b/tests/DCPS/Compiler/XtypesExtensibility/Extensibility.idl
@@ -90,4 +90,18 @@ module extensibility {
     case 1: short B;
   };
 
+  @extensibility(FINAL)
+  enum FinalEnum {
+    FE
+  };
+
+  @extensibility(APPENDABLE)
+  enum AppendableEnum {
+    AE
+  };
+
+  enum DefaultEnum {
+    DE
+  };
+
 };

--- a/tests/DCPS/Compiler/XtypesExtensibility/XtypesExtensibility.cpp
+++ b/tests/DCPS/Compiler/XtypesExtensibility/XtypesExtensibility.cpp
@@ -3,6 +3,7 @@
  * Currently IS_AUTOID_HASH is not implemented so that should always return false.
  ***/
 #include "ExtensibilityTypeSupportImpl.h"
+#include "ZeroEnumTypeSupportImpl.h"
 
 #include <dds/DCPS/XTypes/TypeObject.h>
 
@@ -83,6 +84,34 @@ TEST(TestDefault, flags_match)
 
   EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_union_default_nested_xtag>()]
             .minimal.union_type.union_flags, IS_APPENDABLE | IS_NESTED);
+}
+
+TEST(TestDefault, FinalEnum)
+{
+  TypeMap type_map = getMinimalTypeMap<extensibility_FinalEnum_xtag>();
+  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_FinalEnum_xtag>()].minimal.enumerated_type.enum_flags,
+            IS_FINAL);
+}
+
+TEST(TestDefault, AppendableEnum)
+{
+  TypeMap type_map = getMinimalTypeMap<extensibility_AppendableEnum_xtag>();
+  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_AppendableEnum_xtag>()].minimal.enumerated_type.enum_flags,
+            IS_APPENDABLE);
+}
+
+TEST(TestDefault, DefaultEnum)
+{
+  TypeMap type_map = getMinimalTypeMap<extensibility_DefaultEnum_xtag>();
+  EXPECT_EQ(type_map[getMinimalTypeIdentifier<extensibility_DefaultEnum_xtag>()].minimal.enumerated_type.enum_flags,
+            IS_APPENDABLE);
+}
+
+TEST(TestDefault, ZeroEnumDefaultEnum)
+{
+  TypeMap type_map = getMinimalTypeMap<ZeroEnum_DefaultEnum_xtag>();
+  EXPECT_EQ(type_map[getMinimalTypeIdentifier<ZeroEnum_DefaultEnum_xtag>()].minimal.enumerated_type.enum_flags,
+            0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/DCPS/Compiler/XtypesExtensibility/ZeroEnum.idl
+++ b/tests/DCPS/Compiler/XtypesExtensibility/ZeroEnum.idl
@@ -1,0 +1,12 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+module ZeroEnum {
+
+  enum DefaultEnum {
+    DE
+  };
+
+};

--- a/tests/DCPS/ZeroEnum/.gitignore
+++ b/tests/DCPS/ZeroEnum/.gitignore
@@ -1,0 +1,17 @@
+/DCS
+/ZeroEnumC.cpp
+/ZeroEnumC.h
+/ZeroEnumC.inl
+/ZeroEnumS.cpp
+/ZeroEnumS.h
+/ZeroEnumTypeSupport.idl
+/ZeroEnumTypeSupportC.cpp
+/ZeroEnumTypeSupportC.h
+/ZeroEnumTypeSupportC.inl
+/ZeroEnumTypeSupportImpl.cpp
+/ZeroEnumTypeSupportImpl.h
+/ZeroEnumTypeSupportS.cpp
+/ZeroEnumTypeSupportS.h
+/README.html
+/publisher
+/subscriber

--- a/tests/DCPS/ZeroEnum/README.rst
+++ b/tests/DCPS/ZeroEnum/README.rst
@@ -1,0 +1,14 @@
+#############
+ZeroEnum Test
+#############
+
+Previous versions of OpenDDS did not set the extensibility flags for enums (they were zero) in minimal and complete type objects.
+These are treated as wild cards meaning that they will not cause the type assignability check to fail.
+The idl compiler option `-Gxtypes-complete --default-enum-extensibility-zero` was added to force the old behavior.
+
+This test checks that
+
+1. Zero extensibility flags for enums are handled correctly.
+2. The extensibility is set to appendable when converting to a dynamic type.
+
+This test use two processes to force the use of the type lookup service which should log a warning about zero enum flags, e.g., `(48706|123145452138496) WARNING: TypeLookupService::set_type_object_defaults: Zero extensibility flags in TK_ENUM`.

--- a/tests/DCPS/ZeroEnum/ZeroEnum.idl
+++ b/tests/DCPS/ZeroEnum/ZeroEnum.idl
@@ -1,0 +1,32 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+module ZeroEnum {
+
+  const long HELLO_WORLD_DOMAIN = 111;
+
+  // Actors
+  const string MAIN = "MAIN";
+  const string LISTENER = "LISTENER";
+
+  // Conditions
+  const string ON_RECORDER_MATCHED = "ON_RECORDER_MATCHED";
+  const string ON_SAMPLE_DATA_RECEIVED = "ON_SAMPLE_DATA_RECEIVED";
+
+  enum MyEnum {
+    E1,
+    E2
+  };
+
+  @topic
+  struct Message {
+    string value;
+    MyEnum my_enum;
+  };
+
+  const string MESSAGE_TOPIC_NAME = "Message";
+};

--- a/tests/DCPS/ZeroEnum/ZeroEnum.mpc
+++ b/tests/DCPS/ZeroEnum/ZeroEnum.mpc
@@ -1,0 +1,26 @@
+
+project(*Publisher) : dcpsexe, dcps_test, dcps_transports_for_test {
+  requires += no_opendds_safety_profile
+
+  TypeSupport_Files {
+    idlflags += -Gxtypes-complete --default-enum-extensibility-zero
+    ZeroEnum.idl
+  }
+
+  Source_Files {
+    publisher.cpp
+  }
+}
+
+project(*Subscriber) : dcpsexe, dcps_test, dcps_transports_for_test {
+  requires += no_opendds_safety_profile
+
+  TypeSupport_Files {
+    idlflags += -Gxtypes-complete --default-enum-extensibility-zero
+    ZeroEnum.idl
+  }
+
+  Source_Files {
+    subscriber.cpp
+  }
+}

--- a/tests/DCPS/ZeroEnum/publisher.cpp
+++ b/tests/DCPS/ZeroEnum/publisher.cpp
@@ -1,0 +1,64 @@
+// -*- C++ -*-
+#include "ZeroEnumTypeSupportImpl.h"
+
+#include "tests/Utils/DistributedConditionSet.h"
+#include "tests/Utils/StatusMatching.h"
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include "dds/DCPS/StaticIncludes.h"
+
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  DistributedConditionSet_rch distributed_condition_set =
+    OpenDDS::DCPS::make_rch<FileBasedDistributedConditionSet>();
+
+  DDS::DomainParticipantFactory_var domain_participant_factory = TheParticipantFactoryWithArgs(argc, argv);
+  DDS::DomainParticipant_var participant =
+    domain_participant_factory->create_participant(ZeroEnum::HELLO_WORLD_DOMAIN,
+                                                   PARTICIPANT_QOS_DEFAULT,
+                                                   0,
+                                                   0);
+
+  ZeroEnum::MessageTypeSupport_var type_support = new ZeroEnum::MessageTypeSupportImpl();
+  type_support->register_type(participant, "");
+  CORBA::String_var type_name = type_support->get_type_name();
+
+  DDS::Topic_var topic = participant->create_topic(ZeroEnum::MESSAGE_TOPIC_NAME,
+                                                   type_name,
+                                                   TOPIC_QOS_DEFAULT,
+                                                   0,
+                                                   0);
+
+  DDS::Publisher_var publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT,
+                                                               0,
+                                                               0);
+
+  DDS::DataWriter_var data_writer = publisher->create_datawriter(topic,
+                                                                 DATAWRITER_QOS_DEFAULT,
+                                                                 0,
+                                                                 0);
+
+  Utils::wait_match(data_writer, 1);
+  distributed_condition_set->wait_for(ZeroEnum::MAIN, ZeroEnum::LISTENER, ZeroEnum::ON_RECORDER_MATCHED);
+
+  ZeroEnum::MessageDataWriter_var message_data_writer = ZeroEnum::MessageDataWriter::_narrow(data_writer);
+
+  ZeroEnum::Message message;
+  message.value = "Hello World!";
+  message.my_enum = ZeroEnum::E1;
+
+  message_data_writer->write(message, DDS::HANDLE_NIL);
+  distributed_condition_set->wait_for(ZeroEnum::MAIN, ZeroEnum::LISTENER, ZeroEnum::ON_SAMPLE_DATA_RECEIVED);
+
+  participant->delete_contained_entities();
+  domain_participant_factory->delete_participant(participant);
+  TheServiceParticipant->shutdown();
+
+  return EXIT_SUCCESS;
+}

--- a/tests/DCPS/ZeroEnum/rtps.ini
+++ b/tests/DCPS/ZeroEnum/rtps.ini
@@ -1,0 +1,14 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[domain/111]
+DiscoveryConfig=fast_rtps
+
+[rtps_discovery/fast_rtps]
+SedpMulticast=0
+ResendPeriod=2
+UseXTypes=complete
+
+[transport/the_rtps_transport]
+transport_type=rtps_udp
+use_multicast=0

--- a/tests/DCPS/ZeroEnum/run_test.pl
+++ b/tests/DCPS/ZeroEnum/run_test.pl
@@ -1,0 +1,24 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+use Env (DDS_ROOT);
+use lib "$DDS_ROOT/bin";
+use Env (ACE_ROOT);
+use lib "$ACE_ROOT/bin";
+use PerlDDS::Run_Test;
+use File::Path;
+use strict;
+
+my $test = new PerlDDS::TestFramework();
+$test->process('publisher', 'publisher', '-DCPSDebugLevel 4 -DCPSConfigFile rtps.ini ');
+$test->process('subscriber', 'subscriber', '-DCPSDebugLevel 4 -DCPSConfigFile rtps.ini ');
+
+rmtree './DCS';
+
+$test->start_process('publisher');
+$test->start_process('subscriber');
+
+exit $test->finish(30);

--- a/tests/DCPS/ZeroEnum/subscriber.cpp
+++ b/tests/DCPS/ZeroEnum/subscriber.cpp
@@ -1,0 +1,114 @@
+// -*- C++ -*-
+#include "ZeroEnumTypeSupportImpl.h"
+
+#include "tests/Utils/DistributedConditionSet.h"
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include "dds/DCPS/StaticIncludes.h"
+
+#ifdef ACE_AS_STATIC_LIBS
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+class RecorderListenerImpl : public virtual OpenDDS::DCPS::RecorderListener {
+public:
+  RecorderListenerImpl(DistributedConditionSet_rch dcs)
+    : dcs_(dcs)
+  {}
+
+private:
+  void on_sample_data_received(OpenDDS::DCPS::Recorder* recorder,
+                               const OpenDDS::DCPS::RawDataSample& sample)
+  {
+    DDS::DynamicData_var dd = recorder->get_dynamic_data(sample);
+    DDS::DynamicType_var type = dd->type();
+    DDS::DynamicTypeMember_var dtm;
+    if (type->get_member_by_name(dtm, "my_enum") != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "ERROR: TEST could get dynamic type member for my_enum"));
+      abort();
+
+    }
+    DDS::MemberDescriptor_var md;
+    if (dtm->get_descriptor(md) != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "ERROR: TEST could get member descriptor for my_enum"));
+      abort();
+    }
+    DDS::DynamicType_ptr enum_type = md->type();
+    DDS::TypeDescriptor_var desc;
+    if (enum_type->get_descriptor(desc) != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "ERROR: TEST could get type descriptor for my_enum"));
+      abort();
+    }
+
+    if (desc->kind() != OpenDDS::XTypes::TK_ENUM) {
+      ACE_ERROR((LM_ERROR, "ERROR: TEST my_enum is not a TK_ENUM"));
+      abort();
+    }
+
+    if (desc->extensibility_kind() != DDS::APPENDABLE) {
+      ACE_ERROR((LM_ERROR, "ERROR: TEST my_enum does not have the expected extensibility"));
+      abort();
+    }
+
+    dcs_->post(ZeroEnum::LISTENER, ZeroEnum::ON_SAMPLE_DATA_RECEIVED);
+  }
+
+  void on_recorder_matched(OpenDDS::DCPS::Recorder*,
+                           const DDS::SubscriptionMatchedStatus&)
+  {
+    dcs_->post(ZeroEnum::LISTENER, ZeroEnum::ON_RECORDER_MATCHED);
+  }
+
+  DistributedConditionSet_rch dcs_;
+};
+
+int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  DistributedConditionSet_rch distributed_condition_set =
+    OpenDDS::DCPS::make_rch<FileBasedDistributedConditionSet>();
+
+  DDS::DomainParticipantFactory_var domain_participant_factory = TheParticipantFactoryWithArgs(argc, argv);
+  DDS::DomainParticipant_var participant =
+    domain_participant_factory->create_participant(ZeroEnum::HELLO_WORLD_DOMAIN,
+                                                   PARTICIPANT_QOS_DEFAULT,
+                                                   0,
+                                                   0);
+
+  ZeroEnum::MessageTypeSupport_var type_support = new ZeroEnum::MessageTypeSupportImpl();
+  CORBA::String_var type_name = type_support->get_type_name();
+
+  DDS::Topic_var typeless_topic =
+    TheServiceParticipant->create_typeless_topic(participant,
+                                                 ZeroEnum::MESSAGE_TOPIC_NAME,
+                                                 type_name,
+                                                 true,
+                                                 TOPIC_QOS_DEFAULT,
+                                                 0,
+                                                 0);
+
+  DDS::DataReaderQos data_reader_qos = TheServiceParticipant->initial_DataReaderQos();
+  data_reader_qos.representation.value.length(1);
+  data_reader_qos.representation.value[0] = DDS::XCDR2_DATA_REPRESENTATION;
+  data_reader_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+
+  OpenDDS::DCPS::RcHandle<RecorderListenerImpl> listener = OpenDDS::DCPS::make_rch<RecorderListenerImpl>(distributed_condition_set);
+
+  // Create Recorder
+  OpenDDS::DCPS::Recorder_var recorder =
+    TheServiceParticipant->create_recorder(participant,
+                                           typeless_topic,
+                                           SUBSCRIBER_QOS_DEFAULT,
+                                           data_reader_qos,
+                                           listener);
+
+  distributed_condition_set->wait_for(ZeroEnum::LISTENER, ZeroEnum::LISTENER, ZeroEnum::ON_SAMPLE_DATA_RECEIVED);
+
+  TheServiceParticipant->delete_recorder(recorder);
+  participant->delete_contained_entities();
+  domain_participant_factory->delete_participant(participant);
+  TheServiceParticipant->shutdown();
+
+  return EXIT_SUCCESS;
+}

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -496,3 +496,5 @@ tests/dissector/run_test.pl: RAPIDJSON WIRESHARK
 
 tests/DCPS/HelloWorld/run_test.pl: !OPENDDS_SAFETY_PROFILE
 tests/DCPS/HelloWorld/run_test.pl ini=rtps.ini: RTPS !OPENDDS_SAFETY_PROFILE
+
+tests/DCPS/ZeroEnum/run_test.pl: !OPENDDS_SAFETY_PROFILE

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicTypeImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicTypeImpl.cpp
@@ -217,7 +217,7 @@ TEST_F(dds_DCPS_XTypes_DynamicTypeImpl, CompleteToDynamicType_PrimitiveKind)
   td->name("MyModCompleteToDynamic::PrimitiveKind");
   td->bound().length(1);
   td->bound()[0] = 32;
-  td->extensibility_kind(DDS::FINAL);
+  td->extensibility_kind(DDS::APPENDABLE);
   td->is_nested(0);
   XTypes::DynamicTypeMemberImpl* first_expected_dtm = new XTypes::DynamicTypeMemberImpl();
   DDS::DynamicTypeMember_var first_expected_dtm_var = first_expected_dtm;
@@ -321,7 +321,7 @@ TEST_F(dds_DCPS_XTypes_DynamicTypeImpl, CompleteToDynamicType_MyUnion)
   enum_td->name("MyModCompleteToDynamic::PrimitiveKind");
   enum_td->bound().length(1);
   enum_td->bound()[0] = 32;
-  enum_td->extensibility_kind(DDS::FINAL);
+  enum_td->extensibility_kind(DDS::APPENDABLE);
   enum_td->is_nested(0);
   XTypes::DynamicTypeMemberImpl* first_expected_dtm = new XTypes::DynamicTypeMemberImpl();
   DDS::DynamicTypeMember_var first_expected_dtm_var = first_expected_dtm;


### PR DESCRIPTION
Problem
-------

The IDL compiler does not set the extensibility for an enum.

Solution
--------

Set the extensibility in the IDL compiler.  For backwards
compatibility, 1) the extensibility will be set on received
TypeObjects and 2) the IDL compiler will have an option for not
setting the extensibility.