### PR TITLE
TAO sequences compiled for safety profile

### DIFF
--- a/dds/DdsDynamicDataSeq.idl
+++ b/dds/DdsDynamicDataSeq.idl
@@ -8,6 +8,8 @@
 #ifndef OPENDDS_DDS_DYNAMIC_DATA_SEQ_IDL
 #define OPENDDS_DDS_DYNAMIC_DATA_SEQ_IDL
 
+#ifndef OPENDDS_SAFETY_PROFILE
+
 #include <tao/LongSeq.pidl>
 #include <tao/ULongSeq.pidl>
 #include <tao/Int8Seq.pidl>
@@ -48,5 +50,7 @@ module DDS {
   typedef sequence<wstring> WstringSeq;
 
 };
+
+#endif // OPENDDS_SAFETY_PROFILE
 
 #endif /* OPENDDS_DDS_DYNAMIC_DATA_SEQ_IDL */

--- a/tools/scripts/analyze_operator_new.sh
+++ b/tools/scripts/analyze_operator_new.sh
@@ -1,3 +1,7 @@
 #/bin/bash
 
-objdump -C -l -d -S $@ | awk -f $DDS_ROOT/tools/scripts/find_operator_new.awk | grep -v -e '^$' | sort | uniq -c | grep -v -e MemoryPool -e SafetyProfilePool -e Malloc_Allocator -e Object_Manager
+for file in "$@"
+do
+    echo "Processing ${file}"
+    objdump -C -l -d -S "${file}" | awk -f $DDS_ROOT/tools/scripts/find_operator_new.awk | grep -v -e '^$' | sort | uniq -c | grep -v -e MemoryPool -e SafetyProfilePool -e Malloc_Allocator -e Object_Manager
+done


### PR DESCRIPTION
Problem
-------

TAO sequences are being compiled for safety profile which is resulting
in a call to global operator new.  The issue was introduced with
recent changes to Dynamic Data support.

Solution
--------

Don't compile the sequence types in safety profile.