### PR TITLE
Parsing partition names can result in buffer overflow

### DIFF
--- a/dds/FACE/config/QosSettings.cpp
+++ b/dds/FACE/config/QosSettings.cpp
@@ -168,13 +168,23 @@ set_partition_name_qos(
     char buffer[128];
     std::memset(buffer, 0, sizeof(buffer));
     while (const char* next_comma = std::strchr(start, ',')) {
-      // Copy into temp buffer, won't have null
-      std::strncpy(buffer, start, next_comma - start);
-      // Append null
-      buffer[next_comma - start] = '\0';
-      // Add to QOS
-      target.name.length(target.name.length() + 1);
-      target.name[target.name.length() - 1] = static_cast<const char*>(buffer);
+      const size_t size = next_comma - start;
+      if (size < sizeof(buffer)) {
+        // Copy into temp buffer, won't have null
+        std::strncpy(buffer, start, size);
+        // Append null
+        buffer[size] = '\0';
+        // Add to QOS
+        target.name.length(target.name.length() + 1);
+        target.name[target.name.length() - 1] = static_cast<const char*>(buffer);
+      } else {
+        if (DCPS::log_level >= DCPS::LogLevel::Error) {
+          ACE_ERROR((LM_ERROR,
+                     ACE_TEXT("(%P|%t) ERROR: set_partition_name_qos: ")
+                     ACE_TEXT("partition name of length %B exceeds maximum length of %B\n"),
+                     size, sizeof(buffer) - 1));
+        }
+      }
       // Advance pointer
       start = next_comma + 1;
     }

--- a/tests/unit-tests/dds/FACE/config/QosSettings.cpp
+++ b/tests/unit-tests/dds/FACE/config/QosSettings.cpp
@@ -56,6 +56,16 @@ void test_set_publisher_multiple_partitions() {
   EXPECT_TRUE(!strcmp(qos.partition.name[1], "Bar234"));
 }
 
+void test_set_publisher_partition_too_long() {
+  QosSettings settings;
+
+  settings.set_qos(QosSettings::publisher, "partition.name", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+  DDS::PublisherQos qos;
+  settings.apply_to(qos);
+
+  EXPECT_TRUE(0 == qos.partition.name.length());
+}
+
 void test_set_publisher_presentation_access_scope_instance() {
   QosSettings settings;
 

--- a/tests/unit-tests/dds/FACE/config/QosSettings.cpp
+++ b/tests/unit-tests/dds/FACE/config/QosSettings.cpp
@@ -1,3 +1,8 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
 #include "dds/DCPS/Definitions.h"
 
 #ifndef DDS_HAS_WCHAR
@@ -32,7 +37,7 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
 
 /////// Publisher tests
-void test_set_publisher_single_partition() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_single_partition) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "partition.name", "Foo123");
@@ -43,7 +48,7 @@ void test_set_publisher_single_partition() {
   EXPECT_TRUE(!strcmp(qos.partition.name[0], "Foo123"));
 }
 
-void test_set_publisher_multiple_partitions() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_multiple_partitions) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "partition.name", "Foo123,Bar234");
@@ -56,7 +61,7 @@ void test_set_publisher_multiple_partitions() {
   EXPECT_TRUE(!strcmp(qos.partition.name[1], "Bar234"));
 }
 
-void test_set_publisher_partition_too_long() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_partition_too_long) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "partition.name", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
@@ -66,7 +71,7 @@ void test_set_publisher_partition_too_long() {
   EXPECT_TRUE(0 == qos.partition.name.length());
 }
 
-void test_set_publisher_presentation_access_scope_instance() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_access_scope_instance) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.access_scope", "INSTANCE");
@@ -76,7 +81,7 @@ void test_set_publisher_presentation_access_scope_instance() {
   EXPECT_TRUE(DDS::INSTANCE_PRESENTATION_QOS == qos.presentation.access_scope);
 }
 
-void test_set_publisher_presentation_access_scope_topic() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_access_scope_topic) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.access_scope", "TOPIC");
@@ -86,7 +91,7 @@ void test_set_publisher_presentation_access_scope_topic() {
   EXPECT_TRUE(DDS::TOPIC_PRESENTATION_QOS == qos.presentation.access_scope);
 }
 
-void test_set_publisher_presentation_access_scope_group() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_access_scope_group) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.access_scope", "GROUP");
@@ -96,7 +101,7 @@ void test_set_publisher_presentation_access_scope_group() {
   EXPECT_TRUE(DDS::GROUP_PRESENTATION_QOS == qos.presentation.access_scope);
 }
 
-void test_set_publisher_presentation_coherent_access_true() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_coherent_access_true) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.coherent_access", "true");
@@ -106,7 +111,7 @@ void test_set_publisher_presentation_coherent_access_true() {
   EXPECT_TRUE(qos.presentation.coherent_access);
 }
 
-void test_set_publisher_presentation_coherent_access_false() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_coherent_access_false) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.coherent_access", "false");
@@ -116,7 +121,7 @@ void test_set_publisher_presentation_coherent_access_false() {
   EXPECT_TRUE(!qos.presentation.coherent_access);
 }
 
-void test_set_publisher_presentation_ordered_access_true() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_ordered_access_true) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.ordered_access", "true");
@@ -126,7 +131,7 @@ void test_set_publisher_presentation_ordered_access_true() {
   EXPECT_TRUE(qos.presentation.ordered_access);
 }
 
-void test_set_publisher_presentation_ordered_access_false() {
+TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_ordered_access_false) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::publisher, "presentation.ordered_access", "false");
@@ -137,7 +142,7 @@ void test_set_publisher_presentation_ordered_access_false() {
 }
 
 /////// Subscriber tests
-void test_set_subscriber_single_partition() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_single_partition) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "partition.name", "Foo123");
@@ -148,7 +153,7 @@ void test_set_subscriber_single_partition() {
   EXPECT_TRUE(!strcmp(qos.partition.name[0], "Foo123"));
 }
 
-void test_set_subscriber_multiple_partitions() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_multiple_partitions) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "partition.name", "Foo123");
@@ -162,7 +167,7 @@ void test_set_subscriber_multiple_partitions() {
   EXPECT_TRUE(!strcmp(qos.partition.name[1], "Bar234"));
 }
 
-void test_set_subscriber_presentation_access_scope_instance() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_access_scope_instance) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.access_scope", "INSTANCE");
@@ -172,7 +177,7 @@ void test_set_subscriber_presentation_access_scope_instance() {
   EXPECT_TRUE(DDS::INSTANCE_PRESENTATION_QOS == qos.presentation.access_scope);
 }
 
-void test_set_subscriber_presentation_access_scope_topic() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_access_scope_topic) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.access_scope", "TOPIC");
@@ -182,7 +187,7 @@ void test_set_subscriber_presentation_access_scope_topic() {
   EXPECT_TRUE(DDS::TOPIC_PRESENTATION_QOS == qos.presentation.access_scope);
 }
 
-void test_set_subscriber_presentation_access_scope_group() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_access_scope_group) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.access_scope", "GROUP");
@@ -192,7 +197,7 @@ void test_set_subscriber_presentation_access_scope_group() {
   EXPECT_TRUE(DDS::GROUP_PRESENTATION_QOS == qos.presentation.access_scope);
 }
 
-void test_set_subscriber_presentation_coherent_access_true() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_coherent_access_true) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.coherent_access", "true");
@@ -202,7 +207,7 @@ void test_set_subscriber_presentation_coherent_access_true() {
   EXPECT_TRUE(qos.presentation.coherent_access);
 }
 
-void test_set_subscriber_presentation_coherent_access_false() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_coherent_access_false) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.coherent_access", "false");
@@ -212,7 +217,7 @@ void test_set_subscriber_presentation_coherent_access_false() {
   EXPECT_TRUE(!qos.presentation.coherent_access);
 }
 
-void test_set_subscriber_presentation_ordered_access_true() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_ordered_access_true) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.ordered_access", "true");
@@ -222,7 +227,7 @@ void test_set_subscriber_presentation_ordered_access_true() {
   EXPECT_TRUE(qos.presentation.ordered_access);
 }
 
-void test_set_subscriber_presentation_ordered_access_false() {
+TEST(dds_FACE_config_QosSettings, test_set_subscriber_presentation_ordered_access_false) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::subscriber, "presentation.ordered_access", "false");
@@ -233,8 +238,7 @@ void test_set_subscriber_presentation_ordered_access_false() {
 }
 
 /////// DataWriter tests
-void test_set_datawriter_durability_volatile()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_durability_volatile) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "durability.kind", "VOLATILE");
@@ -244,8 +248,7 @@ void test_set_datawriter_durability_volatile()
   EXPECT_TRUE(DDS::VOLATILE_DURABILITY_QOS == qos.durability.kind);
 }
 
-void test_set_datawriter_durability_transient_local()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_durability_transient_local) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "durability.kind", "TRANSIENT_LOCAL");
@@ -255,8 +258,8 @@ void test_set_datawriter_durability_transient_local()
   EXPECT_TRUE(DDS::TRANSIENT_LOCAL_DURABILITY_QOS == qos.durability.kind);
 }
 
-void test_set_datawriter_durability_transient()
-{
+#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_durability_transient) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "durability.kind", "TRANSIENT");
@@ -265,9 +268,10 @@ void test_set_datawriter_durability_transient()
 
   EXPECT_TRUE(DDS::TRANSIENT_DURABILITY_QOS == qos.durability.kind);
 }
+#endif
 
-void test_set_datawriter_durability_persistent()
-{
+#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_durability_persistent) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "durability.kind", "PERSISTENT");
@@ -276,8 +280,9 @@ void test_set_datawriter_durability_persistent()
 
   EXPECT_TRUE(DDS::PERSISTENT_DURABILITY_QOS == qos.durability.kind);
 }
+#endif
 
-void test_set_datawriter_deadline_sec() {
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_deadline_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "deadline.period.sec", "2");
@@ -289,7 +294,7 @@ void test_set_datawriter_deadline_sec() {
   EXPECT_TRUE(0 == qos.deadline.period.nanosec);
 }
 
-void test_set_datawriter_deadline_nanosec() {
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_deadline_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "deadline.period.sec", "0");
@@ -301,7 +306,7 @@ void test_set_datawriter_deadline_nanosec() {
   EXPECT_TRUE(200 == qos.deadline.period.nanosec);
 }
 
-void test_set_datawriter_deadline_both() {
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_deadline_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "deadline.period.sec", "3");
@@ -313,7 +318,7 @@ void test_set_datawriter_deadline_both() {
   EXPECT_TRUE(500 == qos.deadline.period.nanosec);
 }
 
-void test_set_datawriter_latency_budget_sec() {
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_latency_budget_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "latency_budget.duration.sec", "2");
@@ -324,7 +329,7 @@ void test_set_datawriter_latency_budget_sec() {
   EXPECT_TRUE(0 == qos.latency_budget.duration.nanosec);
 }
 
-void test_set_datawriter_latency_budget_nanosec() {
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_latency_budget_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "latency_budget.duration.nanosec", "350");
@@ -335,7 +340,7 @@ void test_set_datawriter_latency_budget_nanosec() {
   EXPECT_TRUE(350 == qos.latency_budget.duration.nanosec);
 }
 
-void test_set_datawriter_latency_budget_both() {
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_latency_budget_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "latency_budget.duration.sec", "1");
@@ -347,9 +352,7 @@ void test_set_datawriter_latency_budget_both() {
   EXPECT_TRUE(150 == qos.latency_budget.duration.nanosec);
 }
 
-void
-test_set_datawriter_liveliness_kind_automatic()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_liveliness_kind_automatic) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "liveliness.kind", "AUTOMATIC");
@@ -359,9 +362,7 @@ test_set_datawriter_liveliness_kind_automatic()
   EXPECT_TRUE(DDS::AUTOMATIC_LIVELINESS_QOS  == qos.liveliness.kind);
 }
 
-void
-test_set_datawriter_liveliness_kind_manual_by_topic()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_liveliness_kind_manual_by_topic) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "liveliness.kind", "MANUAL_BY_TOPIC");
@@ -371,9 +372,7 @@ test_set_datawriter_liveliness_kind_manual_by_topic()
   EXPECT_TRUE(DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS  == qos.liveliness.kind);
 }
 
-void
-test_set_datawriter_liveliness_kind_manual_by_participant()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_liveliness_kind_manual_by_participant) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "liveliness.kind", "MANUAL_BY_PARTICIPANT");
@@ -383,9 +382,7 @@ test_set_datawriter_liveliness_kind_manual_by_participant()
   EXPECT_TRUE(DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS  == qos.liveliness.kind);
 }
 
-void
-test_set_datawriter_liveliness_lease_duration_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_liveliness_lease_duration_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "liveliness.lease_duration.sec", "2");
@@ -397,9 +394,7 @@ test_set_datawriter_liveliness_lease_duration_sec()
   EXPECT_TRUE(0 == qos.liveliness.lease_duration.nanosec);
 }
 
-void
-test_set_datawriter_liveliness_lease_duration_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_liveliness_lease_duration_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "liveliness.lease_duration.sec", "0");
@@ -411,9 +406,7 @@ test_set_datawriter_liveliness_lease_duration_nanosec()
   EXPECT_TRUE(333 == qos.liveliness.lease_duration.nanosec);
 }
 
-void
-test_set_datawriter_liveliness_lease_duration_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_liveliness_lease_duration_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "liveliness.lease_duration.sec", "1");
@@ -425,8 +418,7 @@ test_set_datawriter_liveliness_lease_duration_both()
   EXPECT_TRUE(333 == qos.liveliness.lease_duration.nanosec);
 }
 
-void test_set_datawriter_reliability_kind_best_effort()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_reliability_kind_best_effort) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "reliability.kind", "BEST_EFFORT");
@@ -436,8 +428,7 @@ void test_set_datawriter_reliability_kind_best_effort()
   EXPECT_TRUE(DDS::BEST_EFFORT_RELIABILITY_QOS == qos.reliability.kind);
 }
 
-void test_set_datawriter_reliability_kind_reliable()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_reliability_kind_reliable) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "reliability.kind", "RELIABLE");
@@ -447,8 +438,7 @@ void test_set_datawriter_reliability_kind_reliable()
   EXPECT_TRUE(DDS::RELIABLE_RELIABILITY_QOS == qos.reliability.kind);
 }
 
-void test_set_datawriter_reliability_max_blocking_time_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_reliability_max_blocking_time_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "reliability.max_blocking_time.sec", "2");
@@ -460,8 +450,7 @@ void test_set_datawriter_reliability_max_blocking_time_sec()
   EXPECT_TRUE(0 == qos.reliability.max_blocking_time.nanosec);
 }
 
-void test_set_datawriter_reliability_max_blocking_time_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_reliability_max_blocking_time_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "reliability.max_blocking_time.nanosec", "175");
@@ -472,8 +461,7 @@ void test_set_datawriter_reliability_max_blocking_time_nanosec()
   EXPECT_TRUE(175 == qos.reliability.max_blocking_time.nanosec);
 }
 
-void test_set_datawriter_reliability_max_blocking_time_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_reliability_max_blocking_time_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "reliability.max_blocking_time.sec", "1");
@@ -485,8 +473,7 @@ void test_set_datawriter_reliability_max_blocking_time_both()
   EXPECT_TRUE(175 == qos.reliability.max_blocking_time.nanosec);
 }
 
-void test_set_datawriter_destination_order_kind_by_source_timestamp()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_destination_order_kind_by_source_timestamp) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "destination_order.kind", "BY_SOURCE_TIMESTAMP");
@@ -497,8 +484,7 @@ void test_set_datawriter_destination_order_kind_by_source_timestamp()
              qos.destination_order.kind);
 }
 
-void test_set_datawriter_destination_order_kind_by_reception_timestamp()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_destination_order_kind_by_reception_timestamp) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "destination_order.kind", "BY_RECEPTION_TIMESTAMP");
@@ -509,8 +495,7 @@ void test_set_datawriter_destination_order_kind_by_reception_timestamp()
              qos.destination_order.kind);
 }
 
-void test_set_datawriter_history_kind_keep_all()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_history_kind_keep_all) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "history.kind", "KEEP_ALL");
@@ -520,8 +505,7 @@ void test_set_datawriter_history_kind_keep_all()
   EXPECT_TRUE(DDS::KEEP_ALL_HISTORY_QOS == qos.history.kind);
 }
 
-void test_set_datawriter_history_kind_keep_last()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_history_kind_keep_last) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "history.kind", "KEEP_LAST");
@@ -531,8 +515,7 @@ void test_set_datawriter_history_kind_keep_last()
   EXPECT_TRUE(DDS::KEEP_LAST_HISTORY_QOS == qos.history.kind);
 }
 
-void test_set_datawriter_history_depth()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_history_depth) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "history.depth", "14");
@@ -542,8 +525,7 @@ void test_set_datawriter_history_depth()
   EXPECT_TRUE(14 == qos.history.depth);
 }
 
-void test_set_datawriter_resource_limits_max_samples()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_resource_limits_max_samples) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "resource_limits.max_samples", "14");
@@ -553,8 +535,7 @@ void test_set_datawriter_resource_limits_max_samples()
   EXPECT_TRUE(14 == qos.resource_limits.max_samples);
 }
 
-void test_set_datawriter_resource_limits_max_instances()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_resource_limits_max_instances) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "resource_limits.max_instances", "14");
@@ -564,8 +545,7 @@ void test_set_datawriter_resource_limits_max_instances()
   EXPECT_TRUE(14 == qos.resource_limits.max_instances);
 }
 
-void test_set_datawriter_resource_limits_max_samples_per_instance()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_resource_limits_max_samples_per_instance) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "resource_limits.max_samples_per_instance", "14");
@@ -575,8 +555,7 @@ void test_set_datawriter_resource_limits_max_samples_per_instance()
   EXPECT_TRUE(14 == qos.resource_limits.max_samples_per_instance);
 }
 
-void test_set_datawriter_transport_priority_value()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_transport_priority_value) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "transport_priority.value", "3");
@@ -586,8 +565,7 @@ void test_set_datawriter_transport_priority_value()
   EXPECT_TRUE(3 == qos.transport_priority.value);
 }
 
-void test_set_datawriter_lifespan_duration_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_lifespan_duration_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "lifespan.duration.sec", "3");
@@ -597,8 +575,7 @@ void test_set_datawriter_lifespan_duration_sec()
   EXPECT_TRUE(3 == qos.lifespan.duration.sec);
 }
 
-void test_set_datawriter_lifespan_duration_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_lifespan_duration_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "lifespan.duration.nanosec", "100");
@@ -608,8 +585,7 @@ void test_set_datawriter_lifespan_duration_nanosec()
   EXPECT_TRUE(100 == qos.lifespan.duration.nanosec);
 }
 
-void test_set_datawriter_lifespan_duration_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_lifespan_duration_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "lifespan.duration.sec", "1");
@@ -621,8 +597,7 @@ void test_set_datawriter_lifespan_duration_both()
   EXPECT_TRUE(100 == qos.lifespan.duration.nanosec);
 }
 
-void test_set_datawriter_ownership_kind_shared()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_ownership_kind_shared) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "ownership.kind", "SHARED");
@@ -632,8 +607,7 @@ void test_set_datawriter_ownership_kind_shared()
   EXPECT_TRUE(DDS::SHARED_OWNERSHIP_QOS == qos.ownership.kind);
 }
 
-void test_set_datawriter_ownership_kind_exclusive()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_ownership_kind_exclusive) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "ownership.kind", "EXCLUSIVE");
@@ -643,8 +617,7 @@ void test_set_datawriter_ownership_kind_exclusive()
   EXPECT_TRUE(DDS::EXCLUSIVE_OWNERSHIP_QOS == qos.ownership.kind);
 }
 
-void test_set_datawriter_ownership_strength_value()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datawriter_ownership_strength_value) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datawriter, "ownership_strength.value", "32");
@@ -655,8 +628,7 @@ void test_set_datawriter_ownership_strength_value()
 }
 
 /////// DataReader tests
-void test_set_datareader_durability_volatile()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_durability_volatile) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "durability.kind", "VOLATILE");
@@ -666,8 +638,7 @@ void test_set_datareader_durability_volatile()
   EXPECT_TRUE(DDS::VOLATILE_DURABILITY_QOS == qos.durability.kind);
 }
 
-void test_set_datareader_durability_transient_local()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_durability_transient_local) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "durability.kind", "TRANSIENT_LOCAL");
@@ -677,8 +648,8 @@ void test_set_datareader_durability_transient_local()
   EXPECT_TRUE(DDS::TRANSIENT_LOCAL_DURABILITY_QOS == qos.durability.kind);
 }
 
-void test_set_datareader_durability_transient()
-{
+#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+TEST(dds_FACE_config_QosSettings, test_set_datareader_durability_transient) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "durability.kind", "TRANSIENT");
@@ -687,9 +658,10 @@ void test_set_datareader_durability_transient()
 
   EXPECT_TRUE(DDS::TRANSIENT_DURABILITY_QOS == qos.durability.kind);
 }
+#endif
 
-void test_set_datareader_durability_persistent()
-{
+#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+TEST(dds_FACE_config_QosSettings, test_set_datareader_durability_persistent) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "durability.kind", "PERSISTENT");
@@ -698,8 +670,9 @@ void test_set_datareader_durability_persistent()
 
   EXPECT_TRUE(DDS::PERSISTENT_DURABILITY_QOS == qos.durability.kind);
 }
+#endif
 
-void test_set_datareader_deadline_sec() {
+TEST(dds_FACE_config_QosSettings, test_set_datareader_deadline_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "deadline.period.sec", "2");
@@ -711,7 +684,7 @@ void test_set_datareader_deadline_sec() {
   EXPECT_TRUE(0 == qos.deadline.period.nanosec);
 }
 
-void test_set_datareader_deadline_nanosec() {
+TEST(dds_FACE_config_QosSettings, test_set_datareader_deadline_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "deadline.period.sec", "0");
@@ -723,7 +696,7 @@ void test_set_datareader_deadline_nanosec() {
   EXPECT_TRUE(200 == qos.deadline.period.nanosec);
 }
 
-void test_set_datareader_deadline_both() {
+TEST(dds_FACE_config_QosSettings, test_set_datareader_deadline_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "deadline.period.sec", "3");
@@ -735,9 +708,7 @@ void test_set_datareader_deadline_both() {
   EXPECT_TRUE(500 == qos.deadline.period.nanosec);
 }
 
-void
-test_set_datareader_liveliness_kind_automatic()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_liveliness_kind_automatic) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "liveliness.kind", "AUTOMATIC");
@@ -747,9 +718,7 @@ test_set_datareader_liveliness_kind_automatic()
   EXPECT_TRUE(DDS::AUTOMATIC_LIVELINESS_QOS  == qos.liveliness.kind);
 }
 
-void
-test_set_datareader_liveliness_kind_manual_by_topic()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_liveliness_kind_manual_by_topic) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "liveliness.kind", "MANUAL_BY_TOPIC");
@@ -759,9 +728,7 @@ test_set_datareader_liveliness_kind_manual_by_topic()
   EXPECT_TRUE(DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS  == qos.liveliness.kind);
 }
 
-void
-test_set_datareader_liveliness_kind_manual_by_participant()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_liveliness_kind_manual_by_participant) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "liveliness.kind", "MANUAL_BY_PARTICIPANT");
@@ -771,9 +738,7 @@ test_set_datareader_liveliness_kind_manual_by_participant()
   EXPECT_TRUE(DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS  == qos.liveliness.kind);
 }
 
-void
-test_set_datareader_liveliness_lease_duration_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_liveliness_lease_duration_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "liveliness.lease_duration.sec", "2");
@@ -785,9 +750,7 @@ test_set_datareader_liveliness_lease_duration_sec()
   EXPECT_TRUE(0 == qos.liveliness.lease_duration.nanosec);
 }
 
-void
-test_set_datareader_liveliness_lease_duration_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_liveliness_lease_duration_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "liveliness.lease_duration.sec", "0");
@@ -799,9 +762,7 @@ test_set_datareader_liveliness_lease_duration_nanosec()
   EXPECT_TRUE(333 == qos.liveliness.lease_duration.nanosec);
 }
 
-void
-test_set_datareader_liveliness_lease_duration_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_liveliness_lease_duration_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "liveliness.lease_duration.sec", "1");
@@ -813,8 +774,7 @@ test_set_datareader_liveliness_lease_duration_both()
   EXPECT_TRUE(333 == qos.liveliness.lease_duration.nanosec);
 }
 
-void test_set_datareader_reliability_kind_best_effort()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reliability_kind_best_effort) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reliability.kind", "BEST_EFFORT");
@@ -824,8 +784,7 @@ void test_set_datareader_reliability_kind_best_effort()
   EXPECT_TRUE(DDS::BEST_EFFORT_RELIABILITY_QOS == qos.reliability.kind);
 }
 
-void test_set_datareader_reliability_kind_reliable()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reliability_kind_reliable) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reliability.kind", "RELIABLE");
@@ -835,8 +794,7 @@ void test_set_datareader_reliability_kind_reliable()
   EXPECT_TRUE(DDS::RELIABLE_RELIABILITY_QOS == qos.reliability.kind);
 }
 
-void test_set_datareader_reliability_max_blocking_time_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reliability_max_blocking_time_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reliability.max_blocking_time.sec", "2");
@@ -848,8 +806,7 @@ void test_set_datareader_reliability_max_blocking_time_sec()
   EXPECT_TRUE(0 == qos.reliability.max_blocking_time.nanosec);
 }
 
-void test_set_datareader_reliability_max_blocking_time_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reliability_max_blocking_time_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reliability.max_blocking_time.sec", "0");
@@ -861,8 +818,7 @@ void test_set_datareader_reliability_max_blocking_time_nanosec()
   EXPECT_TRUE(175 == qos.reliability.max_blocking_time.nanosec);
 }
 
-void test_set_datareader_reliability_max_blocking_time_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reliability_max_blocking_time_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reliability.max_blocking_time.sec", "1");
@@ -874,8 +830,7 @@ void test_set_datareader_reliability_max_blocking_time_both()
   EXPECT_TRUE(175 == qos.reliability.max_blocking_time.nanosec);
 }
 
-void test_set_datareader_destination_order_kind_by_source_timestamp()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_destination_order_kind_by_source_timestamp) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "destination_order.kind", "BY_SOURCE_TIMESTAMP");
@@ -886,8 +841,7 @@ void test_set_datareader_destination_order_kind_by_source_timestamp()
              qos.destination_order.kind);
 }
 
-void test_set_datareader_destination_order_kind_by_reception_timestamp()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_destination_order_kind_by_reception_timestamp) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "destination_order.kind", "BY_RECEPTION_TIMESTAMP");
@@ -898,8 +852,7 @@ void test_set_datareader_destination_order_kind_by_reception_timestamp()
              qos.destination_order.kind);
 }
 
-void test_set_datareader_history_kind_keep_all()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_history_kind_keep_all) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "history.kind", "KEEP_ALL");
@@ -909,8 +862,7 @@ void test_set_datareader_history_kind_keep_all()
   EXPECT_TRUE(DDS::KEEP_ALL_HISTORY_QOS == qos.history.kind);
 }
 
-void test_set_datareader_history_kind_keep_last()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_history_kind_keep_last) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "history.kind", "KEEP_LAST");
@@ -920,8 +872,7 @@ void test_set_datareader_history_kind_keep_last()
   EXPECT_TRUE(DDS::KEEP_LAST_HISTORY_QOS == qos.history.kind);
 }
 
-void test_set_datareader_history_depth()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_history_depth) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "history.depth", "21");
@@ -931,8 +882,7 @@ void test_set_datareader_history_depth()
   EXPECT_TRUE(21 == qos.history.depth);
 }
 
-void test_set_datareader_resource_limits_max_samples()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_resource_limits_max_samples) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "resource_limits.max_samples", "14");
@@ -942,8 +892,7 @@ void test_set_datareader_resource_limits_max_samples()
   EXPECT_TRUE(14 == qos.resource_limits.max_samples);
 }
 
-void test_set_datareader_resource_limits_max_instances()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_resource_limits_max_instances) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "resource_limits.max_instances", "14");
@@ -953,8 +902,7 @@ void test_set_datareader_resource_limits_max_instances()
   EXPECT_TRUE(14 == qos.resource_limits.max_instances);
 }
 
-void test_set_datareader_resource_limits_max_samples_per_instance()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_resource_limits_max_samples_per_instance) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "resource_limits.max_samples_per_instance", "14");
@@ -964,8 +912,7 @@ void test_set_datareader_resource_limits_max_samples_per_instance()
   EXPECT_TRUE(14 == qos.resource_limits.max_samples_per_instance);
 }
 
-void test_set_datareader_ownership_kind_shared()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_ownership_kind_shared) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "ownership.kind", "SHARED");
@@ -975,8 +922,7 @@ void test_set_datareader_ownership_kind_shared()
   EXPECT_TRUE(DDS::SHARED_OWNERSHIP_QOS == qos.ownership.kind);
 }
 
-void test_set_datareader_ownership_kind_exclusive()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_ownership_kind_exclusive) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "ownership.kind", "EXCLUSIVE");
@@ -986,8 +932,7 @@ void test_set_datareader_ownership_kind_exclusive()
   EXPECT_TRUE(DDS::EXCLUSIVE_OWNERSHIP_QOS == qos.ownership.kind);
 }
 
-void test_set_datareader_time_based_filter_minimum_separation_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_time_based_filter_minimum_separation_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "time_based_filter.minimum_separation.sec", "2");
@@ -998,8 +943,7 @@ void test_set_datareader_time_based_filter_minimum_separation_sec()
   EXPECT_TRUE(0 == qos.time_based_filter.minimum_separation.nanosec);
 }
 
-void test_set_datareader_time_based_filter_minimum_separation_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_time_based_filter_minimum_separation_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "time_based_filter.minimum_separation.nanosec", "170");
@@ -1010,8 +954,7 @@ void test_set_datareader_time_based_filter_minimum_separation_nanosec()
   EXPECT_TRUE(170 == qos.time_based_filter.minimum_separation.nanosec);
 }
 
-void test_set_datareader_time_based_filter_minimum_separation_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_time_based_filter_minimum_separation_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "time_based_filter.minimum_separation.sec", "1");
@@ -1023,8 +966,7 @@ void test_set_datareader_time_based_filter_minimum_separation_both()
   EXPECT_TRUE(100 == qos.time_based_filter.minimum_separation.nanosec);
 }
 
-void test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reader_data_lifecycle.autopurge_nowriter_samples_delay.sec", "5");
@@ -1036,8 +978,7 @@ void test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_
   EXPECT_TRUE(0 == qos.reader_data_lifecycle.autopurge_nowriter_samples_delay.nanosec);
 }
 
-void test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reader_data_lifecycle.autopurge_nowriter_samples_delay.sec", "0");
@@ -1049,8 +990,7 @@ void test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_
   EXPECT_TRUE(5000 == qos.reader_data_lifecycle.autopurge_nowriter_samples_delay.nanosec);
 }
 
-void test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reader_data_lifecycle.autopurge_nowriter_samples_delay.nanosec", "1000");
@@ -1062,8 +1002,7 @@ void test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_
   EXPECT_TRUE(1000 == qos.reader_data_lifecycle.autopurge_nowriter_samples_delay.nanosec);
 }
 
-void test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_sec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_sec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reader_data_lifecycle.autopurge_disposed_samples_delay.sec", "5");
@@ -1075,8 +1014,7 @@ void test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_
   EXPECT_TRUE(0 == qos.reader_data_lifecycle.autopurge_disposed_samples_delay.nanosec);
 }
 
-void test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_nanosec()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_nanosec) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reader_data_lifecycle.autopurge_disposed_samples_delay.sec", "0");
@@ -1088,8 +1026,7 @@ void test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_
   EXPECT_TRUE(5000 == qos.reader_data_lifecycle.autopurge_disposed_samples_delay.nanosec);
 }
 
-void test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_both()
-{
+TEST(dds_FACE_config_QosSettings, test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_both) {
   QosSettings settings;
 
   settings.set_qos(QosSettings::datareader, "reader_data_lifecycle.autopurge_disposed_samples_delay.nanosec", "1000");
@@ -1099,112 +1036,6 @@ void test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_
 
   EXPECT_TRUE(1 == qos.reader_data_lifecycle.autopurge_disposed_samples_delay.sec);
   EXPECT_TRUE(1000 == qos.reader_data_lifecycle.autopurge_disposed_samples_delay.nanosec);
-}
-
-TEST(dds_FACE_config_QosSettings, maintest)
-{
-  // Publisher QOS
-  test_set_publisher_single_partition();
-  test_set_publisher_multiple_partitions();
-  test_set_publisher_presentation_access_scope_instance();
-  test_set_publisher_presentation_access_scope_topic();
-  test_set_publisher_presentation_access_scope_group();
-  test_set_publisher_presentation_coherent_access_true();
-  test_set_publisher_presentation_coherent_access_false();
-  test_set_publisher_presentation_ordered_access_true();
-  test_set_publisher_presentation_ordered_access_false();
-
-  // Subscriber QOS
-  test_set_subscriber_single_partition();
-  test_set_subscriber_multiple_partitions();
-  test_set_subscriber_presentation_access_scope_instance();
-  test_set_subscriber_presentation_access_scope_topic();
-  test_set_subscriber_presentation_access_scope_group();
-  test_set_subscriber_presentation_coherent_access_true();
-  test_set_subscriber_presentation_coherent_access_false();
-  test_set_subscriber_presentation_ordered_access_true();
-  test_set_subscriber_presentation_ordered_access_false();
-
-  // DataWriter QOS
-  test_set_datawriter_durability_volatile();
-  test_set_datawriter_durability_transient_local();
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-  test_set_datawriter_durability_transient();
-  test_set_datawriter_durability_persistent();
-#endif // OPENDDS_NO_PERSISTENCE_PROFILE
-  test_set_datawriter_deadline_sec();
-  test_set_datawriter_deadline_nanosec();
-  test_set_datawriter_deadline_both();
-  test_set_datawriter_latency_budget_sec();
-  test_set_datawriter_latency_budget_nanosec();
-  test_set_datawriter_latency_budget_both();
-  test_set_datawriter_liveliness_kind_automatic();
-  test_set_datawriter_liveliness_kind_manual_by_topic();
-  test_set_datawriter_liveliness_kind_manual_by_participant();
-  test_set_datawriter_liveliness_lease_duration_sec();
-  test_set_datawriter_liveliness_lease_duration_nanosec();
-  test_set_datawriter_liveliness_lease_duration_both();
-  test_set_datawriter_reliability_kind_best_effort();
-  test_set_datawriter_reliability_kind_reliable();
-  test_set_datawriter_reliability_max_blocking_time_sec();
-  test_set_datawriter_reliability_max_blocking_time_nanosec();
-  test_set_datawriter_reliability_max_blocking_time_both();
-  test_set_datawriter_destination_order_kind_by_source_timestamp();
-  test_set_datawriter_destination_order_kind_by_reception_timestamp();
-  test_set_datawriter_history_kind_keep_all();
-  test_set_datawriter_history_kind_keep_last();
-  test_set_datawriter_history_depth();
-  test_set_datawriter_resource_limits_max_samples();
-  test_set_datawriter_resource_limits_max_instances();
-  test_set_datawriter_resource_limits_max_samples_per_instance();
-  test_set_datawriter_transport_priority_value();
-  test_set_datawriter_lifespan_duration_sec();
-  test_set_datawriter_lifespan_duration_nanosec();
-  test_set_datawriter_lifespan_duration_both();
-  test_set_datawriter_ownership_kind_shared();
-  test_set_datawriter_ownership_kind_exclusive();
-  test_set_datawriter_ownership_strength_value();
-
-  // DataReader QOS
-  test_set_datareader_durability_volatile();
-  test_set_datareader_durability_transient_local();
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-  test_set_datareader_durability_transient();
-  test_set_datareader_durability_persistent();
-#endif // OPENDDS_NO_PERSISTENCE_PROFILE
-  test_set_datareader_deadline_sec();
-  test_set_datareader_deadline_nanosec();
-  test_set_datareader_deadline_both();
-  test_set_datareader_liveliness_kind_automatic();
-  test_set_datareader_liveliness_kind_manual_by_topic();
-  test_set_datareader_liveliness_kind_manual_by_participant();
-  test_set_datareader_liveliness_lease_duration_sec();
-  test_set_datareader_liveliness_lease_duration_nanosec();
-  test_set_datareader_liveliness_lease_duration_both();
-  test_set_datareader_reliability_kind_best_effort();
-  test_set_datareader_reliability_kind_reliable();
-  test_set_datareader_reliability_max_blocking_time_sec();
-  test_set_datareader_reliability_max_blocking_time_nanosec();
-  test_set_datareader_reliability_max_blocking_time_both();
-  test_set_datareader_destination_order_kind_by_source_timestamp();
-  test_set_datareader_destination_order_kind_by_reception_timestamp();
-  test_set_datareader_history_kind_keep_all();
-  test_set_datareader_history_kind_keep_last();
-  test_set_datareader_history_depth();
-  test_set_datareader_resource_limits_max_samples();
-  test_set_datareader_resource_limits_max_instances();
-  test_set_datareader_resource_limits_max_samples_per_instance();
-  test_set_datareader_ownership_kind_shared();
-  test_set_datareader_ownership_kind_exclusive();
-  test_set_datareader_time_based_filter_minimum_separation_sec();
-  test_set_datareader_time_based_filter_minimum_separation_nanosec();
-  test_set_datareader_time_based_filter_minimum_separation_both();
-  test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_sec();
-  test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_nanosec();
-  test_set_datareader_reader_data_lifecycle_autopurge_nowriter_samples_delay_both();
-  test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_sec();
-  test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_nanosec();
-  test_set_datareader_reader_data_lifecycle_autopurge_disposed_samples_delay_both();
 }
 
 #endif


### PR DESCRIPTION
Problem
-------

Parsing comma-separated lists of partitions names assumes each
partition is less than 127 characters.  A partition name longer than
this will cause buffer overflow.

Solution
--------

Check the length of the partition name and log an error if it is too
long.