### PR TITLE
Disable -Wnonnull for bench worker

### DIFF
--- a/performance-tests/bench/worker/Bench_Worker.mpc
+++ b/performance-tests/bench/worker/Bench_Worker.mpc
@@ -1,3 +1,6 @@
 project: ../bench_builder_exe, ../bench_exe, opendds_optional_security, dcps_rtps_udp, dcps_tcp, dcps_udp, dcps_multicast {
   exename = worker
+  verbatim(gnuace, local) {
+    CPPFLAGS += -Wno-nonnull
+  }
 }


### PR DESCRIPTION
Problem: Bench worker has a feature to force SEGV… for testing node_controller response to spawned process death. Ubuntu 22 / gcc 11 creates a warning for known / detected dereference of null pointers, causing an unhelpful warning for this process.

Solution: Turn off this warning for bench worker project