### PR TITLE
Fix infinite loop when initiating connection

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -449,6 +449,7 @@ TransportClient::PendingAssoc::initiate_connect(TransportClient* tc,
   while (!impls_.empty()) {
     RcHandle<TransportImpl> impl = impls_.back().lock();
     if (!impl) {
+      impls_.pop_back();
       continue;
     }
     const OPENDDS_STRING type = impl->transport_type();


### PR DESCRIPTION
`TransportClient::PendingAssoc::initiate_connect` forgot to remove an invalid `TransportImpl` in a loop that seems to be the cause of the ConfigTransports test's timeout issue.