### PR TITLE
Fix Bench Worker MPC verbatim clause

### DIFF
--- a/performance-tests/bench/worker/Bench_Worker.mpc
+++ b/performance-tests/bench/worker/Bench_Worker.mpc
@@ -1,6 +1,6 @@
 project: ../bench_builder_exe, ../bench_exe, opendds_optional_security, dcps_rtps_udp, dcps_tcp, dcps_udp, dcps_multicast {
   exename = worker
-  verbatim(gnuace, local) {
+  verbatim(gnuace, local, 1) {
     CPPFLAGS += -Wno-nonnull
   }
 }


### PR DESCRIPTION
Problem: Breaks verbatim inherited from other projects / configs

Solution: Use the inheritance flag for verbatim.