### PR TITLE
GitHub Actions: MacOS 12 builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11706,8 +11706,8 @@ jobs:
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
         find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        gtar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../../${{ github.job }}.tar
         xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v3
@@ -11750,7 +11750,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+        gtar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
     - name: configure OpenDDS
       run: |
         cd OpenDDS
@@ -11783,8 +11783,8 @@ jobs:
         rm -rf ACE_TAO
         find . -iname "*\.o" | xargs rm
         find bin dds lib tests -type f -print0 | xargs -0 shasum > manifest 2> manifest_errors || true
-        tar cvf ../${{ github.job }}.tar setenv.sh manifest manifest_errors
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        gtar cvf ../${{ github.job }}.tar setenv.sh manifest manifest_errors
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../${{ github.job }}.tar
         xz -3 ../${{ github.job }}.tar
     - name: upload OpenDDS artifact
       uses: actions/upload-artifact@v3
@@ -11832,7 +11832,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+        gtar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
@@ -11842,7 +11842,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_m12_o1d0_sec.tar.xz
+        gtar xvfJ build_m12_o1d0_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -11937,7 +11937,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+        gtar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
@@ -11947,7 +11947,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_m12_o1d0_sec.tar.xz
+        gtar xvfJ build_m12_o1d0_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -12066,8 +12066,8 @@ jobs:
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
         find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        gtar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../../${{ github.job }}.tar
         xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v3
@@ -12111,7 +12111,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
+        gtar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
     - name: configure OpenDDS
       run: |
         cd OpenDDS
@@ -12159,8 +12159,8 @@ jobs:
         rm -rf ACE_TAO
         find . -iname "*\.o" | xargs rm
         find bin dds lib tests -type f -print0 | xargs -0 shasum > manifest 2> manifest_errors || true
-        tar cvf ../${{ github.job }}.tar setenv.sh manifest manifest_errors
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        gtar cvf ../${{ github.job }}.tar setenv.sh manifest manifest_errors
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../${{ github.job }}.tar
         xz -3 ../${{ github.job }}.tar
     - name: upload OpenDDS artifact
       uses: actions/upload-artifact@v3
@@ -12208,7 +12208,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
+        gtar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
@@ -12218,7 +12218,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_m12_i0_j_FM-1f.tar.xz
+        gtar xvfJ build_m12_i0_j_FM-1f.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -12313,7 +12313,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
+        gtar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
@@ -12323,7 +12323,7 @@ jobs:
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_m12_i0_j_FM-1f.tar.xz
+        gtar xvfJ build_m12_i0_j_FM-1f.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11642,737 +11642,741 @@ jobs:
 
   # macOS 12.5
 
-  # ACE_TAO_m12_o1d0_sec:
+  ACE_TAO_m12_o1d0_sec:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: get ACE_TAO commit
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       export ACE_COMMIT=$(git rev-parse HEAD)
-  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-  #   - name: get compiler version
-  #     shell: bash
-  #     run: |
-  #       export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)
-  #       echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
-  #   - name: Cache Artifact
-  #     id: cache-artifact
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ${{ github.job }}.tar.xz
-  #       key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
-  #   - name: install xerces-c
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: configure OpenDDS
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       cd OpenDDS
-  #       ./configure --optimize --no-debug --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
-  #   - name: build ACE and TAO
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd ACE_TAO/ACE
-  #       make -j4
-  #       cd ../TAO
-  #       make -j4
-  #   - name: create ACE_TAO tar.xz artifact
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-  #       find . -iname "*\.o" | xargs rm
-  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-  #       xz -3 ../../${{ github.job }}.tar
-  #   - name: upload ACE_TAO artifact
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: get compiler version
+      shell: bash
+      run: |
+        export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)
+        echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+    - name: install xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure --optimize --no-debug --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  # build_m12_o1d0_sec:
+  build_m12_o1d0_sec:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   needs: ACE_TAO_m12_o1d0_sec
+    needs: ACE_TAO_m12_o1d0_sec
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m12_o1d0_sec_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
-  #   - name: configure OpenDDS
-  #     run: |
-  #       cd OpenDDS
-  #       ./configure --optimize --no-debug --std=c++11 --tests --rapidjson --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - uses: ammaraskar/gcc-problem-matcher@0.1
-  #   - name: build OpenDDS
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       make -j4
-  #   - name: Build CMake Tests
-  #     run: |
-  #       source OpenDDS/setenv.sh
-  #       mkdir OpenDDS/tests/cmake/build
-  #       cd OpenDDS/tests/cmake/build
-  #       cmake -DCMAKE_CXX_STANDARD=11 ..
-  #       cmake --build . -- -j4
-  #   - name: create OpenDDS tar.xz artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       rm -rf ACE_TAO
-  #       find . -iname "*\.o" | xargs rm
-  #       tar cvf ../${{ github.job }}.tar setenv.sh
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-  #       xz -3 ../${{ github.job }}.tar
-  #   - name: upload OpenDDS artifact
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m12_o1d0_sec_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        clang++ --version
+        ./configure --optimize --no-debug --std=c++11 --tests --rapidjson --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: Build CMake Tests
+      run: |
+        source OpenDDS/setenv.sh
+        mkdir OpenDDS/tests/cmake/build
+        cd OpenDDS/tests/cmake/build
+        cmake -DCMAKE_CXX_STANDARD=11 ..
+        cmake --build . -- -j4
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        find bin dds lib tests -type f -print0 | xargs -0 shasum > manifest 2> manifest_errors || true
+        tar cvf ../${{ github.job }}.tar setenv.sh manifest manifest_errors
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  # test_m12_o1d0_sec:
+  test_m12_o1d0_sec:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   needs: build_m12_o1d0_sec
+    needs: build_m12_o1d0_sec
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m12_o1d0_sec_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m12_o1d0_sec_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m12_o1d0_sec.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       ulimit -c unlimited
-  #       sudo chmod o+w /cores
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_cmake_version"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m12_o1d0_sec_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m12_o1d0_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_m12_o1d0_sec.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        ulimit -c unlimited
+        sudo chmod o+w /cores
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # cmake_m12_o1d0_sec:
+  cmake_m12_o1d0_sec:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   needs: build_m12_o1d0_sec
+    needs: build_m12_o1d0_sec
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m12_o1d0_sec_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m12_o1d0_sec_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m12_o1d0_sec.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       ulimit -c unlimited
-  #       sudo chmod o+w /cores
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_cmake_version"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m12_o1d0_sec_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m12_o1d0_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_m12_o1d0_sec.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        ulimit -c unlimited
+        sudo chmod o+w /cores
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # ACE_TAO_m12_i0_j_FM-1f:
+  ACE_TAO_m12_i0_j_FM-1f:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: get ACE_TAO commit
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       export ACE_COMMIT=$(git rev-parse HEAD)
-  #       echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-  #   - name: get compiler version
-  #     shell: bash
-  #     run: |
-  #       export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)
-  #       echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
-  #   - name: Cache Artifact
-  #     id: cache-artifact
-  #     uses: actions/cache@v3
-  #     with:
-  #       path: ${{ github.job }}.tar.xz
-  #       key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
-  #   - name: install xerces-c
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: configure OpenDDS
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       cd OpenDDS
-  #       ./configure  --no-inline --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
-  #   - name: build ACE and TAO
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd ACE_TAO/ACE
-  #       make -j4
-  #       cd ../TAO
-  #       make -j4
-  #   - name: create ACE_TAO tar.xz artifact
-  #     if: steps.cache-artifact.outputs.cache-hit != 'true'
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
-  #       find . -iname "*\.o" | xargs rm
-  #       tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
-  #       xz -3 ../../${{ github.job }}.tar
-  #   - name: upload ACE_TAO artifact
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: get ACE_TAO commit
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        export ACE_COMMIT=$(git rev-parse HEAD)
+        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
+    - name: get compiler version
+      shell: bash
+      run: |
+        export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)
+        echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
+    - name: Cache Artifact
+      id: cache-artifact
+      uses: actions/cache@v3
+      with:
+        path: ${{ github.job }}.tar.xz
+        key: c01_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+    - name: install xerces-c
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: configure OpenDDS
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        ./configure  --no-inline --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
+    - name: build ACE and TAO
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd ACE_TAO/ACE
+        make -j4
+        cd ../TAO
+        make -j4
+    - name: create ACE_TAO tar.xz artifact
+      if: steps.cache-artifact.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
+        find . -iname "*\.o" | xargs rm
+        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        xz -3 ../../${{ github.job }}.tar
+    - name: upload ACE_TAO artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
 
-  # build_m12_i0_j_FM-1f:
+  build_m12_i0_j_FM-1f:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   needs: ACE_TAO_m12_i0_j_FM-1f
+    needs: ACE_TAO_m12_i0_j_FM-1f
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m12_i0_j_FM-1f_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
-  #   - name: configure OpenDDS
-  #     run: |
-  #       cd OpenDDS
-  #       ./configure --no-inline --std=c++11 --tests --rapidjson --java --no-built-in-topics --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - uses: ammaraskar/gcc-problem-matcher@0.1
-  #   - name: build OpenDDS
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       make -j4
-  #   - name: Build CMake Tests
-  #     run: |
-  #       source OpenDDS/setenv.sh
-  #       mkdir OpenDDS/tests/cmake/build
-  #       cd OpenDDS/tests/cmake/build
-  #       cmake -DCMAKE_CXX_STANDARD=11 ..
-  #       cmake --build . -- -j4
-  #   - name: set up Modeling tests
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       cd tools/modeling/tests
-  #       ./setup.pl
-  #       cd -
-  #       mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
-  #   - name: build Modeling tests
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       make -j4 -C tools/modeling/tests
-  #   - name: create OpenDDS tar.xz artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       rm -rf ACE_TAO
-  #       find . -iname "*\.o" | xargs rm
-  #       tar cvf ../${{ github.job }}.tar setenv.sh
-  #       git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
-  #       xz -3 ../${{ github.job }}.tar
-  #   - name: upload OpenDDS artifact
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_artifact
-  #       path: ${{ github.job }}.tar.xz
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m12_i0_j_FM-1f_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
+    - name: configure OpenDDS
+      run: |
+        cd OpenDDS
+        clang++ --version
+        ./configure --no-inline --std=c++11 --tests --rapidjson --java --no-built-in-topics --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - name: build OpenDDS
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4
+    - name: Build CMake Tests
+      run: |
+        source OpenDDS/setenv.sh
+        mkdir OpenDDS/tests/cmake/build
+        cd OpenDDS/tests/cmake/build
+        cmake -DCMAKE_CXX_STANDARD=11 ..
+        cmake --build . -- -j4
+    - name: set up Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        cd tools/modeling/tests
+        ./setup.pl
+        cd -
+        mwc.pl -type gnuace -workers 4 -features built_in_topics=0 tools/modeling/tests/modeling_tests.mwc
+    - name: build Modeling tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        make -j4 -C tools/modeling/tests
+    - name: create OpenDDS tar.xz artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        rm -rf ACE_TAO
+        find . -iname "*\.o" | xargs rm
+        find bin dds lib tests -type f -print0 | xargs -0 shasum > manifest 2> manifest_errors || true
+        tar cvf ../${{ github.job }}.tar setenv.sh manifest manifest_errors
+        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        xz -3 ../${{ github.job }}.tar
+    - name: upload OpenDDS artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_artifact
+        path: ${{ github.job }}.tar.xz
 
-  # test_m12_i0_j_FM-1f:
+  test_m12_i0_j_FM-1f:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   needs: build_m12_i0_j_FM-1f
+    needs: build_m12_i0_j_FM-1f
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m12_i0_j_FM-1f_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m12_i0_j_FM-1f_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m12_i0_j_FM-1f.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       ulimit -c unlimited
-  #       sudo chmod o+w /cores
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_cmake_version"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m12_i0_j_FM-1f_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m12_i0_j_FM-1f_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_m12_i0_j_FM-1f.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        ulimit -c unlimited
+        sudo chmod o+w /cores
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # cmake_modeling_m12_i0_j_FM-1f:
+  cmake_modeling_m12_i0_j_FM-1f:
 
-  #   runs-on: macos-12
+    runs-on: macos-12
 
-  #   needs: build_m12_i0_j_FM-1f
+    needs: build_m12_i0_j_FM-1f
 
-  #   steps:
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: OpenDDS/ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m12_i0_j_FM-1f_artifact
-  #       path: OpenDDS/ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS/ACE_TAO
-  #       tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m12_i0_j_FM-1f_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m12_i0_j_FM-1f.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       ulimit -c unlimited
-  #       sudo chmod o+w /cores
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_cmake_version"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12 --modeling --cmake"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: OpenDDS/ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m12_i0_j_FM-1f_artifact
+        path: OpenDDS/ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd OpenDDS/ACE_TAO
+        tar xvfJ ACE_TAO_m12_i0_j_FM-1f.tar.xz
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m12_i0_j_FM-1f_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        tar xvfJ build_m12_i0_j_FM-1f.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        ulimit -c unlimited
+        sudo chmod o+w /cores
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_cmake_version"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12 --modeling --cmake"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   build_u14_gcc4:
 


### PR DESCRIPTION
The MacOS 12 builds in GHA mysteriously fail.  This immediate cause is that large binary files are corrupt.  The goal of this PR was to add a manifest to determine if the corruption occurs before or after archiving.  However, after adding the manifest, the problem has not occurred.