### PR TITLE
Partition parsing is inconsistent

### DIFF
--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1689,26 +1689,12 @@ namespace {
   {
     // Value can be a comma-separated list
     const char* start = value.c_str();
-    char buffer[128];
-    std::memset(buffer, 0, sizeof(buffer));
     while (const char* next_comma = std::strchr(start, ',')) {
       const size_t size = next_comma - start;
-      if (size < sizeof(buffer)) {
-        // Copy into temp buffer, won't have null
-        std::strncpy(buffer, start, size);
-        // Append null
-        buffer[size] = '\0';
-        // Add to QOS
-        x.name.length(x.name.length() + 1);
-        x.name[x.name.length() - 1] = static_cast<const char*>(buffer);
-      } else {
-        if (log_level >= LogLevel::Error) {
-          ACE_ERROR((LM_ERROR,
-                     ACE_TEXT("(%P|%t) ERROR: StaticDiscovery: ")
-                     ACE_TEXT("partition name of length %B exceeds maximum length of %B\n"),
-                     size, sizeof(buffer) - 1));
-        }
-      }
+      const OPENDDS_STRING temp(start, size);
+      // Add to QOS
+      x.name.length(x.name.length() + 1);
+      x.name[x.name.length() - 1] = temp.c_str();
       // Advance pointer
       start = next_comma + 1;
     }

--- a/dds/FACE/config/QosSettings.cpp
+++ b/dds/FACE/config/QosSettings.cpp
@@ -165,26 +165,12 @@ set_partition_name_qos(
   if (!std::strcmp(name, "partition.name")) {
     // Value can be a comma-separated list
     const char* start = value;
-    char buffer[128];
-    std::memset(buffer, 0, sizeof(buffer));
     while (const char* next_comma = std::strchr(start, ',')) {
       const size_t size = next_comma - start;
-      if (size < sizeof(buffer)) {
-        // Copy into temp buffer, won't have null
-        std::strncpy(buffer, start, size);
-        // Append null
-        buffer[size] = '\0';
-        // Add to QOS
-        target.name.length(target.name.length() + 1);
-        target.name[target.name.length() - 1] = static_cast<const char*>(buffer);
-      } else {
-        if (DCPS::log_level >= DCPS::LogLevel::Error) {
-          ACE_ERROR((LM_ERROR,
-                     ACE_TEXT("(%P|%t) ERROR: set_partition_name_qos: ")
-                     ACE_TEXT("partition name of length %B exceeds maximum length of %B\n"),
-                     size, sizeof(buffer) - 1));
-        }
-      }
+      const OPENDDS_STRING temp(start, size);
+      // Add to QOS
+      target.name.length(target.name.length() + 1);
+      target.name[target.name.length() - 1] = temp.c_str();
       // Advance pointer
       start = next_comma + 1;
     }

--- a/tests/unit-tests/dds/FACE/config/QosSettings.cpp
+++ b/tests/unit-tests/dds/FACE/config/QosSettings.cpp
@@ -61,16 +61,6 @@ TEST(dds_FACE_config_QosSettings, test_set_publisher_multiple_partitions) {
   EXPECT_TRUE(!strcmp(qos.partition.name[1], "Bar234"));
 }
 
-TEST(dds_FACE_config_QosSettings, test_set_publisher_partition_too_long) {
-  QosSettings settings;
-
-  settings.set_qos(QosSettings::publisher, "partition.name", "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
-  DDS::PublisherQos qos;
-  settings.apply_to(qos);
-
-  EXPECT_TRUE(0 == qos.partition.name.length());
-}
-
 TEST(dds_FACE_config_QosSettings, test_set_publisher_presentation_access_scope_instance) {
   QosSettings settings;
 


### PR DESCRIPTION
Problem
-------

Partition parsing uses a fixed size buffer.  All partitions except the
last one are subject to a length check based on the size of the
buffer.

Solution
--------

Dynamically allocate a buffer to not impose a length restriction.