### PR TITLE
Revert a change to ConfigTransports test

### DIFF
--- a/tests/DCPS/ConfigTransports/subscriber.cpp
+++ b/tests/DCPS/ConfigTransports/subscriber.cpp
@@ -84,7 +84,6 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
               }
 
             r1.pull(ACE_Time_Value(1));
-            r2.pull(ACE_Time_Value(1));
           }
         else if (configopt.collocation_str == "participant")
           {


### PR DESCRIPTION
- Problem:
In one test case of the ConfigTransports test, the subscriber unnecessarily waits for the second writer of the publisher which caused the subscriber to time out.
- Solution:
Remove waiting from the subscriber.