### PR TITLE
Use ACE::init() for AddressLookup test

### DIFF
--- a/tests/DCPS/AddressLookup/main.cpp
+++ b/tests/DCPS/AddressLookup/main.cpp
@@ -145,7 +145,7 @@ void address_info() {
 }
 
 
-int ACE_TMAIN(int argc, char* argv[]) {
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   ACE_UNUSED_ARG(argc);
   ACE_UNUSED_ARG(argv);
   const int attempts = 3;

--- a/tests/DCPS/AddressLookup/main.cpp
+++ b/tests/DCPS/AddressLookup/main.cpp
@@ -1,13 +1,13 @@
+#include <ace/Init_ACE.h>
 #include <ace/INET_Addr.h>
-#include <ace/OS_NS_netdb.h>
-#include <ace/Sock_Connect.h>
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_netdb.h>
 #include <ace/OS_NS_string.h>
 #include <ace/OS_NS_unistd.h>
+#include <ace/Sock_Connect.h>
 
-#include <string>
 #include <cstring>
-
+#include <string>
 
 void print_addr(const ACE_INET_Addr& addr, const char* prefix) {
   char buffer[256] = {'\0'};
@@ -149,11 +149,13 @@ void address_info() {
 int main(int argc, char* argv[]) {
   ACE_UNUSED_ARG(argc);
   ACE_UNUSED_ARG(argv);
+  ACE::init();
   const int attempts = 3;
   for (int i = 0; i < attempts; ++i) {
     ACE_DEBUG((LM_DEBUG, "========= Attempt %d....\n", i));
     address_info();
     ACE_OS::sleep((i+1)*2);
   }
+  ACE::fini();
   return 0;
 }

--- a/tests/DCPS/AddressLookup/main.cpp
+++ b/tests/DCPS/AddressLookup/main.cpp
@@ -1,4 +1,3 @@
-#include <ace/Init_ACE.h>
 #include <ace/INET_Addr.h>
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_netdb.h>
@@ -146,16 +145,14 @@ void address_info() {
 }
 
 
-int main(int argc, char* argv[]) {
+int ACE_TMAIN(int argc, char* argv[]) {
   ACE_UNUSED_ARG(argc);
   ACE_UNUSED_ARG(argv);
-  ACE::init();
   const int attempts = 3;
   for (int i = 0; i < attempts; ++i) {
     ACE_DEBUG((LM_DEBUG, "========= Attempt %d....\n", i));
     address_info();
     ACE_OS::sleep((i+1)*2);
   }
-  ACE::fini();
   return 0;
 }


### PR DESCRIPTION
Problem: WinSock2 was not being properly initialized for some (all?) windows builds, causing interface lookup errors.

Solution: Use ACE::init() and ACE::fini() (via ACE_TMAIN) for the AddressLookup test.