### PR TITLE
Prevent Use Of IPv4-mapped IPv6 'Any' Addresses In RTPS Locators

### DIFF
--- a/dds/DCPS/NetworkAddress.cpp
+++ b/dds/DCPS/NetworkAddress.cpp
@@ -206,12 +206,11 @@ bool NetworkAddress::is_any() const
     return inet_addr_.in4_.sin_addr.s_addr == INADDR_ANY;
 #if defined (ACE_HAS_IPV6)
   } else if (inet_addr_.in6_.sin6_family == AF_INET6) {
-    const bool ipv6_unspec = IN6_IS_ADDR_UNSPECIFIED(&inet_addr_.in6_.sin6_addr);
-    if (!ipv6_unspec) {
-      const unsigned char buff[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0, 0, 0 };
-      return memcmp(buff, &inet_addr_.in6_.sin6_addr, sizeof (buff)) == 0;
+    if (IN6_IS_ADDR_UNSPECIFIED(&inet_addr_.in6_.sin6_addr)) {
+      return true;
     }
-    return true;
+    static const unsigned char buff[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0, 0, 0 };
+    return memcmp(buff, &inet_addr_.in6_.sin6_addr, sizeof (buff)) == 0;
 #endif
   }
   return false;

--- a/dds/DCPS/NetworkAddress.cpp
+++ b/dds/DCPS/NetworkAddress.cpp
@@ -206,7 +206,12 @@ bool NetworkAddress::is_any() const
     return inet_addr_.in4_.sin_addr.s_addr == INADDR_ANY;
 #if defined (ACE_HAS_IPV6)
   } else if (inet_addr_.in6_.sin6_family == AF_INET6) {
-    return IN6_IS_ADDR_UNSPECIFIED(&inet_addr_.in6_.sin6_addr);
+    const bool ipv6_unspec = IN6_IS_ADDR_UNSPECIFIED(&inet_addr_.in6_.sin6_addr);
+    if (!ipv6_unspec) {
+      const unsigned char buff[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0, 0, 0 };
+      return memcmp(buff, &inet_addr_.in6_.sin6_addr, sizeof (buff)) == 0;
+    }
+    return true;
 #endif
   }
   return false;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -605,7 +605,11 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
                      false);
   }
 
-  config.ipv6_local_address(NetworkAddress(address));
+  NetworkAddress temp(address);
+  if (address.is_ipv4_mapped_ipv6() && temp.is_any()) {
+    temp = NetworkAddress(address.get_port_number(), "::");
+  }
+  config.ipv6_local_address(temp);
 
 #ifdef ACE_RECVPKTINFO6
   if (ipv6_unicast_socket_.set_option(IPPROTO_IPV6, ACE_RECVPKTINFO6, &sockopt, sizeof sockopt) == -1) {

--- a/tests/unit-tests/dds/DCPS/NetworkAddress.cpp
+++ b/tests/unit-tests/dds/DCPS/NetworkAddress.cpp
@@ -245,6 +245,40 @@ TEST(dds_DCPS_NetworkAddress, OperatorsIpSix)
 
 #endif
 
+TEST(dds_DCPS_NetworkAddress, IsAnyIpFour)
+{
+  const NetworkAddress sa1;
+  const NetworkAddress sa2(1234, "0.0.0.0");
+  const NetworkAddress sa3(1234, "192.168.10.3");
+
+  EXPECT_TRUE(sa1.is_any());
+  EXPECT_TRUE(sa2.is_any());
+
+  EXPECT_FALSE(sa3.is_any());
+}
+
+#if defined (ACE_HAS_IPV6)
+
+TEST(dds_DCPS_NetworkAddress, IsAnyIpSix)
+{
+  const NetworkAddress sa1;
+  const NetworkAddress sa2(1234, "::");
+  const NetworkAddress sa3(8080, "::ffff:0:0");
+  const NetworkAddress sa4(8080, "0000:0000:0000:0000:0000:FFFF:0000:0000");
+  const NetworkAddress sa5(8080, "0000:0000:0000:0000:0000:FFFF:C0A8:0A04");
+  const NetworkAddress sa6(5678, "0101:0101:0101:0101:0101:0101:0101:0101");
+
+  EXPECT_TRUE(sa1.is_any());
+  EXPECT_TRUE(sa2.is_any());
+  EXPECT_TRUE(sa3.is_any());
+  EXPECT_TRUE(sa4.is_any());
+
+  EXPECT_FALSE(sa5.is_any());
+  EXPECT_FALSE(sa6.is_any());
+}
+
+#endif
+
 TEST(dds_DCPS_NetworkAddress, IsLoopbackIpFour)
 {
   NetworkAddress sa1(1234, "1.2.3.4");


### PR DESCRIPTION
Problem: Some machines give back IPv4-mapped IPv6 addresses from opened sockets, which weren't being caught by checking for `is_any()` before adding to the list of locators.

Solution:
- Update is_any() to check for IPv4-mapped IPv6 "any" (zeros) address.
- Add Unit Tests For This
- Explicitly check IPV6 addresses returned from IPV6 sockets and avoid subtle conversion to mapped IPV4 addresses.