### PR TITLE
Add Check Before Dereferencing DataReaderImpl::topic_servant_

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -2792,7 +2792,7 @@ DataReaderImpl::get_reactor()
 OpenDDS::DCPS::RepoId
 DataReaderImpl::get_topic_id()
 {
-  return this->topic_servant_->get_id();
+  return topic_servant_ ? topic_servant_->get_id() : GUID_UNKNOWN;
 }
 
 OpenDDS::DCPS::RepoId


### PR DESCRIPTION
Problem: DataReaderImpl::get_topic_id() does not check the validity of topic_servant_ before dereferencing, which can lead to a SEGV as it does here: https://github.com/objectcomputing/OpenDDS/runs/8118287779?check_suite_focus=true

Solution: Check before dereferencing, returning unknown if the check fails.