### PR TITLE
GitHub Actions: Migrate Ubuntu 18 to 20

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1494,7 +1494,7 @@ jobs:
         ./configure \
           --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
-          --compiler=clang++-5.0 \
+          --compiler=clang++-12 \
           --std=c++11 \
           --no-inline \
           --features=uses_wchar=1 \
@@ -1520,7 +1520,7 @@ jobs:
         source OpenDDS/setenv.sh
         mkdir OpenDDS/tests/cmake/build
         cd OpenDDS/tests/cmake/build
-        cmake -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_COMPILER=clang++-5.0 ..
+        cmake -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_COMPILER=clang++-12 ..
         cmake --build . -- -j4
     - name: create OpenDDS tar.xz artifact
       shell: bash
@@ -2078,7 +2078,7 @@ jobs:
         source OpenDDS/setenv.sh
         mkdir OpenDDS/tests/cmake/build
         cd OpenDDS/tests/cmake/build
-        cmake -DCMAKE_CXX_STANDARD=98 -DCMAKE_CXX_COMPILER=g++-6 ..
+        cmake -DCMAKE_CXX_STANDARD=98 -DCMAKE_CXX_COMPILER=g++-9 ..
         cmake --build . -- -j4
     - name: create OpenDDS tar.xz artifact
       shell: bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,9 +65,9 @@ env:
 
 jobs:
 
-  ACE_TAO_u18_i0_xer0_js0_j12:
+  ACE_TAO_u20_i0_xer0_js0_j12:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: checkout OpenDDS
@@ -134,11 +134,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u18_i0_xer0_js0_j12:
+  build_u20_i0_xer0_js0_j12:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u18_i0_xer0_js0_j12
+    needs: ACE_TAO_u20_i0_xer0_js0_j12
 
     steps:
     - name: checkout MPC
@@ -155,13 +155,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_i0_xer0_js0_j12_artifact
+        name: ACE_TAO_u20_i0_xer0_js0_j12_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_i0_xer0_js0_j12.tar.xz
+        tar xvfJ ACE_TAO_u20_i0_xer0_js0_j12.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -213,11 +213,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u18_i0_xer0_js0_j12:
+  cmake_u20_i0_xer0_js0_j12:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: build_u18_i0_xer0_js0_j12
+    needs: build_u20_i0_xer0_js0_j12
 
     steps:
     - name: checkout MPC
@@ -239,13 +239,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_i0_xer0_js0_j12_artifact
+        name: ACE_TAO_u20_i0_xer0_js0_j12_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_i0_xer0_js0_j12.tar.xz
+        tar xvfJ ACE_TAO_u20_i0_xer0_js0_j12.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -254,13 +254,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u18_i0_xer0_js0_j12_artifact
+        name: build_u20_i0_xer0_js0_j12_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u18_i0_xer0_js0_j12.tar.xz
+        tar xvfJ build_u20_i0_xer0_js0_j12.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -1372,9 +1372,9 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ACE_TAO_u18_clang5_i0w1_sec:
+  ACE_TAO_u20_clang5_i0w1_sec:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: install clang++
@@ -1456,11 +1456,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u18_clang5_i0w1_sec:
+  build_u20_clang5_i0w1_sec:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u18_clang5_i0w1_sec
+    needs: ACE_TAO_u20_clang5_i0w1_sec
 
     steps:
     - name: install xerces
@@ -1482,13 +1482,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_clang5_i0w1_sec_artifact
+        name: ACE_TAO_u20_clang5_i0w1_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_clang5_i0w1_sec.tar.xz
+        tar xvfJ ACE_TAO_u20_clang5_i0w1_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1543,11 +1543,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u18_clang5_i0w1_sec:
+  cmake_u20_clang5_i0w1_sec:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: build_u18_clang5_i0w1_sec
+    needs: build_u20_clang5_i0w1_sec
 
     steps:
     - name: install xerces
@@ -1571,13 +1571,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_clang5_i0w1_sec_artifact
+        name: ACE_TAO_u20_clang5_i0w1_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_clang5_i0w1_sec.tar.xz
+        tar xvfJ ACE_TAO_u20_clang5_i0w1_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1586,13 +1586,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u18_clang5_i0w1_sec_artifact
+        name: build_u20_clang5_i0w1_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u18_clang5_i0w1_sec.tar.xz
+        tar xvfJ build_u20_clang5_i0w1_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -1659,9 +1659,9 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ACE_TAO_u18_clang10_sec_js0:
+  ACE_TAO_u20_clang10_sec_js0:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: install clang++
@@ -1742,11 +1742,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u18_clang10_sec_js0:
+  build_u20_clang10_sec_js0:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u18_clang10_sec_js0
+    needs: ACE_TAO_u20_clang10_sec_js0
 
     steps:
     - name: install clang++
@@ -1768,13 +1768,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_clang10_sec_js0_artifact
+        name: ACE_TAO_u20_clang10_sec_js0_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_clang10_sec_js0.tar.xz
+        tar xvfJ ACE_TAO_u20_clang10_sec_js0.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1828,11 +1828,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u18_clang10_sec_js0:
+  cmake_u20_clang10_sec_js0:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: build_u18_clang10_sec_js0
+    needs: build_u20_clang10_sec_js0
 
     steps:
     - name: install xerces
@@ -1856,13 +1856,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_clang10_sec_js0_artifact
+        name: ACE_TAO_u20_clang10_sec_js0_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_clang10_sec_js0.tar.xz
+        tar xvfJ ACE_TAO_u20_clang10_sec_js0.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1871,13 +1871,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u18_clang10_sec_js0_artifact
+        name: build_u20_clang10_sec_js0_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u18_clang10_sec_js0.tar.xz
+        tar xvfJ build_u20_clang10_sec_js0.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -1944,9 +1944,9 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ACE_TAO_u18_gcc6_d0w1_cpp03:
+  ACE_TAO_u20_gcc6_d0w1_cpp03:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: install gcc and g++
@@ -2027,11 +2027,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u18_gcc6_d0w1_cpp03:
+  build_u20_gcc6_d0w1_cpp03:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u18_gcc6_d0w1_cpp03
+    needs: ACE_TAO_u20_gcc6_d0w1_cpp03
 
     steps:
     - name: install gcc and g++
@@ -2053,13 +2053,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_gcc6_d0w1_cpp03_artifact
+        name: ACE_TAO_u20_gcc6_d0w1_cpp03_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_gcc6_d0w1_cpp03.tar.xz
+        tar xvfJ ACE_TAO_u20_gcc6_d0w1_cpp03.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -2113,11 +2113,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u18_gcc6_d0w1_cpp03:
+  cmake_u20_gcc6_d0w1_cpp03:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: build_u18_gcc6_d0w1_cpp03
+    needs: build_u20_gcc6_d0w1_cpp03
 
     steps:
     - name: checkout MPC
@@ -2139,13 +2139,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_gcc6_d0w1_cpp03_artifact
+        name: ACE_TAO_u20_gcc6_d0w1_cpp03_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_gcc6_d0w1_cpp03.tar.xz
+        tar xvfJ ACE_TAO_u20_gcc6_d0w1_cpp03.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -2154,13 +2154,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u18_gcc6_d0w1_cpp03_artifact
+        name: build_u20_gcc6_d0w1_cpp03_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u18_gcc6_d0w1_cpp03.tar.xz
+        tar xvfJ build_u20_gcc6_d0w1_cpp03.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -2226,9 +2226,9 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ACE_TAO_u18_gcc8_i0_js0_j:
+  ACE_TAO_u20_gcc8_i0_js0_j:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - name: install gcc and g++
@@ -2301,11 +2301,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u18_gcc8_i0_js0_j:
+  build_u20_gcc8_i0_js0_j:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u18_gcc8_i0_js0_j
+    needs: ACE_TAO_u20_gcc8_i0_js0_j
 
     steps:
     - name: install gcc and g++
@@ -2327,13 +2327,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_gcc8_i0_js0_j_artifact
+        name: ACE_TAO_u20_gcc8_i0_js0_j_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_gcc8_i0_js0_j.tar.xz
+        tar xvfJ ACE_TAO_u20_gcc8_i0_js0_j.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -2378,11 +2378,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u18_gcc8_i0_js0_j:
+  cmake_u20_gcc8_i0_js0_j:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
-    needs: build_u18_gcc8_i0_js0_j
+    needs: build_u20_gcc8_i0_js0_j
 
     steps:
     - name: checkout MPC
@@ -2404,13 +2404,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u18_gcc8_i0_js0_j_artifact
+        name: ACE_TAO_u20_gcc8_i0_js0_j_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u18_gcc8_i0_js0_j.tar.xz
+        tar xvfJ ACE_TAO_u20_gcc8_i0_js0_j.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -2419,13 +2419,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u18_gcc8_i0_js0_j_artifact
+        name: build_u20_gcc8_i0_js0_j_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u18_gcc8_i0_js0_j.tar.xz
+        tar xvfJ build_u20_gcc8_i0_js0_j.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1372,7 +1372,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ACE_TAO_u20_clang5_i0w1_sec:
+  ACE_TAO_u20_clang12_i0w1_sec:
 
     runs-on: ubuntu-20.04
 
@@ -1453,11 +1453,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u20_clang5_i0w1_sec:
+  build_u20_clang12_i0w1_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u20_clang5_i0w1_sec
+    needs: ACE_TAO_u20_clang12_i0w1_sec
 
     steps:
     - name: install xerces
@@ -1476,13 +1476,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u20_clang5_i0w1_sec_artifact
+        name: ACE_TAO_u20_clang12_i0w1_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_clang5_i0w1_sec.tar.xz
+        tar xvfJ ACE_TAO_u20_clang12_i0w1_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1537,11 +1537,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u20_clang5_i0w1_sec:
+  cmake_u20_clang12_i0w1_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: build_u20_clang5_i0w1_sec
+    needs: build_u20_clang12_i0w1_sec
 
     steps:
     - name: install xerces
@@ -1565,13 +1565,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u20_clang5_i0w1_sec_artifact
+        name: ACE_TAO_u20_clang12_i0w1_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_clang5_i0w1_sec.tar.xz
+        tar xvfJ ACE_TAO_u20_clang12_i0w1_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1580,13 +1580,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u20_clang5_i0w1_sec_artifact
+        name: build_u20_clang12_i0w1_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u20_clang5_i0w1_sec.tar.xz
+        tar xvfJ build_u20_clang12_i0w1_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,7 +65,7 @@ env:
 
 jobs:
 
-  ACE_TAO_u20_i0_xer0_js0_j12:
+  ACE_TAO_u20_i0_xer0:
 
     runs-on: ubuntu-20.04
 
@@ -134,11 +134,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u20_i0_xer0_js0_j12:
+  build_u20_i0_xer0_js0_j17:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u20_i0_xer0_js0_j12
+    needs: ACE_TAO_u20_i0_xer0
 
     steps:
     - name: checkout MPC
@@ -155,13 +155,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u20_i0_xer0_js0_j12_artifact
+        name: ACE_TAO_u20_i0_xer0_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_i0_xer0_js0_j12.tar.xz
+        tar xvfJ ACE_TAO_u20_i0_xer0.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -213,11 +213,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u20_i0_xer0_js0_j12:
+  cmake_u20_i0_xer0_js0_j17:
 
     runs-on: ubuntu-20.04
 
-    needs: build_u20_i0_xer0_js0_j12
+    needs: build_u20_i0_xer0_js0_j17
 
     steps:
     - name: checkout MPC
@@ -239,13 +239,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u20_i0_xer0_js0_j12_artifact
+        name: ACE_TAO_u20_i0_xer0_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_i0_xer0_js0_j12.tar.xz
+        tar xvfJ ACE_TAO_u20_i0_xer0.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -254,13 +254,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u20_i0_xer0_js0_j12_artifact
+        name: build_u20_i0_xer0_js0_j17_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u20_i0_xer0_js0_j12.tar.xz
+        tar xvfJ build_u20_i0_xer0_js0_j17.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -170,7 +170,7 @@ jobs:
     - name: configure OpenDDS
       run: |
         cd OpenDDS
-        ./configure --no-inline --tests --java=/usr/lib/jvm/adoptopenjdk-12-hotspot-amd64 --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+        ./configure --no-inline --tests --java=$JAVA_HOME_17_X64 --no-rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: check build configuration
       shell: bash
       run: |
@@ -1377,9 +1377,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: install clang++
-      run: |
-        sudo apt-get install -y clang-5.0
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1400,7 +1397,7 @@ jobs:
     - name: get compiler version
       shell: bash
       run: |
-        export COMPILER_VERSION=$(clang++-5.0 --version 2>&1 | head -n 1)
+        export COMPILER_VERSION=$(clang++-12 --version 2>&1 | head -n 1)
         echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
@@ -1424,7 +1421,7 @@ jobs:
         ./configure \
           --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE \
           --mpc=$GITHUB_WORKSPACE/MPC \
-          --compiler=clang++-5.0 \
+          --compiler=clang++-12 \
           --std=c++11 \
           --no-inline \
           --features=uses_wchar=1 \
@@ -1465,9 +1462,6 @@ jobs:
     steps:
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
-    - name: install clang++
-      run: |
-        sudo apt-get install -y clang-5.0
     - name: checkout MPC
       uses: actions/checkout@v3
       with:
@@ -1664,9 +1658,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: install clang++
-      run: |
-        sudo apt-get install -y clang-10
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1749,9 +1740,6 @@ jobs:
     needs: ACE_TAO_u20_clang10_sec_js0
 
     steps:
-    - name: install clang++
-      run: |
-        sudo apt-get install -y clang-10
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -1949,9 +1937,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: install gcc and g++
-      run: |
-        sudo apt-get install g++-6
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -1972,7 +1957,7 @@ jobs:
     - name: get compiler version
       shell: bash
       run: |
-        export COMPILER_VERSION=$(g++-6 --version 2>&1 | head -n 1)
+        export COMPILER_VERSION=$(g++-9 --version 2>&1 | head -n 1)
         echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
     - name: Cache Artifact
       id: cache-artifact
@@ -1995,7 +1980,7 @@ jobs:
         cd OpenDDS
         ./configure \
           --force-clone-submodules \
-          --compiler=g++-6 \
+          --compiler=g++-9 \
           --no-debug \
           --features=uses_wchar=1 \
           --std=c++03 \
@@ -2034,9 +2019,6 @@ jobs:
     needs: ACE_TAO_u20_gcc6_d0w1_cpp03
 
     steps:
-    - name: install gcc and g++
-      run: |
-        sudo apt-get install g++-6
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -2070,7 +2052,7 @@ jobs:
         cd OpenDDS
         ./configure \
           --force-clone-submodules \
-          --compiler=g++-6 \
+          --compiler=g++-9 \
           --no-debug \
           --features=uses_wchar=1 \
           --std=c++03 \
@@ -2756,9 +2738,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - name: install gcc and g++
-      run: |
-        sudo apt-get install g++-10
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout OpenDDS
@@ -2862,9 +2841,6 @@ jobs:
     needs: ACE_TAO_u20_gcc10_bsafe_js0_FM-2c
 
     steps:
-    - name: install gcc and g++
-      run: |
-        sudo apt-get install g++-10
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -3279,9 +3255,6 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
-    - name: install clang-12
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install clang-12
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3338,8 +3311,6 @@ jobs:
     needs: ACE_TAO_u20_p1_asan
 
     steps:
-    - name: install clang-12
-      run: sudo apt-get -y install clang-12
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -3566,9 +3537,6 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
-    - name: install clang-12
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install clang-12
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3623,8 +3591,6 @@ jobs:
     needs: ACE_TAO_u20_p1_tsan
 
     steps:
-    - name: install clang-12
-      run: sudo apt-get -y install clang-12
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC
@@ -3843,9 +3809,6 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
-    - name: install clang-12
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      run: sudo apt-get -y install clang-12
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3902,8 +3865,6 @@ jobs:
     needs: ACE_TAO_u20_p1_ubsan
 
     steps:
-    - name: install clang-12
-      run: sudo apt-get -y install clang-12
     - name: install xerces
       run: sudo apt-get -y install libxerces-c-dev
     - name: checkout MPC

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1932,7 +1932,7 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  ACE_TAO_u20_gcc6_d0w1_cpp03:
+  ACE_TAO_u20_gcc9_d0w1_cpp03:
 
     runs-on: ubuntu-20.04
 
@@ -2012,11 +2012,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u20_gcc6_d0w1_cpp03:
+  build_u20_gcc9_d0w1_cpp03:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u20_gcc6_d0w1_cpp03
+    needs: ACE_TAO_u20_gcc9_d0w1_cpp03
 
     steps:
     - name: install xerces
@@ -2035,13 +2035,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u20_gcc6_d0w1_cpp03_artifact
+        name: ACE_TAO_u20_gcc9_d0w1_cpp03_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_gcc6_d0w1_cpp03.tar.xz
+        tar xvfJ ACE_TAO_u20_gcc9_d0w1_cpp03.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -2095,11 +2095,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  cmake_u20_gcc6_d0w1_cpp03:
+  cmake_u20_gcc9_d0w1_cpp03:
 
     runs-on: ubuntu-20.04
 
-    needs: build_u20_gcc6_d0w1_cpp03
+    needs: build_u20_gcc9_d0w1_cpp03
 
     steps:
     - name: checkout MPC
@@ -2121,13 +2121,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_u20_gcc6_d0w1_cpp03_artifact
+        name: ACE_TAO_u20_gcc9_d0w1_cpp03_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_gcc6_d0w1_cpp03.tar.xz
+        tar xvfJ ACE_TAO_u20_gcc9_d0w1_cpp03.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -2136,13 +2136,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_u20_gcc6_d0w1_cpp03_artifact
+        name: build_u20_gcc9_d0w1_cpp03_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u20_gcc6_d0w1_cpp03.tar.xz
+        tar xvfJ build_u20_gcc9_d0w1_cpp03.tar.xz
     - name: check build configuration
       shell: bash
       run: |


### PR DESCRIPTION
- All u18 jobs moved to u20

- JDK version upgraded: build_u20_i0_xer0_js0_j17 uses Java 17 (hence j17), upgraded from 12

- Compiler versions upgraded: build_u18_clang5_i0w1_sec became build_u20_clang12_i0w1_sec and build_u18_gcc6_d0w1_cpp03 became build_u20_gcc9_d0w1_cpp03