### PR TITLE
Cleanup DataReaderImpl::get_topic_id() and MonitorLib Usage

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -64,6 +64,7 @@ DataReaderImpl::DataReaderImpl()
   , qos_(TheServiceParticipant->initial_DataReaderQos())
   , reverse_sample_lock_(sample_lock_)
   , topic_servant_(0)
+  , topic_id_(GUID_UNKNOWN)
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   , is_exclusive_ownership_(false)
 #endif
@@ -187,6 +188,7 @@ void DataReaderImpl::init(
   topic_desc_ = DDS::TopicDescription::_duplicate(a_topic_desc);
   if (TopicImpl* a_topic = dynamic_cast<TopicImpl*>(a_topic_desc)) {
     topic_servant_ = a_topic;
+    topic_id_ = a_topic->get_id();
   }
 
 #ifndef DDS_HAS_MINIMUM_BIT
@@ -2792,7 +2794,7 @@ DataReaderImpl::get_reactor()
 OpenDDS::DCPS::RepoId
 DataReaderImpl::get_topic_id()
 {
-  return topic_servant_ ? topic_servant_->get_id() : GUID_UNKNOWN;
+  return topic_id_;
 }
 
 OpenDDS::DCPS::RepoId

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -785,6 +785,7 @@ protected:
 
   WeakRcHandle<DomainParticipantImpl> participant_servant_;
   TopicDescriptionPtr<TopicImpl> topic_servant_;
+  RepoId topic_id_;
 
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   bool is_exclusive_ownership_;

--- a/dds/monitor/DPMonitorImpl.cpp
+++ b/dds/monitor/DPMonitorImpl.cpp
@@ -18,8 +18,8 @@ namespace DCPS {
 
 DPMonitorImpl::DPMonitorImpl(DomainParticipantImpl* dp,
               OpenDDS::DCPS::DomainParticipantReportDataWriter_ptr dp_writer)
-  : dp_(dp),
-    dp_writer_(DomainParticipantReportDataWriter::_duplicate(dp_writer))
+  : dp_(dp)
+  , dp_writer_(DomainParticipantReportDataWriter::_duplicate(dp_writer))
 {
   char host[256];
   ACE_OS::hostname(host, 256);
@@ -33,14 +33,14 @@ DPMonitorImpl::~DPMonitorImpl()
 
 void
 DPMonitorImpl::report() {
-  if (!CORBA::is_nil(this->dp_writer_.in())) {
+  if (!CORBA::is_nil(dp_writer_.in())) {
     DomainParticipantReport report;
-    report.host       = this->hostname_.c_str();
-    report.pid        = this->pid_;
-    report.dp_id      = this->dp_->get_id();
-    report.domain_id  = this->dp_->get_domain_id();
+    report.host = hostname_.c_str();
+    report.pid = pid_;
+    report.dp_id = dp_->get_id();
+    report.domain_id = dp_->get_domain_id();
     DomainParticipantImpl::TopicIdVec topics;
-    this->dp_->get_topic_ids(topics);
+    dp_->get_topic_ids(topics);
     CORBA::ULong length = 0;
     report.topics.length(static_cast<CORBA::ULong>(topics.size()));
     for (DomainParticipantImpl::TopicIdVec::iterator iter = topics.begin();
@@ -48,10 +48,9 @@ DPMonitorImpl::report() {
          ++iter) {
       report.topics[length++] = *iter;
     }
-    this->dp_writer_->write(report, DDS::HANDLE_NIL);
+    dp_writer_->write(report, DDS::HANDLE_NIL);
   }
 }
-
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/monitor/DRMonitorImpl.cpp
+++ b/dds/monitor/DRMonitorImpl.cpp
@@ -19,8 +19,8 @@ namespace DCPS {
 
 DRMonitorImpl::DRMonitorImpl(DataReaderImpl* dr,
               OpenDDS::DCPS::DataReaderReportDataWriter_ptr dr_writer)
-  : dr_(dr),
-    dr_writer_(DataReaderReportDataWriter::_duplicate(dr_writer))
+  : dr_(dr)
+  , dr_writer_(DataReaderReportDataWriter::_duplicate(dr_writer))
 {
 }
 
@@ -30,15 +30,15 @@ DRMonitorImpl::~DRMonitorImpl()
 
 void
 DRMonitorImpl::report() {
-  if (!CORBA::is_nil(this->dr_writer_.in())) {
+  if (!CORBA::is_nil(dr_writer_.in())) {
     DataReaderReport report;
-    report.dp_id = this->dr_->get_dp_id();
-    DDS::Subscriber_var sub = this->dr_->get_subscriber();
+    report.dp_id = dr_->get_dp_id();
+    DDS::Subscriber_var sub = dr_->get_subscriber();
     report.sub_handle = sub->get_instance_handle();
-    report.dr_id   = this->dr_->get_repo_id();
-    report.topic_id = this->dr_->get_topic_id();
+    report.dr_id = dr_->get_repo_id();
+    report.topic_id = dr_->get_topic_id();
     DataReaderImpl::InstanceHandleVec instances;
-    this->dr_->get_instance_handles(instances);
+    dr_->get_instance_handles(instances);
     CORBA::ULong length = 0;
     report.instances.length(static_cast<CORBA::ULong>(instances.size()));
     for (DataReaderImpl::InstanceHandleVec::iterator iter = instances.begin();
@@ -47,7 +47,7 @@ DRMonitorImpl::report() {
       report.instances[length++] = *iter;
     }
     DataReaderImpl::WriterStatePairVec writer_states;
-    this->dr_->get_writer_states(writer_states);
+    dr_->get_writer_states(writer_states);
     length = 0;
     report.associations.length(static_cast<CORBA::ULong>(writer_states.size()));
     for (DataReaderImpl::WriterStatePairVec::iterator iter = writer_states.begin();
@@ -57,10 +57,9 @@ DRMonitorImpl::report() {
       report.associations[length].state = iter->second;
       length++;
     }
-    this->dr_writer_->write(report, DDS::HANDLE_NIL);
+    dr_writer_->write(report, DDS::HANDLE_NIL);
   }
 }
-
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/monitor/DWMonitorImpl.cpp
+++ b/dds/monitor/DWMonitorImpl.cpp
@@ -18,8 +18,8 @@ namespace DCPS {
 
 DWMonitorImpl::DWMonitorImpl(DataWriterImpl* dw,
               OpenDDS::DCPS::DataWriterReportDataWriter_ptr dw_writer)
-  : dw_(dw),
-    dw_writer_(DataWriterReportDataWriter::_duplicate(dw_writer))
+  : dw_(dw)
+  , dw_writer_(DataWriterReportDataWriter::_duplicate(dw_writer))
 {
 }
 
@@ -29,13 +29,13 @@ DWMonitorImpl::~DWMonitorImpl()
 
 void
 DWMonitorImpl::report() {
-  if (!CORBA::is_nil(this->dw_writer_.in())) {
+  if (!CORBA::is_nil(dw_writer_.in())) {
     DataWriterReport report;
-    report.dp_id = this->dw_->get_dp_id();
-    DDS::Publisher_var pub = this->dw_->get_publisher();
+    report.dp_id = dw_->get_dp_id();
+    DDS::Publisher_var pub = dw_->get_publisher();
     report.pub_handle = pub->get_instance_handle();
-    report.dw_id   = this->dw_->get_repo_id();
-    DDS::Topic_var topic = this->dw_->get_topic();
+    report.dw_id = dw_->get_repo_id();
+    DDS::Topic_var topic = dw_->get_topic();
     OpenDDS::DCPS::TopicImpl* ti = dynamic_cast<TopicImpl*>(topic.in());
     if (!ti) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DWMonitorImpl::report():")
@@ -44,7 +44,7 @@ DWMonitorImpl::report() {
     }
     report.topic_id = ti->get_id();
     DataWriterImpl::InstanceHandleVec instances;
-    this->dw_->get_instance_handles(instances);
+    dw_->get_instance_handles(instances);
     CORBA::ULong length = 0;
     report.instances.length(static_cast<CORBA::ULong>(instances.size()));
     for (DataWriterImpl::InstanceHandleVec::iterator iter = instances.begin();
@@ -53,7 +53,7 @@ DWMonitorImpl::report() {
       report.instances[length++] = *iter;
     }
     DCPS::RepoIdSet readers;
-    this->dw_->get_readers(readers);
+    dw_->get_readers(readers);
     length = 0;
     report.associations.length(static_cast<CORBA::ULong>(readers.size()));
     for (DCPS::RepoIdSet::iterator iter = readers.begin();
@@ -62,10 +62,9 @@ DWMonitorImpl::report() {
       report.associations[length].dr_id = *iter;
       length++;
     }
-    this->dw_writer_->write(report, DDS::HANDLE_NIL);
+    dw_writer_->write(report, DDS::HANDLE_NIL);
   }
 }
-
 
 } // namespace DCPS
 } // namespace OpenDDS


### PR DESCRIPTION
Problem: Previously, `DRMonitorImpl` could cause a SEGV by calling into `DataReaderImpl::get_topic_id()` after `DataReaderImpl::cleanup()` had been called (`topic_servant_` would be dereferenced when `0`). PR #3714 fixed this SEGV, but didn't attempt to address any larger design issues.

Solution: Upon reviewing the issue in more detail, it seems better to cache the topic id GUID during initialization (during `DataReaderImpl::init()`, similar to what's done in `DataWriterImpl`) so that "late" calls to `get_topic_id()` will still get the correct GUID (and not the default `GUID_UNKNOWN`) for any interested reports.