### PR TITLE
Docker updates

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,49 @@
+name: Create and publish a Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - latest-release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/DevGuideExamples/DCPS/Messenger/docker-compose-inforepo.yml
+++ b/DevGuideExamples/DCPS/Messenger/docker-compose-inforepo.yml
@@ -7,11 +7,11 @@ services:
       - $PWD:/opt/workspace
   subscriber:
     image: objectcomputing/opendds
-    command: ["./wait-for-it.sh", "inforepo:3897", "--", "subscriber", "-DCPSInfoRepo",  "inforepo:3897" ]
+    command: ["./wait-for-it.sh", "inforepo:3897", "--", "./subscriber", "-DCPSInfoRepo",  "inforepo:3897" ]
     volumes:
       - $PWD:/opt/workspace
   publisher:
     image: objectcomputing/opendds
-    command: ["./wait-for-it.sh", "inforepo:3897", "--", "publisher", "-DCPSInfoRepo",  "inforepo:3897" ]
+    command: ["./wait-for-it.sh", "inforepo:3897", "--", "./publisher", "-DCPSInfoRepo",  "inforepo:3897" ]
     volumes:
       - $PWD:/opt/workspace

--- a/DevGuideExamples/DCPS/Messenger/docker-compose.yml
+++ b/DevGuideExamples/DCPS/Messenger/docker-compose.yml
@@ -2,11 +2,11 @@ version: '2'
 services:
   subscriber:
     image: objectcomputing/opendds
-    command: ["subscriber", "-DCPSConfigFile",  "rtps.ini" ]
+    command: ["./subscriber", "-DCPSConfigFile",  "rtps.ini" ]
     volumes:
       - $PWD:/opt/workspace
   publisher:
     image: objectcomputing/opendds
-    command: ["publisher", "-DCPSConfigFile",  "rtps.ini" ]
+    command: ["./publisher", "-DCPSConfigFile",  "rtps.ini" ]
     volumes:
       - $PWD:/opt/workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASIS=ubuntu:bionic
+ARG BASIS=ubuntu:focal
 FROM $BASIS
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -28,10 +28,6 @@ RUN cd /opt/OpenDDS && \
 ENV ACE_ROOT=/usr/local/share/ace \
     TAO_ROOT=/usr/local/share/tao \
     DDS_ROOT=/usr/local/share/dds \
-    MPC_ROOT=/usr/local/share/MPC \
-    PATH=".:/usr/local/share/ace/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-
-WORKDIR /opt/OpenDDS/tests/DCPS/Messenger
-RUN mwc.pl -type gnuace && make
+    MPC_ROOT=/usr/local/share/MPC
 
 WORKDIR /opt/workspace


### PR DESCRIPTION
Dockerfile:
* reduce changes to PATH
* do not build tests/DCPS/Messenger
* use Ubuntu 20.04 "focal" as the basis

Docker Compose files
* work with default PATH

GitHub Actions
* added a workflow that builds the container image and puts it in GitHub's repository