### PR TITLE
Unauthenticated participant leads to invalid iterator

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1535,7 +1535,7 @@ Sedp::send_builtin_crypto_tokens(const DCPS::RepoId& remoteId)
 }
 #endif
 
-bool
+void
 Sedp::disassociate(DiscoveredParticipant& participant)
 {
   const RepoId part = make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
@@ -1545,12 +1545,8 @@ Sedp::disassociate(DiscoveredParticipant& participant)
   OPENDDS_VECTOR(DiscoveredPublication) pubs_to_remove_from_bit;
   OPENDDS_VECTOR(DiscoveredSubscription) subs_to_remove_from_bit;
 
-  bool result = false;
-  if (spdp_.has_discovered_participant(part)) {
-    remove_entities_belonging_to(discovered_publications_, part, false, pubs_to_remove_from_bit);
-    remove_entities_belonging_to(discovered_subscriptions_, part, true, subs_to_remove_from_bit);
-    result = true;
-  }
+  remove_entities_belonging_to(discovered_publications_, part, false, pubs_to_remove_from_bit);
+  remove_entities_belonging_to(discovered_subscriptions_, part, true, subs_to_remove_from_bit);
 
   for (OPENDDS_VECTOR(DiscoveredPublication)::iterator it = pubs_to_remove_from_bit.begin(); it != pubs_to_remove_from_bit.end(); ++it) {
     remove_from_bit_i(*it);
@@ -1627,8 +1623,6 @@ Sedp::disassociate(DiscoveredParticipant& participant)
     }
   }
 #endif
-
-  return result;
 }
 
 void

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -531,7 +531,7 @@ public:
   void resend_user_crypto_tokens(const DCPS::RepoId& remote_participant);
 #endif
 
-  bool disassociate(DiscoveredParticipant& participant);
+  void disassociate(DiscoveredParticipant& participant);
 
   void update_locators(const ParticipantData_t& pdata);
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -380,10 +380,7 @@ Spdp::shutdown()
     }
 #endif
 
-    for (DiscoveredParticipantIter part = participants_.begin();
-         part != participants_.end();
-         /* Update in loop*/)
-    {
+    for (DiscoveredParticipantIter part = participants_.begin(); part != participants_.end(); ++part) {
 #ifdef OPENDDS_SECURITY
       DCPS::WeakRcHandle<ICE::Endpoint> sedp_endpoint = sedp_->get_ice_endpoint();
       if (sedp_endpoint) {
@@ -396,7 +393,7 @@ Spdp::shutdown()
       }
       purge_handshake_deadlines(part);
 #endif
-      remove_discovered_participant(part++);
+      purge_discovered_participant(part);
     }
   }
 
@@ -836,7 +833,9 @@ Spdp::handle_participant_data(DCPS::MessageId id,
               DCPS::LogGuid(guid).c_str()));
           }
           // FUTURE: This is probably not a good idea since it will just get rediscovered.
-          erase_participant(iter);
+          purge_discovered_participant(iter);
+          participants_.erase(iter);
+          iter = participants_.end();
         } else { // allow_unauthenticated_participants == true
           set_auth_state(iter->second, AUTH_STATE_UNAUTHENTICATED);
           match_unauthenticated(iter);
@@ -860,14 +859,18 @@ Spdp::handle_participant_data(DCPS::MessageId id,
                 ACE_TEXT("Incompatible security attributes in discovered participant: %C\n"),
                 DCPS::LogGuid(guid).c_str()));
             }
-            erase_participant(iter);
+            purge_discovered_participant(iter);
+            participants_.erase(iter);
+            iter = participants_.end();
           } else { // allow_unauthenticated_participants == true
             set_auth_state(iter->second, AUTH_STATE_UNAUTHENTICATED);
             match_unauthenticated(iter);
           }
         } else if (iter->second.auth_state_ == AUTH_STATE_AUTHENTICATED) {
           if (match_authenticated(guid, iter) == false) {
-            erase_participant(iter);
+            purge_discovered_participant(iter);
+            participants_.erase(iter);
+            iter = participants_.end();
           }
         }
         // otherwise just return, since we're waiting for input to finish authentication
@@ -922,7 +925,8 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       process_location_updates_i(iter);
 #endif
       if (iter != participants_.end()) {
-        remove_discovered_participant(iter);
+        purge_discovered_participant(iter);
+        participants_.erase(iter);
       }
       return;
     }
@@ -974,7 +978,8 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       process_location_updates_i(iter);
 #endif
       if (iter != participants_.end()) {
-        remove_discovered_participant(iter);
+        purge_discovered_participant(iter);
+        participants_.erase(iter);
       }
       return;
     }
@@ -1741,7 +1746,8 @@ Spdp::process_handshake_deadlines(const DCPS::MonotonicTimePoint& now)
           ice_agent_->stop_ice(spdp_endpoint, guid_, pit->first);
         }
         handshake_deadlines_.erase(pos);
-        remove_discovered_participant(pit);
+        purge_discovered_participant(pit);
+        participants_.erase(pit);
       } else {
         purge_handshake_resends(pit);
         set_auth_state(pit->second, AUTH_STATE_UNAUTHENTICATED);
@@ -2105,83 +2111,6 @@ void Spdp::remove_agent_info(const DCPS::RepoId&)
   }
 }
 #endif
-
-void
-Spdp::remove_discovered_participant_i(const DiscoveredParticipantIter& iter)
-{
-
-  remove_lease_expiration_i(iter);
-
-#ifdef OPENDDS_SECURITY
-  if (security_config_) {
-    DDS::Security::SecurityException se = {"", 0, 0};
-    DDS::Security::Authentication_var auth = security_config_->get_authentication();
-    DDS::Security::AccessControl_var access = security_config_->get_access_control();
-
-    DDS::Security::ParticipantCryptoHandle pch =
-      sedp_->get_handle_registry()->get_remote_participant_crypto_handle(iter->first);
-    if (!security_config_->get_crypto_key_factory()->unregister_participant(pch, se)) {
-      if (DCPS::security_debug.auth_warn) {
-        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                   ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
-                   ACE_TEXT("Unable to return crypto handle. ")
-                   ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                   se.code, se.minor_code, se.message.in()));
-      }
-    }
-    sedp_->get_handle_registry()->erase_remote_participant_crypto_handle(iter->first);
-    sedp_->get_handle_registry()->erase_remote_participant_permissions_handle(iter->first);
-
-    if (iter->second.identity_handle_ != DDS::HANDLE_NIL) {
-      if (!auth->return_identity_handle(iter->second.identity_handle_, se)) {
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
-                     ACE_TEXT("Unable to return identity handle. ")
-                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                     se.code, se.minor_code, se.message.in()));
-        }
-      }
-    }
-
-    if (iter->second.handshake_handle_ != DDS::HANDLE_NIL) {
-      if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
-                     ACE_TEXT("Unable to return handshake handle. ")
-                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                     se.code, se.minor_code, se.message.in()));
-        }
-      }
-    }
-
-    if (iter->second.shared_secret_handle_ != 0) {
-      if (!auth->return_sharedsecret_handle(iter->second.shared_secret_handle_, se)) {
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
-                     ACE_TEXT("Unable to return sharedsecret handle. ")
-                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                     se.code, se.minor_code, se.message.in()));
-        }
-      }
-    }
-
-    if (iter->second.permissions_handle_ != DDS::HANDLE_NIL) {
-      if (!access->return_permissions_handle(iter->second.permissions_handle_, se)) {
-        if (DCPS::security_debug.auth_warn) {
-          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
-                     ACE_TEXT("Spdp::remove_discovered_participant_i() - ")
-                     ACE_TEXT("Unable to return permissions handle. ")
-                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
-                     se.code, se.minor_code, se.message.in()));
-        }
-      }
-    }
-  }
-#endif
-}
 
 void
 Spdp::init_bit(DCPS::RcHandle<DCPS::BitSubscriber> bit_subscriber)
@@ -2809,8 +2738,8 @@ Spdp::update_rtps_relay_application_participant_i(DiscoveredParticipantIter iter
                    ACE_TEXT("(%P|%t) Spdp::update_rtps_relay_application_participant - removing previous RtpsRelay application participant %C\n"),
                    DCPS::LogGuid(pos->first).c_str()));
       }
-      DiscoveredParticipantIter to_erase = pos++;
-      remove_discovered_participant(to_erase);
+      purge_discovered_participant(pos);
+      participants_.erase(pos++);
     } else {
       ++pos;
     }
@@ -3778,7 +3707,7 @@ Spdp::process_lease_expirations(const DCPS::MonotonicTimePoint& now)
   for (TimeQueue::iterator pos = lease_expirations_.begin(), limit = lease_expirations_.end();
        pos != limit && pos->first <= now;) {
     DiscoveredParticipantIter part = participants_.find(pos->second);
-    // Pre-emptively erase so remove_discovered_participant will not modify lease_expirations_.
+    // Pre-emptively erase so purge_discovered_participant will not modify lease_expirations_.
     lease_expirations_.erase(pos++);
 
     if (part == participants_.end()) {
@@ -3804,7 +3733,8 @@ Spdp::process_lease_expirations(const DCPS::MonotonicTimePoint& now)
     }
     purge_handshake_deadlines(part);
 #endif
-    remove_discovered_participant(part);
+    purge_discovered_participant(part);
+    participants_.erase(part);
   }
 
   if (!lease_expirations_.empty()) {
@@ -4676,7 +4606,8 @@ void Spdp::ignore_domain_participant(const GUID_t& ignoreId)
 
   DiscoveredParticipantIter iter = participants_.find(ignoreId);
   if (iter != participants_.end()) {
-    remove_discovered_participant(iter);
+    purge_discovered_participant(iter);
+    participants_.erase(iter);
   }
 }
 
@@ -4686,7 +4617,8 @@ void Spdp::remove_domain_participant(const GUID_t& removeId)
 
   DiscoveredParticipantIter iter = participants_.find(removeId);
   if (iter != participants_.end()) {
-    remove_discovered_participant(iter);
+    purge_discovered_participant(iter);
+    participants_.erase(iter);
   }
 }
 
@@ -4718,24 +4650,94 @@ DCPS::TopicStatus Spdp::assert_topic(GUID_t& topicId, const char* topicName,
   return endpoint_manager().assert_topic(topicId, topicName, dataTypeName, qos, hasDcpsKey, topic_callbacks);
 }
 
-void Spdp::remove_discovered_participant(const DiscoveredParticipantIter& iter)
+void Spdp::purge_discovered_participant(const DiscoveredParticipantIter& iter)
 {
   if (iter == participants_.end()) {
     return;
   }
-  bool removed = endpoint_manager().disassociate(iter->second);
-  if (removed) {
-    bit_subscriber_->remove_participant(iter->second.bit_ih_, iter->second.location_ih_);
-    if (DCPS_debug_level > 3) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) LocalParticipant::remove_discovered_participant: "
-        "erasing %C (%B)\n",
-        DCPS::LogGuid(iter->first).c_str(), participants_.size()));
+  endpoint_manager().disassociate(iter->second);
+  bit_subscriber_->remove_participant(iter->second.bit_ih_, iter->second.location_ih_);
+  if (DCPS_debug_level > 3) {
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) LocalParticipant::purge_discovered_participant: "
+               "erasing %C (%B)\n",
+               DCPS::LogGuid(iter->first).c_str(), participants_.size()));
+  }
+
+  remove_lease_expiration_i(iter);
+
+#ifdef OPENDDS_SECURITY
+  if (security_config_) {
+    DDS::Security::SecurityException se = {"", 0, 0};
+    DDS::Security::Authentication_var auth = security_config_->get_authentication();
+    DDS::Security::AccessControl_var access = security_config_->get_access_control();
+
+    DDS::Security::ParticipantCryptoHandle pch =
+      sedp_->get_handle_registry()->get_remote_participant_crypto_handle(iter->first);
+    if (!security_config_->get_crypto_key_factory()->unregister_participant(pch, se)) {
+      if (DCPS::security_debug.auth_warn) {
+        ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                   ACE_TEXT("Spdp::purge_discovered_participant() - ")
+                   ACE_TEXT("Unable to return crypto handle. ")
+                   ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                   se.code, se.minor_code, se.message.in()));
+      }
+    }
+    sedp_->get_handle_registry()->erase_remote_participant_crypto_handle(iter->first);
+    sedp_->get_handle_registry()->erase_remote_participant_permissions_handle(iter->first);
+
+    if (iter->second.identity_handle_ != DDS::HANDLE_NIL) {
+      if (!auth->return_identity_handle(iter->second.identity_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::purge_discovered_participant() - ")
+                     ACE_TEXT("Unable to return identity handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+      }
     }
 
-    remove_discovered_participant_i(iter);
+    if (iter->second.handshake_handle_ != DDS::HANDLE_NIL) {
+      if (!auth->return_handshake_handle(iter->second.handshake_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::purge_discovered_participant() - ")
+                     ACE_TEXT("Unable to return handshake handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+      }
+    }
 
-    erase_participant(iter);
+    if (iter->second.shared_secret_handle_ != 0) {
+      if (!auth->return_sharedsecret_handle(iter->second.shared_secret_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::purge_discovered_participant() - ")
+                     ACE_TEXT("Unable to return sharedsecret handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+      }
+    }
+
+    if (iter->second.permissions_handle_ != DDS::HANDLE_NIL) {
+      if (!access->return_permissions_handle(iter->second.permissions_handle_, se)) {
+        if (DCPS::security_debug.auth_warn) {
+          ACE_DEBUG((LM_WARNING, ACE_TEXT("(%P|%t) {auth_warn} ")
+                     ACE_TEXT("Spdp::purge_discovered_participant() - ")
+                     ACE_TEXT("Unable to return permissions handle. ")
+                     ACE_TEXT("Security Exception[%d.%d]: %C\n"),
+                     se.code, se.minor_code, se.message.in()));
+        }
+      }
+    }
   }
+
+  if (iter->second.auth_state_ == AUTH_STATE_HANDSHAKE) {
+    --n_participants_in_authentication_;
+  }
+#endif
 }
 
 #ifdef OPENDDS_SECURITY
@@ -4748,16 +4750,6 @@ void Spdp::set_auth_state(DiscoveredParticipant& dp, AuthState new_state)
   dp.auth_state_ = new_state;
 }
 #endif
-
-void Spdp::erase_participant(DiscoveredParticipantIter iter)
-{
-#ifdef OPENDDS_SECURITY
-  if (iter->second.auth_state_ == AUTH_STATE_HANDSHAKE) {
-    --n_participants_in_authentication_;
-  }
-#endif
-  participants_.erase(iter);
-}
 
 } // namespace RTPS
 } // namespace OpenDDS

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -362,9 +362,7 @@ public:
 protected:
   Sedp& endpoint_manager() { return *sedp_; }
 
-  void remove_discovered_participant(const DiscoveredParticipantIter& iter);
-
-  void remove_discovered_participant_i(const DiscoveredParticipantIter& iter);
+  void purge_discovered_participant(const DiscoveredParticipantIter& iter);
 
 #ifndef DDS_HAS_MINIMUM_BIT
   void enqueue_location_update_i(DiscoveredParticipantIter iter, DCPS::ParticipantLocation mask, const ACE_INET_Addr& from);
@@ -670,8 +668,6 @@ private:
   size_t n_participants_in_authentication_;
   void set_auth_state(DiscoveredParticipant& dp, AuthState state);
 #endif
-
-  void erase_participant(DiscoveredParticipantIter iter);
 
   friend class ::DDS_TEST;
 };

--- a/tests/security/attributes/run_test.pl
+++ b/tests/security/attributes/run_test.pl
@@ -171,9 +171,9 @@ if ($scenario) {
     @pub_perm_files = ("permissions/permissions_test_participant_01_join_signed.p7s");
     # doesn't have permission to read
     @sub_perm_files = ("permissions/permissions_test_participant_02_join_signed.p7s");
-    @topic_names = ("OD_OL_OA_OM_OD");
-    $pub_expect = "~16";
-    $sub_expect = "~27";
+    @topic_names = ("OD_OL_RWA_OM_OD");
+    $pub_expect = "~13";
+    $sub_expect = "~23";
   } elsif ($scenario eq "SC1_sec_on_success") {
     #SC1 (join controlled domain) : valid participants join and send
     @gov_keys = ("PU_PA_ED_EL_NR");

--- a/tests/security/security_tests.lst
+++ b/tests/security/security_tests.lst
@@ -6,10 +6,12 @@ tests/security/attributes/run_test.pl SC0_sec_on
 tests/security/attributes/run_test.pl SC0_sec_on_ec_pub
 tests/security/attributes/run_test.pl SC0_sec_on_ec_sub
 tests/security/attributes/run_test.pl SC0_sec_on_ec_both
-#tests/security/attributes/run_test.pl SC1_sec_off_failure
+tests/security/attributes/run_test.pl SC1_sec_off_success
+tests/security/attributes/run_test.pl SC1_sec_sub_failure
+tests/security/attributes/run_test.pl SC1_sec_pub_failure
 tests/security/attributes/run_test.pl SC1_sec_on_bad_cert_failure
 tests/security/attributes/run_test.pl SC1_sec_on_bad_perm_1_failure
-#tests/security/attributes/run_test.pl SC1_sec_on_bad_perm_2_failure
+tests/security/attributes/run_test.pl SC1_sec_on_bad_perm_2_failure
 tests/security/attributes/run_test.pl SC1_sec_on_success
 tests/security/attributes/run_test.pl SC2
 tests/security/attributes/run_test.pl SC3
@@ -30,7 +32,7 @@ tests/security/attributes/run_test.pl FullMsgSign_SubMsgSign_PayloadEncrypt
 tests/security/attributes/run_test.pl FullMsgSign_SubMsgEncrypt_PayloadEncrypt
 tests/security/attributes/run_test.pl FullMsgEncrypt_SubMsgSign_PayloadEncrypt
 tests/security/attributes/run_test.pl FullMsgEncrypt_SubMsgEncrypt_PayloadEncrypt
-#tests/security/attributes/run_test.pl FullMsgSign_PayloadEncrypt_Frag
+tests/security/attributes/run_test.pl FullMsgSign_PayloadEncrypt_Frag
 tests/security/attributes/run_test.pl Partitions_DefaultQoS
 tests/security/attributes/run_test.pl Partitions_Denied
 tests/security/attributes/run_test.pl Partitions_Match

--- a/tests/transport/spdp/spdp_transport.cpp
+++ b/tests/transport/spdp/spdp_transport.cpp
@@ -61,7 +61,8 @@ public:
     ACE_GUARD(ACE_Thread_Mutex, g, spdp_->lock_);
     Spdp::DiscoveredParticipantIter iter = spdp_->participants_.find(guid_);
     if (iter != spdp_->participants_.end()) {
-      spdp_->remove_discovered_participant(iter);
+      spdp_->purge_discovered_participant(iter);
+      spdp_->participants_.erase(iter);
     }
   }
 


### PR DESCRIPTION
Problem
-------

A participant with incompatible security attributes is discovered and then removed without resetting the iterator.  The invalid iterator then causes a run-time error.

Solution
--------

* Refactor the code in SPDP to make participant removal more obvious.
* Add/enable security tests that test this scenario.
* Fix the `SC1_sec_on_bad_perm_2_failure` scenario to use an access-controlled topic.