### PR TITLE
Tighten RtpsSendQueue Count Checks

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsSendQueue.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSendQueue.cpp
@@ -138,6 +138,13 @@ void RtpsSendQueue::condense_and_swap(MetaSubmessageVec& vec)
   queue_.swap(vec);
 }
 
+void RtpsSendQueue::purge(const RepoId& local, const RepoId& remote)
+{
+  const KeyType key(local, remote);
+  heartbeat_map_.erase(key);
+  acknack_map_.erase(key);
+}
+
 void RtpsSendQueue::purge_remote(const RepoId& id)
 {
   for (MapType::iterator it = heartbeat_map_.begin(), limit = heartbeat_map_.end(); it != limit;) {

--- a/dds/DCPS/transport/rtps_udp/RtpsSendQueue.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSendQueue.cpp
@@ -10,6 +10,15 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+namespace {
+
+bool check_counts(bool redundant, CORBA::Long v1, CORBA::Long v2)
+{
+  return redundant ? v1 <= v2 : v1 < v2;
+}
+
+}
+
 RtpsSendQueue::RtpsSendQueue()
 : enabled_(true)
 , heartbeats_need_merge_(false)
@@ -28,7 +37,7 @@ bool RtpsSendQueue::push_back(const MetaSubmessage& ms)
         heartbeat_map_.insert(std::make_pair(key, ms));
         result = true;
         heartbeats_need_merge_ = true;
-      } else if (pos->second.redundant_ || pos->second.sm_.heartbeat_sm().count.value < ms.sm_.heartbeat_sm().count.value) {
+      } else if (check_counts(pos->second.redundant_, pos->second.sm_.heartbeat_sm().count.value, ms.sm_.heartbeat_sm().count.value)) {
         pos->second = ms;
         result = true;
         heartbeats_need_merge_ = true;
@@ -42,7 +51,7 @@ bool RtpsSendQueue::push_back(const MetaSubmessage& ms)
         acknack_map_.insert(std::make_pair(key, ms));
         result = true;
         acknacks_need_merge_ = true;
-      } else if (pos->second.redundant_ || pos->second.sm_.acknack_sm().count.value < ms.sm_.acknack_sm().count.value) {
+      } else if (check_counts(pos->second.redundant_, pos->second.sm_.acknack_sm().count.value, ms.sm_.acknack_sm().count.value)) {
         pos->second = ms;
         result = true;
         acknacks_need_merge_ = true;
@@ -73,7 +82,7 @@ bool RtpsSendQueue::merge(RtpsSendQueue& from)
           heartbeat_map_.insert(std::make_pair(it->first, it->second));
           result = true;
           heartbeats_need_merge_ = true;
-        } else if (pos->second.redundant_ || pos->second.sm_.heartbeat_sm().count.value < it->second.sm_.heartbeat_sm().count.value) {
+        } else if (check_counts(pos->second.redundant_, pos->second.sm_.heartbeat_sm().count.value, it->second.sm_.heartbeat_sm().count.value)) {
           pos->second = it->second;
           result = true;
           heartbeats_need_merge_ = true;
@@ -92,7 +101,7 @@ bool RtpsSendQueue::merge(RtpsSendQueue& from)
           acknack_map_.insert(std::make_pair(it->first, it->second));
           result = true;
           acknacks_need_merge_ = true;
-        } else if (pos->second.redundant_ || pos->second.sm_.acknack_sm().count.value < it->second.sm_.acknack_sm().count.value) {
+        } else if (check_counts(pos->second.redundant_, pos->second.sm_.acknack_sm().count.value, it->second.sm_.acknack_sm().count.value)) {
           pos->second = it->second;
           result = true;
           acknacks_need_merge_ = true;

--- a/dds/DCPS/transport/rtps_udp/RtpsSendQueue.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsSendQueue.h
@@ -40,6 +40,9 @@ public:
   /// Note: calls clear() on the input vector before swapping
   void condense_and_swap(MetaSubmessageVec& vec);
 
+  /// Remove all queued submessage with the given source and destination
+  void purge(const RepoId& local, const RepoId& remote);
+
   /// Remove all queued submessage with the given destination (dst_guid_)
   void purge_remote(const RepoId& id);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -561,6 +561,8 @@ RtpsUdpDataLink::associated(const RepoId& local_id, const RepoId& remote_id,
                             const NetworkAddress& last_addr_hint,
                             bool requires_inline_qos)
 {
+  sq_.purge(local_id, remote_id);
+
   update_locators(remote_id, unicast_addresses, multicast_addresses, requires_inline_qos, true);
   if (last_addr_hint != NetworkAddress()) {
     update_last_recv_addr(remote_id, last_addr_hint);

--- a/dds/DCPS/transport/rtps_udp/ThreadedRtpsSendQueue.cpp
+++ b/dds/DCPS/transport/rtps_udp/ThreadedRtpsSendQueue.cpp
@@ -81,6 +81,15 @@ void ThreadedRtpsSendQueue::condense_and_swap(MetaSubmessageVec& vec)
   has_data_to_send_ = false;
 }
 
+void ThreadedRtpsSendQueue::purge(const RepoId& local, const RepoId& remote)
+{
+  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  for (ThreadQueueMap::iterator it = thread_queue_map_.begin(), limit = thread_queue_map_.end(); it != limit; ++it) {
+    it->second.purge(local, remote);
+  }
+  primary_queue_.purge(local, remote);
+}
+
 void ThreadedRtpsSendQueue::purge_remote(const RepoId& id)
 {
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);

--- a/dds/DCPS/transport/rtps_udp/ThreadedRtpsSendQueue.h
+++ b/dds/DCPS/transport/rtps_udp/ThreadedRtpsSendQueue.h
@@ -49,6 +49,9 @@ public:
   /// Note: calls clear() on the input vector before swapping
   void condense_and_swap(MetaSubmessageVec& vec);
 
+  /// Remove all queued submessage with the given source and destination
+  void purge(const RepoId& local, const RepoId& remote);
+
   /// Remove all queued submessage with the given destination (dst_guid_)
   void purge_remote(const RepoId& id);
 

--- a/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsSendQueue.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsSendQueue.cpp
@@ -267,6 +267,20 @@ TEST(dds_DCPS_RtpsSendQueue, Purging)
   sq.push_back(create_heartbeat(w2, r1, first, last, count++));
   sq.push_back(create_heartbeat(w2, r2, first, last, count++));
 
+  sq.purge(w1, r2);
+
+  sq.condense_and_swap(vec);
+  EXPECT_EQ(vec.size(), 5u);
+  vec.clear();
+
+  sq.push_back(create_heartbeat(w1, GUID_UNKNOWN, first, last, count++));
+  sq.push_back(create_heartbeat(w1, r1, first, last, count++));
+  sq.push_back(create_heartbeat(w1, r2, first, last, count++));
+
+  sq.push_back(create_heartbeat(w2, GUID_UNKNOWN, first, last, count++));
+  sq.push_back(create_heartbeat(w2, r1, first, last, count++));
+  sq.push_back(create_heartbeat(w2, r2, first, last, count++));
+
   sq.purge_remote(r2);
 
   sq.condense_and_swap(vec);

--- a/tests/unit-tests/dds/DCPS/transport/rtps_udp/ThreadedRtpsSendQueue.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/rtps_udp/ThreadedRtpsSendQueue.cpp
@@ -127,6 +127,43 @@ TEST(dds_DCPS_ThreadedRtpsSendQueue, EnableDisable)
   vec.clear();
 }
 
+TEST(dds_DCPS_ThreadedRtpsSendQueue, Purge)
+{
+  ThreadedRtpsSendQueue sq;
+
+  sq.enable_thread_queue();
+  EXPECT_FALSE(sq.disable_thread_queue());
+  sq.enable_thread_queue();
+
+  const ACE_INT64 first = 3;
+  const ACE_INT64 last = 5;
+  ACE_INT32 hb_count = 0;
+
+  const ACE_INT64 base = 3;
+  ACE_INT32 an_count = 0;
+
+  MetaSubmessageVec vec;
+  vec.push_back(create_heartbeat(w1, r2, first, last, hb_count++));
+  vec.push_back(create_heartbeat(w1, r1, first, last, hb_count++));
+  vec.push_back(create_acknack(r1, w2, base, an_count++));
+  vec.push_back(create_acknack(r2, w2, base, an_count++));
+  sq.enqueue(vec);
+
+  vec.clear();
+  sq.condense_and_swap(vec);
+
+  EXPECT_EQ(vec.size(), 0u);
+  vec.clear();
+
+  sq.purge(w1, r1);
+
+  EXPECT_TRUE(sq.disable_thread_queue());
+  sq.condense_and_swap(vec);
+
+  EXPECT_EQ(vec.size(), 3u);
+  vec.clear();
+}
+
 TEST(dds_DCPS_ThreadedRtpsSendQueue, PurgeLocal)
 {
   ThreadedRtpsSendQueue sq;


### PR DESCRIPTION
Problem: RtpsSendQueue checks for redundant can allow significantly lower counts to be added to the send queue.

Solution: Tighten checks against redundant to only allow repetitions of the current count to be added, and add pairwise purge-upon-association to handle instances of multiple associations happening without a disassociate