### PR TITLE
Building for VxWorks on Windows

### DIFF
--- a/cmake/OpenDDSConfig.cmake
+++ b/cmake/OpenDDSConfig.cmake
@@ -76,8 +76,13 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/init.cmake)
 
+## Adding ${TAO_BIN_DIR} to the ace bin hints allows users of
+## VxWorks layer builds to set TAO_BIN_DIR to the location of
+## the partner host tools directory, but keep ACE_BIN_DIR the
+## value of $ACE_ROOT so that other ACE related scripts can
+## be located.
 set(_dds_bin_hints ${OPENDDS_BIN_DIR})
-set(_ace_bin_hints ${ACE_BIN_DIR})
+set(_ace_bin_hints ${ACE_BIN_DIR} ${TAO_BIN_DIR})
 set(_tao_bin_hints ${TAO_BIN_DIR})
 
 find_program(PERL perl)

--- a/cmake/OpenDDSConfig.cmake
+++ b/cmake/OpenDDSConfig.cmake
@@ -133,9 +133,12 @@ if(OPENDDS_XERCES3)
 endif()
 
 set(_ace_libs
-  ACE_XML_Utils
   ACE
 )
+
+if(OPENDDS_XERCES3)
+  list(APPEND _ace_libs ACE_XML_Utils)
+endif()
 
 set(_tao_libs
   TAO_IORManip
@@ -162,14 +165,16 @@ set(_opendds_libs
   OpenDDS_Model
   OpenDDS_monitor
   OpenDDS_Multicast
-  OpenDDS_QOS_XML_XSC_Handler
   OpenDDS_Rtps
   OpenDDS_Rtps_Udp
-  OpenDDS_Security
   OpenDDS_Shmem
   OpenDDS_Tcp
   OpenDDS_Udp
 )
+
+if(OPENDDS_SECURITY)
+  list(APPEND _opendds_libs OpenDDS_QOS_XML_XSC_Handler OpenDDS_Security)
+endif()
 
 list(APPEND _all_libs ${_opendds_libs} ${_ace_libs} ${_tao_libs})
 

--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -238,11 +238,14 @@ function(opendds_target_idl_sources target)
 
     _tao_append_runtime_lib_dir_to_path(_tao_extra_lib_dirs)
 
+    ## CMake wants forward slashes for commands
+    string(REPLACE "\\" "/" _tao_extra_lib_dirs ${_tao_extra_lib_dirs})
+
     add_custom_command(
       OUTPUT ${_cur_idl_outputs} ${_cur_type_support_idl} ${_cur_java_list}
       DEPENDS opendds_idl ${DDS_ROOT}/dds/idl/IDLTemplate.txt
       MAIN_DEPENDENCY ${abs_filename}
-      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}" "TAO_ROOT=${TAO_INCLUDE_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}" "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=-E"
               "${_tao_extra_lib_dirs}"
               $<TARGET_FILE:opendds_idl> -I${idl_file_dir}
               ${_ddsidl_flags} ${file_dds_idl_flags} ${abs_filename}

--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -238,9 +238,6 @@ function(opendds_target_idl_sources target)
 
     _tao_append_runtime_lib_dir_to_path(_tao_extra_lib_dirs)
 
-    ## CMake wants forward slashes for commands
-    string(REPLACE "\\" "/" _tao_extra_lib_dirs ${_tao_extra_lib_dirs})
-
     add_custom_command(
       OUTPUT ${_cur_idl_outputs} ${_cur_type_support_idl} ${_cur_java_list}
       DEPENDS opendds_idl ${DDS_ROOT}/dds/idl/IDLTemplate.txt

--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -242,7 +242,7 @@ function(opendds_target_idl_sources target)
       OUTPUT ${_cur_idl_outputs} ${_cur_type_support_idl} ${_cur_java_list}
       DEPENDS opendds_idl ${DDS_ROOT}/dds/idl/IDLTemplate.txt
       MAIN_DEPENDENCY ${abs_filename}
-      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}" "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=\"-E -I${TAO_ROOT} -I${TAO_INCLUDE_DIR}\""
+      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}" "TAO_ROOT=${TAO_INCLUDE_DIR}"
               "${_tao_extra_lib_dirs}"
               $<TARGET_FILE:opendds_idl> -I${idl_file_dir}
               ${_ddsidl_flags} ${file_dds_idl_flags} ${abs_filename}

--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -245,7 +245,7 @@ function(opendds_target_idl_sources target)
       OUTPUT ${_cur_idl_outputs} ${_cur_type_support_idl} ${_cur_java_list}
       DEPENDS opendds_idl ${DDS_ROOT}/dds/idl/IDLTemplate.txt
       MAIN_DEPENDENCY ${abs_filename}
-      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}" "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=-E"
+      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}" "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=\"-E -I${TAO_ROOT} -I${TAO_INCLUDE_DIR}\""
               "${_tao_extra_lib_dirs}"
               $<TARGET_FILE:opendds_idl> -I${idl_file_dir}
               ${_ddsidl_flags} ${file_dds_idl_flags} ${abs_filename}

--- a/cmake/tao_idl_sources.cmake
+++ b/cmake/tao_idl_sources.cmake
@@ -200,7 +200,7 @@ function(tao_idl_command target)
       OUTPUT ${_OUTPUT_FILES}
       DEPENDS tao_idl ${tao_idl_shared_libs} ace_gperf
       MAIN_DEPENDENCY ${idl_file_path}
-      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}"  "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=\"-E -I${TAO_ROOT} -I${TAO_INCLUDE_DIR}\""
+      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}"  "TAO_ROOT=${TAO_INCLUDE_DIR}"
         "${_tao_extra_lib_dirs}"
         $<TARGET_FILE:tao_idl> -g ${GPERF_LOCATION} ${TAO_CORBA_IDL_FLAGS} -Sg
         -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h

--- a/cmake/tao_idl_sources.cmake
+++ b/cmake/tao_idl_sources.cmake
@@ -11,9 +11,11 @@ macro(_tao_append_runtime_lib_dir_to_path dst)
   else()
     set(${dst} "LD_LIBRARY_PATH=")
     if (DEFINED ENV{LD_LIBRARY_PATH})
-      set(${dst} "${${dst}}$ENV{LD_LIBRARY_PATH}:")
+      string(REPLACE "\\" "/" tmp "$ENV{LD_LIBRARY_PATH}")
+      set(${dst} "${${dst}}${tmp}:")
     endif()
-    set(${dst} "${${dst}}${TAO_LIB_DIR}")
+    string(REPLACE "\\" "/" tmp ${TAO_LIB_DIR})
+    set(${dst} "\"${${dst}}${tmp}\"")
   endif()
 endmacro()
 
@@ -193,9 +195,6 @@ function(tao_idl_command target)
       ${_ANYOP_CPP_FILES})
 
     _tao_append_runtime_lib_dir_to_path(_tao_extra_lib_dirs)
-
-    ## CMake wants forward slashes for commands
-    string(REPLACE "\\" "/" _tao_extra_lib_dirs ${_tao_extra_lib_dirs})
 
     add_custom_command(
       OUTPUT ${_OUTPUT_FILES}

--- a/cmake/tao_idl_sources.cmake
+++ b/cmake/tao_idl_sources.cmake
@@ -194,11 +194,14 @@ function(tao_idl_command target)
 
     _tao_append_runtime_lib_dir_to_path(_tao_extra_lib_dirs)
 
+    ## CMake wants forward slashes for commands
+    string(REPLACE "\\" "/" _tao_extra_lib_dirs ${_tao_extra_lib_dirs})
+
     add_custom_command(
       OUTPUT ${_OUTPUT_FILES}
       DEPENDS tao_idl ${tao_idl_shared_libs} ace_gperf
       MAIN_DEPENDENCY ${idl_file_path}
-      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}"  "TAO_ROOT=${TAO_INCLUDE_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}"  "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=-E"
         "${_tao_extra_lib_dirs}"
         $<TARGET_FILE:tao_idl> -g ${GPERF_LOCATION} ${TAO_CORBA_IDL_FLAGS} -Sg
         -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h

--- a/cmake/tao_idl_sources.cmake
+++ b/cmake/tao_idl_sources.cmake
@@ -201,7 +201,7 @@ function(tao_idl_command target)
       OUTPUT ${_OUTPUT_FILES}
       DEPENDS tao_idl ${tao_idl_shared_libs} ace_gperf
       MAIN_DEPENDENCY ${idl_file_path}
-      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}"  "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=-E"
+      COMMAND ${CMAKE_COMMAND} -E env "DDS_ROOT=${DDS_ROOT}"  "TAO_ROOT=${TAO_INCLUDE_DIR}" "TAO_IDL_PREPROCESSOR_ARGS=\"-E -I${TAO_ROOT} -I${TAO_INCLUDE_DIR}\""
         "${_tao_extra_lib_dirs}"
         $<TARGET_FILE:tao_idl> -g ${GPERF_LOCATION} ${TAO_CORBA_IDL_FLAGS} -Sg
         -Wb,pre_include=ace/pre.h -Wb,post_include=ace/post.h

--- a/docs/cmake.md
+++ b/docs/cmake.md
@@ -242,6 +242,8 @@ is `PRIVATE` by default.
 Command-line options can be supplied to the TAO/OpenDDS IDL compilers using
 `TAO_IDL_OPTIONS` and/or `OPENDDS_IDL_OPTIONS` (if the default behavior is not
 suitable). Add `OPENDDS_IDL_OPTIONS -Lc++11` to use the C++11 IDL Mapping.
+To get a complete list of options and environment variables, see the [TAO IDL](https://htmlpreview.github.io/?https://github.com/DOCGroup/ACE_TAO/blob/master/TAO/docs/compiler.html) and
+[OpenDDS IDL](https://download.objectcomputing.com/OpenDDS/OpenDDS-latest.pdf) documentation.
 
 An option is available to force creation of typecodes by using `SUPPRESS_ANYS
 OFF`. This value will overrule the one received from config.cmake


### PR DESCRIPTION
- Modified opendds_idl and tao_idl cmake files to build for VxWorks on Windows.
- Split library dependencies based on OPENDDS_XERCES3 and OPENDDS_SECURITY.