### PR TITLE
tar is buggy on MacOS 11

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11058,8 +11058,8 @@ jobs:
         cd OpenDDS/ACE_TAO
         perl -ni.bak -e "print unless /opendds/" ACE/bin/MakeProjectCreator/config/default.features # remove opendds features from here, let individual build configure scripts handle those
         find . -iname "*\.o" | xargs rm
-        tar cvf ../../${{ github.job }}.tar ACE/ace/config.h
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../../${{ github.job }}.tar
+        gtar cvf ../../${{ github.job }}.tar ACE/ace/config.h
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../../${{ github.job }}.tar
         xz -3 ../../${{ github.job }}.tar
     - name: upload ACE_TAO artifact
       uses: actions/upload-artifact@v3
@@ -11097,7 +11097,7 @@ jobs:
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_m11_sec.tar.xz
+        gtar xvfJ ACE_TAO_m11_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -11133,8 +11133,8 @@ jobs:
         cd OpenDDS
         rm -rf ACE_TAO
         find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        gtar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../${{ github.job }}.tar
         xz -3 ../${{ github.job }}.tar
     - name: upload OpenDDS artifact
       uses: actions/upload-artifact@v3
@@ -11142,209 +11142,209 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  # test_m11_sec:
+  test_m11_sec:
 
-  #   runs-on: macos-11.0
+    runs-on: macos-11.0
 
-  #   needs: build_m11_sec
+    needs: build_m11_sec
 
-  #   steps:
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m11_sec_artifact
-  #       path: ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_m11_sec.tar.xz
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m11_sec_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m11_sec.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m11_sec_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        gtar xvfJ ACE_TAO_m11_sec.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m11_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        gtar xvfJ build_m11_sec.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # cmake_m11_sec:
+  cmake_m11_sec:
 
-  #   runs-on: macos-11.0
+    runs-on: macos-11.0
 
-  #   needs: build_m11_sec
+    needs: build_m11_sec
 
-  #   steps:
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m11_sec_artifact
-  #       path: ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_m11_sec.tar.xz
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m11_sec_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m11_sec.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m11_sec_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        gtar xvfJ ACE_TAO_m11_sec.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m11_sec_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        gtar xvfJ build_m11_sec.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   build_m11_j_FM-1f:
 
@@ -11376,7 +11376,7 @@ jobs:
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_m11_sec.tar.xz
+        gtar xvfJ ACE_TAO_m11_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v3
       with:
@@ -11427,8 +11427,8 @@ jobs:
         cd OpenDDS
         rm -rf ACE_TAO
         find . -iname "*\.o" | xargs rm
-        tar cvf ../${{ github.job }}.tar setenv.sh
-        git clean -xdfn | cut -d ' ' -f 3- | xargs tar uvf ../${{ github.job }}.tar
+        gtar cvf ../${{ github.job }}.tar setenv.sh
+        git clean -xdfn | cut -d ' ' -f 3- | xargs gtar uvf ../${{ github.job }}.tar
         xz -3 ../${{ github.job }}.tar
     - name: upload OpenDDS artifact
       uses: actions/upload-artifact@v3
@@ -11436,209 +11436,209 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  # test_m11_j_FM-1f:
+  test_m11_j_FM-1f:
 
-  #   runs-on: macos-11.0
+    runs-on: macos-11.0
 
-  #   needs: build_m11_j_FM-1f
+    needs: build_m11_j_FM-1f
 
-  #   steps:
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m11_sec_artifact
-  #       path: ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_m11_sec.tar.xz
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m11_j_FM-1f_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m11_j_FM-1f.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m11_sec_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        gtar xvfJ ACE_TAO_m11_sec.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m11_j_FM-1f_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        gtar xvfJ build_m11_j_FM-1f.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  # cmake_modeling_m11_j_FM-1f:
+  cmake_modeling_m11_j_FM-1f:
 
-  #   runs-on: macos-11.0
+    runs-on: macos-11.0
 
-  #   needs: build_m11_j_FM-1f
+    needs: build_m11_j_FM-1f
 
-  #   steps:
-  #   - name: install xerces-c
-  #     run: |
-  #       brew install xerces-c
-  #   - name: checkout MPC
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/MPC
-  #       path: MPC
-  #   - name: checkout autobuild
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/autobuild
-  #       path: autobuild
-  #   - name: checkout ACE_TAO
-  #     uses: actions/checkout@v3
-  #     with:
-  #       repository: DOCGroup/ACE_TAO
-  #       ref: ace6tao2
-  #       path: ACE_TAO
-  #   - name: download ACE_TAO artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: ACE_TAO_m11_sec_artifact
-  #       path: ACE_TAO
-  #   - name: extract ACE_TAO artifact
-  #     shell: bash
-  #     run: |
-  #       cd ACE_TAO
-  #       tar xvfJ ACE_TAO_m11_sec.tar.xz
-  #   - name: checkout OpenDDS
-  #     uses: actions/checkout@v3
-  #     with:
-  #       path: OpenDDS
-  #       submodules: true
-  #   - name: download OpenDDS artifact
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: build_m11_j_FM-1f_artifact
-  #       path: OpenDDS
-  #   - name: extract OpenDDS artifact
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       tar xvfJ build_m11_j_FM-1f.tar.xz
-  #   - name: check build configuration
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       . setenv.sh
-  #       tools/scripts/show_build_config.pl
-  #   - name: run OpenDDS tests
-  #     shell: bash
-  #     run: |
-  #       cd OpenDDS
-  #       echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
-  #       . setenv.sh
-  #       mkdir ${{ github.job }}_autobuild_workspace
-  #       cd ${{ github.job }}_autobuild_workspace
-  #       echo using commit $TRIGGERING_COMMIT for SHA
-  #       echo $TRIGGERING_COMMIT >> ./SHA
-  #       cat > config.xml <<EOF
-  #       <autobuild>
-  #       <configuration>
-  #       <variable name="log_file" value="output.log"/>
-  #       <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="project_root" value="$DDS_ROOT"/>
-  #       <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
-  #       <variable name="junit_xml_output" value="Tests"/>
-  #       </configuration>
-  #       <command name="log" options="on"/>
-  #       <command name="print_os_version"/>
-  #       <command name="print_env_vars"/>
-  #       <command name="print_ace_config"/>
-  #       <command name="print_make_version"/>
-  #       <command name="check_compiler" options="gcc"/>
-  #       <command name="print_perl_version"/>
-  #       <command name="print_autobuild_config"/>
-  #       <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS --java --cmake --modeling"/>
-  #       <command name="log" options="off"/>
-  #       <command name="process_logs" options="prettify"/>
-  #       </autobuild>
-  #       EOF
-  #       $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
-  #   - name: upload autobuild output
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: ${{ github.job }}_autobuild_output
-  #       path: OpenDDS/${{ github.job }}_autobuild_workspace
-  #   - name: check results
-  #     shell: bash
-  #     run: |
-  #       $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
-  #       cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
-  #       grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+    steps:
+    - name: install xerces-c
+      run: |
+        brew install xerces-c
+    - name: checkout MPC
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/MPC
+        path: MPC
+    - name: checkout autobuild
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/autobuild
+        path: autobuild
+    - name: checkout ACE_TAO
+      uses: actions/checkout@v3
+      with:
+        repository: DOCGroup/ACE_TAO
+        ref: ace6tao2
+        path: ACE_TAO
+    - name: download ACE_TAO artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ACE_TAO_m11_sec_artifact
+        path: ACE_TAO
+    - name: extract ACE_TAO artifact
+      shell: bash
+      run: |
+        cd ACE_TAO
+        gtar xvfJ ACE_TAO_m11_sec.tar.xz
+    - name: checkout OpenDDS
+      uses: actions/checkout@v3
+      with:
+        path: OpenDDS
+        submodules: true
+    - name: download OpenDDS artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: build_m11_j_FM-1f_artifact
+        path: OpenDDS
+    - name: extract OpenDDS artifact
+      shell: bash
+      run: |
+        cd OpenDDS
+        gtar xvfJ build_m11_j_FM-1f.tar.xz
+    - name: check build configuration
+      shell: bash
+      run: |
+        cd OpenDDS
+        . setenv.sh
+        tools/scripts/show_build_config.pl
+    - name: run OpenDDS tests
+      shell: bash
+      run: |
+        cd OpenDDS
+        echo "export ACE_TEST_LOG_STUCK_STACKS=1" >> setenv.sh
+        . setenv.sh
+        mkdir ${{ github.job }}_autobuild_workspace
+        cd ${{ github.job }}_autobuild_workspace
+        echo using commit $TRIGGERING_COMMIT for SHA
+        echo $TRIGGERING_COMMIT >> ./SHA
+        cat > config.xml <<EOF
+        <autobuild>
+        <configuration>
+        <variable name="log_file" value="output.log"/>
+        <variable name="log_root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="project_root" value="$DDS_ROOT"/>
+        <variable name="root" value="$DDS_ROOT/${{ github.job }}_autobuild_workspace"/>
+        <variable name="junit_xml_output" value="Tests"/>
+        </configuration>
+        <command name="log" options="on"/>
+        <command name="print_os_version"/>
+        <command name="print_env_vars"/>
+        <command name="print_ace_config"/>
+        <command name="print_make_version"/>
+        <command name="check_compiler" options="gcc"/>
+        <command name="print_perl_version"/>
+        <command name="print_autobuild_config"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS --java --cmake --modeling"/>
+        <command name="log" options="off"/>
+        <command name="process_logs" options="prettify"/>
+        </autobuild>
+        EOF
+        $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
+    - name: upload autobuild output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ github.job }}_autobuild_output
+        path: OpenDDS/${{ github.job }}_autobuild_workspace
+    - name: check results
+      shell: bash
+      run: |
+        $GITHUB_WORKSPACE/OpenDDS/tools/scripts/autobuild_brief_html_to_text.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/output.log_Brief.html"
+        cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
+        grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
   # macOS 12.5
 


### PR DESCRIPTION
Problem
-------

bsdtar on MacOS 11 is buggy.

Solution
--------

Use gnutar.  This was fixed for MacOS 12 in
beaaf7644c665117eff2140a24d99237c7b0e969.