### PR TITLE
Fix macOS IPv6 Build Issue

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11642,7 +11642,7 @@ jobs:
 
   # macOS 12.5
 
-  ACE_TAO_m12_o1d0_sec:
+  ACE_TAO_m12_p1o1d0_sec:
 
     runs-on: macos-12
 
@@ -11689,7 +11689,7 @@ jobs:
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
         cd OpenDDS
-        ./configure --optimize --no-debug --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
+        ./configure --ipv6 --optimize --no-debug --std=c++11 --tests --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
     - name: build ACE and TAO
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: |
@@ -11715,11 +11715,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_m12_o1d0_sec:
+  build_m12_p1o1d0_sec:
 
     runs-on: macos-12
 
-    needs: ACE_TAO_m12_o1d0_sec
+    needs: ACE_TAO_m12_p1o1d0_sec
 
     steps:
     - name: checkout OpenDDS
@@ -11744,18 +11744,18 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_m12_o1d0_sec_artifact
+        name: ACE_TAO_m12_p1o1d0_sec_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        gtar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+        gtar xvfJ ACE_TAO_m12_p1o1d0_sec.tar.xz
     - name: configure OpenDDS
       run: |
         cd OpenDDS
         clang++ --version
-        ./configure --optimize --no-debug --std=c++11 --tests --rapidjson --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
+        ./configure --ipv6 --optimize --no-debug --std=c++11 --tests --rapidjson --security --ace=$GITHUB_WORKSPACE/OpenDDS/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1
     - name: check build configuration
       shell: bash
       run: |
@@ -11792,11 +11792,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_m12_o1d0_sec:
+  test_m12_p1o1d0_sec:
 
     runs-on: macos-12
 
-    needs: build_m12_o1d0_sec
+    needs: build_m12_p1o1d0_sec
 
     steps:
     - name: checkout OpenDDS
@@ -11826,23 +11826,23 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_m12_o1d0_sec_artifact
+        name: ACE_TAO_m12_p1o1d0_sec_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        gtar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+        gtar xvfJ ACE_TAO_m12_p1o1d0_sec.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_m12_o1d0_sec_artifact
+        name: build_m12_p1o1d0_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        gtar xvfJ build_m12_o1d0_sec.tar.xz
+        gtar xvfJ build_m12_p1o1d0_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |
@@ -11879,7 +11879,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12"/>
+        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config IPV6 -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11897,11 +11897,11 @@ jobs:
         cat "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
         grep -q 'Failures: 0' "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/latest.txt"
 
-  cmake_m12_o1d0_sec:
+  cmake_m12_p1o1d0_sec:
 
     runs-on: macos-12
 
-    needs: build_m12_o1d0_sec
+    needs: build_m12_p1o1d0_sec
 
     steps:
     - name: checkout OpenDDS
@@ -11931,23 +11931,23 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v3
       with:
-        name: ACE_TAO_m12_o1d0_sec_artifact
+        name: ACE_TAO_m12_p1o1d0_sec_artifact
         path: OpenDDS/ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd OpenDDS/ACE_TAO
-        gtar xvfJ ACE_TAO_m12_o1d0_sec.tar.xz
+        gtar xvfJ ACE_TAO_m12_p1o1d0_sec.tar.xz
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v3
       with:
-        name: build_m12_o1d0_sec_artifact
+        name: build_m12_p1o1d0_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        gtar xvfJ build_m12_o1d0_sec.tar.xz
+        gtar xvfJ build_m12_p1o1d0_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/dds/DCPS/NetworkConfigModifier.cpp
+++ b/dds/DCPS/NetworkConfigModifier.cpp
@@ -88,7 +88,7 @@ void NetworkConfigModifier::update_interfaces()
         ACE_INET_Addr address;
         address.set(reinterpret_cast<struct sockaddr_in *> (addr), sizeof(sockaddr_in6));
 
-        nia_list.push_back(NetworkInterfaceAddress(ACE_OS::if_nametoindex(p_if->ifa_name), p_if->ifa_name, p_if->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK), address));
+        nia_list.push_back(NetworkInterfaceAddress(p_if->ifa_name, p_if->ifa_flags & (IFF_MULTICAST | IFF_LOOPBACK), NetworkAddress(address)));
       }
     }
 # endif /* ACE_HAS_IPV6 */


### PR DESCRIPTION
Problem: IPv6 compile error in `NetworkConfigModifier.cpp` (macOS).

Solution: Modify IPv6 path similar to previous changes to IPv4 path.