### PR TITLE
Fix Call To pending_messages in MessageTracker

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11989,6 +11989,13 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
+        echo "--- ip addr ---"
+        ip addr
+        echo "--- ip -4 -d route ---"
+        ip -4 -d route
+        echo "--- ip -6 -d route ---"
+        ip -6 -d route
+        echo "---"
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11989,12 +11989,12 @@ jobs:
         <command name="process_logs" options="prettify"/>
         </autobuild>
         EOF
-        echo "--- ip addr ---"
-        ip addr
-        echo "--- ip -4 -d route ---"
-        ip -4 -d route
-        echo "--- ip -6 -d route ---"
-        ip -6 -d route
+        echo "--- ifconfig ---"
+        ifconfig
+        echo "--- netstat -r ---"
+        netstat -r
+        echo "--- netstat -r6 ---"
+        netstat -r6
         echo "---"
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11991,10 +11991,8 @@ jobs:
         EOF
         echo "--- ifconfig ---"
         ifconfig
-        echo "--- netstat -r ---"
-        netstat -r
-        echo "--- netstat -r6 ---"
-        netstat -r6
+        echo "--- netstat -nr ---"
+        netstat -nr
         echo "---"
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
     - name: upload autobuild output

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11226,7 +11226,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -11520,7 +11520,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -11879,7 +11879,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config IPV6 -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config IPV6 -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>
@@ -12260,7 +12260,7 @@ jobs:
         <command name="check_compiler" options="gcc"/>
         <command name="print_perl_version"/>
         <command name="print_autobuild_config"/>
-        <command name="auto_run_tests" options="script_path=$ACE_ROOT/bin dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12"/>
+        <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -l tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12"/>
         <command name="log" options="off"/>
         <command name="process_logs" options="prettify"/>
         </autobuild>

--- a/DevGuideExamples/DCPS/Messenger/DataReaderListenerImpl.cpp
+++ b/DevGuideExamples/DCPS/Messenger/DataReaderListenerImpl.cpp
@@ -71,6 +71,8 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
                 << "         count      = " << message.count        << std::endl
                 << "         text       = " << message.text.in()    << std::endl;
 
+    } else {
+      std::cout << "Message Key: subject_id = " << message.subject_id << std::endl;
     }
 
   } else {

--- a/DevGuideExamples/DCPS/Messenger/Publisher.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Publisher.cpp
@@ -116,14 +116,15 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     DDS::StatusCondition_var condition = writer->get_statuscondition();
     condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS);
 
-    DDS::WaitSet_var ws = new DDS::WaitSet;
+    DDS::WaitSet_var ws(new DDS::WaitSet);
     ws->attach_condition(condition);
 
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("Block until subscriber is available\n")));
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("Block until subscriber is available\n")));
+
+    DDS::PublicationMatchedStatus matches = { 0, 0, 0, 0, 0 };
+    DDS::ConditionSeq conditions;
 
     while (true) {
-      DDS::PublicationMatchedStatus matches;
       if (writer->get_publication_matched_status(matches) != ::DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")
@@ -135,7 +136,6 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         break;
       }
 
-      DDS::ConditionSeq conditions;
       DDS::Duration_t timeout = { 60, 0 };
       if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
@@ -172,7 +172,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
 
     // Wait for samples to be acknowledged
-    DDS::Duration_t timeout = { 30, 0 };
+    const DDS::Duration_t timeout = { 30, 0 };
     if (message_writer->wait_for_acknowledgments(timeout) != DDS::RETCODE_OK) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("ERROR: %N:%l: main() -")

--- a/DevGuideExamples/DCPS/Messenger/Publisher.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Publisher.cpp
@@ -22,9 +22,13 @@
 
 #include "MessengerTypeSupportImpl.h"
 
+#include <dds/DCPS/transport/framework/TransportDebug.h>
+
 int
 ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
+  OpenDDS::DCPS::transport_debug.log_progress = true;
+
   try {
     // Initialize DomainParticipantFactory
     DDS::DomainParticipantFactory_var dpf =

--- a/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
@@ -123,11 +123,13 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     DDS::StatusCondition_var condition = reader->get_statuscondition();
     condition->set_enabled_statuses(DDS::SUBSCRIPTION_MATCHED_STATUS);
 
-    DDS::WaitSet_var ws = new DDS::WaitSet;
+    DDS::WaitSet_var ws(new DDS::WaitSet);
     ws->attach_condition(condition);
 
+    DDS::SubscriptionMatchedStatus matches = { 0, 0, 0, 0, 0 };
+    DDS::ConditionSeq conditions;
+
     while (true) {
-      DDS::SubscriptionMatchedStatus matches;
       if (reader->get_subscription_matched_status(matches) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")
@@ -139,8 +141,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         break;
       }
 
-      DDS::ConditionSeq conditions;
-      DDS::Duration_t timeout = { 60, 0 };
+      const DDS::Duration_t timeout = { 60, 0 };
       if (ws->wait(conditions, timeout) != DDS::RETCODE_OK) {
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("ERROR: %N:%l: main() -")

--- a/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
+++ b/DevGuideExamples/DCPS/Messenger/Subscriber.cpp
@@ -23,10 +23,13 @@
 #include "DataReaderListenerImpl.h"
 #include "MessengerTypeSupportImpl.h"
 
+#include <dds/DCPS/transport/framework/TransportDebug.h>
 
 int
 ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 {
+  OpenDDS::DCPS::transport_debug.log_progress = true;
+
   try {
     // Initialize DomainParticipantFactory
     DDS::DomainParticipantFactory_var dpf =

--- a/DevGuideExamples/DCPS/Messenger/rtps.ini
+++ b/DevGuideExamples/DCPS/Messenger/rtps.ini
@@ -1,5 +1,6 @@
 [common]
 DCPSGlobalTransportConfig=$file
+DCPSTransportDebugLevel=5
 
 [domain/42]
 DiscoveryConfig=uni_rtps

--- a/DevGuideExamples/DCPS/Messenger/rtps.ini
+++ b/DevGuideExamples/DCPS/Messenger/rtps.ini
@@ -1,6 +1,11 @@
 [common]
-DCPSDefaultDiscovery=DEFAULT_RTPS
 DCPSGlobalTransportConfig=$file
+
+[domain/42]
+DiscoveryConfig=uni_rtps
+
+[rtps_discovery/uni_rtps]
+ResendPeriod=1
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp

--- a/DevGuideExamples/DCPS/Messenger/run_test.pl
+++ b/DevGuideExamples/DCPS/Messenger/run_test.pl
@@ -40,7 +40,7 @@ if ($help) {
 unlink "subscriber.log";
 unlink "publisher.log";
 
-my $common_opts = "-ORBDebugLevel 10 -DCPSDebugLevel 10 -ORBVerboseLogging 1 -DCPSTransportDebugLevel 6 ";
+my $common_opts = "-ORBDebugLevel 10 -DCPSDebugLevel 10 -ORBVerboseLogging 1 -DCPSTransportDebugLevel 6 -DCPSPendingTimeout 3 ";
 
 if ($rtps) {
   $common_opts .= " -DCPSConfigFile rtps.ini";

--- a/dds/DCPS/MessageTracker.cpp
+++ b/dds/DCPS/MessageTracker.cpp
@@ -99,7 +99,7 @@ void MessageTracker::wait_messages_pending(const char* caller, const MonotonicTi
   while (loop && pending_messages_i()) {
     switch (done_condition_.wait_until(deadline, thread_status_manager)) {
     case CvStatus_Timeout:
-      if (DCPS_debug_level && pending_messages()) {
+      if (DCPS_debug_level && pending_messages_i()) {
         ACE_DEBUG((LM_DEBUG,
                    "(%P|%t) MessageTracker::wait_messages_pending: "
                    "Timed out waiting for messages to be transported (caller: %C)\n",

--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -245,6 +245,7 @@ my $query = $show_configs || $list_configs || $list_tests;
 # Determine what test list files to use
 my @file_list = ();
 if ($auto_config) {
+    print "about to check files: auto_config == $auto_config\n";
     foreach my $list (@builtin_test_lists) {
         push(@file_list, "$DDS_ROOT/$list->{file}") if ($query_all || $list->{enabled});
     }
@@ -252,11 +253,14 @@ if ($auto_config) {
 push(@file_list, @ARGV);
 
 if ($auto_config) {
+    print "about add os_configs: auto_config == $auto_config\n";
     die("auto_run_tests.pl: Error: unknown perl OS: $^O") if (!exists($os_configs{$^O}));
     push(@PerlACE::ConfigList::Configs, $os_configs{$^O});
 
+    print "about add RTPS: auto_config == $auto_config\n";
     push(@PerlACE::ConfigList::Configs, "RTPS");
     if ($gh_actions) {
+        print "about add GH_ACTIONS: auto_config == $auto_config\n";
         push(@PerlACE::ConfigList::Configs, 'GH_ACTIONS');
     }
 }
@@ -285,11 +289,11 @@ if ($list_configs) {
     exit(0);
 }
 
-if (!$list_tests) {
+#if (!$list_tests) {
     print "Test Lists: ", join(', ', @file_list), "\n";
     print "Configs: ", join(', ', @PerlACE::ConfigList::Configs), "\n";
     print "Excludes: ", join(', ', @PerlACE::ConfigList::Excludes), "\n";
-}
+#}
 
 foreach my $test_lst (@file_list) {
 


### PR DESCRIPTION
Problem: MessageTracker `wait_messages_pending` sometimes uses the wrong flavor of `pending_messages` and causes a double-lock. See https://github.com/objectcomputing/OpenDDS/actions/runs/3184202831/jobs/5193569354

Solution: Use `pending_messages_i` and be sure to set the DCPSPendingTimeout value for the DevGuideExamples tests.