### PR TITLE
Thrasher fails on certains VMs

### DIFF
--- a/tests/DCPS/Thrasher/thrasher_rtps.ini
+++ b/tests/DCPS/Thrasher/thrasher_rtps.ini
@@ -13,6 +13,7 @@ passive_connect_duration=900000
 SedpMulticast=0
 ResendPeriod=2
 SedpPassiveConnectDuration=900000
+MaxSpdpSequenceMsgResetChecks=10000
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp


### PR DESCRIPTION
Problem
-------

The Thrasher test is designed to stress the system and often results in lost packets.  In some situations, the packet loss is enough to trigger a rediscovery of a remote participant based on sequence number checking.

Solution
--------

Set a very high threshold for the sequence number reset logic.