### PR TITLE
Clean Up End-of-Namespace Comments

### DIFF
--- a/dds/DCPS/DcpsUpcalls.cpp
+++ b/dds/DCPS/DcpsUpcalls.cpp
@@ -87,7 +87,7 @@ void DcpsUpcalls::writer_done()
   wait(); // ACE_Task_Base::wait does not accept a timeout
 }
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/DcpsUpcalls.h
+++ b/dds/DCPS/DcpsUpcalls.h
@@ -44,8 +44,8 @@ private:
   ConditionVariable<ACE_Thread_Mutex> cnd_;
 };
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/Definitions.h
+++ b/dds/DCPS/Definitions.h
@@ -133,8 +133,8 @@ const size_t AceTimestampSize = 27;
 /// Size of TCHAR buffer for use with addr_to_string.
 const size_t AddrToStringSize = 256;
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/Logging.cpp
+++ b/dds/DCPS/Logging.cpp
@@ -29,7 +29,7 @@ void OpenDDS_Dcps_Export log_progress(const char* activity,
              activity));
 }
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/Logging.h
+++ b/dds/DCPS/Logging.h
@@ -31,8 +31,8 @@ extern void OpenDDS_Dcps_Export log_progress(const char* activity,
                                              const MonotonicTime_t& start_time,
                                              const GUID_t& reference = GUID_UNKNOWN);
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/RepoIdTypes.h
+++ b/dds/DCPS/RepoIdTypes.h
@@ -22,8 +22,8 @@ namespace DCPS {
 typedef RepoId PublicationId;
 typedef RepoId SubscriptionId;
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/SequenceNumber.h
+++ b/dds/DCPS/SequenceNumber.h
@@ -203,8 +203,8 @@ void serialized_size(const Encoding& encoding, size_t& size,
 typedef std::pair<SequenceNumber, SequenceNumber> SequenceRange;
 extern OpenDDS_Dcps_Export const SequenceRange unknown_sequence_range;
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -395,7 +395,7 @@ void Service_Participant::type_object_encoding(TypeObjectEncoding encoding)
   type_object_encoding_ = encoding;
 }
 
-} // namespace DDS
+} // namespace DCPS
 } // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/WriteDataContainer.cpp
+++ b/dds/DCPS/WriteDataContainer.cpp
@@ -1754,7 +1754,7 @@ WriteDataContainer::cancel_deadline(const PublicationInstance_rch& instance)
   }
 }
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/WriteDataContainer.h
+++ b/dds/DCPS/WriteDataContainer.h
@@ -576,8 +576,8 @@ private:
   void cancel_deadline(const PublicationInstance_rch& instance);
 };
 
-} /// namespace OpenDDS
 } /// namespace DCPS
+} /// namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/ZeroCopyAllocator_T.inl
+++ b/dds/DCPS/ZeroCopyAllocator_T.inl
@@ -55,7 +55,7 @@ FirstTimeFastAllocator<T, N>::free(void *ptr)
   }
 }
 
-} // namespace  DDS
+} // namespace DCPS
 } // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/debug.h
+++ b/dds/DCPS/debug.h
@@ -194,8 +194,8 @@ private:
 };
 #endif // OPENDDS_UTIL_BUILD
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/transport/framework/TransportDebug.h
+++ b/dds/DCPS/transport/framework/TransportDebug.h
@@ -70,8 +70,8 @@ public:
 };
 extern OpenDDS_Dcps_Export TransportDebug transport_debug;
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/transport/framework/TransportSendStrategy.inl
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.inl
@@ -155,7 +155,7 @@ TransportQueueElement* TransportSendStrategy::current_packet_first_element() con
   return this->elems_.peek();
 }
 
-} // namespace OpenDDS
 } // namespace DCPS
+} // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
Problem: Several of these comments are inaccurate, either with regard to the order of closing namespaces or with the actual namespace names themselves.

Solution: Clean them up for clarity and consistency.