### PR TITLE
Docker image workflow does not build release tags

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - latest-release
+    tags:
+      - DDS-*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Problem
-------

The Docker image workflow does not build release tags.  This is useful for trying specific versions.

Solution
--------

Build release tags.