### PR TITLE
Fixes for shemem and tcp Null Rch

### DIFF
--- a/dds/DCPS/transport/shmem/ShmemDataLink.cpp
+++ b/dds/DCPS/transport/shmem/ShmemDataLink.cpp
@@ -123,7 +123,7 @@ int ShmemDataLink::make_reservation(const GUID_t& remote_pub, const GUID_t& loca
   // Resend until we get a response.
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, assoc_resends_mutex_, result);
-    assoc_resends_.insert(std::pair<GuidPair, unsigned>(GuidPair(remote_pub, local_sub),
+    assoc_resends_.insert(std::pair<GuidPair, unsigned>(GuidPair(local_sub, remote_pub),
       config().association_resend_max_count()));
   }
   return result;
@@ -199,7 +199,7 @@ ShmemDataLink::request_ack_received(ReceivedDataSample& sample)
       } else {
         // Writer has responded to association ack, stop sending.
         ACE_GUARD(ACE_Thread_Mutex, g, assoc_resends_mutex_);
-        assoc_resends_.erase(GuidPair(remote, local));
+        assoc_resends_.erase(GuidPair(local, remote));
       }
     }
     return;
@@ -229,8 +229,6 @@ ShmemDataLink::stop_i()
     delete peer_alloc_;
     peer_alloc_ = 0;
   }
-  delete peer_alloc_;
-  peer_alloc_ = 0;
 }
 
 ShmemTransport&

--- a/dds/DCPS/transport/tcp/TcpConnection.cpp
+++ b/dds/DCPS/transport/tcp/TcpConnection.cpp
@@ -363,7 +363,8 @@ OpenDDS::DCPS::TcpConnection::close(u_long)
 const std::string&
 OpenDDS::DCPS::TcpConnection::config_name() const
 {
-  return impl_->config().name();
+  static const std::string null_name("(couldn't get name)");
+  return impl_ ? impl_->config().name() : null_name;
 }
 
 int


### PR DESCRIPTION
Follow up to https://github.com/objectcomputing/OpenDDS/pull/3549

- Fix Coverity CID 1525386 where it noticed the arguments names to `GuidPair` where flipped from the constructor parameters. This couldn't cause an issue because both insertion and removal where flipped the same way, but this should be fixed anyway.
- Commit removal of 2 lines in `ShmemDataLink::stop_i` that should have gone into the 3549, but I missed when staging the changes chunk by chunk in neovim.
- Also fix possible null RcHandle access during shutdown when using tcp that was found when using rr.