### PR TITLE
Add NetworkAdddress::is_multicast

### DIFF
--- a/dds/DCPS/NetworkAddress.cpp
+++ b/dds/DCPS/NetworkAddress.cpp
@@ -229,6 +229,18 @@ bool NetworkAddress::is_loopback() const
   return false;
 }
 
+bool NetworkAddress::is_multicast() const
+{
+  if (inet_addr_.in4_.sin_family == AF_INET) {
+    return (ACE_HTONL(inet_addr_.in4_.sin_addr.s_addr) & 0xF0000000) == 0xE0000000;
+#if defined (ACE_HAS_IPV6)
+  } else if (inet_addr_.in6_.sin6_family == AF_INET6) {
+    return this->inet_addr_.in6_.sin6_addr.s6_addr[0] == 0xFF;
+#endif
+  }
+  return false;
+}
+
 bool NetworkAddress::is_private() const
 {
   if (inet_addr_.in4_.sin_family == AF_INET) {

--- a/dds/DCPS/NetworkAddress.h
+++ b/dds/DCPS/NetworkAddress.h
@@ -65,6 +65,7 @@ public:
 
   bool is_any() const;
   bool is_loopback() const;
+  bool is_multicast() const;
 
   bool is_private() const; // IPv4 only
 

--- a/tests/unit-tests/dds/DCPS/NetworkAddress.cpp
+++ b/tests/unit-tests/dds/DCPS/NetworkAddress.cpp
@@ -311,6 +311,40 @@ TEST(dds_DCPS_NetworkAddress, IsLoopbackIpSix)
 
 #endif
 
+TEST(dds_DCPS_NetworkAddress, IsMulticastIpFour)
+{
+  NetworkAddress sa1(1234, "224.0.1.4");
+  NetworkAddress sa2(1234, "239.255.0.9");
+  NetworkAddress sa3(1234, "127.0.0.1");
+  NetworkAddress sa4(1234, "192.168.10.7");
+  NetworkAddress sa5(1234, "7.5.3.1");
+
+  EXPECT_TRUE(sa1.is_multicast());
+  EXPECT_TRUE(sa2.is_multicast());
+
+  EXPECT_FALSE(sa3.is_multicast());
+  EXPECT_FALSE(sa4.is_multicast());
+  EXPECT_FALSE(sa5.is_multicast());
+}
+
+#if defined (ACE_HAS_IPV6)
+
+TEST(dds_DCPS_NetworkAddress, IsMulticastIpSix)
+{
+  NetworkAddress sa1(1234, "ff20::3");
+  NetworkAddress sa2(1234, "::2");
+  NetworkAddress sa3(1234, "0101:0101:0101:0101:0101:0101:0101:0101");
+  NetworkAddress sa4(1234, "0202:0202:0202:0202:0202:0202:0202:0202");
+
+  EXPECT_TRUE(sa1.is_multicast());
+
+  EXPECT_FALSE(sa2.is_multicast());
+  EXPECT_FALSE(sa3.is_multicast());
+  EXPECT_FALSE(sa4.is_multicast());
+}
+
+#endif
+
 TEST(dds_DCPS_NetworkAddress, IsPrivateIpFour)
 {
   NetworkAddress sa1(1234, "7.8.9.10");


### PR DESCRIPTION
Problem: During consideration of recent algorithm changes for IPv6 multicast support, it was determined that NetworkAddress had no direct support for determining whether a destination address was multicast or not, meaning that it would require conversion of the address to something like ACE_INET_Addr in order to make this check, which is not create for performance and code clarity.

Solution: Add the check to NetworkAddress (w/ unit test).