### PR TITLE
Add Result Grouping For GitHub Actions Test Results

### DIFF
--- a/tools/scripts/autobuild_brief_html_to_text.pl
+++ b/tools/scripts/autobuild_brief_html_to_text.pl
@@ -8,17 +8,27 @@ use Term::ANSIColor;
 use HTML::Parser 3.00 ();
 
 my %inside;
+my $needs_groupend = 0;
+my $gh_actions = ($ENV{GITHUB_ACTIONS} // "") eq "true";
 
 sub tag {
   my($tag, $num) = @_;
   $inside{$tag} += $num;
   if ($tag =~ /h[1-3]/) {
+    if ($num > 0 && $needs_groupend) {
+      $needs_groupend = 0;
+      print "::endgroup::\n";
+    }
     print "\n";  # not for all tags
   }
   if ($tag eq "br") {
     print "\n";  # not for all tags
   }
   if ($tag eq "body" && $num < 0) {
+    if ($num < 0 && $needs_groupend) {
+      $needs_groupend = 0;
+      print "::endgroup::\n";
+    }
     print "\n";  # not for all tags
   }
 }
@@ -26,17 +36,21 @@ sub tag {
 sub text {
   return if $inside{script} || $inside{style};
   my $esc = 1;
-  if ( $inside{h2}) {
+  my $line = $_[0];
+  $line =~ s/\R//g;
+  if ($inside{h2}) {
     print color 'yellow';
   }
-  elsif ( $inside{h3}) {
+  elsif ($inside{h3}) {
+    if ($gh_actions) {
+      $needs_groupend = 1;
+      print "::group::";
+    }
     print color 'red';
   }
   else {
     $esc = 0;
   }
-  my $line = $_[0];
-  $line =~ s/\R//g;
   print $line;
   print color 'reset' if $esc;
 }


### PR DESCRIPTION
Puts test failure lines into expandable / collapsible groups for easier viewing in GitHub Actions console logs.