### PR TITLE
Fix Configure Submodule Checkout on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -398,15 +398,24 @@ my %specific =
     'refpost' => '}', 'comment' => '#')
   );
 
+sub might_be_executable {
+  my $path = shift;
+  return -x $path && -f $path; # On Windows -x can return true for directories
+}
+
 sub which {
   my $file = shift;
   for my $p (File::Spec->path()) {
     next if $p eq '.';
-    if (-x "$p/$file") {
-      return "$p/$file";
+    my $path = "$p/$file";
+    if (might_be_executable($path)) {
+      return $path;
     }
-    elsif ($exeext ne '' && -x "$p/$file$exeext") {
-      return "$p/$file$exeext";
+    elsif ($exeext ne '') {
+      $path .= $exeext;
+      if (might_be_executable($path)) {
+        return $path;
+      }
     }
   }
   return undef;
@@ -470,7 +479,7 @@ sub git_submodule_prop {
     or die("git_submodule_prop open failed: $!\nStopped");
   my $prop_value = <$fd>;
   close($fd);
-  chomp($prop_value);
+  chomp($prop_value) if (defined($prop_value));
   if (!$prop_value) {
     die("Couldn't get $full_prop_name from .gitmodules\nStopped");
   }


### PR DESCRIPTION
This fixes the first issue described in https://github.com/objectcomputing/OpenDDS/discussions/3784:

If doing a normal build on Windows with no git installed on the PATH, the configure script's `which` function will erroneously report there is a git command available and try, but fail, to use git to get the commit hash needed for RapidJSON.

The which function is erroneous because it is using `-x`, which seems to return true for directories on Windows. There is a `Git` directory in the PATH that Visual Studio adds that it's picking up. As a side note this actually has a working git command in it, but since it's not on the PATH I'm not sure if we should try to take advantage of it.

Even with these fixes there's still an issue with the 3.22.0 zips because they're missing the `.gitmodules` file.