### PR TITLE
NetworkConfigMonitor Should Have Virtual Destructor

### DIFF
--- a/dds/DCPS/NetworkConfigMonitor.cpp
+++ b/dds/DCPS/NetworkConfigMonitor.cpp
@@ -40,6 +40,9 @@ NetworkConfigMonitor::NetworkConfigMonitor()
   : writer_(make_rch<InternalDataWriter<NetworkInterfaceAddress> >(true))
 {}
 
+NetworkConfigMonitor::~NetworkConfigMonitor()
+{}
+
 void NetworkConfigMonitor::connect(RcHandle<InternalTopic<NetworkInterfaceAddress> > topic)
 {
   topic->connect(writer_);

--- a/dds/DCPS/NetworkConfigMonitor.h
+++ b/dds/DCPS/NetworkConfigMonitor.h
@@ -80,6 +80,7 @@ public:
   typedef OPENDDS_LIST(NetworkInterfaceAddress) List;
 
   NetworkConfigMonitor();
+  virtual ~NetworkConfigMonitor();
 
   void connect(RcHandle<InternalTopic<NetworkInterfaceAddress> > topic);
   virtual bool open() = 0;


### PR DESCRIPTION
Problem: NetworkConfigMonitor is stored by RcHandle in the Service_Participant, but it has derived classes and no virtual destructor. See also unit test failure [here](https://github.com/objectcomputing/OpenDDS/actions/runs/3292216384/jobs/5427929382) (ignore other failures, they're from tests that shouldn't run in TSAN).

Solution: Make the destructor virtual.