### PR TITLE
Locks For Header Blocks

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -841,6 +841,8 @@ TransportSendStrategy::start()
 
   header_db_allocator_.reset( new TransportDataBlockAllocator(header_chunks));
   header_mb_allocator_.reset( new TransportMessageBlockAllocator(header_chunks));
+  header_db_lock_pool_.reset(new DataBlockLockPool(static_cast<unsigned long>(TheServiceParticipant->n_chunks())));
+  header_data_allocator_.reset(new DataAllocator(TheServiceParticipant->association_chunk_multiplier(), max_header_size_));
 
   // Since we (the TransportSendStrategy object) are a reference-counted
   // object, but the synch_ object doesn't necessarily know this, we need
@@ -1656,10 +1658,10 @@ TransportSendStrategy::prepare_packet()
     static_cast<ACE_Message_Block*>(header_mb_allocator_->malloc()),
     ACE_Message_Block(max_header_size_,
                       ACE_Message_Block::MB_DATA,
-                      0,
-                      0,
-                      0,
-                      0,
+                      0, // cont
+                      0, // data
+                      header_data_allocator_.get(),
+                      header_db_lock_pool_->get_lock(),
                       ACE_DEFAULT_MESSAGE_BLOCK_PRIORITY,
                       ACE_Time_Value::zero,
                       ACE_Time_Value::max_time,

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -8,10 +8,6 @@
 #ifndef OPENDDS_DCPS_TRANSPORT_FRAMEWORK_TRANSPORTSENDSTRATEGY_H
 #define OPENDDS_DCPS_TRANSPORT_FRAMEWORK_TRANSPORTSENDSTRATEGY_H
 
-#include "dds/DCPS/dcps_export.h"
-#include "dds/DCPS/Definitions.h"
-#include "dds/DCPS/RcObject.h"
-#include "dds/DCPS/PoolAllocator.h"
 #include "ThreadSynchWorker.h"
 #include "TransportDefs.h"
 #include "BasicQueue_T.h"
@@ -19,13 +15,21 @@
 #include "TransportReplacedElement.h"
 #include "TransportRetainedElement.h"
 #include "ThreadSynchStrategy_rch.h"
-#include "ace/Synch_Traits.h"
+
+#include <dds/DCPS/dcps_export.h>
+#include <dds/DCPS/Definitions.h>
+#include <dds/DCPS/RcObject.h>
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/DataBlockLockPool.h>
+#include <dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h>
 
 #if defined(OPENDDS_SECURITY)
-#include "dds/DdsSecurityCoreC.h"
-#include "dds/DCPS/security/framework/SecurityConfig.h"
-#include "dds/DCPS/security/framework/SecurityConfig_rch.h"
+#include <dds/DdsSecurityCoreC.h>
+#include <dds/DCPS/security/framework/SecurityConfig.h>
+#include <dds/DCPS/security/framework/SecurityConfig_rch.h>
 #endif
+
+#include <ace/Synch_Traits.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -397,6 +401,13 @@ private:
 
   /// Allocator for header message block.
   unique_ptr<TransportDataBlockAllocator> header_db_allocator_;
+
+  /// DataBlockLockPool
+  unique_ptr<DataBlockLockPool> header_db_lock_pool_;
+
+  /// Allocator for data buffers.
+  typedef Dynamic_Cached_Allocator_With_Overflow<ACE_Thread_Mutex> DataAllocator;
+  unique_ptr<DataAllocator> header_data_allocator_;
 
   /// The thread synch object.
   unique_ptr<ThreadSynch> synch_;


### PR DESCRIPTION
Problem: ACE_Message_Blocks allocated as part of transport headers don't have locking strategies and, as a result, can cause race conditions when touched by different threads. See TSAN report [here](https://github.com/objectcomputing/OpenDDS/actions/runs/3293279313/jobs/5430419411).

Solution: Add lock pool and separate allocator.