### PR TITLE
Enable disco_relay Bench Scenario in TSAN Coverage and Fix Issues

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -79,7 +79,10 @@ RtpsUdpTransport::rtps_relay_only_now(bool flag)
 
 #ifdef OPENDDS_SECURITY
   if (flag) {
-    relay_stun_task_falloff_.set(config().heartbeat_period_);
+    {
+      ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+      relay_stun_task_falloff_.set(config().heartbeat_period_);
+    }
     relay_stun_task_->schedule(TimeDuration::zero_value);
   } else {
     if (!config().use_rtps_relay()) {
@@ -96,7 +99,10 @@ RtpsUdpTransport::use_rtps_relay_now(bool flag)
 
 #ifdef OPENDDS_SECURITY
   if (flag) {
-    relay_stun_task_falloff_.set(config().heartbeat_period_);
+    {
+      ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+      relay_stun_task_falloff_.set(config().heartbeat_period_);
+    }
     relay_stun_task_->schedule(TimeDuration::zero_value);
   } else {
     if (!config().rtps_relay_only()) {
@@ -131,7 +137,10 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
   if (equal_guid_prefixes(local_prefix_, GUIDPREFIX_UNKNOWN)) {
     assign(local_prefix_, local_prefix);
 #ifdef OPENDDS_SECURITY
-    relay_stun_task_falloff_.set(config().heartbeat_period_);
+    {
+      ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+      relay_stun_task_falloff_.set(config().heartbeat_period_);
+    }
     relay_stun_task_->schedule(TimeDuration::zero_value);
 #endif
   }
@@ -503,7 +512,10 @@ RtpsUdpTransport::rtps_relay_address_change()
 {
 #ifdef OPENDDS_SECURITY
   relay_stun_task_->cancel();
-  relay_stun_task_falloff_.set(config().heartbeat_period_);
+  {
+    ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+    relay_stun_task_falloff_.set(config().heartbeat_period_);
+  }
   relay_stun_task_->schedule(TimeDuration::zero_value);
 #endif
 }
@@ -637,7 +649,10 @@ RtpsUdpTransport::configure_i(RtpsUdpInst& config)
   }
 
 #ifdef OPENDDS_SECURITY
-  relay_stun_task_falloff_.set(config.heartbeat_period_);
+  {
+    ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+    relay_stun_task_falloff_.set(config.heartbeat_period_);
+  }
   relay_stun_task_->schedule(TimeDuration::zero_value);
 #endif
 
@@ -945,8 +960,11 @@ RtpsUdpTransport::relay_stun_task(const DCPS::MonotonicTimePoint& /*now*/)
       !equal_guid_prefixes(local_prefix_, GUIDPREFIX_UNKNOWN)) {
     process_relay_sra(relay_srsm_.send(relay_address, ICE::Configuration::instance()->server_reflexive_indication_count(), local_prefix_));
     ice_endpoint_->send(relay_address, relay_srsm_.message());
-    relay_stun_task_falloff_.advance(ICE::Configuration::instance()->server_reflexive_address_period());
-    relay_stun_task_->schedule(relay_stun_task_falloff_.get());
+    {
+      ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+      relay_stun_task_falloff_.advance(ICE::Configuration::instance()->server_reflexive_address_period());
+      relay_stun_task_->schedule(relay_stun_task_falloff_.get());
+    }
   }
 }
 
@@ -971,7 +989,10 @@ RtpsUdpTransport::process_relay_sra(ICE::ServerReflexiveStateMachine::StateChang
   case ICE::ServerReflexiveStateMachine::SRSM_Set:
   case ICE::ServerReflexiveStateMachine::SRSM_Change:
     // Lengthen to normal period.
-    relay_stun_task_falloff_.set(ICE::Configuration::instance()->server_reflexive_address_period());
+    {
+      ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+      relay_stun_task_falloff_.set(ICE::Configuration::instance()->server_reflexive_address_period());
+    }
     connection_record.address = DCPS::LogAddr(relay_srsm_.stun_server_address()).c_str();
     connection_record.latency = relay_srsm_.latency().to_dds_duration();
     relay_srsm_.latency_available(false);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -193,6 +193,7 @@ private:
   void relay_stun_task(const MonotonicTimePoint& now);
   RcHandle<Sporadic> relay_stun_task_;
   DCPS::FibonacciSequence<TimeDuration> relay_stun_task_falloff_;
+  ThreadLockType relay_stun_task_falloff_mutex_;
   ICE::ServerReflexiveStateMachine relay_srsm_;
 
   mutable ACE_Thread_Mutex relay_stun_mutex_;

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -122,7 +122,7 @@ tests/DCPS/Thrasher/run_test.pl high rtps durable: !DCPS_MIN RTPS !LYNXOS !OPEND
 #performance-tests/bench/run_test.pl disco show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl disco_long show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl disco_repo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
-#performance-tests/bench/run_test.pl disco_relay show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
+performance-tests/bench/run_test.pl disco_relay show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl echo_frag show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl fan show-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON


### PR DESCRIPTION
Problem: TSAN is reporting a data race based on different threads interacting with the `relay_stun_task_falloff_` object.

Solution: It's not particularly pretty, but wrap interactions with that object in an ACE_Thread_Mutex.