### PR TITLE
Realign conditional definition of types migrated from SecurityHelpers.h

### DIFF
--- a/dds/DCPS/RTPS/MessageTypes.h
+++ b/dds/DCPS/RTPS/MessageTypes.h
@@ -17,7 +17,7 @@ namespace OpenDDS {
 
     using OpenDDS::DCPS::EntityId_t;
 
-    #ifdef OPENDDS_SECURITY
+#ifdef OPENDDS_SECURITY
     /**
      * The below entities
      are from the security spec. V1.1
@@ -45,7 +45,7 @@ namespace OpenDDS {
 
     const DDS::Security::ParticipantSecurityInfo PARTICIPANT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
     const DDS::Security::EndpointSecurityInfo ENDPOINT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
-    #endif
+#endif
     // end of EntityId section
 
     // For messages we create, the "octetsToInlineQoS" value will be constant.

--- a/dds/DCPS/RTPS/MessageTypes.h
+++ b/dds/DCPS/RTPS/MessageTypes.h
@@ -17,6 +17,7 @@ namespace OpenDDS {
 
     using OpenDDS::DCPS::EntityId_t;
 
+    #ifdef OPENDDS_SECURITY
     /**
      * The below entities
      are from the security spec. V1.1
@@ -41,7 +42,7 @@ namespace OpenDDS {
     const EntityId_t ENTITYID_TL_SVC_REPLY_WRITER_SECURE = {{0xff, 0x03, 0x01}, 0xc3 };
     const EntityId_t ENTITYID_TL_SVC_REPLY_READER_SECURE = {{0xff, 0x03, 0x01}, 0xc4 };
     ///@}
-    #ifdef OPENDDS_SECURITY
+
     const DDS::Security::ParticipantSecurityInfo PARTICIPANT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
     const DDS::Security::EndpointSecurityInfo ENDPOINT_SECURITY_ATTRIBUTES_INFO_DEFAULT = {0, 0};
     #endif


### PR DESCRIPTION
Moved conditional check for OPENDDS_SECURITY to be around all types migrated from SecurityHelpers.h
Fixed #ifdef and #endif lines to start at the beginning instead of following whitespace.