### PR TITLE
[Bench] Give Name To Loaded Configuration To Avoid Static Build Issues

### DIFF
--- a/performance-tests/bench/builder/BuilderProcess.cpp
+++ b/performance-tests/bench/builder/BuilderProcess.cpp
@@ -5,7 +5,7 @@
 namespace Builder {
 
 BuilderProcess::BuilderProcess(const ProcessConfig& config)
-  : config_sections_(std::make_shared<ConfigSectionManager>(config.config_sections))
+  : config_sections_(std::make_shared<ConfigSectionManager>(config.name.in(), config.config_sections))
   , participants_(std::make_shared<ParticipantManager>(config.participants, report_.participants, reader_map_, writer_map_, cft_map_))
 {
 }

--- a/performance-tests/bench/builder/ConfigSectionManager.cpp
+++ b/performance-tests/bench/builder/ConfigSectionManager.cpp
@@ -40,7 +40,7 @@ ConfigSectionManager::ConfigSectionManager(const std::string& name, const Config
       }
     }
   }
-  TheServiceParticipant->load_configuration(ach, ACE_TEXT(name.c_str()));
+  TheServiceParticipant->load_configuration(ach, ACE_TEXT_CHAR_TO_TCHAR(name.c_str()));
 }
 
 }

--- a/performance-tests/bench/builder/ConfigSectionManager.cpp
+++ b/performance-tests/bench/builder/ConfigSectionManager.cpp
@@ -8,7 +8,7 @@
 
 namespace Builder {
 
-ConfigSectionManager::ConfigSectionManager(const ConfigSectionSeq& seq)
+ConfigSectionManager::ConfigSectionManager(const std::string& name, const ConfigSectionSeq& seq)
 {
   ACE_Configuration_Heap ach;
   ach.open();
@@ -40,7 +40,7 @@ ConfigSectionManager::ConfigSectionManager(const ConfigSectionSeq& seq)
       }
     }
   }
-  TheServiceParticipant->load_configuration(ach, ACE_TEXT(""));
+  TheServiceParticipant->load_configuration(ach, ACE_TEXT(name.c_str()));
 }
 
 }

--- a/performance-tests/bench/builder/ConfigSectionManager.h
+++ b/performance-tests/bench/builder/ConfigSectionManager.h
@@ -6,7 +6,7 @@ namespace Builder {
 
 class ConfigSectionManager {
 public:
-  explicit ConfigSectionManager(const ConfigSectionSeq& seq);
+  ConfigSectionManager(const std::string& name, const ConfigSectionSeq& seq);
 };
 
 }

--- a/performance-tests/bench/builder_idl/Builder.idl
+++ b/performance-tests/bench/builder_idl/Builder.idl
@@ -396,6 +396,7 @@ module Builder {
 
   @topic
   struct ProcessConfig {
+    string name;
     ConfigSectionSeq config_sections;
     ParticipantConfigSeq participants;
   };

--- a/performance-tests/bench/worker/main.cpp
+++ b/performance-tests/bench/worker/main.cpp
@@ -117,7 +117,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
         report_file_fullname = get_option_argument(i, argc, argv);
       } else if (config_file_fullname.empty()) {
         config_file_fullname = ACE_TEXT_ALWAYS_CHAR(argument);
-        config_file_basename = ACE::basename(argument);
+        config_file_basename = ACE_TEXT_ALWAYS_CHAR(ACE::basename(argument));
       } else {
         std::cerr << "Invalid option: " << argument << std::endl;
         return 1;

--- a/performance-tests/bench/worker/main.cpp
+++ b/performance-tests/bench/worker/main.cpp
@@ -103,26 +103,28 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   Builder::NullStream null_stream_i;
   std::ostream null_stream(&null_stream_i);
 
-  std::string log_file_path;
-  std::string report_file_path;
-  std::string config_file_path;
+  std::string log_file_fullname;
+  std::string report_file_fullname;
+  std::string config_file_fullname;
+  std::string config_file_basename;
 
   try {
     for (int i = 1; i < argc; i++) {
       const ACE_TCHAR* argument = argv[i];
       if (!ACE_OS::strcmp(argv[i], ACE_TEXT("--log"))) {
-        log_file_path = get_option_argument(i, argc, argv);
+        log_file_fullname = get_option_argument(i, argc, argv);
       } else if (!ACE_OS::strcmp(argv[i], ACE_TEXT("--report"))) {
-        report_file_path = get_option_argument(i, argc, argv);
-      } else if (config_file_path.empty()) {
-        config_file_path = ACE_TEXT_ALWAYS_CHAR(argument);
+        report_file_fullname = get_option_argument(i, argc, argv);
+      } else if (config_file_fullname.empty()) {
+        config_file_fullname = ACE_TEXT_ALWAYS_CHAR(argument);
+        config_file_basename = ACE::basename(argument);
       } else {
         std::cerr << "Invalid option: " << argument << std::endl;
         return 1;
       }
     }
 
-    if (config_file_path.empty()) {
+    if (config_file_fullname.empty()) {
       std::cerr << "Must pass a configuration file" << std::endl;
       throw 1;
     }
@@ -131,17 +133,17 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
     return value;
   }
 
-  std::ifstream config_file(config_file_path);
+  std::ifstream config_file(config_file_fullname);
   if (!config_file.is_open()) {
-    std::cerr << "Unable to open configuration file: '" << config_file_path << "'" << std::endl;
+    std::cerr << "Unable to open configuration file: '" << config_file_fullname << "'" << std::endl;
     return 2;
   }
 
   std::ofstream log_file;
-  if (!log_file_path.empty()) {
-    log_file.open(log_file_path, ios::app);
+  if (!log_file_fullname.empty()) {
+    log_file.open(log_file_fullname, ios::app);
     if (!log_file.good()) {
-      std::cerr << "Unable to open log file: '" << log_file_path << "'" << std::endl;
+      std::cerr << "Unable to open log file: '" << log_file_fullname << "'" << std::endl;
       return 2;
     }
     Log::stream = &log_file;
@@ -150,10 +152,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
   }
 
   std::ofstream report_file;
-  if (!report_file_path.empty()) {
-    report_file.open(report_file_path);
+  if (!report_file_fullname.empty()) {
+    report_file.open(report_file_fullname);
     if (!report_file.good()) {
-      std::cerr << "Unable to open report file: '" << report_file_path << "'" << std::endl;
+      std::cerr << "Unable to open report file: '" << report_file_fullname << "'" << std::endl;
       return 2;
     }
   }
@@ -174,6 +176,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
     std::cerr << "Unable to parse configuration" << std::endl;
     return 3;
   }
+
+  config.process.name = config_file_basename.c_str();
 
   if (config.create_time == ZERO) {
     config.create_time = Builder::get_sys_time();
@@ -302,8 +306,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
     redirect_ace_log = static_cast<size_t>(redirect_ace_log_prop->value.ull_prop());
   }
 
-  if (redirect_ace_log && !log_file_path.empty()) {
-    std::ofstream* output_stream = new std::ofstream(log_file_path.c_str(), ios::app);
+  if (redirect_ace_log && !log_file_fullname.empty()) {
+    std::ofstream* output_stream = new std::ofstream(log_file_fullname.c_str(), ios::app);
     if (output_stream->bad()) {
       delete output_stream;
     } else {
@@ -544,7 +548,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[]) {
 
   // If requested, write out worker report to file
 
-  if (!report_file_path.empty()) {
+  if (!report_file_fullname.empty()) {
     idl_2_json(worker_report, report_file, max_decimal_places);
   }
 


### PR DESCRIPTION
Problem: Static builds can make use of the empty config name section for storing default transport instances, causing trouble when custom config sections are loaded without a configuration file name name.

Solution: Since this is an opt-in behavior for static builds (and bench is opting in since it doesn't know which transport libraries will be required), it makes the most sense to have bench avoid using an empty configuration name.