### PR TITLE
RtpsRelay Admission Control

### DIFF
--- a/performance-tests/bench/example/config/scenario/ci-disco-relay.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco-relay.json
@@ -4,7 +4,7 @@
   "any_node": [
     {
       "executable": "RtpsRelay",
-      "command" : "%executable% -Id relay1 -UserData relay1 -DCPSDebugLevel 1 -DCPSSecurityDebugLevel 2 -LogDiscovery 1 -LogActivity 1 -DCPSThreadStatusInterval 1 -LogRelayStatistics 3 -LogParticipantStatistics 1 -DCPSConfigFile %bench_root%%ds%example%ds%config%ds%relay%ds%ci-disco-relay.ini -ApplicationDomain 7 -VerticalAddress 4444 -ORBLogFile %log% -DCPSPendingTimeout 3",
+      "command" : "%executable% -Id relay1 -UserData relay1 -DCPSDebugLevel 1 -DCPSSecurityDebugLevel 2 -LogDiscovery 1 -LogActivity 1 -DCPSThreadStatusInterval 1 -LogRelayStatistics 3 -LogParticipantStatistics 1 -DCPSConfigFile %bench_root%%ds%example%ds%config%ds%relay%ds%ci-disco-relay.ini -ApplicationDomain 7 -VerticalAddress 4444 -MetaDiscoveryAddress 0 -ORBLogFile %log% -DCPSPendingTimeout 3",
       "no_report": true,
       "ignore_errors": true,
       "count": 1

--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -164,6 +164,7 @@ module RtpsRelay {
     unsigned long relay_partitions_pub_count;
     unsigned long relay_address_pub_count;
     unsigned long spdp_replay_pub_count;
+    unsigned long admission_deferral_count;
   };
 };
 

--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -32,6 +32,7 @@ public:
     , log_participant_statistics_(false)
     , publish_participant_statistics_(false)
     , restart_detection_(false)
+    , admission_control_queue_size_(0)
   {}
 
   void relay_id(const std::string& value)
@@ -264,6 +265,26 @@ public:
     return restart_detection_;
   }
 
+  void admission_control_queue_size(size_t value)
+  {
+    admission_control_queue_size_ = value;
+  }
+
+  size_t admission_control_queue_size() const
+  {
+    return admission_control_queue_size_;
+  }
+
+  void admission_control_queue_duration(OpenDDS::DCPS::TimeDuration value)
+  {
+    admission_control_queue_duration_ = value;
+  }
+
+  OpenDDS::DCPS::TimeDuration admission_control_queue_duration() const
+  {
+    return admission_control_queue_duration_;
+  }
+
 private:
   std::string relay_id_;
   OpenDDS::DCPS::GUID_t application_participant_guid_;
@@ -288,6 +309,8 @@ private:
   OpenDDS::DCPS::TimeDuration publish_relay_status_;
   OpenDDS::DCPS::TimeDuration publish_relay_status_liveliness_;
   bool restart_detection_;
+  size_t admission_control_queue_size_;
+  OpenDDS::DCPS::TimeDuration admission_control_queue_duration_;
 };
 
 }

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -151,6 +151,13 @@ public:
     report(now);
   }
 
+  void admission_deferral_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ++log_relay_statistics_.admission_deferral_count();
+    ++publish_relay_statistics_.admission_deferral_count();
+    report(now);
+  }
+
   void report()
   {
     report(OpenDDS::DCPS::MonotonicTimePoint::now(), true);

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -184,6 +184,7 @@ private:
     log_helper_.reset(log_relay_statistics_, now);
     log_relay_statistics_.new_address_count(0);
     log_relay_statistics_.expired_address_count(0);
+    log_relay_statistics_.admission_deferral_count(0);
   }
 
   void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
@@ -202,6 +203,7 @@ private:
     publish_helper_.reset(publish_relay_statistics_, now);
     publish_relay_statistics_.new_address_count(0);
     publish_relay_statistics_.expired_address_count(0);
+    publish_relay_statistics_.admission_deferral_count(0);
   }
 
   const Config& config_;

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -201,6 +201,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-RestartDetection"))) {
       config.restart_detection(ACE_OS::atoi(arg));
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-AdmissionControlQueueSize"))) {
+      config.admission_control_queue_size(ACE_OS::atoi(arg));
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-AdmissionControlQueueDuration"))) {
+      config.admission_control_queue_duration(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
+      args.consume_arg();
 #ifdef OPENDDS_SECURITY
     } else if ((arg = args.get_the_parameter("-IdentityCA"))) {
       identity_ca_file = file + arg;


### PR DESCRIPTION
Problem: Under periods of abnormally high levels of discovery traffic (such as during overall system redeployment), the RtpsRelay struggles to maintain an optimal rate of participant discovery, in effect worsening the experienced problem of slow discovery times.

Solution: Add an admission control queue in order to only allow a limited subset of the unknown remote participants to go through discovery at once. The admission control queue maximum size (total undergoing discovery at a time) and admittance duration (time considered sufficient for aiding discovery) are both configurable.