### PR TITLE
Fix TSAN data race in RelayStatisticsReporter

### DIFF
--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -31,18 +31,20 @@ public:
                      const OpenDDS::DCPS::MonotonicTimePoint& now,
                      MessageType type)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.input_message(log_relay_statistics_, byte_count, time, type);
     publish_helper_.input_message(publish_relay_statistics_, byte_count, time, type);
-    report(now);
+    report(guard, now);
   }
 
   void ignored_message(size_t byte_count,
                        const OpenDDS::DCPS::MonotonicTimePoint& now,
                        MessageType type)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.ignored_message(log_relay_statistics_, byte_count, type);
     publish_helper_.ignored_message(publish_relay_statistics_, byte_count, type);
-    report(now);
+    report(guard, now);
   }
 
   void output_message(size_t byte_count,
@@ -51,9 +53,10 @@ public:
                       const OpenDDS::DCPS::MonotonicTimePoint& now,
                       MessageType type)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.output_message(log_relay_statistics_, byte_count, time, queue_latency, type);
     publish_helper_.output_message(publish_relay_statistics_, byte_count, time, queue_latency, type);
-    report(now);
+    report(guard, now);
   }
 
   void dropped_message(size_t byte_count,
@@ -62,114 +65,130 @@ public:
                        const OpenDDS::DCPS::MonotonicTimePoint& now,
                        MessageType type)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.dropped_message(log_relay_statistics_, byte_count, time, queue_latency, type);
     publish_helper_.dropped_message(publish_relay_statistics_, byte_count, time, queue_latency, type);
-    report(now);
+    report(guard, now);
   }
 
   void max_gain(size_t value, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.max_gain(log_relay_statistics_, value);
     publish_helper_.max_gain(publish_relay_statistics_, value);
-    report(now);
+    report(guard, now);
   }
 
   void local_active_participants(size_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.local_active_participants() = static_cast<uint32_t>(count);
     publish_relay_statistics_.local_active_participants() = static_cast<uint32_t>(count);
-    report(now);
+    report(guard, now);
   }
 
   void error(const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.error(log_relay_statistics_);
     publish_helper_.error(publish_relay_statistics_);
-    report(now);
+    report(guard, now);
   }
 
   void new_address(const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     ++log_relay_statistics_.new_address_count();
     ++publish_relay_statistics_.new_address_count();
-    report(now);
+    report(guard, now);
   }
 
   void expired_address(const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     ++log_relay_statistics_.expired_address_count();
     ++publish_relay_statistics_.expired_address_count();
-    report(now);
+    report(guard, now);
   }
 
   void max_queue_size(size_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_helper_.max_queue_size(log_relay_statistics_, size);
     publish_helper_.max_queue_size(publish_relay_statistics_, size);
-    report(now);
+    report(guard, now);
   }
 
   void local_participants(size_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.local_participants() = static_cast<uint32_t>(count);
     publish_relay_statistics_.local_participants() = static_cast<uint32_t>(count);
-    report(now);
+    report(guard, now);
   }
 
   void local_writers(size_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.local_writers() = static_cast<uint32_t>(count);
     publish_relay_statistics_.local_writers() = static_cast<uint32_t>(count);
-    report(now);
+    report(guard, now);
   }
 
   void local_readers(size_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.local_readers() = static_cast<uint32_t>(count);
     publish_relay_statistics_.local_readers() = static_cast<uint32_t>(count);
-    report(now);
+    report(guard, now);
   }
 
   void relay_partitions_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.relay_partitions_pub_count() = count;
     publish_relay_statistics_.relay_partitions_pub_count() = count;
-    report(now);
+    report(guard, now);
   }
 
   void relay_address_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.relay_address_pub_count() = count;
     publish_relay_statistics_.relay_address_pub_count() = count;
-    report(now);
+    report(guard, now);
   }
 
   void spdp_replay_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     log_relay_statistics_.spdp_replay_pub_count() = count;
     publish_relay_statistics_.spdp_replay_pub_count() = count;
-    report(now);
+    report(guard, now);
   }
 
   void admission_deferral_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
     ++log_relay_statistics_.admission_deferral_count();
     ++publish_relay_statistics_.admission_deferral_count();
-    report(now);
+    report(guard, now);
   }
 
   void report()
   {
-    report(OpenDDS::DCPS::MonotonicTimePoint::now(), true);
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    report(guard, OpenDDS::DCPS::MonotonicTimePoint::now(), true);
   }
 
 private:
 
-  void report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+  void report(ACE_Guard<ACE_Thread_Mutex>& guard,
+              const OpenDDS::DCPS::MonotonicTimePoint& now,
               bool force = false)
   {
     log_report(now, force);
-    publish_report(now, force);
+    publish_report(guard, now, force);
   }
 
   void log_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
@@ -187,25 +206,32 @@ private:
     log_relay_statistics_.admission_deferral_count(0);
   }
 
-  void publish_report(const OpenDDS::DCPS::MonotonicTimePoint& now,
+  void publish_report(ACE_Guard<ACE_Thread_Mutex>& guard,
+                      const OpenDDS::DCPS::MonotonicTimePoint& now,
                       bool force)
   {
     if (!publish_helper_.prepare_report(publish_relay_statistics_, now, force, config_.publish_relay_statistics())) {
       return;
     }
 
-    const auto ret = writer_->write(publish_relay_statistics_, DDS::HANDLE_NIL);
-    if (ret != DDS::RETCODE_OK) {
-      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
-        "RelayStatisticsReporter::publish_report failed to write relay statistics\n"));
-    }
+    const auto writer_copy = writer_;
+    const auto stats_copy = publish_relay_statistics_;
 
     publish_helper_.reset(publish_relay_statistics_, now);
     publish_relay_statistics_.new_address_count(0);
     publish_relay_statistics_.expired_address_count(0);
     publish_relay_statistics_.admission_deferral_count(0);
+
+    guard.release();
+
+    const auto ret = writer_copy->write(stats_copy, DDS::HANDLE_NIL);
+    if (ret != DDS::RETCODE_OK) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
+        "RelayStatisticsReporter::publish_report failed to write relay statistics\n"));
+    }
   }
 
+  mutable ACE_Thread_Mutex mutex_;
   const Config& config_;
 
   typedef CommonIoStatsReportHelper<RelayStatistics> Helper;


### PR DESCRIPTION
Fix a data race between RelayHandler threads and DDS Listener threads when touching the relay statistics.
