### PR TITLE
Attempt to address data race in DataReaderImpl::get_value_dispatcher()

### DIFF
--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -639,7 +639,8 @@ public:
 
   const ValueDispatcher* get_value_dispatcher() const
   {
-    return topic_servant_ ? dynamic_cast<const ValueDispatcher*>(topic_servant_->get_type_support()) : 0;
+    TopicDescriptionPtr<TopicImpl> temp(topic_servant_);
+    return temp ? dynamic_cast<const ValueDispatcher*>(temp->get_type_support()) : 0;
   }
 
 protected:

--- a/dds/DCPS/TopicDescriptionImpl.h
+++ b/dds/DCPS/TopicDescriptionImpl.h
@@ -102,31 +102,34 @@ public:
   TopicDescriptionPtr(Topic* topic=0)
     : topic_(topic)
   {
-    if (topic_)
+    if (topic_) {
       topic_->add_entity_ref();
+    }
   }
 
   ~TopicDescriptionPtr()
   {
-    if (topic_)
+    if (topic_) {
       topic_->remove_entity_ref();
+    }
   }
 
   TopicDescriptionPtr(const TopicDescriptionPtr& other)
     : topic_(other.topic_)
   {
-    if (topic_)
+    if (topic_) {
       topic_->add_entity_ref();
+    }
   }
 
-  TopicDescriptionPtr& operator = (Topic* other)
+  TopicDescriptionPtr& operator=(Topic* other)
   {
     TopicDescriptionPtr tmp(other);
     std::swap(this->topic_, tmp.topic_);
     return *this;
   }
 
-  TopicDescriptionPtr& operator = (const TopicDescriptionPtr& other)
+  TopicDescriptionPtr& operator=(const TopicDescriptionPtr& other)
   {
     TopicDescriptionPtr tmp(other);
     std::swap(this->topic_, tmp.topic_);


### PR DESCRIPTION
Problem: https://github.com/objectcomputing/OpenDDS/actions/runs/3388172713/jobs/5631246398

Solution: Ultimately, this may require a mutex, but this PR is first attempting to resolve the "test / deleted / access" race condition issue by first making a copy and testing / accessing the copy rather than the class member.