### PR TITLE
configure script updates for cross-compiling

### DIFF
--- a/configure
+++ b/configure
@@ -1165,6 +1165,12 @@ if (scalar(@fsanitize)) {
   @sanitizer_linker_args = (@common, @sanitizer_linker_args);
 }
 
+sub compiler {
+  my %buildEnv = %{shift()};
+  return ($buildEnv{'build'} eq 'target' && $opts{'target-compiler'}) ?
+    $opts{'target-compiler'} : $opts{'compiler'};
+}
+
 my @ace_macros = ('debug',
                   'optimize',
                   'inline',
@@ -1191,6 +1197,7 @@ sub write_platform_macros {
         }
       }
       if ($cross_compile) {
+        print $PMG "CROSS-COMPILE = 1\n";
         print $PMG 'TAO_IDL = $(HOST_ACE)/bin/tao_idl', "\n";
         if ($is_windows) {
           print $PMG "HOST_EXE_EXT = .exe\n";
@@ -1254,8 +1261,9 @@ sub write_platform_macros {
     $plat .= '_' . $opts{'host_version'} if $opts{'host_version'};
     print $PMG "include \$(ACE_ROOT)/include/makeinclude/platform_$plat.GNU\n";
     if ($opts{'nonstdcompiler'} && !$macro_cross_compile) {
+      my $comp = compiler(\%buildEnv);
       for my $var ('CC', 'CXX', 'LD') {
-        print $PMG "$var = $opts{'compiler'}\n";
+        print $PMG "$var = $comp\n";
       }
     }
     if ($opts{'prefix'} && $opts{'install-origin-relative'}) {
@@ -2130,7 +2138,6 @@ OPENDDS_IDL = $(HOST_DDS)/bin/opendds_idl
 OPENDDS_IDL_DEP = $(OPENDDS_IDL)$(HOST_EXE_EXT)
 IDL2JNI = $(HOST_DDS)/bin/idl2jni
 IDL2JNI_DEP = $(IDL2JNI)$(HOST_EXE_EXT)
-CROSS-COMPILE = 1
 EOT
       }
     }


### PR DESCRIPTION
* `CROSS-COMPILE = 1` needs to be set in platform_macros.GNU to be in effect during the TAO build
* When CC, CXX, LD variables are set explicitly, they may need to resolve to the `target-compiler`