### PR TITLE
Avoid Sending Gap Submessages For Future Sequence Numbers

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3553,7 +3553,7 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
             ++cumulative_send_count;
             continue;
           }
-        } else if (proxy.pre_contains(seq)) {
+        } else if (proxy.pre_contains(seq) || seq > max_sn_) {
           // Can't answer, don't gap.
           continue;
         }
@@ -3602,7 +3602,7 @@ RtpsUdpDataLink::RtpsWriter::gather_nack_replies_i(MetaSubmessageVec& meta_subme
           }
           continue;
         }
-      } else if (proxy.pre_contains(seq)) {
+      } else if (proxy.pre_contains(seq) || seq > max_sn_) {
         // Can't answer, don't gap.
         continue;
       }


### PR DESCRIPTION
When NACK messages come in, for whatever reason, with requests for "future" sequence number values (outside the advertised heartbeat range), avoid sending gap submessages in response, since we may eventually want to send valid data for those sequence numbers.