### PR TITLE
SignedDocument can't handle non-openssl documents

### DIFF
--- a/dds/DCPS/security/AccessControl/Governance.cpp
+++ b/dds/DCPS/security/AccessControl/Governance.cpp
@@ -111,8 +111,7 @@ namespace {
 
 int Governance::load(const SSL::SignedDocument& doc)
 {
-  std::string xml;
-  doc.get_original_minus_smime(xml);
+  const std::string& xml = doc.content();
   ParserPtr parser;
   if (!get_parser(parser, doc.filename(), xml)) {
     if (security_debug.access_error) {

--- a/dds/DCPS/security/AccessControl/LocalAccessCredentialData.h
+++ b/dds/DCPS/security/AccessControl/LocalAccessCredentialData.h
@@ -28,6 +28,7 @@ public:
   ~LocalAccessCredentialData();
 
   bool load(const DDS::PropertySeq& props, DDS::Security::SecurityException& ex);
+  bool verify(DDS::Security::SecurityException& ex);
 
   const SSL::Certificate& get_ca_cert() const
   {
@@ -36,19 +37,19 @@ public:
 
   const SSL::SignedDocument& get_governance_doc() const
   {
-    return *governance_doc_;
+    return governance_doc_;
   }
 
   const SSL::SignedDocument& get_permissions_doc() const
   {
-    return *permissions_doc_;
+    return permissions_doc_;
   }
 
 private:
 
   SSL::Certificate::unique_ptr ca_cert_;
-  SSL::SignedDocument::unique_ptr governance_doc_;
-  SSL::SignedDocument::unique_ptr permissions_doc_;
+  SSL::SignedDocument governance_doc_;
+  SSL::SignedDocument permissions_doc_;
 };
 
 }

--- a/dds/DCPS/security/AccessControl/Permissions.cpp
+++ b/dds/DCPS/security/AccessControl/Permissions.cpp
@@ -21,8 +21,7 @@ int Permissions::load(const SSL::SignedDocument& doc)
   using XML::XStr;
   using namespace XmlUtils;
 
-  std::string xml;
-  doc.get_original_minus_smime(xml);
+  const std::string& xml = doc.content();
   ParserPtr parser;
   if (!get_parser(parser, doc.filename(), xml)) {
     if (security_debug.access_error) {

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -98,14 +98,11 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
     return DDS::HANDLE_NIL;
   }
 
-  const SSL::Certificate& local_ca = local_access_credential_data->get_ca_cert();
-  const SSL::SignedDocument& local_gov = local_access_credential_data->get_governance_doc();
-
-  if (local_gov.verify_signature(local_ca)) {
-    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_local_permissions: Governance signature not verified");
+  if (!local_access_credential_data->verify(ex)) {
     return DDS::HANDLE_NIL;
   }
 
+  const SSL::SignedDocument& local_gov = local_access_credential_data->get_governance_doc();
   Governance::shared_ptr governance = DCPS::make_rch<Governance>();
 
   if (governance->load(local_gov)) {
@@ -119,13 +116,6 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   if (permissions->load(local_perm)) {
     CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_local_permissions: Invalid permission file");
     return DDS::HANDLE_NIL;
-  }
-
-  if (local_perm.verify_signature(local_ca)) {
-    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_local_permissions: Permissions signature not verified");
-    return DDS::HANDLE_NIL;
-  } else if (DCPS::DCPS_debug_level) {
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) AccessControlBuiltInImpl::validate_local_permissions: Permissions document verified.\n")));
   }
 
   TokenReader tr(id_token);
@@ -142,7 +132,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   DDS::Security::PermissionsCredentialToken permissions_cred_token;
   TokenWriter pctWriter(permissions_cred_token, PermissionsCredentialTokenClassId);
 
-  pctWriter.add_property("dds.perm.cert", local_perm.get_original());
+  pctWriter.add_property("dds.perm.cert", local_perm.original());
 
   // Set and store the permissions token
   DDS::Security::PermissionsToken permissions_token;
@@ -216,13 +206,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   // permissions file
   TokenReader remote_perm_wrapper(remote_credential_token);
-  SSL::SignedDocument remote_perm_doc;
-
-  if (remote_perm_doc.deserialize(remote_perm_wrapper.get_bin_property_value("c.perm"))) {
-    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_remote_permissions: Failed to deserialize c.perm into signed-document");
-    return DDS::HANDLE_NIL;
-  }
-
+  SSL::SignedDocument remote_perm_doc(remote_perm_wrapper.get_bin_property_value("c.perm"));
   Permissions::shared_ptr remote_permissions = DCPS::make_rch<Permissions>();
 
   if (remote_permissions->load(remote_perm_doc)) {
@@ -238,7 +222,7 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
 
   local_ca.subject_name_to_str(ca_subject);
 
-  if (remote_perm_doc.verify_signature(local_ca)) {
+  if (!remote_perm_doc.verify(local_ca)) {
     CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_remote_permissions: Remote permissions signature not verified");
     return DDS::HANDLE_NIL;
   }

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -207,12 +207,6 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   // permissions file
   TokenReader remote_perm_wrapper(remote_credential_token);
   SSL::SignedDocument remote_perm_doc(remote_perm_wrapper.get_bin_property_value("c.perm"));
-  Permissions::shared_ptr remote_permissions = DCPS::make_rch<Permissions>();
-
-  if (remote_permissions->load(remote_perm_doc)) {
-    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_remote_permissions: Invalid permission file");
-    return DDS::HANDLE_NIL;
-  }
 
   const LocalAccessCredentialData::shared_ptr& local_access_credential_data = piter->second.local_access_credential_data;
 
@@ -231,6 +225,12 @@ AccessControlBuiltInImpl::~AccessControlBuiltInImpl()
   if (DCPS::DCPS_debug_level) {
     ACE_DEBUG((LM_DEBUG, ACE_TEXT(
       "(%P|%t) AccessControlBuiltInImpl::validate_remote_permissions: Remote permissions document verified.\n")));
+  }
+
+  Permissions::shared_ptr remote_permissions = DCPS::make_rch<Permissions>();
+  if (remote_permissions->load(remote_perm_doc)) {
+    CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl::validate_remote_permissions: Invalid permission file");
+    return DDS::HANDLE_NIL;
   }
 
   //Extract and compare the remote subject name for validation

--- a/dds/DCPS/security/SSL/Certificate.h
+++ b/dds/DCPS/security/SSL/Certificate.h
@@ -93,6 +93,8 @@ public:
 
   const char* keypair_algo() const;
 
+  X509* x509() const { return x_; }
+
  private:
 
   bool loaded()

--- a/dds/DCPS/security/SSL/Err.h
+++ b/dds/DCPS/security/SSL/Err.h
@@ -9,8 +9,12 @@
 #include <ace/Log_Msg.h>
 #include <openssl/err.h>
 
-#define OPENDDS_SSL_LOG_ERR(MSG)                                  \
-  ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: '%C' %C\n"), \
-             ERR_reason_error_string(ERR_get_error()), (MSG)))
+#define OPENDDS_SSL_LOG_ERR(MSG)                                    \
+  for (unsigned long e = ERR_get_error(); e != 0; e = ERR_get_error()) { \
+    char buf[256];                                                      \
+    ERR_error_string(e, buf);                                           \
+    ACE_ERROR((LM_WARNING, ACE_TEXT("(%P|%t) WARNING: %C: %C\n"),        \
+               (MSG), buf));                                            \
+  }
 
 #endif

--- a/dds/DCPS/security/SSL/SignedDocument.h
+++ b/dds/DCPS/security/SSL/SignedDocument.h
@@ -26,13 +26,8 @@ class OpenDDS_Security_Export SignedDocument {
 public:
   explicit SignedDocument(const DDS::OctetSeq& src);
 
-  SignedDocument(const SignedDocument& rhs);
-
   SignedDocument();
-
   virtual ~SignedDocument();
-
-  SignedDocument& operator=(const SignedDocument& rhs);
 
   bool load(const std::string& uri, DDS::Security::SecurityException& ex);
   bool verify(const Certificate& ca);
@@ -40,7 +35,7 @@ public:
   const DDS::OctetSeq& original() const {return original_;}
   const std::string& content() const {return content_;}
   bool verified() const { return verified_; }
-  const std::string filename() const {return filename_;}
+  const std::string& filename() const {return filename_;}
 
   bool operator==(const SignedDocument& other) const;
 

--- a/dds/DCPS/security/SSL/SignedDocument.h
+++ b/dds/DCPS/security/SSL/SignedDocument.h
@@ -24,13 +24,6 @@ namespace SSL {
 
 class OpenDDS_Security_Export SignedDocument {
 public:
-  typedef DCPS::unique_ptr<SignedDocument> unique_ptr;
-
-  friend OpenDDS_Security_Export bool operator==(
-    const SignedDocument& lhs, const SignedDocument& rhs);
-
-  explicit SignedDocument(const std::string& uri);
-
   explicit SignedDocument(const DDS::OctetSeq& src);
 
   SignedDocument(const SignedDocument& rhs);
@@ -42,72 +35,23 @@ public:
   SignedDocument& operator=(const SignedDocument& rhs);
 
   bool load(const std::string& uri, DDS::Security::SecurityException& ex);
+  bool verify(const Certificate& ca);
 
-  void get_original(std::string& dst) const;
+  const DDS::OctetSeq& original() const {return original_;}
+  const std::string& content() const {return content_;}
+  bool verified() const { return verified_; }
+  const std::string filename() const {return filename_;}
 
-  const DDS::OctetSeq& get_original() const
-  {
-    return original_;
-  }
-
-  const std::string& get_verifiable() const
-  {
-    return verifiable_;
-  }
-
-  bool get_original_minus_smime(std::string& dst) const;
-
-  /**
-   * @return int 0 on success; 1 on failure.
-   */
-  int verify_signature(const Certificate& ca) const;
-
-  /**
-   * @return int 0 on success; 1 on failure.
-   */
-  int serialize(DDS::OctetSeq& dst) const;
-
-  /**
-   * @return int 0 on success; 1 on failure.
-   */
-  int deserialize(const DDS::OctetSeq& src);
-
-  /**
-   * @return int 0 on success; 1 on failure.
-   */
-  int deserialize(const std::string& src);
-
-  const std::string filename() const
-  {
-    return filename_;
-  }
+  bool operator==(const SignedDocument& other) const;
 
 private:
+  void load_file(const std::string& path);
 
-  bool loaded()
-  {
-    return doc_ && original_.length() && verifiable_.length();
-  }
-
-  /**
-   * @return int 0 on success; 1 on failure.
-   *
-   * @param from BIO containing data populated by a call to SMIME_read_PKCS7.
-   */
-  int cache_verifiable(BIO* from);
-
-  PKCS7* PKCS7_from_SMIME_file(const std::string& path);
-
-  PKCS7* PKCS7_from_data(const DDS::OctetSeq& s_mime_data);
-
-  PKCS7* doc_;
   DDS::OctetSeq original_;
-  std::string verifiable_;
+  std::string content_;
+  bool verified_;
   std::string filename_;
 };
-
-OpenDDS_Security_Export bool operator==(
-  const SignedDocument& lhs, const SignedDocument& rhs);
 
 }  // namespace SSL
 }  // namespace Security

--- a/tests/unit-tests/dds/DCPS/security/SSL/SignedDocument.cpp
+++ b/tests/unit-tests/dds/DCPS/security/SSL/SignedDocument.cpp
@@ -49,8 +49,13 @@ public:
       "DHYxM+pYtQAgmBKLBxTyDrgJZ+3j3FVOp0orRxarE3XjJ+0bIVnO6yhjunPOpgsy\n"
       "EcxH9/7Enm8=\n"
       "-----END CERTIFICATE-----"),
-    doc_("file:../security/governance/governance_SC1_ProtectedDomain1_signed.p7s")
+    doc_()
   {
+    DDS::Security::SecurityException ex;
+    if (!doc_.load("file:../security/governance/governance_SC1_ProtectedDomain1_signed.p7s", ex)) {
+      throw std::runtime_error("Could not load governance file");
+    }
+
   }
 
   ~dds_DCPS_security_SSL_SignedDocument()
@@ -66,19 +71,18 @@ public:
 
 TEST_F(dds_DCPS_security_SSL_SignedDocument, GetContent_Success)
 {
-  std::string content;
-  doc_.get_original(content);
+  const DDS::OctetSeq& content =  doc_.original();
   ASSERT_TRUE(0 < content.length());
 }
 
 TEST_F(dds_DCPS_security_SSL_SignedDocument, VerifySignature_Success)
 {
-  ASSERT_EQ(0, doc_.verify_signature(ca_));
+  ASSERT_TRUE(doc_.verify(ca_));
 }
 
 TEST_F(dds_DCPS_security_SSL_SignedDocument, VerifySignature_Data_Success)
 {
-  ASSERT_EQ(0, doc_.verify_signature(ca_data_));
+  ASSERT_TRUE(doc_.verify(ca_data_));
 }
 
 TEST_F(dds_DCPS_security_SSL_SignedDocument, LoadFromMemory)


### PR DESCRIPTION
Problem
-------

Loading a governance file or permissions file signed by Bouncy Castle fails.  The root cause is the (lack of) MIME parsing.

Solution
--------

Use openssl to extract the signed content.