### PR TITLE
[Bench] Add Scenario and Test Run Parameters For Use In Performance Dashboard

### DIFF
--- a/performance-tests/bench/dashboard_summarizer/main.cpp
+++ b/performance-tests/bench/dashboard_summarizer/main.cpp
@@ -18,7 +18,9 @@ Value& find_or_create(Value& parent, const std::string& name, Type type, Documen
     pos = parent.FindMember(Value(name.c_str(), length));
     assert(pos != parent.MemberEnd());
   }
-  assert(pos->value.GetType() == type);
+  if (type != kNullType) {
+    assert(pos->value.GetType() == type);
+  }
   return pos->value;
 }
 
@@ -129,25 +131,38 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       return 1;
     }
 
-    // Determine Scenario Name
-    std::string scn;
-    for (auto it = known_scenario_names.begin(); scn.empty() && it != known_scenario_names.end(); ++it) {
-      const std::string with_underscore = *it + '_';
-      if (file_names[i].find(with_underscore) == 0) {
-        scn = *it;
+    // Parse Run Parameters
+    const auto rp_it = doc_in.FindMember("run_parameters");
+    if (rp_it != doc_in.MemberEnd()) {
+      const Value& rp_value_in = rp_it->value;
+      Value& rp_value_out = find_or_create(doc_out, "run_parameters", kObjectType, doc_out.GetAllocator());
+      for (Value::ConstMemberIterator rpi = rp_value_in.MemberBegin(); rpi != rp_value_in.MemberEnd(); ++rpi) {
+        Value& rpi_value_out = find_or_create(rp_value_out, rpi->name.GetString(), kNullType, doc_out.GetAllocator());
+        if (rpi_value_out.IsNull()) {
+          rpi_value_out = rapidjson::Value(rpi->value, doc_out.GetAllocator());
+        } else if (rpi_value_out != rpi->value) {
+          std::cerr << "Run Parameter '" << rpi->name.GetString() << "' is not consistent across input files ('" << rpi_value_out.GetString() << "' vs '" << rpi->value.GetString() <<"'). Exiting" << std::endl;
+          return 1;
+        }
       }
     }
-    if (scn.empty()) {
-      scn = file_names[i].substr(0, file_names[i].find_last_of('_'));
-      std::cerr << "Found Unknown Scenario: " << scn << std::endl;
-    }
-    const std::string scenario_name = scn;
-    const size_t offset = scenario_name.size() + 1;
-    const std::string variety_name = file_names[i].substr(offset, file_names[i].find_first_of('.') - offset);
 
-    // Find or Create Values For Scenario and 'Variety'
-    Value& scenario_value = find_or_create(doc_out, scenario_name, kObjectType, doc_out.GetAllocator());
-    Value& variety_value = find_or_create(scenario_value, variety_name, kObjectType, doc_out.GetAllocator());
+    // Determine Full Scenario Name
+    const std::string full_scenario_name = file_names[i].substr(0, file_names[i].find_first_of('.'));
+
+    // Find or Create Values For Scenario
+    Value& full_scenario_value = find_or_create(doc_out, full_scenario_name, kObjectType, doc_out.GetAllocator());
+
+    // Parse Scenario Parameters
+    const auto sp_it = doc_in.FindMember("scenario_parameters");
+    if (sp_it != doc_in.MemberEnd()) {
+      const Value& sp_value_in = sp_it->value;
+      Value& sp_value_out = find_or_create(full_scenario_value, "scenario_parameters", kObjectType, doc_out.GetAllocator());
+      for (Value::ConstMemberIterator spi = sp_value_in.MemberBegin(); spi != sp_value_in.MemberEnd(); ++spi) {
+        Value& spi_value_out = find_or_create(sp_value_out, spi->name.GetString(), kObjectType, doc_out.GetAllocator());
+        spi_value_out = rapidjson::Value(spi->value, doc_out.GetAllocator());
+      }
+    }
 
     // Write Errors Value
     uint64_t errors = 0;
@@ -159,7 +174,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       }
     }
 
-    Value& errors_value = find_or_create(variety_value, "Errors", kNumberType, doc_out.GetAllocator());
+    Value& errors_value = find_or_create(full_scenario_value, "Errors", kNumberType, doc_out.GetAllocator());
     errors_value.SetUint64(errors);
 
     // Write Max Discovery Time Delta Value
@@ -175,7 +190,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       }
     }
 
-    Value& mdtd_value = find_or_create(variety_value, "Max Discovery Time Delta", kNumberType, doc_out.GetAllocator());
+    Value& mdtd_value = find_or_create(full_scenario_value, "Max Discovery Time Delta", kNumberType, doc_out.GetAllocator());
     mdtd_value.SetDouble(discovery_delta_max);
 
     if (stats_it != doc_in.MemberEnd()) {
@@ -183,7 +198,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       for (Value::ConstMemberIterator ssi = stats_value.MemberBegin(); ssi != stats_value.MemberEnd(); ++ssi) {
         const auto pos = known_stat_names.find(ssi->name.GetString());
         const std::string display_name = pos != known_stat_names.end() ? pos->second : ssi->name.GetString();
-        write_statistic(variety_value, doc_out.GetAllocator(), display_name, ssi->value);
+        write_statistic(full_scenario_value, doc_out.GetAllocator(), display_name, ssi->value);
       }
     }
   }

--- a/performance-tests/bench/example/config/scenario/ci-disco-long.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco-long.json
@@ -1,6 +1,28 @@
 {
   "name": "Continuous Integration Discovery Test",
   "desc": "This is a small slightly-less-quick test for (quiet) discovery capability with many participant processes",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "disco" }
+    },
+    {
+      "name": "Config",
+      "desc": "Discovery Configuration",
+      "value": { "$discriminator": "PK_STRING", "string_param": "RTPS Multicast" }
+    },
+    {
+      "name": "Time",
+      "desc": "Allowed Discovery Time In Seconds",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 60 }
+    },
+    {
+      "name": "Participants",
+      "desc": "Domain Participants",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 20 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-disco-long.json",

--- a/performance-tests/bench/example/config/scenario/ci-disco-relay-only.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco-relay-only.json
@@ -1,6 +1,28 @@
 {
   "name": "Continuous Integration Discovery Test",
   "desc": "This is a small quick test for (quiet) discovery capability via the relay with many participant processes",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "disco" }
+    },
+    {
+      "name": "Config",
+      "desc": "Discovery Configuration",
+      "value": { "$discriminator": "PK_STRING", "string_param": "RtpsRelay Only" }
+    },
+    {
+      "name": "Time",
+      "desc": "Allowed Discovery Time In Seconds",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 30 }
+    },
+    {
+      "name": "Participants",
+      "desc": "Domain Participants",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 2 }
+    }
+  ],
   "any_node": [
     {
       "executable": "RtpsRelay",

--- a/performance-tests/bench/example/config/scenario/ci-disco-relay.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco-relay.json
@@ -1,6 +1,28 @@
 {
   "name": "Continuous Integration Discovery Test",
   "desc": "This is a small quick test for (quiet) discovery capability via the relay with many participant processes",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "disco" }
+    },
+    {
+      "name": "Config",
+      "desc": "Discovery Configuration",
+      "value": { "$discriminator": "PK_STRING", "string_param": "RtpsRelay" }
+    },
+    {
+      "name": "Time",
+      "desc": "Allowed Discovery Time In Seconds",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 30 }
+    },
+    {
+      "name": "Participants",
+      "desc": "Domain Participants",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 2 }
+    }
+  ],
   "any_node": [
     {
       "executable": "RtpsRelay",

--- a/performance-tests/bench/example/config/scenario/ci-disco-repo.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco-repo.json
@@ -1,6 +1,28 @@
 {
   "name": "Continuous Integration Discovery Test",
   "desc": "This is a small quick test for (quiet) discovery capability via the inforepo with many participant processes",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "disco" }
+    },
+    {
+      "name": "Config",
+      "desc": "Discovery Configuration",
+      "value": { "$discriminator": "PK_STRING", "string_param": "InfoRepo" }
+    },
+    {
+      "name": "Time",
+      "desc": "Allowed Discovery Time In Seconds",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 30 }
+    },
+    {
+      "name": "Participants",
+      "desc": "Domain Participants",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 20 }
+    }
+  ],
   "any_node": [
     {
       "executable": "DCPSInfoRepo",

--- a/performance-tests/bench/example/config/scenario/ci-disco.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco.json
@@ -1,6 +1,28 @@
 {
   "name": "Continuous Integration Discovery Test",
   "desc": "This is a small quick test for (quiet) discovery capability with many participant processes",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "disco" }
+    },
+    {
+      "name": "Config",
+      "desc": "Discovery Configuration",
+      "value": { "$discriminator": "PK_STRING", "string_param": "RTPS Multicast" }
+    },
+    {
+      "name": "Time",
+      "desc": "Allowed Discovery Time In Seconds",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 10 }
+    },
+    {
+      "name": "Participants",
+      "desc": "Domain Participants",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 20 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-disco.json",

--- a/performance-tests/bench/example/config/scenario/ci-echo-frag.json
+++ b/performance-tests/bench/example/config/scenario/ci-echo-frag.json
@@ -1,6 +1,18 @@
 {
   "name": "Continuous Integration Rapid-Fire Echo Test",
   "desc": "This is a small quick test for rapid-fire data send / receive capability with large samples (fragmentation)",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "echo" }
+    },
+    {
+      "name": "Bytes",
+      "desc": "Payload Bytes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 100000 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-echo-frag_client.json",

--- a/performance-tests/bench/example/config/scenario/ci-echo.json
+++ b/performance-tests/bench/example/config/scenario/ci-echo.json
@@ -1,6 +1,18 @@
 {
   "name": "Continuous Integration Rapid-Fire Echo Test",
   "desc": "This is a small quick test for rapid-fire data send / receive capability",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "echo" }
+    },
+    {
+      "name": "Bytes",
+      "desc": "Payload Bytes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 100 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-echo_client.json",

--- a/performance-tests/bench/example/config/scenario/ci-fan-frag-ws.json
+++ b/performance-tests/bench/example/config/scenario/ci-fan-frag-ws.json
@@ -1,6 +1,33 @@
 {
   "name": "Continuous Integration Fan-Out / Fan-In Test Using WaitSets",
   "desc": "This is a small quick test for data fan-out / fan-in capability with large samples (fragmentation) that uses waitsets and read conditions for reading data",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "fan" }
+    },
+    {
+      "name": "Bytes",
+      "desc": "Payload Bytes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 256000 }
+    },
+    {
+      "name": "Strategy",
+      "desc": "Message Read Strategy",
+      "value": { "$discriminator": "PK_STRING", "string_param": "WaitSet" }
+    },
+    {
+      "name": "Max Message Size",
+      "desc": "RTPS Transport Configuration Max Message Size",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 1450 }
+    },
+    {
+      "name": "Servers",
+      "desc": "Total Server Count",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 10 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-fan-frag-ws_client.json",

--- a/performance-tests/bench/example/config/scenario/ci-fan-frag.json
+++ b/performance-tests/bench/example/config/scenario/ci-fan-frag.json
@@ -1,6 +1,33 @@
 {
   "name": "Continuous Integration Fan-Out / Fan-In Test",
   "desc": "This is a small quick test for data fan-out / fan-in capability with large samples (fragmentation)",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "fan" }
+    },
+    {
+      "name": "Bytes",
+      "desc": "Payload Bytes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 256000 }
+    },
+    {
+      "name": "Strategy",
+      "desc": "Message Read Strategy",
+      "value": { "$discriminator": "PK_STRING", "string_param": "Listener" }
+    },
+    {
+      "name": "Max Message Size",
+      "desc": "RTPS Transport Configuration Max Message Size",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 65536 }
+    },
+    {
+      "name": "Servers",
+      "desc": "Total Server Count",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 10 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-fan-frag_client.json",

--- a/performance-tests/bench/example/config/scenario/ci-fan-ws.json
+++ b/performance-tests/bench/example/config/scenario/ci-fan-ws.json
@@ -1,6 +1,33 @@
 {
   "name": "Continuous Integration Fan-Out / Fan-In Test Using WaitSet",
   "desc": "This is a small quick test for data fan-out / fan-in capability that uses waitsets and read conditions for reading data",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "fan" }
+    },
+    {
+      "name": "Bytes",
+      "desc": "Payload Bytes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 256 }
+    },
+    {
+      "name": "Strategy",
+      "desc": "Message Read Strategy",
+      "value": { "$discriminator": "PK_STRING", "string_param": "WaitSet" }
+    },
+    {
+      "name": "Max Message Size",
+      "desc": "RTPS Transport Configuration Max Message Size",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 65536 }
+    },
+    {
+      "name": "Servers",
+      "desc": "Total Server Count",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 10 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-fan-ws_client.json",

--- a/performance-tests/bench/example/config/scenario/ci-fan.json
+++ b/performance-tests/bench/example/config/scenario/ci-fan.json
@@ -1,6 +1,33 @@
 {
   "name": "Continuous Integration Fan-Out / Fan-In Test",
   "desc": "This is a small quick test for data fan-out / fan-in capability",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "fan" }
+    },
+    {
+      "name": "Bytes",
+      "desc": "Payload Bytes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 256 }
+    },
+    {
+      "name": "Strategy",
+      "desc": "Message Read Strategy",
+      "value": { "$discriminator": "PK_STRING", "string_param": "Listener" }
+    },
+    {
+      "name": "Max Message Size",
+      "desc": "RTPS Transport Configuration Max Message Size",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 65536 }
+    },
+    {
+      "name": "Servers",
+      "desc": "Total Server Count",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 10 }
+    }
+  ],
   "any_node": [
     {
       "config": "ci-fan_client.json",

--- a/performance-tests/bench/example/config/scenario/ci-mixed.json
+++ b/performance-tests/bench/example/config/scenario/ci-mixed.json
@@ -1,6 +1,23 @@
 {
   "name": "CI Showtime Mixed 5",
   "desc": "This is a small mixed-qos & configuration scenario. Reliable and durable topics are actively used during discovery.",
+  "scenario_parameters": [
+    {
+      "name": "Base",
+      "desc": "Scenario Base",
+      "value": { "$discriminator": "PK_STRING", "string_param": "mixed" }
+    },
+    {
+      "name": "Nodes",
+      "desc": "Worker Nodes",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 5 }
+    },
+    {
+      "name": "Participants",
+      "desc": "Domain Participants",
+      "value": { "$discriminator": "PK_NUMBER", "number_param": 17 }
+    }
+  ],
   "nodes": [
     {
       "workers": [

--- a/performance-tests/bench/idl/Bench.idl
+++ b/performance-tests/bench/idl/Bench.idl
@@ -187,11 +187,30 @@ module Bench {
     };
     typedef sequence<NodePrototype> NodePrototypes;
 
+    enum ParameterKind { PK_NUMBER, PK_STRING, PK_TIME };
+    union ParameterValue switch (ParameterKind) {
+      case PK_NUMBER:
+        double number_param;
+      case PK_STRING:
+        string string_param;
+      case PK_TIME:
+        Builder::TimeStamp time_param;
+    };
+
+    struct Parameter {
+      string name;
+      string desc;
+      ParameterValue value;
+    };
+    typedef sequence<Parameter> ParameterSeq;
+
     // This is the type of the scenario configuration
     struct ScenarioPrototype {
       // Unused Metadata
       string name;
       string desc;
+      // Scenario parameters (for comparison with other scenarios)
+      ParameterSeq scenario_parameters;
       // Workers that must be deployed in sets
       NodePrototypes nodes;
       // Workers that can be assigned to any node
@@ -230,6 +249,8 @@ module Bench {
 
     struct Report {
       string scenario_name;
+      ParameterSeq run_parameters;
+      ParameterSeq scenario_parameters;
       Builder::TimeStamp time;
       NodeReportSeq node_reports;
       unsigned long missing_reports;

--- a/performance-tests/bench/run_test.pl
+++ b/performance-tests/bench/run_test.pl
@@ -10,6 +10,7 @@ use Env (DDS_ROOT);
 use lib "$DDS_ROOT/bin";
 use Env (ACE_ROOT);
 use lib "$ACE_ROOT/bin";
+use Env (TEST_RUN_PARAMS);
 use PerlDDS::Run_Test;
 use strict;
 
@@ -27,6 +28,10 @@ $test->{add_pending_timeout} = 0;
 my $tc_opts = "--wait-for-nodes 7 example";
 my $nc_opts = "one-shot --name test_nc_" . $$;
 my $is_rtps_disc = 0;
+
+if ($TEST_RUN_PARAMS ne "") {
+  $tc_opts .= " $TEST_RUN_PARAMS";
+}
 
 if ($test->flag('--show-worker-logs')) {
   # This should be set for CI & autobuild runs to catch any error messages in worker DDS logs


### PR DESCRIPTION
Problem: The [OpenDDS Performance Dashboard](https://github.com/OpenDDS/opendds-performance-dashboard) currently must attempt to deduce certain kinds of metadata about various bench test scenarios from output filenames. This makes it difficult to add new test scenarios and is prone to breakages when file names change.

Solution: Allow scenarios to specify both "test run" and "scenario" parameter metadata that will get passed through to the test result output, and then eventually through the report_parser and dashboard_summarizer for eventual consumption and use by the OpenDDS Performance Dashboard.

Disclaimer: Merging these changes will cause temporary incompatibilities with the existing performance dashboard, as the output format for the dashboard_summarizer has changed to more-generically represent the new parameter data (removing the old  "scenario" / "variety" hierarchy).

Disclaimer, part 2: Before merging these changes, any existing performance dashboard scenarios should be updated with appropriate scenario parameters (see updates to ci-*.json scenario files for examples) and the dashboard Jenkins instance should be updated to add test run parameters via the test_controller command line (most likely via the run scripts in the test environment).