### PR TITLE
Fix for new compiler warning.  

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -24,19 +24,6 @@
 #include <cstdlib>
 #include <limits>
 
-namespace {
-  u_short get_default_d0(u_short fallback)
-  {
-#if !defined ACE_LACKS_GETENV && !defined ACE_LACKS_ENV
-    const char* from_env = std::getenv("OPENDDS_RTPS_DEFAULT_D0");
-    if (from_env) {
-      return static_cast<u_short>(std::atoi(from_env));
-    }
-#endif
-    return fallback;
-  }
-}
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {


### PR DESCRIPTION
This was from prior PR 3859, where local method was left in original location in addition to being copied to new file:  
https://github.com/objectcomputing/OpenDDS/pull/3859
