### PR TITLE
[Bench] Update Bench Example and CI Configs To Use Unique Partitions

### DIFF
--- a/performance-tests/bench/example/config/worker/ci-disco-long.json
+++ b/performance-tests/bench/example/config/worker/ci-disco-long.json
@@ -81,6 +81,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -113,6 +117,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-disco-relay-only.json
+++ b/performance-tests/bench/example/config/worker/ci-disco-relay-only.json
@@ -90,6 +90,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -122,6 +126,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-disco-relay.json
+++ b/performance-tests/bench/example/config/worker/ci-disco-relay.json
@@ -84,6 +84,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -116,6 +120,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-disco-repo.json
+++ b/performance-tests/bench/example/config/worker/ci-disco-repo.json
@@ -68,6 +68,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -100,6 +104,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-disco.json
+++ b/performance-tests/bench/example/config/worker/ci-disco.json
@@ -81,6 +81,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -113,6 +117,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-echo-frag_client.json
+++ b/performance-tests/bench/example/config/worker/ci-echo-frag_client.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-echo-frag_server.json
+++ b/performance-tests/bench/example/config/worker/ci-echo-frag_server.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/ci-echo_client.json
+++ b/performance-tests/bench/example/config/worker/ci-echo_client.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-echo_server.json
+++ b/performance-tests/bench/example/config/worker/ci-echo_server.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/ci-fan-frag-ws_client.json
+++ b/performance-tests/bench/example/config/worker/ci-fan-frag-ws_client.json
@@ -92,6 +92,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -121,6 +125,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-fan-frag-ws_server.json
+++ b/performance-tests/bench/example/config/worker/ci-fan-frag-ws_server.json
@@ -92,6 +92,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -121,6 +125,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/ci-fan-frag_client.json
+++ b/performance-tests/bench/example/config/worker/ci-fan-frag_client.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-fan-frag_server.json
+++ b/performance-tests/bench/example/config/worker/ci-fan-frag_server.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/ci-fan-ws_client.json
+++ b/performance-tests/bench/example/config/worker/ci-fan-ws_client.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -84,6 +88,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-fan-ws_server.json
+++ b/performance-tests/bench/example/config/worker/ci-fan-ws_server.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -84,6 +88,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/ci-fan_client.json
+++ b/performance-tests/bench/example/config/worker/ci-fan_client.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/ci-fan_server.json
+++ b/performance-tests/bench/example/config/worker/ci-fan_server.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -87,6 +91,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/ci-mixed_daemon.json
+++ b/performance-tests/bench/example/config/worker/ci-mixed_daemon.json
@@ -102,7 +102,7 @@
         "subscribers": [
           { "name": "subscriber_B1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -131,7 +131,7 @@
         "publishers": [
           { "name": "publisher_B1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [
@@ -176,7 +176,7 @@
         "subscribers": [
           { "name": "subscriber_B2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -218,7 +218,7 @@
         "publishers": [
           { "name": "publisher_B2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [

--- a/performance-tests/bench/example/config/worker/ci-mixed_master.json
+++ b/performance-tests/bench/example/config/worker/ci-mixed_master.json
@@ -102,7 +102,7 @@
         "subscribers": [
           { "name": "subscriber_A1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -131,7 +131,7 @@
         "publishers": [
           { "name": "publisher_A1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [
@@ -176,7 +176,7 @@
         "subscribers": [
           { "name": "subscriber_A2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -212,7 +212,7 @@
         "publishers": [
           { "name": "publisher_A2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [

--- a/performance-tests/bench/example/config/worker/ci-mixed_worker.json
+++ b/performance-tests/bench/example/config/worker/ci-mixed_worker.json
@@ -85,7 +85,7 @@
         "subscribers": [
           { "name": "subscriber_C1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -127,7 +127,7 @@
         "publishers": [
           { "name": "publisher_C1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [

--- a/performance-tests/bench/example/config/worker/script.json
+++ b/performance-tests/bench/example/config/worker/script.json
@@ -58,6 +58,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -90,6 +94,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/selfish-echo_client.json
+++ b/performance-tests/bench/example/config/worker/selfish-echo_client.json
@@ -52,6 +52,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/showtime-mixed_daemon.json
+++ b/performance-tests/bench/example/config/worker/showtime-mixed_daemon.json
@@ -102,7 +102,7 @@
         "subscribers": [
           { "name": "subscriber_B1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -126,7 +126,7 @@
         "publishers": [
           { "name": "publisher_B1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [
@@ -166,7 +166,7 @@
         "subscribers": [
           { "name": "subscriber_B2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -198,7 +198,7 @@
         "publishers": [
           { "name": "publisher_B2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [

--- a/performance-tests/bench/example/config/worker/showtime-mixed_master.json
+++ b/performance-tests/bench/example/config/worker/showtime-mixed_master.json
@@ -102,7 +102,7 @@
         "subscribers": [
           { "name": "subscriber_A1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -126,7 +126,7 @@
         "publishers": [
           { "name": "publisher_A1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [
@@ -166,7 +166,7 @@
         "subscribers": [
           { "name": "subscriber_A2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -192,7 +192,7 @@
         "publishers": [
           { "name": "publisher_A2",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [

--- a/performance-tests/bench/example/config/worker/showtime-mixed_worker.json
+++ b/performance-tests/bench/example/config/worker/showtime-mixed_worker.json
@@ -85,7 +85,7 @@
         "subscribers": [
           { "name": "subscriber_C1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datareaders": [
@@ -117,7 +117,7 @@
         "publishers": [
           { "name": "publisher_C1",
 
-            "qos": { "partition": { "name": [ "bench_showtime_mixed" ] } },
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
             "qos_mask": { "partition": { "has_name": true } },
 
             "datawriters": [

--- a/performance-tests/bench/example/config/worker/simple-echo_client.json
+++ b/performance-tests/bench/example/config/worker/simple-echo_client.json
@@ -55,6 +55,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_02",
                 "topic_name": "topic_02",
@@ -69,6 +73,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_01",
                 "topic_name": "topic_01",

--- a/performance-tests/bench/example/config/worker/simple-echo_server.json
+++ b/performance-tests/bench/example/config/worker/simple-echo_server.json
@@ -55,6 +55,10 @@
         ],
         "subscribers": [
           { "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               { "name": "datareader_01",
                 "topic_name": "topic_01",
@@ -69,6 +73,10 @@
         ],
         "publishers": [
           { "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               { "name": "datawriter_02",
                 "topic_name": "topic_02",

--- a/performance-tests/bench/example/config/worker/simple-tags_control.json
+++ b/performance-tests/bench/example/config/worker/simple-tags_control.json
@@ -61,6 +61,10 @@
         "publishers": [
           {
             "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               {
                 "name": "datawriter_control_data",
@@ -80,6 +84,10 @@
         "subscribers": [
           {
             "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               {
                 "name": "datareader_processed_data",

--- a/performance-tests/bench/example/config/worker/simple-tags_processing.json
+++ b/performance-tests/bench/example/config/worker/simple-tags_processing.json
@@ -65,6 +65,10 @@
         "publishers": [
           {
             "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               {
                 "name": "datawriter_processed_data",
@@ -84,6 +88,10 @@
         "subscribers": [
           {
             "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               {
                 "name": "datareader_raw_data",

--- a/performance-tests/bench/example/config/worker/simple-tags_raw.json
+++ b/performance-tests/bench/example/config/worker/simple-tags_raw.json
@@ -61,6 +61,10 @@
         "publishers": [
           {
             "name": "publisher_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datawriters": [
               {
                 "name": "datawriter_raw_data",
@@ -80,6 +84,10 @@
         "subscribers": [
           {
             "name": "subscriber_01",
+
+            "qos": { "partition": { "name": [ "bench_partition" ] } },
+            "qos_mask": { "partition": { "has_name": true } },
+
             "datareaders": [
               {
                 "name": "datareader_control_data",


### PR DESCRIPTION
Problem: The bench test scenarios should ideally run in their own unique partitions to avoid accidental interactions with other active bench scenarios configured in such a way that they are mutually discoverable. This is the intended purpose of the `test_controller`'s "bench partition suffix". However, this suffix is only applied to partitions that begin with the "bench_" prefix, and currently the only scenario worker config files using such a partition are the "mixed" scenarios. Ideally, these should be universally used by example and CI scenario worker configuration files in order to avoid any cross-talk during normal, CI, or scoreboard testing. Any scenarios that don't provide a "bench_" partition do so at their own peril (or if they are certain they really need empty partitions, for some reason).

Solution: Update example and CI bench scenario worker configs to all use a "bench_partition" partition which will get the unique partition suffix added by the test_controller.