### PR TITLE
TypeSupportInitializer is also needed in FACE TS

### DIFF
--- a/dds/idl/ts_generator.cpp
+++ b/dds/idl/ts_generator.cpp
@@ -506,6 +506,9 @@ namespace face_ts_generator {
       "  OpenDDS::FaceTSS::register_callback(connection_id, waitset,\n"
       "                                      data_callback,\n"
       "                                      max_message_size, return_code);\n"
+      "}\n\n"
+      "namespace {\n"
+      "  OpenDDS::DCPS::TypeSupportInitializer<" << cxx_name << "TypeSupportImpl> ts_init_" << name_underscores << ";\n"
       "}\n\n";
   }
 }


### PR DESCRIPTION
The approach added in #3736 was changed in #3871.  Those modifications worked for most cases except for static builds using the FACE Transport Services API.  This PR adds the TypeSupportInitializer to the generated FACE TS compilation unit so that when the middleware library looks in Registered_Data_Types the generated TypeSupport object will be there.