### PR TITLE
Skip TypeSupportPlugin When dlclose is Broken

### DIFF
--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -499,4 +499,4 @@ tests/DCPS/HelloWorld/run_test.pl ini=rtps.ini: RTPS !OPENDDS_SAFETY_PROFILE
 
 tests/DCPS/ZeroEnum/run_test.pl: !OPENDDS_SAFETY_PROFILE
 
-tests/DCPS/TypeSupportPlugin/run_test.pl: !DCPS_MIN
+tests/DCPS/TypeSupportPlugin/run_test.pl: !DCPS_MIN !BROKEN_DLCLOSE


### PR DESCRIPTION
This is the same problem as in https://github.com/objectcomputing/OpenDDS/pull/3520