### PR TITLE
Add SpdpRequestRandomPort

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -322,6 +322,17 @@ RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
                              -1);
           }
           config->spdp_local_address(addr);
+        } else if (name == "SpdpRequestRandomPort") {
+          const OPENDDS_STRING& value = it->second;
+          int smInt = 0;
+          if (!DCPS::convertToInteger(value, smInt)) {
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("(%P|%t) RtpsDiscovery::Config::discovery_config ")
+                              ACE_TEXT("Invalid entry (%C) for SpdpRequestRandomPort in ")
+                              ACE_TEXT("[rtps_discovery/%C] section.\n"),
+                              value.c_str(), rtps_name.c_str()), -1);
+          }
+          config->spdp_request_random_port(bool(smInt));
         } else if (name == "GuidInterface") {
           config->guid_interface(it->second);
         } else if (name == "InteropMulticastOverride") {

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -59,6 +59,7 @@ RtpsDiscoveryConfig::RtpsDiscoveryConfig()
   , ipv6_spdp_local_address_(u_short(0), "::")
   , ipv6_default_multicast_group_(u_short(0), "FF03::1")
 #endif
+  , spdp_request_random_port_(false)
   , max_auth_time_(300, 0)
   , auth_resend_period_(1, 0)
   , max_spdp_sequence_msg_reset_check_(3)

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -390,15 +390,13 @@ public:
 
 #endif
 
-  AddrVec spdp_send_addrs() const
+  bool spdp_request_random_port() const
   {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, AddrVec());
-    return spdp_send_addrs_;
+    return spdp_request_random_port_;
   }
-  void spdp_send_addrs(const AddrVec& addrs)
+  void spdp_request_random_port(bool f)
   {
-    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    spdp_send_addrs_ = addrs;
+    spdp_request_random_port_ = f;
   }
 
   OPENDDS_STRING guid_interface() const
@@ -410,6 +408,17 @@ public:
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
     guid_interface_ = gi;
+  }
+
+  AddrVec spdp_send_addrs() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, AddrVec());
+    return spdp_send_addrs_;
+  }
+  void spdp_send_addrs(const AddrVec& addrs)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+    spdp_send_addrs_ = addrs;
   }
 
   DCPS::TimeDuration max_auth_time() const
@@ -747,6 +756,7 @@ private:
   ACE_INET_Addr ipv6_sedp_local_address_, ipv6_sedp_advertised_address_, ipv6_spdp_local_address_;
   ACE_INET_Addr ipv6_default_multicast_group_;
 #endif
+  AtomicBool spdp_request_random_port_;
   OPENDDS_STRING guid_interface_;
   AddrVec spdp_send_addrs_;
   DCPS::TimeDuration max_auth_time_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3420,7 +3420,7 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
   }
 
   if (!fixed_port && outer->config_->spdp_request_random_port()) {
-    ACE_INET_Addr addr = ACE_INET_Addr();
+    ACE_INET_Addr addr;
     if (unicast_socket_.get_local_addr(addr) == 0) {
       uni_port_ = addr.get_port_number();
     }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3420,7 +3420,7 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
   }
 
   if (!fixed_port && outer->config_->spdp_request_random_port()) {
-    ACE_INET_Addr addr{};
+    ACE_INET_Addr addr = ACE_INET_Addr();
     if (unicast_socket_.get_local_addr(addr) == 0) {
       uni_port_ = addr.get_port_number();
     }

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3394,7 +3394,7 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
 
   if (fixed_port) {
     uni_port_ = local_addr.get_port_number();
-  } else {
+  } else if (!outer->config_->spdp_request_random_port()) {
     uni_port_ = port_common + outer->config_->d1() + (outer->config_->pg() * participant_id);
     local_addr.set_port_number(uni_port_);
   }
@@ -3417,6 +3417,13 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
                  DCPS::LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
     }
     return false;
+  }
+
+  if (!fixed_port && outer->config_->spdp_request_random_port()) {
+    ACE_INET_Addr addr{};
+    if (unicast_socket_.get_local_addr(addr) == 0) {
+      uni_port_ = addr.get_port_number();
+    }
   }
 
   if (DCPS::DCPS_debug_level > 3) {


### PR DESCRIPTION
Add a flag to SPDP to request a random SPDP source (unicast) port number (when SpdpLocalAddress does not reqest a specific port) rather than attempting to use the RTPS specification's formula for "well known" unicast port numbers.