### PR TITLE
Update RtpsRelay alive and active Timestamps To Use SystemTimePoint

### DIFF
--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -6,8 +6,9 @@ void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
                                                      const OpenDDS::DCPS::GUID_t& repoid,
                                                      const DDS::ParticipantBuiltinTopicData& data)
 {
-  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
-  const DDS::Time_t timestamp = now.to_dds_time();
+  const auto monotonic_now = OpenDDS::DCPS::MonotonicTimePoint::now();
+  const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
+  const DDS::Time_t timestamp = system_now.to_dds_time();
 
   RelayParticipantStatus status;
   status.relay_id(config_.relay_id());
@@ -33,20 +34,20 @@ void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
         ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::add_participant "
                    "add local participant %C %C %C into session\n",
                    guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-                   proxy.get_session_time(repoid, now).sec_str().c_str()));
+                   proxy.get_session_time(repoid, monotonic_now).sec_str().c_str()));
       }
     } else {
       p.first->second = status;
     }
 
-    stats_reporter_.local_participants(guids_.size(), now);
+    stats_reporter_.local_participants(guids_.size(), monotonic_now);
   }
 }
 
 void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& proxy,
                                                         const OpenDDS::DCPS::GUID_t& repoid)
 {
-  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+  const auto monotonic_now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -67,21 +68,21 @@ void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& prox
     ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::remove_participant "
                "remove local participant %C %C into session\n",
                guid_to_string(repoid).c_str(),
-               proxy.get_session_time(repoid, now).sec_str().c_str()));
+               proxy.get_session_time(repoid, monotonic_now).sec_str().c_str()));
   }
 
-  proxy.remove(repoid, now, nullptr);
+  proxy.remove(repoid, monotonic_now, nullptr);
 
   guids_.erase(pos);
 
-  stats_reporter_.local_participants(guids_.size(), now);
+  stats_reporter_.local_participants(guids_.size(), monotonic_now);
 }
 
 void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy*/,
                                                const OpenDDS::DCPS::GUID_t& repoid,
                                                bool alive)
 {
-  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+  const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
 
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -96,7 +97,7 @@ void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy
   }
 
   pos->second.alive(alive);
-  pos->second.alive_ts(now.to_dds_time());
+  pos->second.alive_ts(system_now.to_dds_time());
 
   if (writer_->write(pos->second, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
@@ -108,7 +109,7 @@ void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*prox
                                                 const OpenDDS::DCPS::GUID_t& repoid,
                                                 bool active)
 {
-  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+  const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
 
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -123,7 +124,7 @@ void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*prox
   }
 
   pos->second.active(active);
-  pos->second.active_ts(now.to_dds_time());
+  pos->second.active_ts(system_now.to_dds_time());
 
   if (writer_->write(pos->second, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: "
@@ -136,7 +137,7 @@ void RelayParticipantStatusReporter::set_alive_active(const GuidAddrSet::Proxy& 
                                                       bool alive,
                                                       bool active)
 {
-  const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
+  const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
 
   ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -150,7 +151,7 @@ void RelayParticipantStatusReporter::set_alive_active(const GuidAddrSet::Proxy& 
     return;
   }
 
-  const DDS::Time_t timestamp = now.to_dds_time();
+  const DDS::Time_t timestamp = system_now.to_dds_time();
   if (pos->second.alive() != alive) {
     pos->second.alive(alive);
     pos->second.alive_ts(timestamp);


### PR DESCRIPTION
Problem: RtpsRelay active_ts and alive_ts statistics are using MonotonicTimePoint for their timestamps. which are not ideal for comparison between processes / machines.

Solution: Use SystemTimePoint for these values.