### PR TITLE
Fix 'sanitize' optimization levels for clang builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3254,7 +3254,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c11_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3536,7 +3536,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c11_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev
@@ -3808,7 +3808,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.job }}.tar.xz
-        key: c10_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
+        key: c11_${{ github.job }}_ace6tao2_${{ env.ACE_COMMIT }}_${{ env.COMPILER_VERSION }}
     - name: install xerces
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       run: sudo apt-get -y install libxerces-c-dev

--- a/configure
+++ b/configure
@@ -1042,7 +1042,7 @@ sub write_config_h {
   my %buildEnv = %{shift()};
   my $platform = $opts{$buildEnv{'build'}};
   my $pi = $platforminfo{$platform};
-  $opts{'optimize'} = 0 if (!exists $opts{'optimize'} || exists $opts{'sanitize'});
+  $opts{'optimize'} = 0 if (!(exists $opts{'optimize'} || exists $opts{'sanitize'}));
 
   my $CFGH = backup_and_open("$buildEnv{'ACE_ROOT'}/ace/config.h");
   if ($buildEnv{'build'} eq 'target') {

--- a/configure
+++ b/configure
@@ -1042,7 +1042,7 @@ sub write_config_h {
   my %buildEnv = %{shift()};
   my $platform = $opts{$buildEnv{'build'}};
   my $pi = $platforminfo{$platform};
-  $opts{'optimize'} = 0 if (!(exists $opts{'optimize'} || exists $opts{'sanitize'}));
+  $opts{'optimize'} = 0 if (!exists $opts{'optimize'} && !exists $opts{'sanitize'});
 
   my $CFGH = backup_and_open("$buildEnv{'ACE_ROOT'}/ace/config.h");
   if ($buildEnv{'build'} eq 'target') {


### PR DESCRIPTION
Problems:
- ACE_TAO handles placement of optimization compiler flags (`-O3` or `-O0`, etc) slightly differently between gcc and clang platforms.
- The configure script currently attempts to default the `optimize` option (and ACE macro) to `0` (off) if either:
  - The user did not specify an optimization level on the command line
  - OR the user specified a sanitize option on the command line (with the thought that the sanitizer compiler args (which get added to `CPP_FLAGS`) will eventually override any arguments generated from an `optimize` option/macro of `0`)
- Unfortunately, this assumption only works for gcc because the clang platform will wind up overriding any optimization level set in `CPP_FLAGS` with its own `-O0`.
- As a result, we're currently running our sanitizer CI builds (which all use clang) with zero optimizations turned on, which is not the preferred method (the majority of the sanitizers suggest using `-O1` which increases performance to compensate for sanitizer slowdown without significantly altering the stack traces returned by the sanitizer reports).
- To an example of a problematic compile line, see [here](https://github.com/objectcomputing/OpenDDS/actions/runs/3589605618/jobs/6042203968#step:11:21)

Solution:
The "correct" way to solve this probably lies in restructuring how ACE handles optimization levels for gcc and clang to have more nuance than a simple on-or-off state, and to make sure the optimization behavior between the two platforms is relatively consistent. That is perhaps worth opening an issue against either ACE_TAO or MPC.

In the mean time, this is a temporary fix to avoid setting `optimize` entirely when the `sanitize` option is used in order to make sure that both gcc and clang's default optimization flags are overridden by the optimization flags provided by the sanitizer compiler args from the configure script.