### PR TITLE
Revert Lint Workflow Back To actions-setup-perl v1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
         ref: ace6tao2
         path: ${{ env.DOC_ROOT }}
     - name: Install Perl Dependencies
-      uses: shogo82148/actions-setup-perl@v1.19.0
+      uses: shogo82148/actions-setup-perl@v1
       with:
         install-modules: |
           YAML


### PR DESCRIPTION
Now that the `.python_version` missing file issue seems to have been fixed in v1.20.1 (and v1 tag updated), revert back to v1 tag for our lint workflow to keep up-to-date with newer versions.