### PR TITLE
Misc Cleanup For Reference Counting Of DataReaders

### DIFF
--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1820,7 +1820,7 @@ void store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_data,
       }
       OpenDDS::DCPS::SubscriptionInstance_rch instance =
         OpenDDS::DCPS::make_rch<OpenDDS::DCPS::SubscriptionInstance>(
-          this,
+          rchandle_from(this),
           qos_,
           ref(instances_lock_),
           handle, owns_handle);

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -25,7 +25,7 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-InstanceState::InstanceState(DataReaderImpl* reader,
+InstanceState::InstanceState(const DataReaderImpl_rch& reader,
                              ACE_Recursive_Thread_Mutex& lock,
                              DDS::InstanceHandle_t handle)
   : ReactorInterceptor(TheServiceParticipant->reactor(),
@@ -38,7 +38,7 @@ InstanceState::InstanceState(DataReaderImpl* reader,
     empty_(true),
     release_pending_(false),
     release_timer_id_(-1),
-    reader_(*reader),
+    reader_(reader),
     handle_(handle),
     owner_(GUID_UNKNOWN),
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE

--- a/dds/DCPS/InstanceState.h
+++ b/dds/DCPS/InstanceState.h
@@ -28,10 +28,13 @@ namespace OpenDDS {
 namespace DCPS {
 
 class DataReaderImpl;
-class ReceivedDataElement;
+typedef RcHandle<DataReaderImpl> DataReaderImpl_rch;
+typedef WeakRcHandle<DataReaderImpl> DataReaderImpl_wrch;
 
 class InstanceState;
 typedef RcHandle<InstanceState> InstanceState_rch;
+
+class ReceivedDataElement;
 
 /**
  * @class InstanceState
@@ -46,7 +49,7 @@ typedef RcHandle<InstanceState> InstanceState_rch;
  */
 class OpenDDS_Dcps_Export InstanceState : public ReactorInterceptor {
 public:
-  InstanceState(DataReaderImpl* reader,
+  InstanceState(const DataReaderImpl_rch& reader,
                 ACE_Recursive_Thread_Mutex& lock,
                 DDS::InstanceHandle_t handle);
 

--- a/dds/DCPS/LinuxNetworkConfigMonitor.h
+++ b/dds/DCPS/LinuxNetworkConfigMonitor.h
@@ -38,12 +38,14 @@ public:
 private:
   class OpenHandler : public ReactorInterceptor::Command {
   public:
-    OpenHandler(WeakRcHandle<LinuxNetworkConfigMonitor> lncm)
+    OpenHandler(const RcHandle<LinuxNetworkConfigMonitor>& lncm)
       : lncm_(lncm)
       , condition_(mutex_)
       , done_(false)
       , retval_(false)
     {}
+
+    virtual ~OpenHandler() {}
 
     bool wait() const;
 
@@ -61,12 +63,14 @@ private:
 
   class CloseHandler : public ReactorInterceptor::Command {
   public:
-    CloseHandler(WeakRcHandle<LinuxNetworkConfigMonitor> lncm)
+    CloseHandler(const RcHandle<LinuxNetworkConfigMonitor>& lncm)
       : lncm_(lncm)
       , condition_(mutex_)
       , done_(false)
       , retval_(false)
     {}
+
+    virtual ~CloseHandler() {}
 
     bool wait() const;
 

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -54,7 +54,7 @@ void OpenDDS::DCPS::ReceivedDataElement::operator delete(void* memory, ACE_New_A
   operator delete(memory);
 }
 
-OpenDDS::DCPS::ReceivedDataElementList::ReceivedDataElementList(DataReaderImpl* reader, InstanceState_rch instance_state)
+OpenDDS::DCPS::ReceivedDataElementList::ReceivedDataElementList(const DataReaderImpl_rch& reader, const InstanceState_rch& instance_state)
   : reader_(reader), head_(0), tail_(0), size_(0)
   , read_sample_count_(0), not_read_sample_count_(0), sample_states_(0)
   , instance_state_(instance_state)
@@ -270,7 +270,10 @@ void OpenDDS::DCPS::ReceivedDataElementList::increment_read_count()
 {
   if (!read_sample_count_) {
     sample_states_ |= DDS::READ_SAMPLE_STATE;
-    reader_->state_updated(instance_state_->instance_handle());
+    DataReaderImpl_rch reader(reader_.lock());
+    if (reader) {
+      reader->state_updated(instance_state_->instance_handle());
+    }
   }
   ++read_sample_count_;
 }
@@ -281,7 +284,10 @@ void OpenDDS::DCPS::ReceivedDataElementList::decrement_read_count()
   --read_sample_count_;
   if (!read_sample_count_) {
     sample_states_ &= (~DDS::READ_SAMPLE_STATE);
-    reader_->state_updated(instance_state_->instance_handle());
+    DataReaderImpl_rch reader(reader_.lock());
+    if (reader) {
+      reader->state_updated(instance_state_->instance_handle());
+    }
   }
 }
 
@@ -289,7 +295,10 @@ void OpenDDS::DCPS::ReceivedDataElementList::increment_not_read_count()
 {
   if (!not_read_sample_count_) {
     sample_states_ |= DDS::NOT_READ_SAMPLE_STATE;
-    reader_->state_updated(instance_state_->instance_handle());
+    DataReaderImpl_rch reader(reader_.lock());
+    if (reader) {
+      reader->state_updated(instance_state_->instance_handle());
+    }
   }
   ++not_read_sample_count_;
 }
@@ -300,7 +309,10 @@ void OpenDDS::DCPS::ReceivedDataElementList::decrement_not_read_count()
   --not_read_sample_count_;
   if (!not_read_sample_count_) {
     sample_states_ &= (~DDS::NOT_READ_SAMPLE_STATE);
-    reader_->state_updated(instance_state_->instance_handle());
+    DataReaderImpl_rch reader(reader_.lock());
+    if (reader) {
+      reader->state_updated(instance_state_->instance_handle());
+    }
   }
 }
 

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -205,7 +205,7 @@ public:
 
 class OpenDDS_Dcps_Export ReceivedDataElementList {
 public:
-  explicit ReceivedDataElementList(DataReaderImpl*, InstanceState_rch instance_state = InstanceState_rch());
+  explicit ReceivedDataElementList(const DataReaderImpl_rch& reader, const InstanceState_rch& instance_state = InstanceState_rch());
 
   ~ReceivedDataElementList();
 
@@ -238,7 +238,7 @@ public:
 #endif
 
 private:
-  DataReaderImpl* reader_;
+  DataReaderImpl_wrch reader_;
 
   /// The first element of the list.
   ReceivedDataElement* head_;

--- a/dds/DCPS/SubscriptionInstance.cpp
+++ b/dds/DCPS/SubscriptionInstance.cpp
@@ -14,12 +14,12 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-SubscriptionInstance::SubscriptionInstance(DataReaderImpl* reader,
+SubscriptionInstance::SubscriptionInstance(const DataReaderImpl_rch& reader,
                                            const DDS::DataReaderQos& qos,
                                            ACE_Recursive_Thread_Mutex& lock,
                                            DDS::InstanceHandle_t handle,
                                            bool owns_handle)
-  : instance_state_(make_rch<InstanceState>(reader, ref(lock), handle))
+  : instance_state_(make_rch<InstanceState>(ref(reader), ref(lock), handle))
   , rcvd_samples_(reader, instance_state_)
   , read_sample_count_(0)
   , not_read_sample_count_(0)

--- a/dds/DCPS/SubscriptionInstance.h
+++ b/dds/DCPS/SubscriptionInstance.h
@@ -35,13 +35,13 @@ class DataReaderImpl;
   */
 class OpenDDS_Dcps_Export SubscriptionInstance : public virtual RcObject {
 public:
-  SubscriptionInstance(DataReaderImpl* reader,
+  SubscriptionInstance(const DataReaderImpl_rch& reader,
                        const DDS::DataReaderQos& qos,
                        ACE_Recursive_Thread_Mutex& lock,
                        DDS::InstanceHandle_t handle,
                        bool owns_handle);
 
-  ~SubscriptionInstance();
+  virtual ~SubscriptionInstance();
 
   bool matches(CORBA::ULong sample_states, CORBA::ULong view_states, CORBA::ULong instance_states) const;
 


### PR DESCRIPTION
Problem: Many classes in the DCPS layer make use of raw pointers for objects which already inherit from RcObject. Particularly, SubscriptionInstance and InstanceState have pointers to DataReaderImpl. The preferred approach is to make use of WeakRcHandles when possible to take advantage of the safety / reliability that comes from reference counting.

Solution: Convert several of these classes over to use WeakRcHandles.