### PR TITLE
Check for null pointer when sending a data sample

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -960,7 +960,7 @@ TransportClient::send_i(SendStateDataSampleList send_list, ACE_UINT64 transactio
     }
     DataLinkSet send_links;
 
-    while (true) {
+    while (cur != 0) {
       // VERY IMPORTANT NOTE:
       //
       // We have to be very careful in how we deal with the current


### PR DESCRIPTION
Each `DataSampleElement` has pointer to a `DataSampleElement` that is next to be sent (`next_send_sample_`).  This pointer is mutable and is modified by the friend class `SendStateDataSampleList`.  When the `dequeue` and `dequeue_head` methods are called, the `next_send_sample_` pointer is set to null.

`TransportClient::send_i` takes a `SendStateDataSampleList` which contains a list of `DataSampleElement` pointers.  Inside this method, the first data sample is taken from the head of the send list and inside a while loop, the next element to be sent is read using the `get_next_send_sample()` method called on the current send sample.  In some situations, the next send sample could be null and would cause a crash the next time around the loop.  The simple solution is to change the condition of the while loop from `true` to `cur != 0`.