### PR TITLE
GitHub Actions updates for ishapes demo

### DIFF
--- a/.github/workflows/ishapes.yml
+++ b/.github/workflows/ishapes.yml
@@ -27,17 +27,6 @@ jobs:
         repository: DOCGroup/ACE_TAO
         ref: Latest_Micro
         path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
-      run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: get compiler version
-      shell: bash
-      run: |
-        export COMPILER_VERSION=$(c++ --version 2>&1 | head -n 1)
-        echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
     - name: checkout MPC
       uses: actions/checkout@v3
       with:
@@ -48,7 +37,7 @@ jobs:
         cd OpenDDS
         ./configure --optimize --no-debug --static --tests --qt
         tools/scripts/show_build_config.pl
-    - uses: ammaraskar/gcc-problem-matcher@0.1
+    - uses: ammaraskar/gcc-problem-matcher@0.2.0
     - name: build
       shell: bash
       run: |
@@ -61,7 +50,7 @@ jobs:
         path: OpenDDS/examples/DCPS/ishapes/ishapes
 
   Windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: checkout OpenDDS
       uses: actions/checkout@v3
@@ -74,25 +63,19 @@ jobs:
         repository: DOCGroup/ACE_TAO
         ref: Latest_Micro
         path: OpenDDS/ACE_TAO
-    - name: get ACE_TAO commit
-      shell: bash
+    - name: setup for run-vcpkg
+      shell: cmd
       run: |
-        cd OpenDDS/ACE_TAO
-        export ACE_COMMIT=$(git rev-parse HEAD)
-        echo "ACE_COMMIT=$ACE_COMMIT" >> $GITHUB_ENV
-    - name: get compiler version
-      shell: bash
-      run: |
-        export COMPILER_VERSION=$("C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -property catalog_productDisplayVersion)
-        echo "COMPILER_VERSION=$COMPILER_VERSION" >> $GITHUB_ENV
+        echo { "name": "opendds", "version-string": "github-actions", "dependencies": [ "qt5-base" ] } > vcpkg.json
+        echo VCPKG_DEFAULT_TRIPLET=x64-windows>> %GITHUB_ENV%
+        echo VCPKG_INSTALLED_DIR=${{ github.workspace }}\vcpkg-qt\installed>> %GITHUB_ENV%
     - name: install vcpkg packages
       id: runvcpkg
-      uses: lukka/run-vcpkg@v7
+      uses: lukka/run-vcpkg@v10
       with:
         vcpkgDirectory: '${{ github.workspace }}/vcpkg-qt'
-        vcpkgGitCommitId: b86c0c35b88e2bf3557ff49dc831689c2f085090
-        vcpkgArguments: --recurse qt5-base
-        vcpkgTriplet: x64-windows
+        vcpkgGitCommitId: 6f7ffeb18f99796233b958aaaf14ec7bd4fb64b2
+        runVcpkgInstall: true
     - name: checkout MPC
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
- no need to set up env vars that are never used
- updated gcc-problem-matcher action dependency
- use Windows 2022 base image
- updated run-vcpkg action dependency
- updated vcpkg version used by run-vcpkg