### PR TITLE
Union members cannot be optional

### DIFF
--- a/dds/idl/dynamic_data_adapter_generator.cpp
+++ b/dds/idl/dynamic_data_adapter_generator.cpp
@@ -173,11 +173,13 @@ namespace {
       std::string optional_value;
       if (field != 0 && be_global->is_optional(field)) {
         if (set) {
-          optional_value = value;
-          be_global->impl_ <<
-            "        " << type_name << " temp;\n";
-          rc_dest = "rc = ";
-          value = "temp";
+          if (!union_node) {
+            optional_value = value;
+            be_global->impl_ <<
+              "        " << type_name << " temp;\n";
+            rc_dest = "rc = ";
+            value = "temp";
+          }
         } else {
           be_global->impl_ <<
             "        if (!" << value << ".has_value()) {\n"

--- a/dds/idl/langmap_generator.cpp
+++ b/dds/idl/langmap_generator.cpp
@@ -1601,8 +1601,7 @@ struct Cxx11Generator : GeneratorBase {
 
   static void union_field(AST_UnionBranch* branch)
   {
-    AST_Type* field_type = branch->field_type();
-    const std::string lang_field_type = generator_->map_type(field_type);
+    const std::string lang_field_type = generator_->map_type(branch);
     be_global->lang_header_ <<
       "    " << lang_field_type << " _" << branch->local_name()->get_string()
       << ";\n";
@@ -1612,7 +1611,7 @@ struct Cxx11Generator : GeneratorBase {
   {
     AST_Type* field_type = branch->field_type();
     AST_Type* actual_field_type = resolveActualType(field_type);
-    const std::string lang_field_type = generator_->map_type(field_type);
+    const std::string lang_field_type = generator_->map_type(branch);
     const Classification cls = classify(actual_field_type);
     const char* nm = branch->local_name()->get_string();
 

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -1177,6 +1177,10 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
       minimal_member.common.member_flags |= OpenDDS::XTypes::IS_EXTERNAL;
     }
 
+    if (be_global->is_optional(branch)) {
+      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_OPTIONAL;
+    }
+
     minimal_member.common.type_id = get_minimal_type_identifier(branch->field_type());
 
     for (unsigned long j = 0; j < branch->label_list_length(); ++j) {

--- a/dds/idl/value_writer_generator.cpp
+++ b/dds/idl/value_writer_generator.cpp
@@ -252,7 +252,6 @@ namespace {
                             Intro&,
                             const std::string&)
   {
-    // TODO: Update the arguments when @optional is available.
     const OpenDDS::XTypes::MemberId id = be_global->get_id(dynamic_cast<AST_UnionBranch*>(branch));
     const bool must_understand = be_global->is_effectively_must_understand(branch);
     be_global->impl_ <<
@@ -260,7 +259,8 @@ namespace {
       (must_understand ? "true" : "false") << ", \"" << canonical_name(branch) << "\", false, true))) {\n"
       "      return false;\n"
       "    }\n";
-    generate_write("value." + field_name + "()", field_name, type, "i", 2);
+    const bool is_optional = be_global->is_optional(branch);
+    generate_write("value." + field_name + "()" + (is_optional ? ".value()" : ""), field_name, type, "i", 2);
     be_global->impl_ <<
       "    if (!value_writer.end_union_member()) {\n"
       "      return false;\n"

--- a/docs/news.d/union-members.rst
+++ b/docs/news.d/union-members.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4797
+
+.. news-start-section: Additions
+- Add support for :ref:`xtypes--optional` union members.
+.. news-end-section

--- a/tests/DCPS/Compiler/xcdr/optional.idl
+++ b/tests/DCPS/Compiler/xcdr/optional.idl
@@ -14,4 +14,11 @@ module Optional {
     @optional sequence<int32> seq_field;
     @optional TestStruct struct_field;
   };
+
+  union TestUnion_Octet switch(long) {
+  case 1:
+    @optional short myshort;
+  default:
+    @optional long mylong;
+  };
 };


### PR DESCRIPTION
Problem
-------

Union members cannot be marked `@optional`.

Solution
--------

Add support for `@optional`.  This only applies to the C++11 language mapping.