### PR TITLE
Heartbeat fallback is not reset for new samples

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -3303,6 +3303,7 @@ RtpsUdpDataLink::RtpsWriter::process_acknack(const RTPS::AckNackSubmessage& ackn
       snris_insert(acked_sn == max_seqnum ? leading_readers_ : lagging_readers_, reader);
       previous_acked_sn = acked_sn;
       check_leader_lagger();
+      fallback_.set(initial_fallback_);
       heartbeat_->schedule(fallback_.get());
 
       if (reader->durable_) {
@@ -3863,6 +3864,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const GUID_t& reader_id,
             lagging_readers_[previous_max_sn] = leading_pos->second;
           }
           leading_readers_.erase(leading_pos);
+          fallback_.set(initial_fallback_);
           heartbeat_->schedule(fallback_.get());
         }
       }
@@ -3886,6 +3888,7 @@ RtpsUdpDataLink::RtpsWriter::make_leader_lagger(const GUID_t& reader_id,
       if (acked_sn == previous_max_sn && previous_max_sn != max_sn_) {
         snris_erase(leading_readers_, acked_sn, reader);
         snris_insert(lagging_readers_, reader);
+        fallback_.set(initial_fallback_);
         heartbeat_->schedule(fallback_.get());
       }
     }
@@ -3914,6 +3917,7 @@ RtpsUdpDataLink::RtpsWriter::make_lagger_leader(const ReaderInfo_rch& reader,
   snris_erase(previous_acked_sn == previous_max_sn ? leading_readers_ : lagging_readers_, previous_acked_sn, reader);
   snris_insert(acked_sn == max_sn ? leading_readers_ : lagging_readers_, reader);
   if (acked_sn != max_sn) {
+    fallback_.set(initial_fallback_);
     heartbeat_->schedule(fallback_.get());
   }
 }

--- a/docs/news.d/reset-heartbeat-fallback.rst
+++ b/docs/news.d/reset-heartbeat-fallback.rst
@@ -1,0 +1,5 @@
+.. news-prs: 5048
+
+.. news-start-section: Fixes
+- Reset heartbeat fallback when the sequence number advances.
+.. news-end-section


### PR DESCRIPTION
Problem
-------

Suppose there is a reliable writer with two readers A and B at steady state.  Reader B goes away without disposing/unregistering itself. The writer then writes a sample, sends a heartbeat, and reader A acknowledges. Since reader B does not acknowledge, the writer will continue to send heartbeats with an increasing interval between them (fallback). When A writes again, the fallback is not reset. In the event that the sample was lost, it will take the current fallback between the writer sends a heartbeat and reliability repairs the missing sample.

Solution
--------

Reset the heartbeat fallback when samples are written or the sequence number advances in other ways.