### PR TITLE
InternalDataWriter doesn't set `source_timestamp`

### DIFF
--- a/dds/DCPS/ConfigStoreImpl.cpp
+++ b/dds/DCPS/ConfigStoreImpl.cpp
@@ -107,9 +107,10 @@ String ConfigPair::canonicalize(const String& key)
   return retval;
 }
 
-ConfigStoreImpl::ConfigStoreImpl(ConfigTopic_rch config_topic)
+ConfigStoreImpl::ConfigStoreImpl(ConfigTopic_rch config_topic,
+                                 const TimeSource& time_source)
   : config_topic_(config_topic)
-  , config_writer_(make_rch<InternalDataWriter<ConfigPair> >(datawriter_qos()))
+  , config_writer_(make_rch<InternalDataWriter<ConfigPair> >(datawriter_qos(), time_source))
   , config_reader_(make_rch<InternalDataReader<ConfigPair> >(datareader_qos()))
 {
   config_topic_->connect(config_writer_);

--- a/dds/DCPS/ConfigStoreImpl.h
+++ b/dds/DCPS/ConfigStoreImpl.h
@@ -116,7 +116,8 @@ public:
 #endif
   };
 
-  ConfigStoreImpl(ConfigTopic_rch config_topic);
+  ConfigStoreImpl(ConfigTopic_rch config_topic,
+                  const TimeSource& time_source);
   ~ConfigStoreImpl();
 
   DDS::Boolean has(const char* key);

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -141,7 +141,7 @@ InfoRepoDiscovery::InfoRepoDiscovery(const String& name)
   , config_prefix_(ConfigPair::canonicalize("REPOSITORY_" + name))
   , use_bidir_giop_(TheServiceParticipant->use_bidir_giop())
   , orb_from_user_(false)
-  , config_store_(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic()))
+  , config_store_(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic(), TheServiceParticipant->time_source()))
 {
   init_bidir_giop();
 }
@@ -153,7 +153,7 @@ InfoRepoDiscovery::InfoRepoDiscovery(const String& name,
   , info_(info)
   , use_bidir_giop_(TheServiceParticipant->use_bidir_giop())
   , orb_from_user_(false)
-  , config_store_(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic()))
+  , config_store_(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic(), TheServiceParticipant->time_source()))
 {
   init_bidir_giop();
 }

--- a/dds/DCPS/InternalDataReader.h
+++ b/dds/DCPS/InternalDataReader.h
@@ -41,6 +41,7 @@ typedef OPENDDS_VECTOR(DDS::SampleInfo) InternalSampleInfoSequence;
 inline DDS::SampleInfo make_sample_info(DDS::SampleStateKind sample_state,
                                         DDS::ViewStateKind view_state,
                                         DDS::InstanceStateKind instance_state,
+                                        const DDS::Time_t& source_timestamp,
                                         CORBA::Long disposed_generation_count,
                                         CORBA::Long no_writers_generation_count,
                                         CORBA::Long sample_rank,
@@ -52,7 +53,7 @@ inline DDS::SampleInfo make_sample_info(DDS::SampleStateKind sample_state,
   si.sample_state = sample_state;
   si.view_state = view_state;
   si.instance_state = instance_state;
-  si.source_timestamp = make_time_t(0, 0); // TODO
+  si.source_timestamp = source_timestamp;
   si.instance_handle = DDS::HANDLE_NIL; // TODO
   si.publication_handle = DDS::HANDLE_NIL; // TODO
   si.disposed_generation_count = disposed_generation_count;
@@ -114,7 +115,9 @@ public:
   /// @{
   bool durable() const { return qos_.durability.kind == DDS::TRANSIENT_LOCAL_DURABILITY_QOS; }
 
-  void remove_publication(InternalEntity_wrch publication_handle, bool autodispose_unregistered_instances)
+  void remove_publication(InternalEntity_wrch publication_handle,
+                          bool autodispose_unregistered_instances,
+                          const DDS::Time_t& source_timestamp)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -122,10 +125,10 @@ public:
     bool schedule = false;
     for (typename InstanceMap::iterator pos = instance_map_.begin(), limit = instance_map_.end(); pos != limit; ++pos) {
       if (pos->second.is_publication(publication_handle)) {
-        if (autodispose_unregistered_instances && pos->second.dispose(publication_handle, qos_)) {
+        if (autodispose_unregistered_instances && pos->second.dispose(publication_handle, source_timestamp, qos_)) {
           schedule = true;
         }
-        if (pos->second.unregister_instance(publication_handle, qos_)) {
+        if (pos->second.unregister_instance(publication_handle, source_timestamp, qos_)) {
           schedule = true;
         }
       }
@@ -140,12 +143,12 @@ public:
     }
   }
 
-  void write(InternalEntity_wrch publication_handle, const T& sample)
+  void write(InternalEntity_wrch publication_handle, const T& sample, const DDS::Time_t& source_timestamp)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
     const std::pair<typename InstanceMap::iterator, bool> p = instance_map_.insert(std::make_pair(sample, Instance()));
-    p.first->second.write(publication_handle, sample, qos_);
+    p.first->second.write(publication_handle, sample, source_timestamp, qos_);
 
     const Listener_rch listener = listener_.lock();
     if (listener) {
@@ -153,7 +156,7 @@ public:
     }
   }
 
-  void dispose(InternalEntity_wrch publication_handle, const T& sample)
+  void dispose(InternalEntity_wrch publication_handle, const T& sample, const DDS::Time_t& source_timestamp)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -162,7 +165,7 @@ public:
       return;
     }
 
-    if (pos->second.dispose(publication_handle, qos_)) {
+    if (pos->second.dispose(publication_handle, source_timestamp, qos_)) {
       const Listener_rch listener = listener_.lock();
       if (listener) {
         listener->schedule(rchandle_from(this));
@@ -170,7 +173,7 @@ public:
     }
   }
 
-  void unregister_instance(InternalEntity_wrch publication_handle, const T& sample)
+  void unregister_instance(InternalEntity_wrch publication_handle, const T& sample, const DDS::Time_t& source_timestamp)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
@@ -179,7 +182,7 @@ public:
       return;
     }
 
-    if (pos->second.unregister_instance(publication_handle, qos_)) {
+    if (pos->second.unregister_instance(publication_handle, source_timestamp, qos_)) {
       const Listener_rch listener = listener_.lock();
       if (listener) {
         listener->schedule(rchandle_from(this));
@@ -326,6 +329,8 @@ private:
       , no_writers_generation_count_(0)
       , informed_of_not_alive_(false)
     {
+      instance_state_change_.sec = 0;
+      instance_state_change_.nanosec = 0;
       disposed_expiration_date_.sec = 0;
       disposed_expiration_date_.nanosec = 0;
       no_writers_expiration_date_.sec = 0;
@@ -387,7 +392,7 @@ private:
         for (typename SampleList::const_iterator pos = read_samples_.begin(), limit = read_samples_.end();
              pos != limit && (max_samples == DDS::LENGTH_UNLIMITED || sample_count < max_samples); ++pos) {
           samples.push_back(pos->sample);
-          infos.push_back(make_sample_info(DDS::READ_SAMPLE_STATE, view_state_, instance_state_, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
+          infos.push_back(make_sample_info(DDS::READ_SAMPLE_STATE, view_state_, instance_state_, pos->source_timestamp, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
           ++sample_count;
         }
       }
@@ -397,7 +402,7 @@ private:
         for (typename SampleList::iterator limit = not_read_samples_.end();
              pos != limit && (max_samples == DDS::LENGTH_UNLIMITED || sample_count < max_samples); ++pos) {
           samples.push_back(pos->sample);
-          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
+          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, pos->source_timestamp, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
           ++sample_count;
         }
         read_samples_.splice(read_samples_.end(), not_read_samples_, not_read_samples_.begin(), pos);
@@ -407,7 +412,7 @@ private:
             instance_state_ != DDS::ALIVE_INSTANCE_STATE &&
             !informed_of_not_alive_) {
           samples.push_back(key);
-          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, disposed_generation_count_, no_writers_generation_count_, 0, 0, 0, false));
+          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, instance_state_change_, disposed_generation_count_, no_writers_generation_count_, 0, 0, 0, false));
           ++sample_count;
         }
       }
@@ -439,7 +444,7 @@ private:
         for (typename SampleList::iterator limit = read_samples_.end();
              pos != limit && (max_samples == DDS::LENGTH_UNLIMITED || sample_count < max_samples); ++pos) {
           samples.push_back(pos->sample);
-          infos.push_back(make_sample_info(DDS::READ_SAMPLE_STATE, view_state_, instance_state_, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
+          infos.push_back(make_sample_info(DDS::READ_SAMPLE_STATE, view_state_, instance_state_, pos->source_timestamp, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
           ++sample_count;
         }
         read_samples_.erase(read_samples_.begin(), pos);
@@ -450,7 +455,7 @@ private:
         for (typename SampleList::iterator limit = not_read_samples_.end();
              pos != limit && (max_samples == DDS::LENGTH_UNLIMITED || sample_count < max_samples); ++pos) {
           samples.push_back(pos->sample);
-          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
+          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, pos->source_timestamp, pos->disposed_generation_count, pos->no_writers_generation_count, 0, 0, 0, true));
           ++sample_count;
         }
         not_read_samples_.erase(not_read_samples_.begin(), pos);
@@ -460,7 +465,7 @@ private:
             instance_state_ != DDS::ALIVE_INSTANCE_STATE &&
             !informed_of_not_alive_) {
           samples.push_back(key);
-          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, disposed_generation_count_, no_writers_generation_count_, 0, 0, 0, false));
+          infos.push_back(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, view_state_, instance_state_, instance_state_change_, disposed_generation_count_, no_writers_generation_count_, 0, 0, 0, false));
           ++sample_count;
         }
       }
@@ -475,6 +480,7 @@ private:
 
     void write(InternalEntity_wrch publication_handle,
                const T& sample,
+               const DDS::Time_t& source_timestamp,
                const DDS::DataReaderQos& qos)
     {
       publication_set_.insert(publication_handle);
@@ -495,6 +501,7 @@ private:
       }
 
       instance_state_ = DDS::ALIVE_INSTANCE_STATE;
+      instance_state_change_ = source_timestamp;
 
       if (qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS) {
         while (read_samples_.size() + not_read_samples_.size() >= static_cast<size_t>(qos.history.depth)) {
@@ -506,16 +513,18 @@ private:
         }
       }
 
-      not_read_samples_.push_back(SampleHolder(sample, disposed_generation_count_, no_writers_generation_count_));
+      not_read_samples_.push_back(SampleHolder(sample, source_timestamp, disposed_generation_count_, no_writers_generation_count_));
     }
 
     bool dispose(InternalEntity_wrch publication_handle,
+                 const DDS::Time_t& source_timestamp,
                  const DDS::DataReaderQos& qos)
     {
       publication_set_.insert(publication_handle);
 
       if (instance_state_ == DDS::ALIVE_INSTANCE_STATE) {
         instance_state_ = DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
+        instance_state_change_ = source_timestamp;
         disposed_expiration_date_ = SystemTimePoint::now().to_idl_struct() + qos.reader_data_lifecycle.autopurge_disposed_samples_delay;
         informed_of_not_alive_ = false;
         return true;
@@ -525,12 +534,14 @@ private:
     }
 
     bool unregister_instance(InternalEntity_wrch publication_handle,
+                             const DDS::Time_t& source_timestamp,
                              const DDS::DataReaderQos& qos)
     {
       publication_set_.erase(publication_handle);
 
       if (publication_set_.empty() && instance_state_ == DDS::ALIVE_INSTANCE_STATE) {
         instance_state_ = DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE;
+        instance_state_change_ = source_timestamp;
         no_writers_expiration_date_ = SystemTimePoint::now().to_idl_struct() + qos.reader_data_lifecycle.autopurge_nowriter_samples_delay;
         informed_of_not_alive_ = false;
         return true;
@@ -542,13 +553,16 @@ private:
   private:
     struct SampleHolder {
       T sample;
+      DDS::Time_t source_timestamp;
       CORBA::Long disposed_generation_count;
       CORBA::Long no_writers_generation_count;
 
       SampleHolder(const T& s,
+                   const DDS::Time_t& st,
                    CORBA::Long dgc,
                    CORBA::Long nwgc)
         : sample(s)
+        , source_timestamp(st)
         , disposed_generation_count(dgc)
         , no_writers_generation_count(nwgc)
       {}
@@ -562,6 +576,7 @@ private:
 
     DDS::ViewStateKind view_state_;
     DDS::InstanceStateKind instance_state_;
+    DDS::Time_t instance_state_change_;
     DDS::Time_t disposed_expiration_date_;
     DDS::Time_t no_writers_expiration_date_;
     CORBA::Long disposed_generation_count_;

--- a/dds/DCPS/InternalDataWriter.h
+++ b/dds/DCPS/InternalDataWriter.h
@@ -14,8 +14,9 @@
 #  pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
-#include "RcObject.h"
 #include "InternalDataReader.h"
+#include "RcObject.h"
+#include "TimeSource.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -49,8 +50,10 @@ public:
   typedef WeakRcHandle<InternalDataReader<T> > InternalDataReader_wrch;
   typedef OPENDDS_VECTOR(T) SampleSequence;
 
-  explicit InternalDataWriter(const DDS::DataWriterQos& qos)
+  InternalDataWriter(const DDS::DataWriterQos& qos,
+                     const TimeSource& time_source)
     : qos_(qos)
+    , time_source_(time_source)
   {}
 
   /// @name InternalTopic Interface
@@ -89,8 +92,10 @@ public:
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
+    const DDS::Time_t source_timestamp = time_source_.dds_time_t_now();
+
     if (readers_.erase(reader)) {
-      reader->remove_publication(static_rchandle_cast<InternalEntity>(rchandle_from(this)), qos_.writer_data_lifecycle.autodispose_unregistered_instances);
+      reader->remove_publication(static_rchandle_cast<InternalEntity>(rchandle_from(this)), qos_.writer_data_lifecycle.autodispose_unregistered_instances, source_timestamp);
     }
 
     if (all_instance_readers_.erase(reader)) {
@@ -100,7 +105,7 @@ public:
         typename InstanceReaderSet::iterator pos2 = instance_readers_.find(*pos);
         if (pos2 != instance_readers_.end()) {
           if (pos2->second.erase(reader)) {
-            reader->remove_publication(static_rchandle_cast<InternalEntity>(rchandle_from(this)), qos_.writer_data_lifecycle.autodispose_unregistered_instances);
+            reader->remove_publication(static_rchandle_cast<InternalEntity>(rchandle_from(this)), qos_.writer_data_lifecycle.autodispose_unregistered_instances, source_timestamp);
           }
           if (pos2->second.empty()) {
             instance_readers_.erase(pos2);
@@ -128,22 +133,26 @@ public:
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
 
+    const DDS::Time_t source_timestamp = time_source_.dds_time_t_now();
+
     if (qos_.durability.kind == DDS::TRANSIENT_LOCAL_DURABILITY_QOS) {
       const std::pair<typename InstanceMap::iterator, bool> p = instance_map_.insert(std::make_pair(sample, SampleHolder()));
-      p.first->second.write(sample, qos_);
+      p.first->second.write(sample, source_timestamp, qos_);
     }
 
     typename InstanceReaderSet::const_iterator pos = instance_readers_.find(sample);
     if (pos != instance_readers_.end()) {
-      write_set(sample, pos->second);
+      write_set(sample, source_timestamp, pos->second);
     }
 
-    write_set(sample, readers_);
+    write_set(sample, source_timestamp, readers_);
   }
 
   void dispose(const T& sample)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+    const DDS::Time_t source_timestamp = time_source_.dds_time_t_now();
 
     if (qos_.durability.kind == DDS::TRANSIENT_LOCAL_DURABILITY_QOS) {
       typename InstanceMap::iterator pos = instance_map_.find(sample);
@@ -154,15 +163,17 @@ public:
 
     typename InstanceReaderSet::const_iterator pos = instance_readers_.find(sample);
     if (pos != instance_readers_.end()) {
-      dispose_set(sample, pos->second);
+      dispose_set(sample, source_timestamp, pos->second);
     }
 
-    dispose_set(sample, readers_);
+    dispose_set(sample, source_timestamp, readers_);
   }
 
   void unregister_instance(const T& sample)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+
+    const DDS::Time_t source_timestamp = time_source_.dds_time_t_now();
 
     if (qos_.durability.kind == DDS::TRANSIENT_LOCAL_DURABILITY_QOS) {
       instance_map_.erase(sample);
@@ -170,15 +181,16 @@ public:
 
     typename InstanceReaderSet::const_iterator pos = instance_readers_.find(sample);
     if (pos != instance_readers_.end()) {
-      unregister_instance_set(sample, pos->second);
+      unregister_instance_set(sample, source_timestamp, pos->second);
     }
 
-    unregister_instance_set(sample, readers_);
+    unregister_instance_set(sample, source_timestamp, readers_);
   }
   /// @}
 
 private:
   const DDS::DataWriterQos qos_;
+  const TimeSource& time_source_;
 
   typedef OPENDDS_SET(InternalDataReader_wrch) ReaderSet;
   ReaderSet readers_;
@@ -187,37 +199,40 @@ private:
   InstanceReaderSet instance_readers_;
 
   void write_set(const T& sample,
+                 const DDS::Time_t& source_timestamp,
                  const ReaderSet& readers)
   {
     for (typename ReaderSet::const_iterator pos = readers.begin(), limit = readers.end(); pos != limit; ++pos) {
       InternalDataReader_rch reader = pos->lock();
       if (reader) {
-        reader->write(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample);
+        reader->write(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample, source_timestamp);
       }
     }
   }
 
   void dispose_set(const T& sample,
+                   const DDS::Time_t& source_timestamp,
                    const ReaderSet& readers)
   {
     for (typename ReaderSet::const_iterator pos = readers.begin(), limit = readers.end(); pos != limit; ++pos) {
       InternalDataReader_rch reader = pos->lock();
       if (reader) {
-        reader->dispose(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample);
+        reader->dispose(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample, source_timestamp);
       }
     }
   }
 
   void unregister_instance_set(const T& sample,
+                               const DDS::Time_t& source_timestamp,
                                const ReaderSet& readers)
   {
     for (typename ReaderSet::const_iterator pos = readers.begin(), limit = readers.end(); pos != limit; ++pos) {
       InternalDataReader_rch reader = pos->lock();
       if (reader) {
         if (qos_.writer_data_lifecycle.autodispose_unregistered_instances) {
-          reader->dispose(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample);
+          reader->dispose(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample, source_timestamp);
         }
-        reader->unregister_instance(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample);
+        reader->unregister_instance(static_rchandle_cast<InternalEntity>(rchandle_from(this)), sample, source_timestamp);
       }
     }
   }
@@ -229,14 +244,15 @@ private:
     void add_reader(InternalDataReader_rch reader, RcHandle<InternalEntity> writer)
     {
       for (typename SampleList::const_iterator pos = samples_.begin(), limit = samples_.end(); pos != limit; ++pos) {
-        reader->write(writer, *pos);
+        reader->write(writer, pos->first, pos->second);
       }
     }
 
     void write(const T& sample,
+               const DDS::Time_t& source_timestamp,
                const DDS::DataWriterQos& qos)
     {
-      samples_.push_back(sample);
+      samples_.push_back(std::make_pair(sample, source_timestamp));
       if (qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS) {
         while (samples_.size() > static_cast<std::size_t>(qos.history.depth)) {
           samples_.pop_front();
@@ -250,7 +266,8 @@ private:
     }
 
   private:
-    typedef OPENDDS_LIST(T) SampleList;
+    typedef std::pair<T, DDS::Time_t> SampleAndTimestamp;
+    typedef OPENDDS_LIST(SampleAndTimestamp) SampleList;
     SampleList samples_;
   };
 

--- a/dds/DCPS/NetworkConfigMonitor.cpp
+++ b/dds/DCPS/NetworkConfigMonitor.cpp
@@ -43,7 +43,7 @@ bool NetworkInterfaceAddress::exclude_from_multicast(const char* configured_inte
 }
 
 NetworkConfigMonitor::NetworkConfigMonitor()
-  : writer_(make_rch<InternalDataWriter<NetworkInterfaceAddress> >(DataWriterQosBuilder().durability_transient_local()))
+  : writer_(make_rch<InternalDataWriter<NetworkInterfaceAddress> >(DataWriterQosBuilder().durability_transient_local(), TheServiceParticipant->time_source()))
 {}
 
 NetworkConfigMonitor::~NetworkConfigMonitor()

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -36,7 +36,7 @@ using DCPS::TimeDuration;
 RtpsDiscovery::RtpsDiscovery(const RepoKey& key)
   : key_(key)
   , config_(DCPS::make_rch<RtpsDiscoveryConfig>(key))
-  , stats_writer_(DCPS::make_rch<DCPS::StatisticsDataWriter>(DCPS::DataWriterQosBuilder().durability_transient_local()))
+  , stats_writer_(DCPS::make_rch<DCPS::StatisticsDataWriter>(DCPS::DataWriterQosBuilder().durability_transient_local(), TheServiceParticipant->time_source()))
   , stats_task_(DCPS::make_rch<PeriodicTask>(TheServiceParticipant->reactor_task(), *this, &RtpsDiscovery::write_stats))
 {
   TheServiceParticipant->statistics_topic()->connect(stats_writer_);

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -301,7 +301,7 @@ RtpsDiscoveryCore::RtpsDiscoveryCore(RcHandle<RtpsDiscoveryConfig> config,
 {}
 
 Sedp::Sedp(const GUID_t& participant_id, Spdp& owner, ACE_Thread_Mutex& lock)
-  : config_store_(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic()))
+  : config_store_(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic(), TheServiceParticipant->time_source()))
   , spdp_(owner)
   , lock_(lock)
   , participant_id_(participant_id)

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -158,7 +158,7 @@ Service_Participant::Service_Participant()
   , network_interface_address_topic_(make_rch<InternalTopic<NetworkInterfaceAddress> >())
   , statistics_topic_(make_rch<StatisticsTopic>())
   , config_topic_(make_rch<InternalTopic<ConfigPair> >())
-  , config_store_(make_rch<ConfigStoreImpl>(config_topic_))
+  , config_store_(make_rch<ConfigStoreImpl>(config_topic_, time_source_))
   , config_reader_(make_rch<InternalDataReader<ConfigPair> >(DataReaderQosBuilder().reliability_reliable().durability_transient_local()))
   , config_reader_listener_(make_rch<ConfigReaderListener>(ref(*this)))
   , pending_timeout_(0,0) // Can't use COMMON_DCPS_PENDING_TIMEOUT_default due to initialization order.

--- a/dds/DCPS/TimeSource.h
+++ b/dds/DCPS/TimeSource.h
@@ -23,10 +23,15 @@ class TimeSource {
 public:
   virtual ~TimeSource() {}
 
-  virtual MonotonicTimePoint monotonic_time_point_now() const {
+  virtual MonotonicTimePoint monotonic_time_point_now() const
+  {
     return MonotonicTimePoint::now();
   }
 
+  virtual DDS::Time_t dds_time_t_now() const
+  {
+    return SystemTimePoint::now().to_idl_struct();
+  }
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -60,7 +60,7 @@ RtpsUdpTransport::RtpsUdpTransport(const RtpsUdpInst_rch& inst,
   , ice_agent_(ICE::Agent::instance())
 #endif
   , core_(inst)
-  , stats_writer_(make_rch<StatisticsDataWriter>(DataWriterQosBuilder().durability_transient_local()))
+  , stats_writer_(make_rch<StatisticsDataWriter>(DataWriterQosBuilder().durability_transient_local(), TheServiceParticipant->time_source()))
   , stats_template_(stats_template())
 {
   assign(local_prefix_, GUIDPREFIX_UNKNOWN);

--- a/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
@@ -119,7 +119,8 @@ TEST(dds_DCPS_ConfigPair, key_has_prefix)
 TEST(dds_DCPS_ConfigStoreImpl, has)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   EXPECT_FALSE(store.has("key"));
   store.set_boolean("key", true);
   EXPECT_TRUE(store.has("key"));
@@ -128,7 +129,8 @@ TEST(dds_DCPS_ConfigStoreImpl, has)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_boolean)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   EXPECT_TRUE(store.get_boolean("key", true));
   EXPECT_FALSE(store.get_boolean("key", false));
   store.set_boolean("key", "true");
@@ -140,7 +142,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_boolean)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_int32)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   EXPECT_EQ(store.get_int32("key", -37), -37);
   store.set_int32("key", -38);
   EXPECT_EQ(store.get_int32("key", -37), -38);
@@ -153,7 +156,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_int32)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_uint32)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   EXPECT_EQ(store.get_uint32("key", 37), 37u);
   store.set_uint32("key", 38);
   EXPECT_EQ(store.get_uint32("key", 37), 38u);
@@ -166,7 +170,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_uint32)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_float64)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   EXPECT_EQ(store.get_float64("key", 1.5), 1.5);
   store.set_float64("key", 2);
   EXPECT_EQ(store.get_float64("key", 1.5), 2);
@@ -177,7 +182,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_float64)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_string)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   CORBA::String_var str = store.get_string("key", "default");
   EXPECT_STREQ(str, "default");
   store.set_string("key", "not default");
@@ -190,7 +196,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_duration)
   using OpenDDS::DCPS::operator==;
 
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   const DDS::Duration_t default_duration = make_duration_t(1,2);
   const DDS::Duration_t duration = make_duration_t(3,4);
   EXPECT_TRUE(store.get_duration("key", default_duration) == default_duration);
@@ -203,7 +210,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_duration)
 TEST(dds_DCPS_ConfigStoreImpl, unset)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   store.set_boolean("key", true);
   store.unset("key");
   EXPECT_FALSE(store.has("key"));
@@ -212,7 +220,8 @@ TEST(dds_DCPS_ConfigStoreImpl, unset)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_String)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   const String default_string = "default";
   const String other_string = "other";
   EXPECT_EQ(store.get("key", default_string), default_string);
@@ -226,7 +235,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_String)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_StringList)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   ConfigStoreImpl::StringList default_list;
   default_list.push_back("Lorem");
   default_list.push_back("ipsum");
@@ -242,7 +252,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_StringList)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_IntList)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   ConfigStoreImpl::UInt32List default_list;
   default_list.push_back(1);
   default_list.push_back(2);
@@ -272,7 +283,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_Enum)
     };
 
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   // Get the default if there is no entry.
   EXPECT_EQ(store.get("key", GAMMA, kinds), GAMMA);
 
@@ -299,7 +311,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_Enum)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_seconds)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   const TimeDuration default_duration(1,2);
   const TimeDuration duration(3);
   EXPECT_EQ(store.get("key", default_duration, ConfigStoreImpl::Format_IntegerSeconds), default_duration);
@@ -312,7 +325,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_seconds)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_milliseconds)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   const TimeDuration default_duration(1,2);
   const TimeDuration duration(3,4000);
   EXPECT_EQ(store.get("key", default_duration, ConfigStoreImpl::Format_IntegerMilliseconds), default_duration);
@@ -325,7 +339,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_milliseconds)
 TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_fractional_seconds)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
   const TimeDuration default_duration(1,500000);
   const TimeDuration duration(2,500000);
   EXPECT_EQ(store.get("key", default_duration, ConfigStoreImpl::Format_FractionalSeconds), default_duration);
@@ -338,7 +353,8 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_fractional_seconds)
 TEST(dds_DCPS_ConfigStoreImpl, get_NetworkAddress)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
 
   {
     const NetworkAddress default_value("0.0.0.0:0");
@@ -426,7 +442,8 @@ TEST(dds_DCPS_ConfigStoreImpl, get_NetworkAddress)
 TEST(dds_DCPS_ConfigStoreImpl, get_NetworkAddressSet)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store(topic, time_source);
 
   {
     NetworkAddressSet default_value;
@@ -516,7 +533,8 @@ TEST(dds_DCPS_ConfigStoreImpl, get_NetworkAddressSet)
 TEST(dds_DCPS_ConfigStoreImpl, take_has_prefix)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl store1(topic);
+  TimeSource time_source;
+  ConfigStoreImpl store1(topic, time_source);
   ConfigReader_rch reader = make_rch<ConfigReader>(store1.datareader_qos());
   topic->connect(reader);
 
@@ -542,7 +560,8 @@ TEST(dds_DCPS_ConfigStoreImpl, process_section)
 {
   JobQueue_rch job_queue = make_rch<JobQueue>(ACE_Reactor::instance());
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl config_store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl config_store(topic, time_source);
   config_store.set("MYPREFIX_MY_SECTION_THIRDKEY", "firstvalue");
   ConfigReader_rch reader = make_rch<ConfigReader>(config_store.datareader_qos());
   RcHandle<Listener> listener = make_rch<Listener>(job_queue);
@@ -567,7 +586,8 @@ TEST(dds_DCPS_ConfigStoreImpl, process_section)
 TEST(dds_DCPS_ConfigStoreImpl, process_section_allow_overwrite)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl config_store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl config_store(topic, time_source);
   config_store.set("MYPREFIX_MY_SECTION_THIRDKEY", "firstvalue");
   ACE_Configuration_Heap config;
   ACE_Configuration_Section_Key section_key;
@@ -587,7 +607,8 @@ TEST(dds_DCPS_ConfigStoreImpl, process_section_allow_overwrite)
 TEST(dds_DCPS_ConfigStoreImpl, get_section_names)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl config_store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl config_store(topic, time_source);
   config_store.set("MYPREFIX_MY_SECTION", "@my_section");
   config_store.set("MYPREFIX_MY_SECTION_KEY", "not a section");
   config_store.set("MYPREFIX_MY_SECTION2", "@my_section2");
@@ -605,7 +626,8 @@ TEST(dds_DCPS_ConfigStoreImpl, get_section_values)
 {
   JobQueue_rch job_queue = make_rch<JobQueue>(ACE_Reactor::instance());
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl config_store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl config_store(topic, time_source);
   ConfigReader_rch reader = make_rch<ConfigReader>(config_store.datareader_qos());
   RcHandle<Listener> listener = make_rch<Listener>(job_queue);
   ACE_Configuration_Heap config;
@@ -632,7 +654,8 @@ TEST(dds_DCPS_ConfigStoreImpl, get_section_values)
 TEST(dds_DCPS_ConfigStoreImpl, delete_section)
 {
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  ConfigStoreImpl config_store(topic);
+  TimeSource time_source;
+  ConfigStoreImpl config_store(topic, time_source);
   config_store.set("MYPREFIX_MY_SECTION", "@my_section");
   config_store.set("MYPREFIX_MY_SECTION_KEY", "not a section");
   config_store.set("MYPREFIX_MY_SECTION2", "@my_section2");

--- a/tests/unit-tests/dds/DCPS/InternalDataReader.cpp
+++ b/tests/unit-tests/dds/DCPS/InternalDataReader.cpp
@@ -26,6 +26,10 @@ namespace {
     }
   };
 
+  const DDS::Time_t time1 = make_time_t(0, 1);
+  const DDS::Time_t time2 = make_time_t(0, 2);
+  const DDS::Time_t time3 = make_time_t(0, 3);
+  const DDS::Time_t time4 = make_time_t(0, 4);
 }
 
 std::ostream& operator<<(std::ostream& out, const SIW& siw)
@@ -80,16 +84,16 @@ TEST(dds_DCPS_InternalDataReader, write)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
   // Twice to exercise history.
-  reader->write(writer, sample);
+  reader->write(writer, sample, time2);
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time2, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, write_keep_all)
@@ -101,18 +105,18 @@ TEST(dds_DCPS_InternalDataReader, write_keep_all)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable().history_keep_all());
 
-  reader->write(writer, sample);
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
+  reader->write(writer, sample, time2);
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 2U);
   ASSERT_EQ(infos.size(), 2U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 1, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 1, 0, 0, true)));
 
   EXPECT_EQ(samples[1], sample);
-  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time2, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, unregister_instance)
@@ -124,15 +128,15 @@ TEST(dds_DCPS_InternalDataReader, unregister_instance)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
-  reader->unregister_instance(writer, sample);
+  reader->write(writer, sample, time1);
+  reader->unregister_instance(writer, sample, time2);
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, dispose)
@@ -144,15 +148,15 @@ TEST(dds_DCPS_InternalDataReader, dispose)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
-  reader->dispose(writer, sample);
+  reader->write(writer, sample, time1);
+  reader->dispose(writer, sample, time2);
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, remove_publication_autodispose)
@@ -164,15 +168,15 @@ TEST(dds_DCPS_InternalDataReader, remove_publication_autodispose)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
-  reader->remove_publication(writer, true);
+  reader->write(writer, sample, time1);
+  reader->remove_publication(writer, true, time2);
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, remove_publication)
@@ -184,15 +188,15 @@ TEST(dds_DCPS_InternalDataReader, remove_publication)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
-  reader->remove_publication(writer, false);
+  reader->write(writer, sample, time1);
+  reader->remove_publication(writer, false, time2);
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, listener)
@@ -210,7 +214,7 @@ TEST(dds_DCPS_InternalDataReader, listener)
   // This increases the reference count on reader which prevents the destruction and check of the listener.
   EXPECT_CALL(*listener.get(), on_data_available(reader));
 
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
 
   ACE_Time_Value tv(1,0);
   ACE_Reactor::run_event_loop(tv);
@@ -227,7 +231,7 @@ TEST(dds_DCPS_InternalDataReader, read)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
 
   reader->read(samples, infos, DDS::LENGTH_UNLIMITED, DDS::READ_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -243,7 +247,7 @@ TEST(dds_DCPS_InternalDataReader, read)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 
   reader->read(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
@@ -251,7 +255,7 @@ TEST(dds_DCPS_InternalDataReader, read)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, read_instance_state)
@@ -263,7 +267,7 @@ TEST(dds_DCPS_InternalDataReader, read_instance_state)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
 
   reader->read(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE | DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -274,9 +278,9 @@ TEST(dds_DCPS_InternalDataReader, read_instance_state)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 
-  reader->dispose(writer, sample);
+  reader->dispose(writer, sample, time2);
 
   reader->read(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE | DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -287,11 +291,11 @@ TEST(dds_DCPS_InternalDataReader, read_instance_state)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 
   // Revive the instance.
-  reader->write(writer, sample);
-  reader->unregister_instance(writer, sample);
+  reader->write(writer, sample, time3);
+  reader->unregister_instance(writer, sample, time4);
 
   reader->read(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE | DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -302,7 +306,7 @@ TEST(dds_DCPS_InternalDataReader, read_instance_state)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, 1, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, time3, 1, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, take)
@@ -314,7 +318,7 @@ TEST(dds_DCPS_InternalDataReader, take)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
 
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::READ_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -330,7 +334,7 @@ TEST(dds_DCPS_InternalDataReader, take)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
@@ -347,7 +351,7 @@ TEST(dds_DCPS_InternalDataReader, take_instance_state)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample);
+  reader->write(writer, sample, time1);
 
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE | DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -358,9 +362,9 @@ TEST(dds_DCPS_InternalDataReader, take_instance_state)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 
-  reader->dispose(writer, sample);
+  reader->dispose(writer, sample, time2);
 
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE | DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -371,11 +375,11 @@ TEST(dds_DCPS_InternalDataReader, take_instance_state)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, false)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time2, 0, 0, 0, 0, 0, false)));
 
   // Revive the instance.
-  reader->write(writer, sample);
-  reader->unregister_instance(writer, sample);
+  reader->write(writer, sample, time3);
+  reader->unregister_instance(writer, sample, time4);
 
   reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE | DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE);
   ASSERT_EQ(samples.size(), 0U);
@@ -386,7 +390,7 @@ TEST(dds_DCPS_InternalDataReader, take_instance_state)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, 1, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, time3, 1, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataReader, read_instance)
@@ -400,15 +404,15 @@ TEST(dds_DCPS_InternalDataReader, read_instance)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample1);
-  reader->write(writer, sample2);
+  reader->write(writer, sample1, time1);
+  reader->write(writer, sample2, time2);
   reader->read_instance(samples, infos, DDS::LENGTH_UNLIMITED, sample1, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample1);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 
   reader->read_instance(samples, infos, DDS::LENGTH_UNLIMITED, sample3, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
@@ -427,15 +431,15 @@ TEST(dds_DCPS_InternalDataReader, take_instance)
   RcHandle<InternalEntity> writer = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer, sample1);
-  reader->write(writer, sample2);
+  reader->write(writer, sample1, time1);
+  reader->write(writer, sample2, time2);
   reader->take_instance(samples, infos, DDS::LENGTH_UNLIMITED, sample2, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample2);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time2, 0, 0, 0, 0, 0, true)));
 
   reader->take_instance(samples, infos, DDS::LENGTH_UNLIMITED, sample3, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
@@ -453,13 +457,13 @@ TEST(dds_DCPS_InternalDataReader, remove_publication_does_not_dispose_everything
   RcHandle<InternalEntity> writer2 = make_rch<InternalEntity>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
 
-  reader->write(writer1, sample);
-  reader->remove_publication(writer2, true);
+  reader->write(writer1, sample, time1);
+  reader->remove_publication(writer2, true, time2);
   reader->read(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   ASSERT_EQ(samples.size(), 1U);
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time1, 0, 0, 0, 0, 0, true)));
 }

--- a/tests/unit-tests/dds/DCPS/InternalDataWriter.cpp
+++ b/tests/unit-tests/dds/DCPS/InternalDataWriter.cpp
@@ -8,6 +8,15 @@ using namespace OpenDDS::DCPS;
 typedef SampleInfoWrapper SIW;
 
 namespace {
+  const DDS::Time_t time0 = make_time_t(0, 0);
+
+  class MyTimeSource : public TimeSource {
+  public:
+    DDS::Time_t dds_time_t_now() const {
+      return time0;
+    }
+  };
+
   struct Sample {
     std::string key;
 
@@ -28,6 +37,7 @@ namespace {
       return key < other.key;
     }
   };
+
 }
 
 typedef InternalDataWriter<Sample> WriterType;
@@ -35,7 +45,8 @@ typedef InternalDataReader<Sample> ReaderType;
 
 TEST(dds_DCPS_InternalDataWriter, add_reader)
 {
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   writer->add_reader(reader);
 
@@ -51,7 +62,8 @@ TEST(dds_DCPS_InternalDataWriter, add_reader_durable)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder().durability_transient_local().history_depth(2));
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder().durability_transient_local().history_depth(2), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable().durability_transient_local().history_keep_all());
 
   writer->write(sample1);
@@ -65,13 +77,13 @@ TEST(dds_DCPS_InternalDataWriter, add_reader_durable)
   ASSERT_EQ(infos.size(), 3U);
 
   EXPECT_EQ(samples[0], sample1);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 
   EXPECT_EQ(samples[1], sample2);
-  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 1, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 1, 0, 0, true)));
 
   EXPECT_EQ(samples[2], sample2);
-  EXPECT_EQ(SIW(infos[2]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[2]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, add_reader_durable_history1)
@@ -83,7 +95,8 @@ TEST(dds_DCPS_InternalDataWriter, add_reader_durable_history1)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder().durability_transient_local());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder().durability_transient_local(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable().durability_transient_local());
 
   writer->write(sample1);
@@ -97,10 +110,10 @@ TEST(dds_DCPS_InternalDataWriter, add_reader_durable_history1)
   ASSERT_EQ(infos.size(), 2U);
 
   EXPECT_EQ(samples[0], sample1);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 
   EXPECT_EQ(samples[1], sample2);
-  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, remove_reader)
@@ -109,7 +122,8 @@ TEST(dds_DCPS_InternalDataWriter, remove_reader)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   writer->add_reader(reader);
   writer->write(sample);
@@ -122,7 +136,7 @@ TEST(dds_DCPS_InternalDataWriter, remove_reader)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, write)
@@ -131,7 +145,8 @@ TEST(dds_DCPS_InternalDataWriter, write)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   writer->add_reader(reader);
 
@@ -142,7 +157,7 @@ TEST(dds_DCPS_InternalDataWriter, write)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, unregister_instance)
@@ -151,7 +166,8 @@ TEST(dds_DCPS_InternalDataWriter, unregister_instance)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   writer->add_reader(reader);
 
@@ -163,7 +179,7 @@ TEST(dds_DCPS_InternalDataWriter, unregister_instance)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, unregister_instance_no_dispose)
@@ -172,7 +188,8 @@ TEST(dds_DCPS_InternalDataWriter, unregister_instance_no_dispose)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder().writer_data_lifecycle_autodispose_unregistered_instances(false));
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder().writer_data_lifecycle_autodispose_unregistered_instances(false), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   writer->add_reader(reader);
 
@@ -184,7 +201,7 @@ TEST(dds_DCPS_InternalDataWriter, unregister_instance_no_dispose)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, dispose)
@@ -193,7 +210,8 @@ TEST(dds_DCPS_InternalDataWriter, dispose)
   ReaderType::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   writer->add_reader(reader);
 
@@ -205,7 +223,7 @@ TEST(dds_DCPS_InternalDataWriter, dispose)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], sample);
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 }
 
 TEST(dds_DCPS_InternalDataWriter, add_instance_reader)
@@ -214,7 +232,8 @@ TEST(dds_DCPS_InternalDataWriter, add_instance_reader)
   interesting_samples.push_back(Sample("a"));
   interesting_samples.push_back(Sample("c"));
 
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  MyTimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
   reader->set_interesting_instances(interesting_samples);
   writer->add_reader(reader);
@@ -232,9 +251,9 @@ TEST(dds_DCPS_InternalDataWriter, add_instance_reader)
   ASSERT_EQ(infos.size(), 2U);
 
   EXPECT_EQ(samples[0], Sample("a"));
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
   EXPECT_EQ(samples[1], Sample("c"));
-  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, 0, 0, 0, 0, 0, true)));
+  EXPECT_EQ(SIW(infos[1]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NEW_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, true)));
 
   writer->dispose(Sample("a"));
   writer->dispose(Sample("b"));
@@ -245,7 +264,7 @@ TEST(dds_DCPS_InternalDataWriter, add_instance_reader)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], Sample("a"));
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, false)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, false)));
 
   writer->unregister_instance(Sample("a"));
   writer->unregister_instance(Sample("b"));
@@ -257,5 +276,5 @@ TEST(dds_DCPS_InternalDataWriter, add_instance_reader)
   ASSERT_EQ(infos.size(), 1U);
 
   EXPECT_EQ(samples[0], Sample("c"));
-  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, 0, 0, 0, 0, 0, false)));
+  EXPECT_EQ(SIW(infos[0]), SIW(make_sample_info(DDS::NOT_READ_SAMPLE_STATE, DDS::NOT_NEW_VIEW_STATE, DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE, time0, 0, 0, 0, 0, 0, false)));
 }

--- a/tests/unit-tests/dds/DCPS/InternalTopic.cpp
+++ b/tests/unit-tests/dds/DCPS/InternalTopic.cpp
@@ -23,7 +23,8 @@ TEST(dds_DCPS_InternalTopic, connect_writer)
 {
   RcHandle<TopicType> topic = make_rch<TopicType>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  TimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
 
   topic->connect(reader);
   topic->connect(writer);
@@ -35,7 +36,8 @@ TEST(dds_DCPS_InternalTopic, connect_reader)
 {
   RcHandle<TopicType> topic = make_rch<TopicType>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  TimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
 
   topic->connect(writer);
   topic->connect(reader);
@@ -47,7 +49,8 @@ TEST(dds_DCPS_InternalTopic, disconnect_writer)
 {
   RcHandle<TopicType> topic = make_rch<TopicType>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  TimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
 
   topic->connect(reader);
   topic->connect(writer);
@@ -60,7 +63,8 @@ TEST(dds_DCPS_InternalTopic, disconnect_reader)
 {
   RcHandle<TopicType> topic = make_rch<TopicType>();
   RcHandle<ReaderType> reader = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
-  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder());
+  TimeSource time_source;
+  RcHandle<WriterType> writer = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
 
   topic->connect(writer);
   topic->connect(reader);
@@ -73,9 +77,10 @@ TEST(dds_DCPS_InternalTopic, connect_multiple)
 {
   RcHandle<TopicType> topic = make_rch<TopicType>();
   RcHandle<ReaderType> reader1 = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
-  RcHandle<WriterType> writer1 = make_rch<WriterType>(DataWriterQosBuilder());
+  TimeSource time_source;
+  RcHandle<WriterType> writer1 = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
   RcHandle<ReaderType> reader2 = make_rch<ReaderType>(DataReaderQosBuilder().reliability_reliable());
-  RcHandle<WriterType> writer2 = make_rch<WriterType>(DataWriterQosBuilder());
+  RcHandle<WriterType> writer2 = make_rch<WriterType>(DataWriterQosBuilder(), time_source);
 
   topic->connect(reader1);
   topic->connect(writer1);

--- a/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -13,7 +13,7 @@ namespace {
     bool fixed;
 
     AddressTest()
-    : store(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic()))
+    : store(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic(), TheServiceParticipant->time_source()))
     , rtps("ADDRESS_TEST")
     , addr()
     , fixed(false)

--- a/tests/unit-tests/dds/DCPS/transport/framework/MessageDropper.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/framework/MessageDropper.cpp
@@ -17,7 +17,8 @@ TEST(dds_DCPS_transport_framework_MessageDropper, reload)
   MessageDropper uut;
 
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  RcHandle<ConfigStoreImpl> config_store = make_rch<ConfigStoreImpl>(topic);
+  TimeSource time_source;
+  RcHandle<ConfigStoreImpl> config_store = make_rch<ConfigStoreImpl>(topic, time_source);
   config_store->set_boolean("KEY_PREFIX_DROP_MESSAGES", true);
   config_store->set_float64("KEY_PREFIX_DROP_MESSAGES_M", 1.0);
   config_store->set_float64("KEY_PREFIX_DROP_MESSAGES_B", 1.0);

--- a/tests/unit-tests/dds/DCPS/transport/framework/TransportStatistics.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/framework/TransportStatistics.cpp
@@ -15,7 +15,8 @@ TEST(dds_DCPS_transport_framework_InternalTransportStatistics, reload)
   InternalTransportStatistics uut("a transport");
 
   ConfigTopic_rch topic = make_rch<ConfigTopic>();
-  RcHandle<ConfigStoreImpl> config_store = make_rch<ConfigStoreImpl>(topic);
+  TimeSource time_source;
+  RcHandle<ConfigStoreImpl> config_store = make_rch<ConfigStoreImpl>(topic, time_source);
   config_store->set_boolean("KEY_PREFIX_COUNT_MESSAGES", true);
   uut.reload(config_store, "KEY_PREFIX");
 

--- a/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -11,7 +11,7 @@ namespace {
     RcHandle<RtpsUdpInst> rtps_udp;
 
     RtpsUdpType()
-    : store(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic()))
+    : store(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic(), TheServiceParticipant->time_source()))
     , rtps_udp(make_rch<RtpsUdpInst>("RTPS_UDP_INST_UNIT_TEST", true))
     {
       store->unset_section(rtps_udp->config_prefix());


### PR DESCRIPTION
Problem
-------

InternalDataWriter doesn't provide a `source_timestamp` to the InternalDataReader for the SampleInfo.

Solution
--------

Provide the `source_timestamp`.