### PR TITLE
Remove Optional Dependencies section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ details.
 * [Dependencies](#dependencies)
   * [ACE/TAO](#acetao)
   * [Perl](#perl)
-  * [Optional Dependencies](#optional-dependencies)
 * [Supported Platforms](#supported-platforms)
   * [Operating Systems](#operating-systems)
   * [Compilers](#compilers)


### PR DESCRIPTION
Section doesn't exist anymore, in the main dependencies there is already a link to https://opendds.readthedocs.io/en/latest-release/devguide/building/dependencies.html#optional-dependencies