### PR TITLE
Increase NetworkResource Test Timeout

### DIFF
--- a/tests/transport/network_resource/run_test.pl
+++ b/tests/transport/network_resource/run_test.pl
@@ -13,7 +13,7 @@ my $status = 0;
 my $test = new PerlDDS::TestFramework();
 $test->process("nr", "NetworkResource", "");
 $test->start_process("nr");
-my $retcode = $test->finish(20);
+my $retcode = $test->finish(30);
 if ($retcode != 0) {
   $status = 1;
 }


### PR DESCRIPTION
Problem:
 - NetworkResource tests call "choose_single_coherent_address" multiple times, which can wind up calling both `getnameinfo` as well as `getaddrinfo`, both of which can, depending on OS and host's network configuration, block for significant periods of time.

Solution:
 - The first few times these are called can sometimes take between 5-10 seconds, possibly longer, so having a generous timeout for theses tests makes sense.
