### PR TITLE
Fix static build for FlexibleTS tests

### DIFF
--- a/tests/DCPS/FlexibleTS/Controller/FlexibleTS_Controller.mpc
+++ b/tests/DCPS/FlexibleTS/Controller/FlexibleTS_Controller.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, dcps_rtps_udp {
+project: dcpsexe, dcps_test, dcps_rtps_udp {
   requires += no_opendds_safety_profile built_in_topics
   idlflags += -SS -I../NewDevice
   TypeSupport_Files {

--- a/tests/DCPS/FlexibleTS/NewDevice/FlexibleTS_NewDevice.mpc
+++ b/tests/DCPS/FlexibleTS/NewDevice/FlexibleTS_NewDevice.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, dcps_rtps_udp {
+project: dcpsexe, dcps_test, dcps_rtps_udp {
   requires += no_opendds_safety_profile built_in_topics
   idlflags += -SS
   TypeSupport_Files {

--- a/tests/DCPS/FlexibleTS/OldDevice/FlexibleTS_OldDevice.mpc
+++ b/tests/DCPS/FlexibleTS/OldDevice/FlexibleTS_OldDevice.mpc
@@ -1,4 +1,4 @@
-project: dcps_test, dcps_rtps_udp {
+project: dcpsexe, dcps_test, dcps_rtps_udp {
   requires += no_opendds_safety_profile built_in_topics
   idlflags += -SS
   TypeSupport_Files {


### PR DESCRIPTION
Problem:
 - Static build for FlexibleTS tests fails for Debian x86 gcc12 with: `./configure --tests --security --ace-tao=ace6tao2 --static --no-inline`
 - Error Message:
 ```
 g++ -Wnon-virtual-dtor -ggdb -pthread -fno-strict-aliasing -Wall -W -Wpointer-arith -pipe -D_GNU_SOURCE -DACE_HAS_CUSTOM_EXPORT_MACROS=0  -I/storage/tsimpson/code/OpenDDS/ACE_wrappers -DACE_NO_INLINE -I/storage/tsimpson/code/OpenDDS/ACE_wrappers -I/storage/tsimpson/code/OpenDDS/ACE_wrappers/TAO -I../../../.. -I/storage/tsimpson/code/OpenDDS/tools/rapidjson/include -DOPENDDS_SECURITY -DOPENDDS_RAPIDJSON -DACE_AS_STATIC_LIBS -DTAO_AS_STATIC_LIBS  -L/storage/tsimpson/code/OpenDDS/ACE_wrappers/lib -L/storage/tsimpson/code/OpenDDS/lib -L.  -L/storage/tsimpson/code/OpenDDS/ACE_wrappers/lib  -L../../../../lib   -o Controller .obj/Controller.o .obj/NewDeviceC.o .obj/NewDeviceTypeSupportC.o .obj/NewDeviceTypeSupportImpl.o -lOpenDDS_Rtps_Udp -lOpenDDS_Rtps -lOpenDDS_Dcps -lTAO_BiDirGIOP -lTAO_PI -lTAO_CodecFactory -lTAO_Valuetype -lTAO_PortableServer -lTAO_AnyTypeCode -lTAO -lACE -ldl -lrt 
/usr/bin/ld: .obj/Controller.o: in function `__static_initialization_and_destruction_0(int, int)':
/storage/tsimpson/code/OpenDDS/tests/DCPS/FlexibleTS/Controller/../../../../dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h:289: undefined reference to `OpenDDS::DCPS::InfoRepoDiscovery::StaticInitializer::StaticInitializer()'
/usr/bin/ld: .obj/Controller.o: in function `__static_initialization_and_destruction_0(int, int)':
/storage/tsimpson/code/OpenDDS/tests/DCPS/FlexibleTS/Controller/../../../../dds/DCPS/transport/tcp/Tcp.h:31: undefined reference to `OpenDDS::DCPS::Tcp_Initializer::Tcp_Initializer()'
collect2: error: ld returned 1 exit status
make[1]: *** [GNUmakefile.FlexibleTS_Controller:360: Controller] Error 1
```

Solution:
 - Adding `dcpsexe` to `.mpc` files (matching other tests in `tests/DCPS`) seems to fix the issue.