### PR TITLE
Fix Publisher Race In RecorderReplayer Test

### DIFF
--- a/tests/DCPS/RecorderReplayer/.gitignore
+++ b/tests/DCPS/RecorderReplayer/.gitignore
@@ -1,3 +1,4 @@
 /publisher
 /relay
 /subscriber
+/DCS

--- a/tests/DCPS/RecorderReplayer/Publisher.cpp
+++ b/tests/DCPS/RecorderReplayer/Publisher.cpp
@@ -7,6 +7,7 @@
 #include "Args.h"
 
 #include <tests/Utils/DistributedConditionSet.h>
+#include <tests/Utils/StatusMatching.h>
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/PublisherImpl.h>
@@ -116,6 +117,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                         ACE_TEXT("ERROR: %N:%l: main() -")
                         ACE_TEXT(" _narrow failed!\n")),
                         -1);
+    }
+
+    // Block until writer matches reader (data won't be discarded)
+    if (Utils::wait_match(writer, 1, Utils::EQ)) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: main(): Error waiting for match for writer\n"));
+      return EXIT_FAILURE;
     }
 
     // Block until Recorder joins


### PR DESCRIPTION
Problem:
 - RecorderReplay Test is flaky. The Distributed Condition Set guarantees the recorder has matched with the publisher, but nothing guarantees the publisher has matched with the recorder, meaning that initial writes might potentially be dropped, leading to missing instances / test failure.

Solution:
 - Use Util::wait_match on the publisher to wait for the writer to match the recorder.
 - Note: The same issue theoretically might exist between the replayer and subscriber, but is less likely to cause issues. Eventually, we may want to extend Util::wait_match to cover DCPS::Recorder and DCPS::Replayer for use in tests that use them.
