### PR TITLE
Add move constructors and assignment operators to improve fragment reassembly

### DIFF
--- a/dds/DCPS/transport/framework/ReceivedDataSample.h
+++ b/dds/DCPS/transport/framework/ReceivedDataSample.h
@@ -39,6 +39,14 @@ public:
 
   explicit ReceivedDataSample(const ACE_Message_Block& payload);
 
+#ifdef ACE_HAS_CPP11
+  ReceivedDataSample(const ReceivedDataSample& other) = default;
+  ReceivedDataSample& operator=(const ReceivedDataSample& rhs) = default;
+
+  ReceivedDataSample(ReceivedDataSample&& other) = default;
+  ReceivedDataSample& operator=(ReceivedDataSample&& rhs) = default;
+#endif
+
   /// The demarshalled sample header.
   DataSampleHeader header_;
 

--- a/dds/DCPS/transport/framework/TransportReassembly.h
+++ b/dds/DCPS/transport/framework/TransportReassembly.h
@@ -122,6 +122,16 @@ private:
     FragSample(const FragmentRange& fragRange,
               const ReceivedDataSample& data);
 
+#ifdef ACE_HAS_CPP11
+    FragSample(const FragmentRange& fragRange,
+              ReceivedDataSample&& data);
+    FragSample(const FragSample&) = default;
+    FragSample(FragSample&&) = default;
+
+    FragSample& operator=(const FragSample&) = default;
+    FragSample& operator=(FragSample&&) = default;
+#endif
+
     FragmentRange frag_range_;
     ReceivedDataSample rec_ds_;
   };
@@ -138,6 +148,11 @@ private:
     FragInfo(const FragInfo& val);
 
     FragInfo& operator=(const FragInfo& rhs);
+
+#ifdef ACE_HAS_CPP11
+    FragInfo(FragInfo&& other) = default;
+    FragInfo& operator=(FragInfo&& rhs) = default;
+#endif
 
     bool insert(const FragmentRange& fragRange, ReceivedDataSample& data);
 


### PR DESCRIPTION
Problem:
 - For data samples with large numbers of fragments, reassembly often is rebuilding temporary MessageBlock objects, forcing calls to ACE_Data_Block::duplicate()

Solution:
 - For C++11 builds, we can use move constructors and assignment operators to improve the behavior for these temporary objects